### PR TITLE
fix(deps): cut typosquatting false positives (exact-match-first, distance 1, non-blocking severity)

### DIFF
--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -193,8 +193,8 @@ func (a *Analyzer) Rules() *rules.RuleSet {
 		ID:          "VULN-002",
 		Version:     "1.0",
 		Description: "Typosquatting: package name suspiciously similar to popular package",
-		Severity:    findings.SeverityCritical,
-		Confidence:  findings.ConfidenceMedium,
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceLow,
 		Tags:        []string{"dependency", "typosquatting", "supply-chain"},
 		Remediation: "Verify the package name is correct. The name is suspiciously similar to a popular package, which may indicate a typosquatting attack.",
 		References:  []string{"https://snyk.io/blog/typosquatting-attacks/"},
@@ -431,12 +431,18 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				})
 			}
 
-			// VULN-002: typosquatting detection.
-			if popularName, typosquat := DetectTyposquatting(pkg.Name, pkg.Ecosystem, 2); typosquat {
+			// VULN-002: typosquatting detection. A distance-1 (single-character)
+			// match is the high-precision signal; distance 2 collides with too
+			// many legitimate packages that merely resemble a popular name
+			// (regex/redux, parse5/parcel, h3/d3, …). This is a heuristic
+			// SUSPICION — not a confirmed malicious package (that is VULN-003) —
+			// so it is medium severity / low confidence, not a CI-blocking
+			// critical.
+			if popularName, typosquat := DetectTyposquatting(pkg.Name, pkg.Ecosystem, 1); typosquat {
 				fs.Add(findings.Finding{
 					RuleID:     "VULN-002",
-					Severity:   findings.SeverityCritical,
-					Confidence: findings.ConfidenceMedium,
+					Severity:   findings.SeverityMedium,
+					Confidence: findings.ConfidenceLow,
 					Location: findings.Location{
 						FilePath:  lockfilePath,
 						StartLine: 1,

--- a/core/analyzers/deps/malicious.go
+++ b/core/analyzers/deps/malicious.go
@@ -20,6 +20,10 @@ var dataFS embed.FS
 var (
 	popularOnce sync.Once
 	popularPkgs map[string][]string // ecosystem → list of names
+	// popularSet is the same data as a normalized membership set per ecosystem,
+	// so DetectTyposquatting can answer "is this name itself a popular package?"
+	// in O(1) BEFORE doing any distance comparison.
+	popularSet map[string]map[string]struct{}
 )
 
 // maliciousPackages holds lazy-loaded known malicious package names per ecosystem.
@@ -32,6 +36,7 @@ var (
 // once via sync.Once to avoid repeated file I/O.
 func loadPopular() {
 	popularPkgs = make(map[string][]string)
+	popularSet = make(map[string]map[string]struct{})
 
 	files := map[string]string{
 		"npm":  "data/popular_npm.txt",
@@ -44,14 +49,17 @@ func loadPopular() {
 			continue
 		}
 		var names []string
+		set := make(map[string]struct{})
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" || strings.HasPrefix(line, "#") {
 				continue
 			}
 			names = append(names, line)
+			set[normalizeDistName(line)] = struct{}{}
 		}
 		popularPkgs[eco] = names
+		popularSet[eco] = set
 	}
 }
 
@@ -140,7 +148,8 @@ func LevenshteinDistance(a, b string) int {
 // (npm, pypi) are checked; all others return ("", false).
 //
 // The threshold parameter controls the maximum Levenshtein distance that is
-// still considered suspicious. A value of 2 is recommended for general use.
+// still considered suspicious. A value of 2 is recommended for general use; it
+// is automatically tightened to 1 for short names (see below).
 func DetectTyposquatting(name, ecosystem string, threshold int) (string, bool) {
 	popularOnce.Do(loadPopular)
 
@@ -151,18 +160,33 @@ func DetectTyposquatting(name, ecosystem string, threshold int) (string, bool) {
 
 	lowerName := normalizeDistName(name)
 
-	for _, popular := range names {
-		lowerPopular := normalizeDistName(popular)
-
-		// Exact match — not a typosquat, it is the real package. Names are
-		// PEP 503-normalized so canonical variants like "huggingface_hub" vs
-		// "huggingface-hub" compare equal instead of looking like a typosquat.
-		if lowerName == lowerPopular {
+	// Exact match FIRST: if the package IS itself a popular package, it is not a
+	// typosquat — regardless of how close some OTHER popular name happens to be.
+	// Checking this only inside the distance loop (as before) was order-
+	// dependent: "vue" would match "vuex" at distance 1 and be flagged before
+	// the loop ever reached the exact "vue" entry. This false-positived every
+	// popular package with a near neighbour (vue, zod, ms, ajv, …).
+	if set, ok := popularSet[ecosystem]; ok {
+		if _, isPopular := set[lowerName]; isPopular {
 			return "", false
 		}
+	}
 
+	// Short names have many spurious neighbours at distance 2 (e.g. "abc" is
+	// distance 2 from hundreds of three-letter names). Require an exact single-
+	// character typo for short names to keep precision high.
+	effThreshold := threshold
+	if len(lowerName) <= 4 && effThreshold > 1 {
+		effThreshold = 1
+	}
+
+	for _, popular := range names {
+		lowerPopular := normalizeDistName(popular)
+		if lowerName == lowerPopular {
+			continue
+		}
 		dist := LevenshteinDistance(lowerName, lowerPopular)
-		if dist > 0 && dist <= threshold {
+		if dist > 0 && dist <= effThreshold {
 			return popular, true
 		}
 	}

--- a/core/analyzers/deps/malicious_test.go
+++ b/core/analyzers/deps/malicious_test.go
@@ -440,3 +440,20 @@ func TestDetectTyposquatting_PEP503Canonical(t *testing.T) {
 		}
 	}
 }
+
+// TestDetectTyposquatting_PopularNotFlagged is a regression test: popular
+// packages that happen to sit within edit distance of ANOTHER popular package
+// (vue↔vuex, etc.) must not be flagged as typosquats, and short names must not
+// false-positive at distance 2 — while a genuine typo is still caught.
+func TestDetectTyposquatting_PopularNotFlagged(t *testing.T) {
+	// These are themselves popular npm packages; none is a typosquat.
+	for _, name := range []string{"vue", "zod", "ms", "ajv", "react", "lodash", "express"} {
+		if popular, ok := DetectTyposquatting(name, "npm", 2); ok {
+			t.Errorf("%q flagged as typosquat of %q, but it is a popular package itself", name, popular)
+		}
+	}
+	// A genuine one-character typo of a popular package is still detected.
+	if _, ok := DetectTyposquatting("expres", "npm", 2); !ok {
+		t.Error("expected 'expres' to be flagged as a typosquat of 'express'")
+	}
+}


### PR DESCRIPTION
## Problem
VULN-002 (typosquatting) flagged popular packages and unrelated real packages as suspected typosquats — **~23 false positives on a single lockfile**: `vue`, `zod`, `ms`, `ajv`, `regex`, `parse5`, `h3`, `emmet`, … — all real, widely-used packages. At **critical** severity these block CI and bury real findings.

## Fixes
1. **Exact-match-first.** If a package IS itself a popular package, it cannot be a typosquat. The old exact-match check lived *inside* the distance loop, so `vue` matched `vuex` (distance 1) and was flagged *before* the loop reached the exact `vue` entry — order-dependent. Membership is now checked up front via a normalized set. (Removes vue/zod/ms/ajv/… → 23 → 12.)
2. **Default distance 1, not 2.** A single-character typo is the high-precision signal; distance 2 collides with too many legitimate packages that merely resemble a popular name (`regex`/`redux`, `parse5`/`parcel`). Short names also clamp to 1. (12 → 1.)
3. **Medium severity / low confidence, not critical/medium.** This is a heuristic *suspicion*, not a confirmed malicious package (that's VULN-003, correctly critical). A low-confidence heuristic should never be a CI-blocking critical.

## Result
On a real repo: **VULN-002 23 → 1**, and the lone remainder (`h3` vs `d3`, a genuine distance-1 coincidence inherent to edit-distance matching) is now a **non-blocking `warning`**, not a critical error.

`TestDetectTyposquatting_PopularNotFlagged`: popular packages (vue, zod, ms, ajv, react, lodash, express) are not flagged, while a real typo (`expres` → `express`) still is. Full `core/...` suite + `go vet` + gofmt clean.

Part of the false-positive-reduction series (follows #118, the lockfile secret-scan skip).