### PR TITLE
fix(deps): skip OSV query for packages in unknown ecosystems

### DIFF
--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -115,21 +115,41 @@ func fixedVersion(vuln *osvVuln, pkgName, ecosystem string) string {
 func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []Package) (map[int][]osvVuln, error) {
 	result := make(map[int][]osvVuln)
 
-	for start := 0; start < len(pkgs); start += osvBatchLimit {
-		end := start + osvBatchLimit
-		if end > len(pkgs) {
-			end = len(pkgs)
+	// Only query packages whose ecosystem OSV.dev actually understands. Other
+	// "packages" reach the inventory too — notably Docker base images (ecosystem
+	// "docker") from Dockerfile scanning — and OSV's /v1/querybatch rejects the
+	// WHOLE request with HTTP 400 if any single query carries an unknown
+	// ecosystem. That 400 was being swallowed by the graceful-degradation path
+	// below, silently dropping every real Go/npm/PyPI result in the batch. So a
+	// repo with a Dockerfile got zero dependency-CVE findings. Filter first, and
+	// remember each kept query's original index so results map back correctly.
+	type indexed struct {
+		orig int
+		pkg  Package
+	}
+	queryable := make([]indexed, 0, len(pkgs))
+	for i, p := range pkgs {
+		if _, ok := osvEcosystem(p.Ecosystem); ok {
+			queryable = append(queryable, indexed{orig: i, pkg: p})
 		}
-		batch := pkgs[start:end]
+	}
+
+	for start := 0; start < len(queryable); start += osvBatchLimit {
+		end := start + osvBatchLimit
+		if end > len(queryable) {
+			end = len(queryable)
+		}
+		batch := queryable[start:end]
 
 		queries := make([]osvQuery, len(batch))
-		for i, p := range batch {
+		for i, item := range batch {
+			eco, _ := osvEcosystem(item.pkg.Ecosystem)
 			queries[i] = osvQuery{
 				Package: osvPackage{
-					Name:      p.Name,
-					Ecosystem: ecosystemToOSV(p.Ecosystem),
+					Name:      item.pkg.Name,
+					Ecosystem: eco,
 				},
-				Version: p.Version,
+				Version: item.pkg.Version,
 			}
 		}
 
@@ -159,7 +179,7 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 
 		for i, br := range vulns {
 			if len(br.Vulns) > 0 {
-				result[start+i] = br.Vulns
+				result[batch[i].orig] = br.Vulns
 			}
 		}
 	}
@@ -244,27 +264,41 @@ func upgradeCommand(ecosystem, pkg, fixedVer string) string {
 	}
 }
 
-// ecosystemToOSV maps nox's internal ecosystem names to the ecosystem strings
-// expected by the OSV.dev API.
-func ecosystemToOSV(eco string) string {
+// osvEcosystem maps a nox internal ecosystem name to the ecosystem string
+// expected by the OSV.dev API. The bool is false when OSV has no matching
+// ecosystem (e.g. "docker" base images), so callers can skip those packages
+// rather than poisoning a batch query — OSV rejects an entire /v1/querybatch
+// request with HTTP 400 if any one query names an unknown ecosystem.
+func osvEcosystem(eco string) (string, bool) {
 	switch eco {
 	case "go":
-		return "Go"
+		return "Go", true
 	case "npm":
-		return "npm"
+		return "npm", true
 	case "pypi":
-		return "PyPI"
+		return "PyPI", true
 	case "rubygems":
-		return "RubyGems"
+		return "RubyGems", true
 	case "cargo":
-		return "crates.io"
+		return "crates.io", true
 	case "maven":
-		return "Maven"
+		return "Maven", true
 	case "gradle":
-		return "Maven"
+		return "Maven", true
 	case "nuget":
-		return "NuGet"
+		return "NuGet", true
 	default:
-		return eco
+		return "", false
 	}
+}
+
+// ecosystemToOSV maps nox's internal ecosystem names to the ecosystem strings
+// expected by the OSV.dev API, returning the input unchanged for ecosystems
+// OSV does not recognise (used only for best-effort name/version matching in
+// already-returned records, not for issuing queries).
+func ecosystemToOSV(eco string) string {
+	if osv, ok := osvEcosystem(eco); ok {
+		return osv
+	}
+	return eco
 }

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -759,3 +759,65 @@ func TestNewAnalyzer_Defaults(t *testing.T) {
 		t.Error("expected default HTTP client")
 	}
 }
+
+// TestQueryOSV_SkipsUnknownEcosystem is a regression test for the bug where a
+// package with an ecosystem OSV doesn't recognise (e.g. a Docker base image,
+// ecosystem "docker") was included in the batch query. OSV's /v1/querybatch
+// rejects the ENTIRE request with HTTP 400 if any single query names an unknown
+// ecosystem, and that 400 was swallowed by graceful degradation — so a repo
+// with a Dockerfile silently lost every real Go/npm/PyPI vulnerability finding.
+func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req osvBatchRequest
+		decodeJSON(t, r, &req)
+
+		// Mimic the real OSV API: reject the whole batch if any query carries an
+		// ecosystem the API does not understand.
+		valid := map[string]bool{
+			"Go": true, "npm": true, "PyPI": true, "RubyGems": true,
+			"crates.io": true, "Maven": true, "NuGet": true,
+		}
+		for _, q := range req.Queries {
+			if !valid[q.Package.Ecosystem] {
+				http.Error(w, "invalid ecosystem", http.StatusBadRequest)
+				return
+			}
+		}
+
+		results := make([]osvBatchResult, len(req.Queries))
+		for i, q := range req.Queries {
+			if q.Package.Name == "esbuild" {
+				results[i] = osvBatchResult{Vulns: []osvVuln{{
+					ID:      "GHSA-g7r4-m6w7-qqqr",
+					Summary: "arbitrary file read in esbuild dev server",
+				}}}
+			}
+		}
+		encodeJSON(t, w, osvBatchResponse{Results: results})
+	}))
+	defer srv.Close()
+
+	// A Docker base image (unknown to OSV) mixed in with a real npm package.
+	pkgs := []Package{
+		{Name: "node", Version: "20-alpine", Ecosystem: "docker"},
+		{Name: "esbuild", Version: "0.27.7", Ecosystem: "npm"},
+	}
+
+	got, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	if err != nil {
+		t.Fatalf("queryOSV returned error: %v", err)
+	}
+
+	// The npm vuln (index 1) must be found despite the docker package (index 0).
+	vulns, ok := got[1]
+	if !ok || len(vulns) != 1 {
+		t.Fatalf("expected esbuild vuln at index 1, got %#v", got)
+	}
+	if vulns[0].ID != "GHSA-g7r4-m6w7-qqqr" {
+		t.Errorf("unexpected vuln id: %s", vulns[0].ID)
+	}
+	// The docker package must not be queried (so no index 0 result).
+	if _, exists := got[0]; exists {
+		t.Errorf("docker package should not have been queried, got result at index 0")
+	}
+}


