### PR TITLE
fix(plugin): locate real plugin binary + absolute workspace root

### DIFF
--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -69,6 +69,15 @@ func runPluginBinaries(ctx context.Context, target string, binaries []string, po
 		policy = &p
 	}
 
+	// Plugins run as subprocesses whose working directory is not guaranteed
+	// to match nox's, so a relative target (commonly ".") would make a plugin
+	// walk the wrong tree and silently find nothing. Always hand the plugin an
+	// absolute workspace root.
+	absTarget, absErr := filepath.Abs(target)
+	if absErr != nil {
+		absTarget = target
+	}
+
 	host := plugin.NewHost(plugin.WithPolicy(policy))
 	defer func() { _ = host.Close() }()
 
@@ -81,8 +90,8 @@ func runPluginBinaries(ctx context.Context, target string, binaries []string, po
 	// Run the analysis `scan` tool across every plugin that declares it.
 	// workspace_root is passed both as the host workspace argument and in the
 	// input map, since plugins read it from req.Input["workspace_root"].
-	input := map[string]any{"workspace_root": target}
-	responses, err := host.InvokeAll(ctx, "scan", input, target)
+	input := map[string]any{"workspace_root": absTarget}
+	responses, err := host.InvokeAll(ctx, "scan", input, absTarget)
 	if err != nil {
 		return nil, fmt.Errorf("invoking analysis plugins: %w", err)
 	}

--- a/registry/oci/binary.go
+++ b/registry/oci/binary.go
@@ -1,0 +1,86 @@
+package oci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// metadataFile reports whether a file in an extracted plugin archive is
+// packaging metadata (license, docs, manifests, signatures) rather than the
+// executable.
+func metadataFile(name string) bool {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".md"),
+		strings.HasSuffix(lower, ".yaml"),
+		strings.HasSuffix(lower, ".yml"),
+		strings.HasSuffix(lower, ".json"),
+		strings.HasSuffix(lower, ".txt"),
+		strings.HasSuffix(lower, ".sig"),
+		strings.HasSuffix(lower, ".pem"),
+		strings.HasSuffix(lower, ".sbom"),
+		lower == "license",
+		strings.HasPrefix(lower, "license."),
+		strings.HasPrefix(lower, "readme"),
+		strings.HasPrefix(lower, "changelog"):
+		return true
+	}
+	return false
+}
+
+// isExecutableFile reports whether path is a regular file with an executable
+// permission bit set.
+func isExecutableFile(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	return fi.Mode().Perm()&0o111 != 0
+}
+
+// findPluginBinary locates the plugin executable inside an extracted archive.
+//
+// goreleaser names the binary after the plugin's repository (e.g.
+// "nox-plugin-taint-analysis"), not its short registry name ("taint-analysis"),
+// so a fixed base-name guess misses it — leaving BinaryPath pointing at a file
+// that does not exist and the plugin failing to start. Resolution order:
+//
+//  1. a file matching the plugin's short name (the simple case),
+//  2. an executable whose name contains the short name,
+//  3. the sole executable in the directory.
+//
+// Falls back to the short-name path (which then fails loudly at registration)
+// when the directory is unreadable or the binary is genuinely ambiguous.
+func findPluginBinary(extractDir, name string) string {
+	short := filepath.Base(name)
+
+	exact := filepath.Join(extractDir, short)
+	if isExecutableFile(exact) {
+		return exact
+	}
+
+	entries, err := os.ReadDir(extractDir)
+	if err != nil {
+		return exact
+	}
+	var execs []string
+	for _, e := range entries {
+		if e.IsDir() || metadataFile(e.Name()) {
+			continue
+		}
+		p := filepath.Join(extractDir, e.Name())
+		if isExecutableFile(p) {
+			execs = append(execs, p)
+		}
+	}
+	for _, p := range execs {
+		if strings.Contains(filepath.Base(p), short) {
+			return p
+		}
+	}
+	if len(execs) == 1 {
+		return execs[0]
+	}
+	return exact
+}

