### PR TITLE
feat(doctor): warn on nox version drift between local and CI [#73 items 7+8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation / interop
 
+- **`nox doctor` version-drift check** — doctor now scans
+  `.github/workflows/*.yml` for `nox-hq/nox/cli@vX.Y.Z` pins and warns
+  when CI and the local nox binary disagree. Same nox version on both
+  sides makes "I just ran nox locally, it's clean" actually meaningful
+  again. Reports `ok` per workflow when versions match, `DRIFT` when
+  they diverge, with a suggested fix-up command (bump CI or
+  `go install` locally). Closes [#73 item 7](https://github.com/Nox-HQ/nox/issues/73).
+- **Exit-code semantics already correct** (item 8 follow-up). Verified
+  that `nox scan` already returns 0 when every finding is baselined or
+  suppressed and exits 1 only on truly-new active findings —
+  `ActiveFindings()` filters `StatusBaselined` and `StatusSuppressed`
+  out of the count that drives the exit code. The `|| true` shim in
+  downstream CI workflows (e.g. felixgeelhaar/fortify) is no longer
+  necessary; remove it on next workflow refresh.
 - **`nox:disable` alias**: inline suppression now accepts both
   `nox:ignore` (legacy spelling) and `nox:disable` (matches gosec
   `#nosec`, staticcheck, golangci-lint `//nolint`). The two are

--- a/cli/doctor_cmd.go
+++ b/cli/doctor_cmd.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 )
 
 // runDoctor reports on the local environment so an operator can
@@ -75,30 +76,57 @@ func runDoctor(_ []string) int {
 		fmt.Printf("  .gitignore not found — entropy rules will scan everything\n")
 	}
 
-	fmt.Println()
-	fmt.Println("[ci]")
-	reportCIVersionDrift(mustGetwd(), version)
+	// reportCIVersionDrift prints its own `[ci]` section header so we
+	// don't end up with a blank one when there's nothing to report.
+	reportCIVersionDrift(repoRoot(), version)
 
 	return 0
 }
 
-// ciNoxVersionRE matches the `go install github.com/nox-hq/nox/cli@vX.Y.Z`
-// or `nox-hq/nox@vX.Y.Z` references commonly used in CI workflows. The
-// version is captured so doctor can compare it against the local
-// binary's version and flag drift.
+// semverRE matches a literal X.Y.Z so we can distinguish a real
+// release tag from a dev build like "dev" or "v0.10.0-3-gabc". The
+// drift comparison only runs when the local binary has a real semver
+// to compare against.
+var semverRE = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// ciNoxVersionRE matches `go install github.com/nox-hq/nox/cli@vX.Y.Z`
+// or `nox-hq/nox@vX.Y.Z` references commonly used in CI workflows.
+// Captures the bare version (no `v` prefix) so it compares directly
+// against stripVPrefix(localVersion).
 var ciNoxVersionRE = regexp.MustCompile(`nox-hq/nox(?:/cli)?@v?(\d+\.\d+\.\d+)`)
 
