### PR TITLE
fix(ai-019): exclude DB/cache .pipeline() method calls + langgraph queue update

### DIFF
--- a/core/analyzers/ai/model_supply_chain_test.go
+++ b/core/analyzers/ai/model_supply_chain_test.go
@@ -154,6 +154,41 @@ func TestNoDetect_ModelWithoutHash_WrongFileType(t *testing.T) {
 	}
 }
 
+// TestNoDetect_ModelWithoutHash_DBPipelineFP ensures that database and cache
+// client `.pipeline()` method calls (psycopg3, redis-py, etc.) do not trigger
+// AI-019. The rule targets HuggingFace's standalone `pipeline("task")` function,
+// not method names that happen to end in "pipeline". Regression test for the
+// langgraph scan-of-the-week false positive (scan-of-week-2026-06-05).
+func TestNoDetect_ModelWithoutHash_DBPipelineFP(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		// psycopg3 sync pipeline
+		{"psycopg_sync_pipeline", `self.supports_pipeline = Capabilities().has_pipeline()`},
+		// psycopg3 async pipeline
+		{"psycopg_async_pipeline", `async with conn.pipeline() as pipe:`},
+		// redis-py pipeline
+		{"redis_pipeline", `pipe = self.redis.pipeline()`},
+		// method call on arbitrary object
+		{"generic_method_pipeline", `result = client.pipeline()`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewAnalyzer()
+			results, err := a.ScanFile("checkpoint.py", []byte(tt.content))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			f := findingWithRule(results, "AI-019")
+			if f != nil {
+				t.Fatalf("AI-019 should not fire on DB/cache pipeline method call: %q", tt.content)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // AI-020: Model from untrusted registry
 // ---------------------------------------------------------------------------

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -278,7 +278,14 @@ func builtinAIRules() []*rules.Rule {
 			// of a hash pin is the signal (lines with revision= or sha256 are
 			// unlikely to match because the keyword filter requires the load call
 			// keywords but the pattern stops before consuming the whole line).
-			pattern:      `(?i)(from_pretrained|load_model|AutoModel|download_model|pipeline)\s*\(`,
+			//
+			// pipeline() is intentionally not matched when it is a method name
+			// suffix (e.g. has_pipeline(), conn.pipeline(), redis.pipeline()).
+			// [^.a-zA-Z0-9_] before "pipeline" excludes those method-call sites
+			// while still catching standalone `pipeline("task")` invocations.
+			// Go RE2 has no negative lookbehind, so this character-class guard
+			// is the RE2-safe equivalent.
+			pattern:      `(?i)(?:from_pretrained|load_model|AutoModel|download_model|[^.a-zA-Z0-9_]pipeline)\s*\(`,
 			description:  "Model loaded without hash verification",
 			cwe:          "CWE-494",
 			keywords:     []string{"from_pretrained", "load_model", "automodel", "download_model", "pipeline"},

--- a/docs/scan-of-the-week-queue.txt
+++ b/docs/scan-of-the-week-queue.txt
@@ -17,7 +17,7 @@
 # DONE 2026-05-09: anthropics/anthropic-cookbook — 1.95M findings (mostly RAG-corpus FPs); precision-tuning post
 # DONE 2026-06-05: deepset-ai/haystack — 12,367 findings (94% docs-website noise); 1 real low-sev (unredacted prompt log); fixed AI-009 ast.literal_eval FP
 # DONE 2026-06-05: huggingface/smolagents — 323 findings (65% from one example dir); 0 true positives; fixed VULN-002 PEP503 typosquat FP
-langchain-ai/langgraph
+# DONE 2026-06-05: langchain-ai/langgraph — 134,614 findings (99.8% examples/ notebook image data + lockfile hashes); 0 true positives; fixed AI-019 DB-pipeline FP; MCP-011 docstring FP tracked
 microsoft/autogen
 modelcontextprotocol/servers
 openai/openai-agents-python


### PR DESCRIPTION
## Summary

- Fixes a false positive in the AI-019 rule ("Model loaded without hash verification") that fired on database and cache client `.pipeline()` method calls
- Marks `langchain-ai/langgraph` DONE in the scan-of-the-week queue

## The bug

The AI-019 pattern `pipeline\s*\(` matches any substring `pipeline(` in a `.py` or `.ipynb` file — including method names that *end* in `pipeline`:

```python
# psycopg3 async — these all triggered AI-019 at high severity
self.supports_pipeline = Capabilities().has_pipeline()
async with conn.pipeline() as pipe:

# redis-py
pipe = self.redis.pipeline()
```

These are database/cache driver calls, not HuggingFace model loading.

## The fix

Go RE2 has no negative lookbehind. The fix uses a character-class guard requiring a non-word, non-dot character before `pipeline`:

```
# Before
(?i)(from_pretrained|load_model|AutoModel|download_model|pipeline)\s*\(

# After  
(?i)(?:from_pretrained|load_model|AutoModel|download_model|[^.a-zA-Z0-9_]pipeline)\s*\(
```

`[^.a-zA-Z0-9_]` excludes `.pipeline()` (method call via dot), `_pipeline()` (tail of name like `has_pipeline`), and alphanumeric prefixes. It passes `= pipeline("task")`, `(pipeline(`, ` pipeline(` — all standalone call sites.

## Tests

- All four existing AI-019 positive cases still pass
- Four new negative cases added: psycopg3 sync/async pipeline, redis-py pipeline, generic method call

```
=== RUN   TestDetect_ModelWithoutHashVerification/pipeline_call     PASS
=== RUN   TestNoDetect_ModelWithoutHash_DBPipelineFP/psycopg_sync_pipeline   PASS
=== RUN   TestNoDetect_ModelWithoutHash_DBPipelineFP/psycopg_async_pipeline  PASS
=== RUN   TestNoDetect_ModelWithoutHash_DBPipelineFP/redis_pipeline          PASS
=== RUN   TestNoDetect_ModelWithoutHash_DBPipelineFP/generic_method_pipeline PASS
```

`go test ./core/analyzers/ai/...` passes clean.

## Companion PR

The scan-of-the-week blog post is in [nox-hq.dev#sotw/langgraph-2026-06-05](https://github.com/Nox-HQ/nox-hq.dev/pulls).

## Scan context

Discovered during the langchain-ai/langgraph scan (@`2b1abc8`). AI-019 fired 20 times on `libs/checkpoint-postgres/` and `libs/checkpoint/langgraph/cache/redis/` — none were model loading calls.

Note: MCP-011 also fired a critical false positive on `_validate_reconnect_location()` (a security function whose docstring describes what it prevents). That gap — extending `IgnoreInComments` to Python docstring bodies — is tracked but not fixed here; the MCP-011 change requires more careful scoping to avoid weakening the rule against real tool-poisoning payloads.

https://claude.ai/code/session_018SbxRsWiY1AijoDCnAMmhD

---
_Generated by [Claude Code](https://claude.ai/code/session_018SbxRsWiY1AijoDCnAMmhD)_