### PR TITLE
fix(deps): warn when an OSV lookup degrades instead of silently reporting none

### DIFF
--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -167,13 +168,20 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 
 		resp, err := client.Do(req)
 		if err != nil {
-			// Network error — degrade gracefully.
+			// Network error — degrade gracefully, but say so: a silent empty
+			// result is indistinguishable from "no vulnerabilities found".
+			slog.WarnContext(ctx, "OSV query failed; dependency vulnerabilities may be under-reported",
+				"error", err, "queries", len(queries))
 			return result, nil
 		}
 
 		vulns, decodeErr := decodeBatchResponse(resp)
 		_ = resp.Body.Close()
 		if decodeErr != nil {
+			// Non-200 status or undecodable body — same risk: don't report a
+			// clean scan when the lookup actually failed.
+			slog.WarnContext(ctx, "OSV query returned an error; dependency vulnerabilities may be under-reported",
+				"error", decodeErr, "queries", len(queries))
 			return result, nil
 		}
 

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -3,6 +3,7 @@ package deps
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -819,5 +820,33 @@ func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 	// The docker package must not be queried (so no index 0 result).
 	if _, exists := got[0]; exists {
 		t.Errorf("docker package should not have been queried, got result at index 0")
+	}
+}
+
+// TestQueryOSV_WarnsOnNon200 verifies that when the OSV API returns a non-200
+// status, queryOSV degrades gracefully (empty result, no error) BUT emits a
+// warning — so an OSV outage is not silently indistinguishable from a clean
+// "no known vulnerabilities" scan.
+func TestQueryOSV_WarnsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	var logBuf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	got, err := queryOSV(context.Background(), srv.Client(), srv.URL,
+		[]Package{{Name: "lodash", Version: "4.17.0", Ecosystem: "npm"}})
+	if err != nil {
+		t.Fatalf("queryOSV returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result on degraded lookup, got %#v", got)
+	}
+	if logged := logBuf.String(); !strings.Contains(logged, "under-reported") || !strings.Contains(logged, "level=WARN") {
+		t.Errorf("expected a WARN about under-reporting, got: %q", logged)
 	}
 }


### PR DESCRIPTION
Follow-up to #116.

## Problem
`queryOSV` swallows network errors and non-200 / undecodable responses as graceful degradation — it returns a partial/empty result with no error, honouring Nox's offline-first design. But that makes an OSV outage, a rate-limit, or a malformed batch **indistinguishable from a genuine "no known vulnerabilities" result**. The scan reports clean when the lookup actually failed.

This is precisely how the docker-ecosystem batch-poisoning bug (#116) stayed invisible: every batch 400'd, the 400 was swallowed, and the scan reported zero dependency CVEs.

## Fix
Emit a `slog.WarnContext` on both degraded paths (network error and non-200/decode error), matching the existing `slog.WarnContext` usage in `core/scan.go`. Behaviour is otherwise unchanged — the scan still degrades gracefully rather than failing, it just no longer does so silently.

```
WARN OSV query returned an error; dependency vulnerabilities may be under-reported error="OSV API returned status 400" queries=183
```

## Test
`TestQueryOSV_WarnsOnNon200` captures the default slog handler, points `queryOSV` at a server returning 503, and asserts (a) the result is empty (graceful) and (b) a WARN mentioning under-reporting is logged. Fails before this change, passes after. Full `core/analyzers/deps` suite + `go vet` + gofmt clean.