-// reportCIVersionDrift walks .github/workflows/*.yml and warns when a
-// pinned nox version differs from the local binary. Silent when no
-// workflow files reference nox. Tolerant of read errors — doctor is
-// informational, never fatal.
-func reportCIVersionDrift(repoRoot, localVersion string) {
-	workflowsDir := filepath.Join(repoRoot, ".github", "workflows")
+// repoRoot resolves the enclosing git repository root via
+// `git rev-parse --show-toplevel` so `nox doctor` invoked from a
+// subdirectory still picks up the top-level `.github/workflows`.
+// Falls back to the current working directory when not in a git repo.
+func repoRoot() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		root := strings.TrimSpace(string(out))
+		if root != "" {
+			return root
+		}
+	}
+	return mustGetwd()
+}
+
+// reportCIVersionDrift walks .github/workflows/*.yml at repoRoot and
+// warns when a pinned nox version differs from the local binary. The
+// function owns its `[ci]` section header — print nothing (no blank
+// header) when there's nothing to report:
+//
+//   - no .github/workflows directory  → silent (probably non-CI'd repo).
+//   - directory exists but no nox refs → silent (nox not used in CI).
+//   - localVersion is not a real semver (e.g. "dev") → print the
+//     pinned versions but skip the DRIFT comparison.
+//
+// Tolerant of read errors throughout — doctor is informational and
+// must never become fatal.
+func reportCIVersionDrift(rRoot, localVersion string) {
+	workflowsDir := filepath.Join(rRoot, ".github", "workflows")
 	entries, err := os.ReadDir(workflowsDir)
 	if err != nil {
-		// No .github/workflows — not necessarily a problem (could be a
-		// non-CI'd repo). Stay silent.
-		return
+		return // silent: probably a non-CI'd repo
 	}
 	type drift struct {
 		file    string
@@ -118,24 +146,31 @@ func reportCIVersionDrift(repoRoot, localVersion string) {
 		}
 	}
 	if len(pinned) == 0 {
-		fmt.Printf("  no nox version pin found in .github/workflows/\n")
-		return
+		return // silent: workflows exist but don't reference nox
 	}
-	// `localVersion` may be a dev build (e.g. "dev") — only compare
-	// when we have a real semver locally.
+
+	// We have something to print — emit the section header now.
+	fmt.Println()
+	fmt.Println("[ci]")
+
 	localBare := stripVPrefix(localVersion)
+	canCompare := semverRE.MatchString(localBare)
+	if !canCompare {
+		fmt.Printf("  local nox version %q is not a release tag; skipping drift comparison\n", localVersion)
+	}
 	allMatch := true
 	for _, p := range pinned {
-		if p.version != localBare {
+		switch {
+		case !canCompare:
+			fmt.Printf("  %s pins nox@v%s\n", p.file, p.version)
+		case p.version == localBare:
+			fmt.Printf("  ok    %s pins nox@v%s (local: %s)\n", p.file, p.version, localVersion)
+		default:
 			allMatch = false
+			fmt.Printf("  DRIFT %s pins nox@v%s (local: %s)\n", p.file, p.version, localVersion)
 		}
-		marker := "ok"
-		if p.version != localBare {
-			marker = "DRIFT"
-		}
-		fmt.Printf("  %s %s pins nox@v%s (local: %s)\n", marker, p.file, p.version, localVersion)
 	}
-	if !allMatch {
+	if canCompare && !allMatch {
 		fmt.Printf("  ! CI and local versions differ — fingerprints / findings may diverge\n")
 		fmt.Printf("    bump CI to v%s, or `go install github.com/nox-hq/nox/cli@v%s` locally\n", localBare, pinned[0].version)
 	}

--- a/cli/doctor_cmd.go
+++ b/cli/doctor_cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 )
 
@@ -74,7 +75,81 @@ func runDoctor(_ []string) int {
 		fmt.Printf("  .gitignore not found — entropy rules will scan everything\n")
 	}
 
+	fmt.Println()
+	fmt.Println("[ci]")
+	reportCIVersionDrift(mustGetwd(), version)
+
 	return 0
+}
+
+// ciNoxVersionRE matches the `go install github.com/nox-hq/nox/cli@vX.Y.Z`
+// or `nox-hq/nox@vX.Y.Z` references commonly used in CI workflows. The
+// version is captured so doctor can compare it against the local
+// binary's version and flag drift.
+var ciNoxVersionRE = regexp.MustCompile(`nox-hq/nox(?:/cli)?@v?(\d+\.\d+\.\d+)`)
+
+// reportCIVersionDrift walks .github/workflows/*.yml and warns when a
+// pinned nox version differs from the local binary. Silent when no
+// workflow files reference nox. Tolerant of read errors — doctor is
+// informational, never fatal.
+func reportCIVersionDrift(repoRoot, localVersion string) {
+	workflowsDir := filepath.Join(repoRoot, ".github", "workflows")
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		// No .github/workflows — not necessarily a problem (could be a
+		// non-CI'd repo). Stay silent.
+		return
+	}
+	type drift struct {
+		file    string
+		version string
+	}
+	var pinned []drift
+	for _, e := range entries {
+		if e.IsDir() || (!hasSuffix(e.Name(), ".yml") && !hasSuffix(e.Name(), ".yaml")) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(workflowsDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, m := range ciNoxVersionRE.FindAllStringSubmatch(string(data), -1) {
+			pinned = append(pinned, drift{file: e.Name(), version: m[1]})
+		}
+	}
+	if len(pinned) == 0 {
+		fmt.Printf("  no nox version pin found in .github/workflows/\n")
+		return
+	}
+	// `localVersion` may be a dev build (e.g. "dev") — only compare
+	// when we have a real semver locally.
+	localBare := stripVPrefix(localVersion)
+	allMatch := true
+	for _, p := range pinned {
+		if p.version != localBare {
+			allMatch = false
+		}
+		marker := "ok"
+		if p.version != localBare {
+			marker = "DRIFT"
+		}
+		fmt.Printf("  %s %s pins nox@v%s (local: %s)\n", marker, p.file, p.version, localVersion)
+	}
+	if !allMatch {
+		fmt.Printf("  ! CI and local versions differ — fingerprints / findings may diverge\n")
+		fmt.Printf("    bump CI to v%s, or `go install github.com/nox-hq/nox/cli@v%s` locally\n", localBare, pinned[0].version)
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+func stripVPrefix(v string) string {
+	if len(v) > 0 && v[0] == 'v' {
+		return v[1:]
+	}
+	return v
 }
 
 func mustGetwd() string {

--- a/cli/doctor_cmd.go
+++ b/cli/doctor_cmd.go
@@ -146,7 +146,7 @@ func hasSuffix(s, suffix string) bool {
 }
 
 func stripVPrefix(v string) string {
-	if len(v) > 0 && v[0] == 'v' {
+	if v != "" && v[0] == 'v' {
 		return v[1:]
 	}
 	return v

--- a/cli/doctor_drift_test.go
+++ b/cli/doctor_drift_test.go
@@ -1,34 +1,124 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestReportCIVersionDrift_MatchingVersion is a smoke test that the
-// drift detector doesn't panic when CI and local agree. We can't
-// easily assert stdout from `runDoctor`, but we can drive the helper
-// directly and verify it tolerates the inputs.
-func TestReportCIVersionDrift_MatchingVersion(t *testing.T) {
+// captureStdout runs fn with os.Stdout redirected to an in-memory
+// buffer and returns whatever fn wrote. Used to verify the
+// human-readable behaviour the PR description promises (silent paths,
+// DRIFT label, fix-up command).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func writeWorkflow(t *testing.T, root, name, body string) {
+	t.Helper()
+	dir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReportCIVersionDrift_Silent_NoWorkflowsDir — repos without any
+// .github/workflows directory must produce ZERO output. The doctor
+// caller relies on this to skip the section header entirely.
+func TestReportCIVersionDrift_Silent_NoWorkflowsDir(t *testing.T) {
+	out := captureStdout(t, func() {
+		reportCIVersionDrift(t.TempDir(), "0.10.0")
+	})
+	if out != "" {
+		t.Errorf("expected silent output, got %q", out)
+	}
+}
+
+// TestReportCIVersionDrift_Silent_NoNoxRefs — repos with workflow
+// files that don't reference nox must also stay silent.
+func TestReportCIVersionDrift_Silent_NoNoxRefs(t *testing.T) {
 	dir := t.TempDir()
-	workflows := filepath.Join(dir, ".github", "workflows")
-	if err := os.MkdirAll(workflows, 0o755); err != nil {
-		t.Fatal(err)
+	writeWorkflow(t, dir, "ci.yml", "name: ci\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: [{run: 'make test'}]\n")
+	out := captureStdout(t, func() {
+		reportCIVersionDrift(dir, "0.10.0")
+	})
+	if out != "" {
+		t.Errorf("expected silent output, got %q", out)
 	}
-	yaml := `name: ci
-on: [push]
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - run: go install github.com/nox-hq/nox/cli@v0.10.0`
-	if err := os.WriteFile(filepath.Join(workflows, "ci.yml"), []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
+}
+
+// TestReportCIVersionDrift_DriftDetected — pinned version differs
+// from local; output must contain DRIFT marker, the local version,
+// and the fix-up command.
+func TestReportCIVersionDrift_DriftDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "ci.yml",
+		"steps:\n  - run: go install github.com/nox-hq/nox/cli@v0.8.1\n")
+	out := captureStdout(t, func() {
+		reportCIVersionDrift(dir, "0.10.0")
+	})
+	for _, want := range []string{"[ci]", "DRIFT", "ci.yml", "v0.8.1", "local: 0.10.0", "bump CI to v0.10.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
 	}
-	// Just exercise the path; correctness is verified by the regex test
-	// below + the manual `nox doctor` run.
-	reportCIVersionDrift(dir, "0.10.0")
+}
+
+// TestReportCIVersionDrift_AllMatch — pinned version matches local;
+// output must contain `ok` markers and NOT contain `DRIFT`.
+func TestReportCIVersionDrift_AllMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "ci.yml",
+		"steps:\n  - run: go install github.com/nox-hq/nox/cli@v0.10.0\n")
+	out := captureStdout(t, func() {
+		reportCIVersionDrift(dir, "0.10.0")
+	})
+	if !strings.Contains(out, "ok    ci.yml") {
+		t.Errorf("expected `ok` marker, got:\n%s", out)
+	}
+	if strings.Contains(out, "DRIFT") {
+		t.Errorf("unexpected DRIFT in matching output:\n%s", out)
+	}
+}
+
+// TestReportCIVersionDrift_DevLocal — local version is a dev build
+// (not a real semver); output must list the pins but skip the DRIFT
+// comparison.
+func TestReportCIVersionDrift_DevLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "ci.yml",
+		"steps:\n  - run: go install github.com/nox-hq/nox/cli@v0.8.1\n")
+	out := captureStdout(t, func() {
+		reportCIVersionDrift(dir, "dev")
+	})
+	if !strings.Contains(out, "skipping drift comparison") {
+		t.Errorf("expected skip notice, got:\n%s", out)
+	}
+	if strings.Contains(out, "DRIFT") {
+		t.Errorf("DRIFT must not fire when local is not a semver:\n%s", out)
+	}
 }
 
 func TestCIVersionRE(t *testing.T) {
@@ -36,7 +126,7 @@ func TestCIVersionRE(t *testing.T) {
 		"go install github.com/nox-hq/nox/cli@v0.10.0": "0.10.0",
 		"go install github.com/nox-hq/nox/cli@v0.8.1":  "0.8.1",
 		"uses: nox-hq/nox@v0.9.5":                      "0.9.5",
-		"uses: nox-hq/nox-remediate-action@v1":         "", // major-only; we don't capture
+		"uses: nox-hq/nox-remediate-action@v1":         "", // major-only; not captured
 		"uses: nox-hq/nox@v0.10.0   # pinned":          "0.10.0",
 		"some unrelated line":                          "",
 	}

--- a/cli/doctor_drift_test.go
+++ b/cli/doctor_drift_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReportCIVersionDrift_MatchingVersion is a smoke test that the
+// drift detector doesn't panic when CI and local agree. We can't
+// easily assert stdout from `runDoctor`, but we can drive the helper
+// directly and verify it tolerates the inputs.
+func TestReportCIVersionDrift_MatchingVersion(t *testing.T) {
+	dir := t.TempDir()
+	workflows := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `name: ci
+on: [push]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go install github.com/nox-hq/nox/cli@v0.10.0`
+	if err := os.WriteFile(filepath.Join(workflows, "ci.yml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Just exercise the path; correctness is verified by the regex test
+	// below + the manual `nox doctor` run.
+	reportCIVersionDrift(dir, "0.10.0")
+}
+
+func TestCIVersionRE(t *testing.T) {
+	cases := map[string]string{
+		"go install github.com/nox-hq/nox/cli@v0.10.0": "0.10.0",
+		"go install github.com/nox-hq/nox/cli@v0.8.1":  "0.8.1",
+		"uses: nox-hq/nox@v0.9.5":                      "0.9.5",
+		"uses: nox-hq/nox-remediate-action@v1":         "", // major-only; we don't capture
+		"uses: nox-hq/nox@v0.10.0   # pinned":          "0.10.0",
+		"some unrelated line":                          "",
+	}
+	for input, want := range cases {
+		m := ciNoxVersionRE.FindStringSubmatch(input)
+		var got string
+		if len(m) == 2 {
+			got = m[1]
+		}
+		if got != want {
+			t.Errorf("input=%q  got=%q  want=%q", input, got, want)
+		}
+	}
+}
+
+func TestStripVPrefix(t *testing.T) {
+	cases := map[string]string{
+		"v0.10.0": "0.10.0",
+		"0.10.0":  "0.10.0",
+		"v":       "",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := stripVPrefix(in); got != want {
+			t.Errorf("stripVPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHasSuffix(t *testing.T) {
+	if !hasSuffix("ci.yml", ".yml") {
+		t.Error("expected ci.yml has .yml suffix")
+	}
+	if hasSuffix("yml", ".yaml") {
+		t.Error("\"yml\" should not have .yaml suffix")
+	}
+	if !hasSuffix("ci.yaml", ".yaml") {
+		t.Error("expected ci.yaml has .yaml suffix")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last two items of #73.

## Item 7 — version-drift warning

The fortify integration hit a silent version-drift bug: CI ran nox v0.8.1 (pinned in workflow), local Homebrew install was v0.10.0. Different versions produced different fingerprints and different rule firings, so \"I just ran nox locally, it's clean\" was meaningless before pushing.

`nox doctor` now grep-scans `.github/workflows/*.yml` for `nox-hq/nox/cli@vX.Y.Z` pins and reports each one against the local binary:

\`\`\`
[ci]
  ok    ci.yml pins nox@v0.10.0 (local: 0.10.0)
  DRIFT release.yml pins nox@v0.8.1 (local: 0.10.0)
  ! CI and local versions differ — fingerprints / findings may diverge
    bump CI to v0.10.0, or `go install github.com/nox-hq/nox/cli@v0.8.1` locally
\`\`\`

Silent when no workflow files reference nox at all (non-CI'd repos shouldn't see noise).

## Item 8 — exit-code/SARIF separation

Inspected and found to be **already correct**: `ActiveFindings()` filters `StatusBaselined` and `StatusSuppressed` before computing the count that drives the exit code (`cli/main.go:509`). The `|| true` workaround in downstream CI workflows (e.g. `felixgeelhaar/fortify` `.github/workflows/ci.yml`) is no longer needed — CHANGELOG note recommends removal on next workflow refresh.

The fortify workflow comment that originally documented \"nox exits non-zero on baselined findings (an upstream quirk)\" must have referred to a pre-v0.6.0 version; current behaviour is correct.

## Test plan

- [x] `TestCIVersionRE` — regex pins versions from `go install …@vX.Y.Z` and `uses: nox-hq/nox@vX.Y.Z` lines; rejects unrelated lines and major-only refs.
- [x] `TestReportCIVersionDrift_MatchingVersion` — smoke test that the helper doesn't panic on the happy path.
- [x] `TestStripVPrefix`, `TestHasSuffix` — trivial helpers pinned against regressions.
- [x] `go test -race ./cli/...` — green.

## #73 closure

PR | Items |
|---|---|
| #74 | 1 + 2 — fingerprint v2 (line-independent, path-normalised) ✓ merged |
| #75 | 3 — AI-012 precision ✓ merged |
| #76 | 4 + 5 — `baseline add` + `baseline diff` ✓ merged |
| #77 | 6 — `nox:disable` alias ✓ merged |
| **this** | 7 + 8 — version drift + exit-code semantics |

All 8 issue items addressed. Closes #73 when this lands.