### PR TITLE
feat(scan): run + merge plugins.required analysis plugins

### DIFF
--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/plugin"
+)
+
+// init registers the analysis-plugin runner with the core scan pipeline.
+// core defines the hook but cannot run plugins itself without importing the
+// plugin host + installed-plugin state (which would create an import cycle),
+// so the CLI wires the implementation here.
+func init() {
+	core.ScanPluginHook = runScanPlugins
+}
+
+// runScanPlugins runs the `scan` tool of every installed plugin named in
+// .nox.yaml plugins.required against target and returns the merged findings,
+// enrichments and graphs. Missing plugins are skipped (auto-install already
+// ran earlier in the scan command); individual plugin failures surface as
+// host diagnostics and never abort the scan.
+func runScanPlugins(ctx context.Context, target string, required []string) (*core.PluginScanOutput, error) {
+	if len(required) == 0 {
+		return nil, nil
+	}
+
+	st, err := LoadState(DefaultStatePath())
+	if err != nil {
+		return nil, fmt.Errorf("loading plugin state: %w", err)
+	}
+
+	// Resolve each required plugin name to its installed binary. Missing or
+	// not-yet-installed plugins are skipped (scan-time auto-install may have
+	// been disabled or failed) rather than aborting the scan.
+	var binaries []string
+	for _, name := range required {
+		ip := st.FindPlugin(name)
+		if ip == nil {
+			continue
+		}
+		if _, statErr := os.Stat(ip.BinaryPath); statErr != nil {
+			continue
+		}
+		binaries = append(binaries, ip.BinaryPath)
+	}
+
+	policy := plugin.DefaultPolicy()
+	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
+		policy = cfg.PluginPolicy.ToPolicy()
+	}
+	return runPluginBinaries(ctx, target, binaries, &policy)
+}
+
+// runPluginBinaries registers the given plugin binaries with a host, runs
+// their `scan` tool against target, and converts the proto output into core
+// findings/enrichments/graphs. It is separated from runScanPlugins so it can
+// be exercised against a freshly-built plugin binary without touching the
+// installed-plugin state.
+func runPluginBinaries(ctx context.Context, target string, binaries []string, policy *plugin.Policy) (*core.PluginScanOutput, error) {
+	if len(binaries) == 0 {
+		return nil, nil
+	}
+	if policy == nil {
+		p := plugin.DefaultPolicy()
+		policy = &p
+	}
+
+	host := plugin.NewHost(plugin.WithPolicy(policy))
+	defer func() { _ = host.Close() }()
+
+	for _, bin := range binaries {
+		if regErr := host.RegisterBinary(ctx, bin, nil); regErr != nil {
+			return nil, fmt.Errorf("registering plugin %q: %w", bin, regErr)
+		}
+	}
+
+	// Run the analysis `scan` tool across every plugin that declares it.
+	// workspace_root is passed both as the host workspace argument and in the
+	// input map, since plugins read it from req.Input["workspace_root"].
+	input := map[string]any{"workspace_root": target}
+	responses, err := host.InvokeAll(ctx, "scan", input, target)
+	if err != nil {
+		return nil, fmt.Errorf("invoking analysis plugins: %w", err)
+	}
+
+	out := &core.PluginScanOutput{}
+	for _, resp := range responses {
+		if resp == nil {
+			continue
+		}
+		for _, pf := range resp.GetFindings() {
+			out.Findings = append(out.Findings, plugin.ProtoFindingToGo(pf))
+		}
+		for _, pe := range resp.GetEnrichments() {
+			out.Enrichments = append(out.Enrichments, plugin.ProtoEnrichmentToGo(pe))
+		}
+		for _, pg := range resp.GetGraphs() {
+			out.Graphs = append(out.Graphs, plugin.ProtoGraphToGo(pg))
+		}
+	}
+
+	// Surface plugin diagnostics (timeouts, partial failures) to stderr so a
+	// silently-empty plugin run is visible without failing the scan.
+	for _, d := range host.Diagnostics() {
+		fmt.Fprintf(os.Stderr, "[plugin %s] %s: %s\n", d.Severity, d.Source, d.Message)
+	}
+
+	return out, nil
+}

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nox-hq/nox/core"
+)
+
+// The heavy path (registering a real plugin binary, gRPC invocation, proto
+// conversion) is covered by plugin/host_test.go and plugin/convert_test.go.
+// These tests cover this package's orchestration branches.
+
+func TestRunScanPlugins_NoRequired_NoOp(t *testing.T) {
+	out, err := runScanPlugins(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil output for empty required, got %+v", out)
+	}
+}
+
+func TestRunPluginBinaries_NoBinaries_NoOp(t *testing.T) {
+	out, err := runPluginBinaries(context.Background(), t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil output for no binaries, got %+v", out)
+	}
+}
+
+func TestRunScanPlugins_UninstalledRequired_Skipped(t *testing.T) {
+	// A required plugin that isn't in the install state resolves to zero
+	// binaries, so the run is a no-op rather than an error.
+	out, err := runScanPlugins(context.Background(), t.TempDir(), []string{"nox/definitely-not-installed"})
+	if err != nil {
+		t.Fatalf("uninstalled required plugin should be skipped, got error: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil output, got %+v", out)
+	}
+}
+
+// The hook must be registered with core at init so `nox scan` runs configured
+// analysis plugins without any explicit wiring.
+func TestScanPluginHook_Registered(t *testing.T) {
+	if core.ScanPluginHook == nil {
+		t.Fatal("core.ScanPluginHook was not registered by init()")
+	}
+}

