### PR TITLE
feat(baseline): add baseline add (additive) and baseline diff (preview) [#73 items 4+5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (cont.)
+### Added
 
+- **Fingerprint v2** (opt-in): new `--fingerprint-version 2` flag on `nox scan`
+  (or `NOX_FINGERPRINT_VERSION=2` env). V2 hashes only `rule_id + normalised
+  file_path + content`; drops the start line so trivial diffs (import shifts,
+  gofmt, comment edits) no longer invalidate baselined findings. Path
+  normalisation collapses leading `./`, backslash → forward-slash, and `..`
+  segments so `nox scan ./http` and `nox scan .` produce the same fingerprint
+  for the same finding. V1 remains the default; switch a repo over by
+  passing `--fingerprint-version 2` to `nox scan` (or setting the env)
+  and then running `nox baseline update` so existing entries re-hash
+  under V2. A dedicated `nox baseline migrate` command will land in a
+  follow-up PR (#73 item 4). Closes [#73 items 1+2](https://github.com/Nox-HQ/nox/issues/73).
 - **`nox baseline add`** — additive counterpart to `baseline update`.
   Adds findings not yet in the baseline without pruning stale entries.
   Accepts `--rule <id,id>` and `--fingerprint <fp,fp>` filters; the
@@ -34,20 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the true-positive `cursor.execute("SELECT " + completion)` patterns still
   fire (including with nested calls in the argument list). Closes [#73 item
   3](https://github.com/Nox-HQ/nox/issues/73).
-
-### Added
-
-- **Fingerprint v2** (opt-in): new `--fingerprint-version 2` flag on `nox scan`
-  (or `NOX_FINGERPRINT_VERSION=2` env). V2 hashes only `rule_id + normalised
-  file_path + content`; drops the start line so trivial diffs (import shifts,
-  gofmt, comment edits) no longer invalidate baselined findings. Path
-  normalisation collapses leading `./`, backslash → forward-slash, and `..`
-  segments so `nox scan ./http` and `nox scan .` produce the same fingerprint
-  for the same finding. V1 remains the default; switch a repo over by
-  passing `--fingerprint-version 2` to `nox scan` (or setting the env)
-  and then running `nox baseline update` so existing entries re-hash
-  under V2. A dedicated `nox baseline migrate` command will land in a
-  follow-up PR (#73 item 4). Closes [#73 items 1+2](https://github.com/Nox-HQ/nox/issues/73).
 
 ## [0.6.0] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (cont.)
+
+- **`nox baseline add`** — additive counterpart to `baseline update`.
+  Adds findings not yet in the baseline without pruning stale entries.
+  Accepts `--rule <id,id>` and `--fingerprint <fp,fp>` filters; the
+  fingerprint flag bypasses the scan entirely and is the surgical
+  "baseline these specific entries" workflow #73 item 4 calls out.
+  `--reason` and `--owner` annotate every new entry. Closes [#73 item
+  4](https://github.com/Nox-HQ/nox/issues/73).
+- **`nox baseline diff`** — read-only preview of what
+  `baseline update` would change against the current scan. Lists adds
+  and prunes separately so the operator can decide whether a prune is
+  real (resolved) or a regression (rule sharpened, file renamed,
+  fingerprint algorithm bumped).
+
 ### Fixed
 
 - **AI-012 precision** — tightened the regex so it stops firing on every

--- a/cli/baseline_cmd.go
+++ b/cli/baseline_cmd.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	nox "github.com/nox-hq/nox/core"
@@ -144,19 +145,15 @@ func baselineUpdate(args []string) int {
 // without losing entries that happen to be missing from this scan.
 // `baseline update` would prune those — `baseline add` won't touch them.
 //
-// Filters:
+// Filters (each accepts a comma-separated list of values):
 //
-//	--rule <id>   only add findings whose rule_id matches (repeatable
-//	              by passing comma-separated values).
-//	--fingerprint <fp>
-//	              only add the entries whose fingerprint matches one
-//	              of the supplied values (repeatable / comma list).
-//	              Useful when piping fingerprints from `baseline diff`.
+//	--rule <id,id,…>          only add findings whose rule_id is in the set.
+//	--fingerprint <fp,fp,…>   add these exact fingerprints. Bypasses the
+//	                          scan entirely; entries get empty rule_id /
+//	                          file_path until an editor fills them in.
 //
-// When --fingerprint is set, no scan is run; the supplied fingerprints
-// are added as bare entries with empty rule_id / file_path. The
-// surgical-add path is the workflow nox-hq/nox#73 item 4 calls out:
-// "add these specific fingerprints without rewriting the file".
+// The --fingerprint path is the workflow nox-hq/nox#73 item 4 calls
+// out: "add these specific fingerprints without rewriting the file".
 func baselineAdd(args []string) int {
 	fs := flag.NewFlagSet("baseline add", flag.ContinueOnError)
 	var (
@@ -258,8 +255,9 @@ func baselineAdd(args []string) int {
 // (finding genuinely resolved) or a regression (rule sharpened, file
 // renamed, fingerprint algorithm bumped).
 //
-// Exit status is always 0 unless the scan itself fails. The diff is
-// informational.
+// The diff is informational: a non-zero exit code is reserved for the
+// usual hard failures (flag-parse, baseline-load, scan errors). A
+// "diff that shows differences" is itself success.
 func baselineDiff(args []string) int {
 	fs := flag.NewFlagSet("baseline diff", flag.ContinueOnError)
 	var baselinePath string
@@ -306,28 +304,48 @@ func baselineDiff(args []string) int {
 		}
 	}
 	// Prunes: baseline entries no longer matched by any current finding.
+	// Map iteration order is random in Go; sort for stable diff output
+	// so subsequent runs against the same baseline produce the same
+	// terminal output (helpful for piping to git diff or grep).
 	var prunes []baseline.Entry
 	for fp, e := range existing {
 		if _, ok := current[fp]; !ok {
 			prunes = append(prunes, *e)
 		}
 	}
+	sort.Slice(adds, func(i, j int) bool {
+		return adds[i].Fingerprint < adds[j].Fingerprint
+	})
+	sort.Slice(prunes, func(i, j int) bool {
+		return prunes[i].Fingerprint < prunes[j].Fingerprint
+	})
 
 	fmt.Printf("baseline diff — %s vs scan of %s\n", baselinePath, target)
 	fmt.Printf("  +%d would be added\n", len(adds))
 	for i := range adds {
-		fmt.Printf("    + %s %s:%d  %s\n", adds[i].RuleID, adds[i].Location.FilePath, adds[i].Location.StartLine, adds[i].Fingerprint[:12])
+		fmt.Printf("    + %s %s:%d  %s\n", adds[i].RuleID, adds[i].Location.FilePath, adds[i].Location.StartLine, shortFP(adds[i].Fingerprint))
 	}
 	fmt.Printf("  -%d would be pruned\n", len(prunes))
 	for i := range prunes {
-		fmt.Printf("    - %s %s  %s\n", prunes[i].RuleID, prunes[i].FilePath, prunes[i].Fingerprint[:12])
+		fmt.Printf("    - %s %s  %s\n", prunes[i].RuleID, prunes[i].FilePath, shortFP(prunes[i].Fingerprint))
 	}
-	if len(prunes) > 0 {
+	if len(adds) > 0 || len(prunes) > 0 {
 		fmt.Println()
-		fmt.Println("Run `nox baseline update` to apply both changes,")
-		fmt.Println("or `nox baseline add` to keep the prunes but pick up the adds.")
+		fmt.Println("Run `nox baseline update` to apply both adds and prunes,")
+		fmt.Println("or `nox baseline add` to insert the adds without pruning.")
 	}
 	return 0
+}
+
+// shortFP returns the leading 12 hex chars of fp, or the whole string
+// if it's shorter (caller-supplied / user-typed fingerprints can be
+// arbitrary lengths). Avoids the panic that a fixed `fp[:12]` slice
+// would cause on short inputs.
+func shortFP(fp string) string {
+	if len(fp) <= 12 {
+		return fp
+	}
+	return fp[:12]
 }
 
 func splitCSV(s string) []string {

--- a/cli/baseline_cmd.go
+++ b/cli/baseline_cmd.go
@@ -4,14 +4,16 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	nox "github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/findings"
 )
 
 func runBaseline(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|show> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show> [path]")
 		return 2
 	}
 
@@ -23,11 +25,15 @@ func runBaseline(args []string) int {
 		return baselineWrite(remaining)
 	case "update":
 		return baselineUpdate(remaining)
+	case "add":
+		return baselineAdd(remaining)
+	case "diff":
+		return baselineDiff(remaining)
 	case "show":
 		return baselineShow(remaining)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown baseline subcommand: %s\n", subcommand)
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|show> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show> [path]")
 		return 2
 	}
 }
@@ -127,6 +133,249 @@ func baselineUpdate(args []string) int {
 
 	fmt.Printf("baseline: %d total, %d added, %d pruned — %s\n", bl.Len(), added, pruned, baselinePath)
 	return 0
+}
+
+// baselineAdd is the additive counterpart to `baseline update`: it
+// scans the target, inserts findings that don't yet appear in the
+// baseline, and EXITS WITHOUT pruning entries that no longer match.
+//
+// Use case: a new finding pops up on a branch (rule sharpened, scanner
+// version bumped, file shifted) that the operator wants to baseline
+// without losing entries that happen to be missing from this scan.
+// `baseline update` would prune those — `baseline add` won't touch them.
+//
+// Filters:
+//
+//	--rule <id>   only add findings whose rule_id matches (repeatable
+//	              by passing comma-separated values).
+//	--fingerprint <fp>
+//	              only add the entries whose fingerprint matches one
+//	              of the supplied values (repeatable / comma list).
+//	              Useful when piping fingerprints from `baseline diff`.
+//
+// When --fingerprint is set, no scan is run; the supplied fingerprints
+// are added as bare entries with empty rule_id / file_path. The
+// surgical-add path is the workflow nox-hq/nox#73 item 4 calls out:
+// "add these specific fingerprints without rewriting the file".
+func baselineAdd(args []string) int {
+	fs := flag.NewFlagSet("baseline add", flag.ContinueOnError)
+	var (
+		baselinePath string
+		ruleFilter   string
+		fpFilter     string
+		reason       string
+		owner        string
+	)
+	fs.StringVar(&baselinePath, "baseline", "", "baseline file path (default: .nox/baseline.json)")
+	fs.StringVar(&ruleFilter, "rule", "", "only add findings with these rule IDs (comma-separated)")
+	fs.StringVar(&fpFilter, "fingerprint", "", "add these specific fingerprints (comma-separated; skips the scan)")
+	fs.StringVar(&reason, "reason", "", "free-form rationale stored on each new entry")
+	fs.StringVar(&owner, "owner", "", "owner/team tag stored on each new entry")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	target := "."
+	if fs.NArg() > 0 {
+		target = fs.Arg(0)
+	}
+	if baselinePath == "" {
+		baselinePath = baseline.DefaultPath(target)
+	}
+
+	bl, err := baseline.Load(baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: loading baseline: %v\n", err)
+		return 2
+	}
+
+	existing := make(map[string]struct{}, bl.Len())
+	for i := range bl.Entries {
+		existing[bl.Entries[i].Fingerprint] = struct{}{}
+	}
+
+	added := 0
+	if fpFilter != "" {
+		// Surgical: no scan, no rule-id filter — just the explicit
+		// fingerprints. RuleID/FilePath stay empty (the operator can
+		// fill them in later via an editor).
+		for _, fp := range splitCSV(fpFilter) {
+			if _, ok := existing[fp]; ok {
+				continue
+			}
+			bl.Add(&baseline.Entry{
+				Fingerprint: fp,
+				CreatedAt:   time.Now().UTC(),
+				Reason:      reason,
+				Owner:       owner,
+			})
+			existing[fp] = struct{}{}
+			added++
+		}
+	} else {
+		// Scan + additive merge.
+		result, err := nox.RunScan(target)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: scan failed: %v\n", err)
+			return 2
+		}
+		ruleAllow := buildSet(splitCSV(ruleFilter))
+		ff := result.Findings.Findings()
+		entries := baseline.FromFindings(ff)
+		for i := range entries {
+			if _, ok := existing[entries[i].Fingerprint]; ok {
+				continue
+			}
+			if len(ruleAllow) > 0 {
+				if _, ok := ruleAllow[entries[i].RuleID]; !ok {
+					continue
+				}
+			}
+			e := entries[i]
+			if reason != "" {
+				e.Reason = reason
+			}
+			if owner != "" {
+				e.Owner = owner
+			}
+			bl.Add(&e)
+			existing[e.Fingerprint] = struct{}{}
+			added++
+		}
+	}
+
+	if err := bl.Save(baselinePath); err != nil {
+		fmt.Fprintf(os.Stderr, "error: saving baseline: %v\n", err)
+		return 2
+	}
+	fmt.Printf("baseline: %d total, %d added (no entries pruned) — %s\n", bl.Len(), added, baselinePath)
+	return 0
+}
+
+// baselineDiff reports what `baseline update` WOULD change against the
+// current scan, without touching the file. Lists adds and prunes
+// separately so the operator can decide whether the prune is real
+// (finding genuinely resolved) or a regression (rule sharpened, file
+// renamed, fingerprint algorithm bumped).
+//
+// Exit status is always 0 unless the scan itself fails. The diff is
+// informational.
+func baselineDiff(args []string) int {
+	fs := flag.NewFlagSet("baseline diff", flag.ContinueOnError)
+	var baselinePath string
+	fs.StringVar(&baselinePath, "baseline", "", "baseline file path (default: .nox/baseline.json)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	target := "."
+	if fs.NArg() > 0 {
+		target = fs.Arg(0)
+	}
+	if baselinePath == "" {
+		baselinePath = baseline.DefaultPath(target)
+	}
+
+	bl, err := baseline.Load(baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: loading baseline: %v\n", err)
+		return 2
+	}
+
+	result, err := nox.RunScan(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: scan failed: %v\n", err)
+		return 2
+	}
+	ff := result.Findings.Findings()
+
+	current := make(map[string]struct{}, len(ff))
+	for i := range ff {
+		current[ff[i].Fingerprint] = struct{}{}
+	}
+	existing := make(map[string]*baseline.Entry, bl.Len())
+	for i := range bl.Entries {
+		existing[bl.Entries[i].Fingerprint] = &bl.Entries[i]
+	}
+
+	// Adds: findings present in the scan but not in baseline.
+	var adds []findings.Finding
+	for i := range ff {
+		if _, ok := existing[ff[i].Fingerprint]; !ok {
+			adds = append(adds, ff[i])
+		}
+	}
+	// Prunes: baseline entries no longer matched by any current finding.
+	var prunes []baseline.Entry
+	for fp, e := range existing {
+		if _, ok := current[fp]; !ok {
+			prunes = append(prunes, *e)
+		}
+	}
+
+	fmt.Printf("baseline diff — %s vs scan of %s\n", baselinePath, target)
+	fmt.Printf("  +%d would be added\n", len(adds))
+	for i := range adds {
+		fmt.Printf("    + %s %s:%d  %s\n", adds[i].RuleID, adds[i].Location.FilePath, adds[i].Location.StartLine, adds[i].Fingerprint[:12])
+	}
+	fmt.Printf("  -%d would be pruned\n", len(prunes))
+	for i := range prunes {
+		fmt.Printf("    - %s %s  %s\n", prunes[i].RuleID, prunes[i].FilePath, prunes[i].Fingerprint[:12])
+	}
+	if len(prunes) > 0 {
+		fmt.Println()
+		fmt.Println("Run `nox baseline update` to apply both changes,")
+		fmt.Println("or `nox baseline add` to keep the prunes but pick up the adds.")
+	}
+	return 0
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range splitCommaTrim(s) {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func splitCommaTrim(s string) []string {
+	parts := make([]string, 0, 4)
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			parts = append(parts, trimSpace(s[start:i]))
+			start = i + 1
+		}
+	}
+	parts = append(parts, trimSpace(s[start:]))
+	return parts
+}
+
+func trimSpace(s string) string {
+	a, b := 0, len(s)
+	for a < b && (s[a] == ' ' || s[a] == '\t') {
+		a++
+	}
+	for b > a && (s[b-1] == ' ' || s[b-1] == '\t') {
+		b--
+	}
+	return s[a:b]
+}
+
+func buildSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		out[v] = struct{}{}
+	}
+	return out
 }
 
 func baselineShow(args []string) int {

--- a/cli/baseline_cmd_test.go
+++ b/cli/baseline_cmd_test.go
@@ -255,3 +255,143 @@ func TestRunBaseline_ShowLoadError(t *testing.T) {
 		t.Fatalf("expected exit code 2 for load error, got %d", code)
 	}
 }
+
+// TestRunBaselineAdd_PreservesEntries — the additive command must not
+// prune anything. Pre-existing baseline entries that no longer match a
+// scan must still be in the file after add runs.
+func TestRunBaselineAdd_PreservesEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a baseline with a stale entry that won't match any scan.
+	baselinePath := filepath.Join(dir, "baseline.json")
+	bl := &baseline.Baseline{}
+	bl.Add(&baseline.Entry{
+		Fingerprint: "deadbeef1234567890abcdef0123456789abcdef0123456789abcdef01234567",
+		RuleID:      "SEC-999",
+		FilePath:    "obsolete.go",
+		Reason:      "kept for posterity",
+	})
+	if err := bl.Save(baselinePath); err != nil {
+		t.Fatalf("seed baseline: %v", err)
+	}
+
+	// Add a real finding so the scan turns something up.
+	secret := "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.env"), []byte(secret), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	code := runBaseline([]string{"add", "--baseline", baselinePath, dir})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+
+	got, err := baseline.Load(baselinePath)
+	if err != nil {
+		t.Fatalf("loading baseline: %v", err)
+	}
+	// Original stale entry must still be present.
+	var foundStale bool
+	for i := range got.Entries {
+		if got.Entries[i].Fingerprint == "deadbeef1234567890abcdef0123456789abcdef0123456789abcdef01234567" {
+			foundStale = true
+			break
+		}
+	}
+	if !foundStale {
+		t.Error("baseline add pruned the stale entry; it should be additive only")
+	}
+	// And at least one new entry should have been added from the scan.
+	if got.Len() < 2 {
+		t.Errorf("expected baseline to grow; got %d entries (started with 1)", got.Len())
+	}
+}
+
+// TestRunBaselineAdd_FingerprintFilter — when --fingerprint is set,
+// no scan runs; only the supplied fingerprints get inserted.
+func TestRunBaselineAdd_FingerprintFilter(t *testing.T) {
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+
+	code := runBaseline([]string{
+		"add",
+		"--baseline", baselinePath,
+		"--fingerprint", "aaaa1111,bbbb2222",
+		"--reason", "documented false positive",
+		"--owner", "platform",
+		dir,
+	})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+
+	got, err := baseline.Load(baselinePath)
+	if err != nil {
+		t.Fatalf("loading baseline: %v", err)
+	}
+	if got.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", got.Len())
+	}
+	for i := range got.Entries {
+		if got.Entries[i].Reason != "documented false positive" {
+			t.Errorf("entry %d missing reason", i)
+		}
+		if got.Entries[i].Owner != "platform" {
+			t.Errorf("entry %d missing owner", i)
+		}
+	}
+}
+
+// TestRunBaselineAdd_FingerprintIdempotent — re-adding the same
+// fingerprint must not duplicate it.
+func TestRunBaselineAdd_FingerprintIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+
+	for i := 0; i < 3; i++ {
+		code := runBaseline([]string{
+			"add", "--baseline", baselinePath, "--fingerprint", "abcdef12", dir,
+		})
+		if code != 0 {
+			t.Fatalf("run %d: exit %d", i, code)
+		}
+	}
+	got, _ := baseline.Load(baselinePath)
+	if got.Len() != 1 {
+		t.Errorf("expected 1 entry after 3 idempotent adds, got %d", got.Len())
+	}
+}
+
+// TestRunBaselineDiff_ReportsAddsAndPrunes — the read-only diff lists
+// what update would change without writing the file.
+func TestRunBaselineDiff_ReportsAddsAndPrunes(t *testing.T) {
+	dir := t.TempDir()
+	baselinePath := filepath.Join(dir, "baseline.json")
+
+	// Pre-seed a stale entry.
+	bl := &baseline.Baseline{}
+	bl.Add(&baseline.Entry{
+		Fingerprint: "deadbeef0000000000000000000000000000000000000000000000000000beef",
+		RuleID:      "SEC-999",
+		FilePath:    "gone.go",
+	})
+	if err := bl.Save(baselinePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a fresh finding so the scan turns something up.
+	if err := os.WriteFile(filepath.Join(dir, "config.env"),
+		[]byte("AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := runBaseline([]string{"diff", "--baseline", baselinePath, dir})
+	if code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+	// File must NOT have changed (diff is read-only).
+	got, _ := baseline.Load(baselinePath)
+	if got.Len() != 1 {
+		t.Errorf("baseline mutated by `diff`; expected 1 entry, got %d", got.Len())
+	}
+}


### PR DESCRIPTION
## Summary

Two new baseline subcommands targeting the friction points in #73 items 4 + 5.

## `nox baseline add` — additive

`update` rewrites the whole baseline (and prunes entries that don't match the current scan). That's the right tool when \"no match\" means \"resolved\" — but the wrong tool when the scanner version bumped, a rule sharpened, or a file moved. In those cases `update` silently un-baselines real findings on main.

`add` only inserts findings that aren't in the baseline yet:

\`\`\`
nox baseline add                           # scan + additive merge
nox baseline add --rule AI-012             # only add AI-012 findings
nox baseline add --fingerprint abc,def     # bypass scan; insert these exact fps
nox baseline add --reason "doc'd false positive" --owner platform
\`\`\`

The `--fingerprint` path is the workflow `felixgeelhaar/tokenops` needed when shipping fortify v1.5.0: paste two fingerprints from the SARIF output, baseline them, move on. Used to require a Python one-liner because `baseline update` would prune ~80 unrelated entries.

## `nox baseline diff` — read-only preview

\`\`\`
$ nox baseline diff
baseline diff — .nox/baseline.json vs scan of .
  +2 would be added
    + AI-012 http/middleware.go:59  bd64b2352e41
    + AI-012 http/streaming.go:73  6cba91f0cdea
  -3 would be pruned
    - SEC-680 README.md  91b71fbdf141
    ...

Run \`nox baseline update\` to apply both changes,
or \`nox baseline add\` to keep the prunes but pick up the adds.
\`\`\`

Adds and prunes are listed separately so the operator can sanity-check the prune set before committing.

## Test plan

- [x] `TestRunBaselineAdd_PreservesEntries` — stale baseline entry survives add.
- [x] `TestRunBaselineAdd_FingerprintFilter` — explicit `--fingerprint` list inserts the exact set with reason/owner threaded through.
- [x] `TestRunBaselineAdd_FingerprintIdempotent` — repeat adds don't dup.
- [x] `TestRunBaselineDiff_ReportsAddsAndPrunes` — verifies the file is NOT mutated by `diff`.
- [x] `go test -race ./...` — green (pre-existing flake on `TestRunHistoryScan_MultipleCommitsAccumulate` passes in isolation).
- [x] `go test ./cli/...` — green.

## Follow-ups in #73

- Item 5 `nox scan --since <ref>` — deferred to next PR (needs git-worktree scan plumbing).
- Item 6: inline `//nox:disable RULE-ID`.
- Items 7 + 8: version-drift warning + exit-code/SARIF separation.