### PR DESCRIPTION
## Bug
OSV.dev's `POST /v1/querybatch` rejects the **entire** request with **HTTP 400** if any single query names an ecosystem it doesn't recognise.

nox adds Docker base images to the package inventory with ecosystem `"docker"` (from Dockerfile scanning), and these were sent in the OSV batch alongside real packages. So **for any repository containing a Dockerfile, every querybatch returned 400** — and because `queryOSV` swallows non-200 responses as graceful degradation (`return result, nil`), the scan silently reported **zero** dependency vulnerabilities (VULN-001) for the real Go / npm / PyPI / … packages too.

The offline checks (VULN-002 typosquatting, VULN-003 malicious-package) were unaffected, which masked the gap — packages clearly *were* in the inventory, they just never produced OSV findings.

### How it was found
Real-world repo: Go backend (`go.mod`) + nested npm app (`web/package-lock.json`) + Dockerfiles. `nox scan .` reported the npm/Go deps but **0 VULN-001**, while `npm audit` and a direct `api.osv.dev` query both flagged known CVEs. Instrumenting `queryOSV` showed:

```
[osv-debug] batch start=0 size=183 ecosystems=map[Go:177 docker:6] sampleNpm="(none)"
[osv-debug] decode error status=400 err=OSV API returned status 400
```

The `docker:6` entries poisoned the batch → 400 → all 177 Go queries dropped silently.

## Fix
Filter the inventory to OSV-supported ecosystems **before** building the batch, tracking each kept package's original index so results still map back to the right package. Added `osvEcosystem(eco) (string, bool)` reporting whether OSV recognises an ecosystem; `ecosystemToOSV` now delegates to it (behaviour unchanged for the record-matching callers `fixedVersion`/finding metadata).

## Test
`TestQueryOSV_SkipsUnknownEcosystem` stands up a fake OSV server that 400s if any query carries an unknown ecosystem (mirroring the real API), mixes a `docker` base image with a vulnerable npm package, and asserts the npm vuln is still found. Verified it **fails before** this change (empty result map) and **passes after**. Full `core/analyzers/deps` suite + `go vet` green.

## Possible follow-up (not in this PR)
`queryOSV` silently swallows non-200 / decode failures as graceful degradation, so a future batch-poisoning bug would again be invisible (scan looks clean). Worth surfacing a warning when OSV returns a non-200 rather than reporting zero findings.