### PR TITLE
fix(scan): honor flags after the positional path (#103)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -231,6 +231,30 @@ func run(args []string) int {
 	}
 }
 
+// parseInterspersed parses fs from args where flags may appear before AND
+// after positional arguments. The stdlib flag package stops at the first
+// non-flag token, so a flag placed after the path (e.g. "scan . -offline")
+// would otherwise be silently dropped (#103). After each positional we
+// re-parse the remainder, so every flag is honored regardless of position.
+// Returns the positional arguments in order.
+func parseInterspersed(fs *flag.FlagSet, args []string) ([]string, error) {
+	var positionals []string
+	rest := args
+	for {
+		if err := fs.Parse(rest); err != nil {
+			return positionals, err
+		}
+		if fs.NArg() == 0 {
+			return positionals, nil
+		}
+		positionals = append(positionals, fs.Arg(0))
+		rest = fs.Args()[1:]
+		if len(rest) == 0 {
+			return positionals, nil
+		}
+	}
+}
+
 func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verbose bool) int {
 	// Parse scan-specific flags.
 	scanFS := flag.NewFlagSet("scan", flag.ContinueOnError)
@@ -240,8 +264,8 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		noOSVFlag     bool
 	)
 	var (
-		vexFlag        string
-		tfPlanFlag     string
+		vexFlag    string
+		tfPlanFlag string
 	)
 	scanFS.BoolVar(&stagedFlag, "staged", false, "scan only git-staged files (index content)")
 	scanFS.StringVar(&thresholdFlag, "severity-threshold", "", "minimum severity to report (critical, high, medium, low)")
@@ -268,7 +292,8 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
 	var fingerprintVersionFlag string
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v1 unless NOX_FINGERPRINT_VERSION is set.")
-	if err := scanFS.Parse(args); err != nil {
+	positionals, err := parseInterspersed(scanFS, args)
+	if err != nil {
 		return 2
 	}
 	// Wire fingerprint version: explicit flag wins, then env var (handled
@@ -286,11 +311,11 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		return 2
 	}
 
-	if scanFS.NArg() == 0 {
+	if len(positionals) == 0 {
 		fmt.Fprintln(os.Stderr, "Usage: nox scan <path> [flags]")
 		return 2
 	}
-	target := scanFS.Arg(0)
+	target := positionals[0]
 
 	// Load project config for output defaults.
 	cfg, err := nox.LoadScanConfig(target)

--- a/cli/parse_interspersed_test.go
+++ b/cli/parse_interspersed_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+// parseInterspersed must honor flags placed before AND after positional
+// arguments, since the stdlib flag package stops parsing at the first
+// positional (the cause of #103: `nox scan . -severity-threshold high`
+// silently dropped the flag).
+func TestParseInterspersed(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantPath  string
+		wantSev   string
+		wantBool  bool
+		wantPosln int
+	}{
+		{
+			name:      "flags before path",
+			args:      []string{"-severity-threshold", "high", "-offline", "."},
+			wantPath:  ".",
+			wantSev:   "high",
+			wantBool:  true,
+			wantPosln: 1,
+		},
+		{
+			name:      "flags after path (the #103 case)",
+			args:      []string{".", "-severity-threshold", "high", "-offline"},
+			wantPath:  ".",
+			wantSev:   "high",
+			wantBool:  true,
+			wantPosln: 1,
+		},
+		{
+			name:      "flags interspersed around path",
+			args:      []string{"-offline", "src", "-severity-threshold", "critical"},
+			wantPath:  "src",
+			wantSev:   "critical",
+			wantBool:  true,
+			wantPosln: 1,
+		},
+		{
+			name:      "path only",
+			args:      []string{"."},
+			wantPath:  ".",
+			wantSev:   "",
+			wantBool:  false,
+			wantPosln: 1,
+		},
+		{
+			name:      "value flag then path",
+			args:      []string{"-severity-threshold", "low", "dir", "-offline"},
+			wantPath:  "dir",
+			wantSev:   "low",
+			wantBool:  true,
+			wantPosln: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+			var sev string
+			var offline bool
+			fs.StringVar(&sev, "severity-threshold", "", "")
+			fs.BoolVar(&offline, "offline", false, "")
+
+			positionals, err := parseInterspersed(fs, tt.args)
+			if err != nil {
+				t.Fatalf("parseInterspersed: %v", err)
+			}
+			if len(positionals) != tt.wantPosln {
+				t.Fatalf("positionals = %v, want %d", positionals, tt.wantPosln)
+			}
+			if positionals[0] != tt.wantPath {
+				t.Errorf("path = %q, want %q", positionals[0], tt.wantPath)
+			}
+			if sev != tt.wantSev {
+				t.Errorf("severity-threshold = %q, want %q (flag dropped?)", sev, tt.wantSev)
+			}
+			if offline != tt.wantBool {
+				t.Errorf("offline = %v, want %v (flag dropped?)", offline, tt.wantBool)
+			}
+		})
+	}
+}
+
+func TestParseInterspersed_InvalidFlag(t *testing.T) {
+	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+	fs.SetOutput(discardWriter{})
+	fs.Bool("offline", false, "")
+	if _, err := parseInterspersed(fs, []string{".", "-nope"}); err == nil {
+		t.Error("expected error for unknown flag, got nil")
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Problem (#103)

`nox scan` silently drops any flag placed **after** the positional path — Go's `flag` package stops at the first non-flag token. So `nox scan . -severity-threshold high` runs with the flag dropped: no error, no effect. In CI a gate the author wrote can silently not apply — a correctness/safety bug.

`extractInterspersedArgs` only reordered a hardcoded subset (`--format`/`--output` + global bools), so those survived after the path but the scan-specific flags (`-severity-threshold`, `-vex`, `-fail-on-unwaived`, `-offline`, …) did not.

## Fix

`parseInterspersed` re-parses the remainder after each positional, so flags before **and** after the path are honored for every `scanFS` flag. No hardcoded flag list.

## Tests

Table test covering flags before / after / interspersed around the path, value-flags, path-only, and an unknown-flag error. The `flags after path` case is the #103 reproduction. Full `cli` suite passes; gofmt + lint clean.

Closes #103.