--- a/core/plugin_hook.go
+++ b/core/plugin_hook.go
@@ -16,9 +16,10 @@ type PluginScanOutput struct {
 	Graphs      []graph.Graph
 }
 
-// ScanPluginHook, when set, runs the analysis plugins listed in a project's
-// .nox.yaml plugins.required and returns their findings, enrichments and
-// graphs so the scan pipeline can merge them with the built-in analyzers.
+// ScanPluginHook runs the analysis plugins listed in a project's .nox.yaml
+// plugins.required and returns their findings, enrichments and graphs so the
+// scan pipeline can merge them with the built-in analyzers. It is nil unless
+// the CLI registers an implementation.
 //
 // It is a package-level hook rather than a direct call because running a
 // plugin needs the plugin host and the installed-plugin state, which live in

--- a/core/plugin_hook.go
+++ b/core/plugin_hook.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"context"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/graph"
+)
+
+// PluginScanOutput is the result of running the analysis plugins declared in
+// .nox.yaml plugins.required against a scan target. It is produced by
+// ScanPluginHook and merged into the scan pipeline.
+type PluginScanOutput struct {
+	Findings    []findings.Finding
+	Enrichments []findings.Enrichment
+	Graphs      []graph.Graph
+}
+
+// ScanPluginHook, when set, runs the analysis plugins listed in a project's
+// .nox.yaml plugins.required and returns their findings, enrichments and
+// graphs so the scan pipeline can merge them with the built-in analyzers.
+//
+// It is a package-level hook rather than a direct call because running a
+// plugin needs the plugin host and the installed-plugin state, which live in
+// packages that import core — calling them from core would create an import
+// cycle. The CLI registers the implementation in an init function.
+//
+// Implementations must be safe to call with an empty required list (returning
+// nil, nil) and must never panic: a plugin failure is reported as a non-fatal
+// error and the built-in scan still completes.
+var ScanPluginHook func(ctx context.Context, target string, required []string) (*PluginScanOutput, error)

