### PR TITLE
fix(secrets): skip lock files & generated artifacts for all secret rules

### DIFF
--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -3783,14 +3783,20 @@ var entropySourceFilePatterns = []string{
 	"Makefile", "*.mk",
 }
 
-// entropyIgnoreFilePatterns explicitly excludes well-known files whose
+// generatedFileIgnorePatterns explicitly excludes well-known files whose
 // content is structurally high-entropy (module checksums, lock files,
 // content-addressed IDs, agent / IDE state dirs). Matches gitleaks /
 // trufflehog / detect-secrets default behaviour and extends with
 // modern-AI-tool state directories that pile up content-addressed IDs
 // outside of source control. Operators can override via config if they
 // want to scan these.
-var entropyIgnoreFilePatterns = []string{
+//
+// This set gates the WHOLE secrets analyzer (see secrets.go: ScanArtifacts),
+// not just the entropy rules — base64 integrity hashes in a package-lock.json
+// match provider-key regexes (e.g. "Firebase / ELK / IBM API key") just as
+// readily as they trip the entropy rules, so a lockfile would otherwise
+// produce thousands of false-positive secret findings.
+var generatedFileIgnorePatterns = []string{
 	// Go module checksums.
 	"go.sum",
 	// Lock files (dependency / build).
@@ -3865,7 +3871,7 @@ func builtinEntropyRules() []*rules.Rule {
 			MatcherType:        "entropy",
 			Keywords:           []string{"=", ":", "password", "secret", "key", "token", "credential", "api_key", "private"},
 			FilePatterns:       entropySourceFilePatterns,
-			IgnoreFilePatterns: entropyIgnoreFilePatterns,
+			IgnoreFilePatterns: generatedFileIgnorePatterns,
 			Tags:               []string{"secrets", "entropy"},
 			Metadata:           map[string]string{"cwe": "CWE-798", "entropy_threshold": "5.0"},
 			Remediation:        "Move high-entropy values to environment variables or a secrets manager. Never hard-code secrets in source files.",
@@ -3880,7 +3886,7 @@ func builtinEntropyRules() []*rules.Rule {
 			MatcherType:        "entropy",
 			Keywords:           []string{"password", "secret", "key", "token", "credential", "api_key", "private", "auth"},
 			FilePatterns:       entropySourceFilePatterns,
-			IgnoreFilePatterns: entropyIgnoreFilePatterns,
+			IgnoreFilePatterns: generatedFileIgnorePatterns,
 			Tags:               []string{"secrets", "entropy"},
 			Metadata:           map[string]string{"cwe": "CWE-798", "entropy_threshold": "5.2", "require_context": "true"},
 			Remediation:        "Inspect this base64-encoded value. If it contains a secret, move it to a secrets manager.",
@@ -3895,7 +3901,7 @@ func builtinEntropyRules() []*rules.Rule {
 			MatcherType:        "entropy",
 			Keywords:           []string{"key", "secret", "token", "password", "credential", "private", "auth"},
 			FilePatterns:       entropySourceFilePatterns,
-			IgnoreFilePatterns: entropyIgnoreFilePatterns,
+			IgnoreFilePatterns: generatedFileIgnorePatterns,
 			Tags:               []string{"secrets", "entropy"},
 			Metadata:           map[string]string{"cwe": "CWE-798", "entropy_threshold": "4.5", "require_context": "true"},
 			Remediation:        "Review this hex string. If it represents a cryptographic key or secret, move it to a secrets manager.",

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -8,12 +8,32 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
 )
+
+// isGeneratedSecretsPath reports whether a path is a lock file, checksum,
+// minified bundle or tool-state file that the secrets analyzer should skip
+// wholesale. It matches each glob in generatedFileIgnorePatterns against both
+// the full (slash-normalised) path and its basename, mirroring the per-rule
+// matching in core/rules/engine.go.
+func isGeneratedSecretsPath(path string) bool {
+	norm := filepath.ToSlash(path)
+	base := filepath.Base(norm)
+	for _, pattern := range generatedFileIgnorePatterns {
+		if matched, _ := filepath.Match(pattern, norm); matched {
+			return true
+		}
+		if matched, _ := filepath.Match(pattern, base); matched {
+			return true
+		}
+	}
+	return false
+}
 
 // Analyzer wraps a rules.Engine pre-loaded with secret detection rules.
 type Analyzer struct {
@@ -97,6 +117,14 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	fs := findings.NewFindingSet()
 
 	for _, artifact := range artifacts {
+		// Skip lock files, checksums, minified bundles and tool state dirs
+		// wholesale: their content-addressed hashes match both the entropy
+		// rules and the provider-key regexes, producing thousands of false
+		// positives. This mirrors gitleaks / trufflehog / detect-secrets.
+		if isGeneratedSecretsPath(artifact.Path) {
+			continue
+		}
+
 		content, err := os.ReadFile(artifact.AbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading artifact %s: %w", artifact.Path, err)

--- a/core/analyzers/secrets/secrets_test.go
+++ b/core/analyzers/secrets/secrets_test.go
@@ -1038,3 +1038,51 @@ func TestSEC574_DescriptionFixed(t *testing.T) {
 	}
 	t.Fatal("SEC-574 not found in builtin rules")
 }
+
+// TestScanArtifacts_SkipsGeneratedFiles is a regression test: a lock file full
+// of base64 integrity hashes must NOT produce secret findings (those hashes
+// match provider-key regexes and the entropy rules, otherwise yielding
+// thousands of false positives), while a real secret in a source file next to
+// it is still detected.
+func TestScanArtifacts_SkipsGeneratedFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// A package-lock.json whose integrity hashes look like high-entropy secrets.
+	lock := `{
+  "name": "x", "lockfileVersion": 3,
+  "packages": {
+    "node_modules/a": {"version": "1.0.0", "integrity": "sha512-AIzaSyB1c3d4e5f6g7h8i9j0kLmNoPqRsTuVwXyZ1234567890abcd"},
+    "node_modules/b": {"version": "2.0.0", "integrity": "sha512-AKIAIOSFODNN7EXAMPLEq1w2e3r4t5y6u7i8o9p0aSdFgHjKlZxCvBnM"}
+  }
+}`
+	lockFile := writeFile(t, dir, "package-lock.json", lock)
+	// A real AWS key in source must still be caught.
+	srcFile := writeFile(t, dir, "config.go", "package main\n\nconst key = \"AKIAIOSFODNN7EXAMPLE\"\n")
+
+	artifacts := []discovery.Artifact{
+		{Path: "package-lock.json", AbsPath: lockFile, Type: discovery.Lockfile, Size: int64(len(lock))},
+		{Path: "config.go", AbsPath: srcFile, Type: discovery.Source, Size: 50},
+	}
+
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(), artifacts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range fs.Findings() {
+		if f.Location.FilePath == "package-lock.json" {
+			t.Errorf("lock file should be skipped, got %s at %s:%d",
+				f.RuleID, f.Location.FilePath, f.Location.StartLine)
+		}
+	}
+	// Control: the source-file secret is still found.
+	found := false
+	for _, f := range fs.Findings() {
+		if f.Location.FilePath == "config.go" && f.RuleID == "SEC-001" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected the AWS key in config.go to still be detected")
+	}
+}


### PR DESCRIPTION
## Problem
The lock-file / checksum / minified / tool-state ignore list (`generatedFileIgnorePatterns`, formerly `entropyIgnoreFilePatterns`) only gated the **entropy** rules (SEC-161/162/163). The ~900 provider-key **regex** rules were not gated, so a `package-lock.json`'s base64 `sha512-…` integrity hashes matched patterns like "Firebase / ELK / IBM Cloud API key".

On a real repo this produced **~2240 false-positive secret findings on a single lockfile** — enough to bury every real finding and force teams to exclude the file entirely (which then also hides genuine dependency-CVE scanning).

## Fix
Apply the generated-file ignore set to the **whole** secrets analyzer in `ScanArtifacts` (covering both pattern matching and the base64/hex decode pass), matching gitleaks / trufflehog / detect-secrets default behaviour: secrets are not scanned in lock files / checksums / minified bundles / tool-state dirs. Operators who genuinely need to scan these can still do so via config.

Renamed `entropyIgnoreFilePatterns` → `generatedFileIgnorePatterns` to reflect its now analyzer-wide role.

## Verification
- `TestScanArtifacts_SkipsGeneratedFiles`: a lockfile full of integrity hashes yields **zero** secret findings, while a real AWS key in an adjacent `.go` file is **still detected**. Fails before this change (SEC-115 on the lockfile), passes after.
- End-to-end on a real repo: `package-lock.json` secret findings **2240 → 0** (total findings 2273 → 30). The remaining lockfile findings are dependency typosquatting (VULN-002), addressed separately.
- Full `core/...` suite + `go vet` + gofmt clean.

First of a small false-positive-reduction series (typosquatting threshold + `--confidence` filter to follow).