### PR TITLE
fix(registry): handle .sigstore.json bundle suffix in deriveChecksumsURL

### DIFF
--- a/registry/oci/store.go
+++ b/registry/oci/store.go
@@ -351,7 +351,13 @@ func dropPolicyLevelViolations(in []trust.Violation) []trust.Violation {
 // resolve to the same `checksums.txt`.
 func deriveChecksumsURL(bundleURL, sigURL string) string {
 	if bundleURL != "" {
-		return strings.TrimSuffix(bundleURL, ".sig.bundle")
+		// The bundle is named "<checksums>.<suffix>". cosign v3.10+/v4 emit
+		// ".sigstore.json"; older releases emit ".sig.bundle". Strip whichever
+		// is present so the real checksums file is fetched as the signed
+		// artifact — otherwise cosign verifies the signature against the
+		// bundle itself and reports "invalid signature".
+		u := strings.TrimSuffix(bundleURL, ".sigstore.json")
+		return strings.TrimSuffix(u, ".sig.bundle")
 	}
 	return strings.TrimSuffix(sigURL, ".sig")
 }

--- a/registry/oci/store_test.go
+++ b/registry/oci/store_test.go
@@ -629,3 +629,22 @@ func TestStoreFetchWithMirror(t *testing.T) {
 		t.Errorf("PluginName = %q, want %q", installed.PluginName, "test/plugin")
 	}
 }
+
+func TestDeriveChecksumsURL(t *testing.T) {
+	const base = "https://github.com/x/y/releases/download/v1/checksums.txt"
+	tests := []struct {
+		name, bundleURL, sigURL, want string
+	}{
+		{"sigstore bundle (cosign v3.10+/v4)", base + ".sigstore.json", "", base},
+		{"legacy sig.bundle", base + ".sig.bundle", "", base},
+		{"legacy detached signature", "", base + ".sig", base},
+		{"bundle wins over sig", base + ".sigstore.json", base + ".sig", base},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveChecksumsURL(tt.bundleURL, tt.sigURL); got != tt.want {
+				t.Errorf("deriveChecksumsURL(%q,%q) = %q, want %q", tt.bundleURL, tt.sigURL, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

`deriveChecksumsURL` only stripped the legacy `.sig.bundle` suffix. cosign v3.10+/v4 emit `.sigstore.json` bundles. For a v0.6.6-style bundle URL, `TrimSuffix(url, ".sig.bundle")` is a no-op, so nox downloaded `checksums.txt.sigstore.json` as the *signed artifact* and asked cosign to verify the signature against the bundle file itself → `invalid signature`.

This is exactly why taint-analysis **v0.6.6 verified fine locally** (where the cached `.sig.bundle` naming was used) **but failed at community trust in CI**. v0.6.5's `.sig.bundle` stripped correctly, which is why it worked.

## Fix

Strip `.sigstore.json` as well as `.sig.bundle` so the real `checksums.txt` is fetched and verified.

## Tests

`TestDeriveChecksumsURL` — sigstore.json bundle, legacy sig.bundle, legacy detached .sig, bundle-wins precedence. All pass; `go build ./...` clean; gofmt clean.