--- a/core/plugin_hook_test.go
+++ b/core/plugin_hook_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/graph"
+)
+
+// writeNoxConfigRequiring writes a .nox.yaml into dir declaring the given
+// plugins under plugins.required.
+func writeNoxConfigRequiring(t *testing.T, dir string, required ...string) {
+	t.Helper()
+	body := "plugins:\n  required:\n"
+	for _, r := range required {
+		body += "    - " + r + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write .nox.yaml: %v", err)
+	}
+}
+
+// setHook installs a ScanPluginHook for the duration of a test and restores
+// the previous value afterwards.
+func setHook(t *testing.T, fn func(ctx context.Context, target string, required []string) (*PluginScanOutput, error)) {
+	t.Helper()
+	prev := ScanPluginHook
+	ScanPluginHook = fn
+	t.Cleanup(func() { ScanPluginHook = prev })
+}
+
+func TestRunScan_MergesPluginFindings(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/taint-analysis")
+
+	var gotTarget string
+	var gotRequired []string
+	setHook(t, func(_ context.Context, target string, required []string) (*PluginScanOutput, error) {
+		gotTarget = target
+		gotRequired = required
+		f := findings.NewFinding(
+			"TAINT-004", findings.SeverityHigh, findings.ConfidenceHigh,
+			findings.Location{FilePath: "main.go", StartLine: 10, EndLine: 10},
+			"Path Traversal: tainted input flows to file operations",
+		)
+		return &PluginScanOutput{
+			Findings:    []findings.Finding{f},
+			Enrichments: []findings.Enrichment{{}},
+			Graphs:      []graph.Graph{{}},
+		}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+
+	// Hook received the target + the configured required list.
+	if gotTarget != dir {
+		t.Errorf("hook target = %q, want %q", gotTarget, dir)
+	}
+	if len(gotRequired) != 1 || gotRequired[0] != "nox/taint-analysis" {
+		t.Errorf("hook required = %v, want [nox/taint-analysis]", gotRequired)
+	}
+
+	// The plugin finding is present...
+	var found *findings.Finding
+	for _, f := range result.Findings.ActiveFindings() {
+		if f.RuleID == "TAINT-004" {
+			ff := f
+			found = &ff
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("plugin finding TAINT-004 not merged into scan results")
+	}
+	// ...and was refined like any built-in finding (fingerprint assigned),
+	// which is the point of merging before Stage 3.
+	if found.Fingerprint == "" {
+		t.Error("plugin finding was not fingerprinted (merged after refinement?)")
+	}
+
+	// Enrichments + graphs propagate to the result.
+	if len(result.Enrichments) != 1 {
+		t.Errorf("result.Enrichments = %d, want 1", len(result.Enrichments))
+	}
+	if len(result.Graphs) != 1 {
+		t.Errorf("result.Graphs = %d, want 1", len(result.Graphs))
+	}
+}
+
+func TestRunScan_NoHook_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/taint-analysis")
+	setHook(t, nil)
+
+	if _, err := RunScan(dir); err != nil {
+		t.Fatalf("RunScan with nil hook should succeed: %v", err)
+	}
+}
+
+func TestRunScan_HookSkippedWhenNoRequired(t *testing.T) {
+	dir := t.TempDir() // no .nox.yaml => no plugins.required
+
+	called := false
+	setHook(t, func(context.Context, string, []string) (*PluginScanOutput, error) {
+		called = true
+		return nil, nil
+	})
+
+	if _, err := RunScan(dir); err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+	if called {
+		t.Error("hook called despite empty plugins.required")
+	}
+}
+
+func TestRunScan_HookErrorIsNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/taint-analysis")
+	setHook(t, func(context.Context, string, []string) (*PluginScanOutput, error) {
+		return nil, context.DeadlineExceeded
+	})
+
+	if _, err := RunScan(dir); err != nil {
+		t.Fatalf("plugin hook error should be non-fatal, got: %v", err)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -4,6 +4,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -323,6 +324,27 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		}
 	}
 
+	// Phase 2c: Run configured analysis plugins (taint, SAST, …) declared in
+	// .nox.yaml plugins.required and merge their findings in BEFORE refinement,
+	// so plugin findings are fingerprinted and baseline-matched like any other.
+	// The hook is nil unless the CLI registered it (avoids a core→plugin import
+	// cycle). Plugin failures are non-fatal — the built-in scan still completes.
+	var pluginEnrichments []findings.Enrichment
+	var pluginGraphs []graph.Graph
+	if ScanPluginHook != nil && len(cfg.Plugins.Required) > 0 {
+		out, hookErr := ScanPluginHook(ctx, target, cfg.Plugins.Required)
+		if hookErr != nil {
+			slog.WarnContext(ctx, "analysis plugins failed; continuing with built-in findings only", "error", hookErr)
+		}
+		if out != nil {
+			for i := range out.Findings {
+				allFindings.Add(out.Findings[i])
+			}
+			pluginEnrichments = out.Enrichments
+			pluginGraphs = out.Graphs
+		}
+	}
+
 	// Stage 3: Refine findings — apply rule config, generated/noise filters,
 	// conditional severity, dedup, inline suppressions, terraform plan,
 	// baseline matching, and VEX.
@@ -333,6 +355,8 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 
 	return &ScanResult{
 		Findings:     allFindings,
+		Enrichments:  pluginEnrichments,
+		Graphs:       pluginGraphs,
 		Inventory:    inventory,
 		AIInventory:  aiInventory,
 		PolicyResult: policyResult,


### PR DESCRIPTION
## Problem

`nox scan` **auto-installs** the plugins listed in `.nox.yaml` `plugins.required` but never **runs** them — so analysis plugins like `nox/taint-analysis` produce nothing through `nox scan`. `ScanResult.Enrichments`/`Graphs` were declared but never populated. Found while wiring nox to own code-level taint SAST in CI: the plugin installed (cosign-verified, community trust) but `nox scan` returned 0 TAINT findings.

## Change

`RunScanContext` now runs the configured analysis plugins and merges their output into the pipeline **before refinement** (Phase 2c), so plugin findings are fingerprinted + baseline-matched exactly like built-in findings. Enrichments and graphs propagate to `ScanResult`.

Running plugins needs the plugin host + installed-plugin state, which import `core` — so `core` exposes a `ScanPluginHook` that the CLI registers in `init()`, avoiding a `core → plugin` import cycle.

- `core/plugin_hook.go` — `ScanPluginHook` + `PluginScanOutput`
- `core/scan.go` — invoke the hook, populate `Enrichments`/`Graphs`
- `cli/plugin_scan.go` — resolve `required` → installed binaries, run via `host.InvokeAll("scan", …)`, convert proto findings/enrichments/graphs (split into a testable `runPluginBinaries`)

## Tests

- `core`: plugin findings merge **and are fingerprinted** (proves merge-before-refine); nil hook / empty required / hook error are all non-fatal no-ops.
- `cli`: orchestration guards (no required, no binaries, uninstalled-skipped) + hook registered at init.
- Full `core` + `cli` suites pass; gofmt clean; new files lint clean.

## Validation note

Unit tests prove the hook plumbing end-to-end (stub plugin). A live e2e against the real `taint-analysis` binary couldn't run on my machine (corrupted local plugin cache: `fork/exec … no such file or directory`; the binary runs fine on clean CI runners). The host invocation + proto conversion it builds on are already covered by `plugin/host_test.go` and `plugin/convert_test.go`. Recommend a release + a CI smoke check that `nox scan` on an HTTP-handler→sink sample emits TAINT-004.