### PR TITLE
chore(registry): add ai-eval v0.1.1 + remediate v0.1.0

### DIFF
--- a/registry-scaffold/index.json
+++ b/registry-scaffold/index.json
@@ -479,9 +479,9 @@
       "homepage": "https://github.com/nox-hq/nox-plugin-ai-eval",
       "versions": [
         {
-          "version": "0.1.0",
+          "version": "0.1.1",
           "api_version": "v1",
-          "published_at": "2026-05-02T15:25:16.607415Z",
+          "published_at": "2026-06-09T10:07:57.530361151Z",
           "digest": "sha256:tbd",
           "capabilities": [
             "ai_eval"
@@ -490,50 +490,50 @@
             {
               "os": "linux",
               "arch": "amd64",
-              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/nox-plugin-ai-eval_0.1.0_linux_amd64.tar.gz",
+              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/nox-plugin-ai-eval_0.1.1_linux_amd64.tar.gz",
               "size": 0,
-              "digest": "sha256:db93be9df99601bfc87125b13a3944d08e2c2c332471397ad73cb172876ebd2a",
-              "cosign_sig_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/checksums.txt.sig",
+              "digest": "sha256:fa95dc9c15f97cbc816dc45de9ddd0dd7dbec716a771ab9aade9103ab079716e",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/checksums.txt.sigstore.json",
               "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-ai-eval/.github/workflows/release.yml@.*",
               "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
             },
             {
               "os": "linux",
               "arch": "arm64",
-              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/nox-plugin-ai-eval_0.1.0_linux_arm64.tar.gz",
+              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/nox-plugin-ai-eval_0.1.1_linux_arm64.tar.gz",
               "size": 0,
-              "digest": "sha256:bde6e3cc3da4baf38afe4f2aeeaaa5cf4f32ed2a04571865253bbe0f708b6833",
-              "cosign_sig_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/checksums.txt.sig",
+              "digest": "sha256:b6ed154ee562b9e6b5ca9781ea9bc58901f622891e9d05a12e0e616c0e3b34e5",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/checksums.txt.sigstore.json",
               "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-ai-eval/.github/workflows/release.yml@.*",
               "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
             },
             {
               "os": "darwin",
               "arch": "amd64",
-              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/nox-plugin-ai-eval_0.1.0_darwin_amd64.tar.gz",
+              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/nox-plugin-ai-eval_0.1.1_darwin_amd64.tar.gz",
               "size": 0,
-              "digest": "sha256:a1649877d419927b80cbdee7e7efb6aba8c1eadc9221189fe9e297741cbbd495",
-              "cosign_sig_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/checksums.txt.sig",
+              "digest": "sha256:a6a48ac9fddbac57633be849dc3a7fe3312826d001cc8ae8cc7ef1ce3e13a208",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/checksums.txt.sigstore.json",
               "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-ai-eval/.github/workflows/release.yml@.*",
               "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
             },
             {
               "os": "darwin",
               "arch": "arm64",
-              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/nox-plugin-ai-eval_0.1.0_darwin_arm64.tar.gz",
+              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/nox-plugin-ai-eval_0.1.1_darwin_arm64.tar.gz",
               "size": 0,
-              "digest": "sha256:4329d6ee78846f739cc2b245f6cd5c7ad56d9d93c409b8724c578a43ddff875b",
-              "cosign_sig_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/checksums.txt.sig",
+              "digest": "sha256:a2b08d2a6d4bd5708872cbd6ba33faa94f812197ad21036825f250f92897fb1d",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/checksums.txt.sigstore.json",
               "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-ai-eval/.github/workflows/release.yml@.*",
               "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
             },
             {
               "os": "windows",
               "arch": "amd64",
-              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/nox-plugin-ai-eval_0.1.0_windows_amd64.zip",
+              "url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/nox-plugin-ai-eval_0.1.1_windows_amd64.zip",
               "size": 0,
-              "digest": "sha256:tbd",
-              "cosign_sig_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.0/checksums.txt.sig",
+              "digest": "sha256:0e2128d52b8bbe11b8dd980c3b228fc166e3b0207ce818f282194a0fe1643b60",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-ai-eval/releases/download/v0.1.1/checksums.txt.sigstore.json",
               "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-ai-eval/.github/workflows/release.yml@.*",
               "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
             }
@@ -1602,6 +1602,84 @@
           ]
         }
       ]