--- a/registry/oci/binary_test.go
+++ b/registry/oci/binary_test.go
@@ -1,0 +1,70 @@
+package oci
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func writeExec(t *testing.T, dir, name string) string {
+	t.Helper()
+	return writeMode(t, dir, name, 0o755)
+}
+
+func writeMode(t *testing.T, dir, name string, mode os.FileMode) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"), mode); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestFindPluginBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable-bit resolution is POSIX-specific")
+	}
+
+	t.Run("repo-named binary (the taint-analysis case)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMode(t, dir, "LICENSE", 0o644)
+		writeMode(t, dir, "README.md", 0o644)
+		writeMode(t, dir, "plugin.yaml", 0o644)
+		want := writeExec(t, dir, "nox-plugin-taint-analysis")
+
+		if got := findPluginBinary(dir, "nox/taint-analysis"); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("short-name binary (exact match)", func(t *testing.T) {
+		dir := t.TempDir()
+		want := writeExec(t, dir, "taint-analysis")
+		writeExec(t, dir, "nox-plugin-taint-analysis") // also present; exact wins
+		if got := findPluginBinary(dir, "nox/taint-analysis"); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("sole executable, unrelated name", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMode(t, dir, "CHANGELOG.md", 0o644)
+		want := writeExec(t, dir, "scanner")
+		if got := findPluginBinary(dir, "nox/whatever"); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("metadata not chosen as binary", func(t *testing.T) {
+		dir := t.TempDir()
+		// An executable-bit .sh-less metadata file must never be picked over
+		// nothing; with only metadata present we fall back to the short path.
+		writeMode(t, dir, "LICENSE", 0o755)
+		writeMode(t, dir, "README.md", 0o755)
+		got := findPluginBinary(dir, "nox/taint-analysis")
+		if got != filepath.Join(dir, "taint-analysis") {
+			t.Errorf("got %q, want fallback short-name path", got)
+		}
+	})
+}

--- a/registry/oci/store.go
+++ b/registry/oci/store.go
@@ -278,8 +278,10 @@ func (s *Store) fetchArtifact(ctx context.Context, name string, ve *registry.Ver
 			}
 		}
 		installed.ExtractDir = extractDir
-		// Look for a binary with the plugin base name in the extracted directory.
-		installed.BinaryPath = filepath.Join(extractDir, filepath.Base(name))
+		// Locate the actual executable: the binary is often named after the
+		// plugin's repo (e.g. "nox-plugin-taint-analysis"), not its short
+		// registry name, so a fixed base-name guess misses it.
+		installed.BinaryPath = findPluginBinary(extractDir, name)
 
 	case FormatRawBinary:
 		if err := SetExecutable(blobPath); err != nil {


### PR DESCRIPTION
## Problem

After wiring `nox scan` to run `plugins.required` analysis plugins (#102), taint findings still never appeared — `nox scan` reported **zero** plugin findings even on a textbook path-traversal sample. Two bugs:

1. **Binary name mismatch.** goreleaser names a plugin's executable after its **repo** (`nox-plugin-taint-analysis`), but `registry/oci/store.go` recorded `BinaryPath = <extractDir>/<short-name>` (`taint-analysis`) — a nonexistent path. `nox plugin call` failed with `fork/exec … no such file`; the scan hook's `os.Stat` guard then **silently skipped** the plugin. `findPluginBinary` now finds the real executable in the extracted archive (exact short-name → name-contains-short → sole executable, skipping LICENSE/README/manifests).
2. **Relative workspace root.** The scan hook handed the plugin subprocess the relative scan target (often `.`); the subprocess cwd may differ, so it walked the wrong tree. Now passes an absolute path.

## Verification

`nox scan` on `func(w,r){ p:=r.URL.Query().Get("file"); os.ReadFile(p) }`:
```
[families] Taint Flow:2
TAINT-004 high  path traversal  main.go L9
TAINT-003 high  XSS             main.go L10
```

## Tests

`findPluginBinary` table test: repo-named binary (the bug), exact short-name, sole-executable, metadata-not-chosen. Full `registry/oci` + `cli` suites pass; gofmt + lint clean.

Follows #102 (the scan→plugin merge) — together they make nox own code-level taint SAST.