+    },
+    {
+      "name": "nox/remediate",
+      "description": "Deterministic remediation planning and application for code findings",
+      "homepage": "https://github.com/nox-hq/nox-plugin-remediate",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "api_version": "v1",
+          "published_at": "2026-06-09T10:28:23.003123394Z",
+          "digest": "sha256:tbd",
+          "capabilities": [
+            "plan_code",
+            "apply_code",
+            "verify_code"
+          ],
+          "artifacts": [
+            {
+              "os": "linux",
+              "arch": "amd64",
+              "url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/nox-plugin-remediate_0.1.0_linux_amd64.tar.gz",
+              "size": 0,
+              "digest": "sha256:b995a6e9577c3662b7597c8fdfb417091c5e3c704fd20d376a31bfc657bb517a",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/checksums.txt.sigstore.json",
+              "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-remediate/.github/workflows/release.yml@.*",
+              "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
+            },
+            {
+              "os": "linux",
+              "arch": "arm64",
+              "url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/nox-plugin-remediate_0.1.0_linux_arm64.tar.gz",
+              "size": 0,
+              "digest": "sha256:999f56db6c8f0e5ff45e790cc649a6a3e52a9a3890af376d93e1c9a0df382f43",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/checksums.txt.sigstore.json",
+              "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-remediate/.github/workflows/release.yml@.*",
+              "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
+            },
+            {
+              "os": "darwin",
+              "arch": "amd64",
+              "url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/nox-plugin-remediate_0.1.0_darwin_amd64.tar.gz",
+              "size": 0,
+              "digest": "sha256:b7fa68af9870f7edfaf346cf1709712fca63de75f0aadc0e90a6a063bfb3c53a",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/checksums.txt.sigstore.json",
+              "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-remediate/.github/workflows/release.yml@.*",
+              "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
+            },
+            {
+              "os": "darwin",
+              "arch": "arm64",
+              "url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/nox-plugin-remediate_0.1.0_darwin_arm64.tar.gz",
+              "size": 0,
+              "digest": "sha256:edf98b589bf1c11017674486102ab4b1d62a6a33fed1bff8024cde509773b5a6",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/checksums.txt.sigstore.json",
+              "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-remediate/.github/workflows/release.yml@.*",
+              "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
+            },
+            {
+              "os": "windows",
+              "arch": "amd64",
+              "url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/nox-plugin-remediate_0.1.0_windows_amd64.zip",
+              "size": 0,
+              "digest": "sha256:35357d37cb5252d9cacb4834997e6823d35df12c4ed43c9c2782084bae094a39",
+              "cosign_bundle_url": "https://github.com/nox-hq/nox-plugin-remediate/releases/download/v0.1.0/checksums.txt.sigstore.json",
+              "cosign_cert_identity_regexp": "(?i)https://github.com/nox-hq/nox-plugin-remediate/.github/workflows/release.yml@.*",
+              "cosign_oidc_issuer": "https://token.actions.githubusercontent.com"
+            }
+          ],
+          "minimum_nox_version": "0.6.0",
+          "changelog_url": "https://github.com/nox-hq/nox-plugin-remediate/blob/main/CHANGELOG.md"
+        }
+      ],
+      "track": "remediation",
+      "maintainers": [
+        "nox-hq"
+      ],
+      "license": "Apache-2.0",
+      "repository": "https://github.com/nox-hq/nox-plugin-remediate"
     }
   ]
 }


### PR DESCRIPTION
Adds marketplace entries for the two re-released plugins (see #110):

- **ai-eval v0.1.1** — replaces the UNSIGNED v0.1.0; now cosign-signed (.sigstore.json).
- **remediate v0.1.0** — first registry presence.

Digests filled from each release `checksums.txt`; `cosign_bundle_url` → `.sigstore.json`; spurious `cosign_sig_url` dropped. `nox plugin entry` generated these fields incorrectly (`sha256:tbd`, `.sig.bundle`, a `.sig` url) — corrected by hand (bug tracked in #110).