### PR TITLE
feat(cli): add --min-confidence filter (CLI + GitHub Action)

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -151,6 +151,9 @@ run_scan() {
   if [[ -n "${INPUT_SEVERITY_THRESHOLD:-}" ]]; then
     extra_args+=(--severity-threshold "${INPUT_SEVERITY_THRESHOLD}")
   fi
+  if [[ -n "${INPUT_MIN_CONFIDENCE:-}" ]]; then
+    extra_args+=(--min-confidence "${INPUT_MIN_CONFIDENCE}")
+  fi
   if [[ -n "${INPUT_VEX:-}" ]]; then
     extra_args+=(--vex "${INPUT_VEX}")
   fi

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Filter findings to those at or above this severity (critical, high, medium, low). Empty = no filter.'
     required: false
     default: ''
+  min-confidence:
+    description: 'Filter findings to those at or above this confidence (high, medium, low). Drops lower-confidence heuristic findings. Empty = no filter.'
+    required: false
+    default: ''
   vex:
     description: 'Path to OpenVEX waiver document (skips VEX-not-affected findings)'
     required: false
@@ -90,6 +94,7 @@ runs:
         INPUT_MAX_COMMENTS: ${{ inputs.max-comments }}
         INPUT_MIN_SEVERITY: ${{ inputs.min-severity }}
         INPUT_SEVERITY_THRESHOLD: ${{ inputs.severity-threshold }}
+        INPUT_MIN_CONFIDENCE: ${{ inputs.min-confidence }}
         INPUT_VEX: ${{ inputs.vex }}
         INPUT_CHANGED_SINCE: ${{ inputs.changed-since }}
         INPUT_OFFLINE: ${{ inputs.offline }}

--- a/cli/main.go
+++ b/cli/main.go
@@ -269,6 +269,8 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	)
 	scanFS.BoolVar(&stagedFlag, "staged", false, "scan only git-staged files (index content)")
 	scanFS.StringVar(&thresholdFlag, "severity-threshold", "", "minimum severity to report (critical, high, medium, low)")
+	var minConfidenceFlag string
+	scanFS.StringVar(&minConfidenceFlag, "min-confidence", "", "minimum confidence to report (high, medium, low); drops lower-confidence heuristic findings")
 	scanFS.BoolVar(&noOSVFlag, "no-osv", false, "disable OSV.dev vulnerability lookups (offline mode)")
 	scanFS.StringVar(&vexFlag, "vex", "", "path to OpenVEX document for vulnerability status overrides")
 	scanFS.StringVar(&tfPlanFlag, "tf-plan", "", "path to terraform plan JSON file to scan")
@@ -413,6 +415,20 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		var filtered []findings.Finding
 		for i := range activeFindings {
 			if nox.SeverityMeetsThreshold(activeFindings[i].Severity, threshold) {
+				filtered = append(filtered, activeFindings[i])
+			}
+		}
+		activeFindings = filtered
+	}
+
+	// Apply confidence threshold filtering if specified. Lets operators drop
+	// lower-confidence heuristic findings (e.g. typosquatting suspicions) while
+	// keeping high-confidence ones.
+	if minConfidenceFlag != "" {
+		threshold := findings.Confidence(minConfidenceFlag)
+		var filtered []findings.Finding
+		for i := range activeFindings {
+			if nox.ConfidenceMeetsThreshold(activeFindings[i].Confidence, threshold) {
 				filtered = append(filtered, activeFindings[i])
 			}
 		}

--- a/core/scan.go
+++ b/core/scan.go
@@ -728,6 +728,26 @@ func SeverityMeetsThreshold(severity, threshold findings.Severity) bool {
 	return sr <= tr
 }
 
+// ConfidenceMeetsThreshold returns true if the given confidence is at or above
+// the threshold confidence. Lower rank = more certain (high=0, medium=1, low=2).
+// An unknown/empty threshold accepts everything so callers can pass through.
+func ConfidenceMeetsThreshold(confidence, threshold findings.Confidence) bool {
+	rank := map[findings.Confidence]int{
+		findings.ConfidenceHigh:   0,
+		findings.ConfidenceMedium: 1,
+		findings.ConfidenceLow:    2,
+	}
+	tr, ok := rank[threshold]
+	if !ok {
+		return true
+	}
+	cr, ok := rank[confidence]
+	if !ok {
+		return false
+	}
+	return cr <= tr
+}
+
 // applySuppressions reads files that have findings and marks suppressed findings.
 func applySuppressions(fs *findings.FindingSet, target string) {
 	// Group findings by file.

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2146,3 +2146,24 @@ func TestRunScanContext_CanceledContext(t *testing.T) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
 }
+
+func TestConfidenceMeetsThreshold(t *testing.T) {
+	cases := []struct {
+		conf, thresh findings.Confidence
+		want         bool
+	}{
+		{findings.ConfidenceHigh, findings.ConfidenceHigh, true},
+		{findings.ConfidenceMedium, findings.ConfidenceHigh, false},
+		{findings.ConfidenceLow, findings.ConfidenceHigh, false},
+		{findings.ConfidenceMedium, findings.ConfidenceMedium, true},
+		{findings.ConfidenceLow, findings.ConfidenceMedium, false},
+		{findings.ConfidenceLow, findings.ConfidenceLow, true},
+		{findings.ConfidenceHigh, findings.ConfidenceLow, true},
+		{findings.ConfidenceMedium, "", true}, // empty threshold = pass-through
+	}
+	for _, c := range cases {
+		if got := ConfidenceMeetsThreshold(c.conf, c.thresh); got != c.want {
+			t.Errorf("ConfidenceMeetsThreshold(%q,%q)=%v want %v", c.conf, c.thresh, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Nox tracks a confidence level (high/medium/low) per finding but never exposed it for filtering — operators could only filter by **severity**. Heuristic findings (typosquatting suspicions, entropy guesses) are intentionally low-confidence, so teams want to keep high-confidence findings while dropping the noisy long tail.

## Change
- `--min-confidence high|medium|low` on `nox scan`, mirroring `--severity-threshold`, backed by `ConfidenceMeetsThreshold` in core (high=0, medium=1, low=2; empty = pass-through).
- Exposed as the `min-confidence` input on the GitHub Action (`action.yml` + `action.sh`).

## Verification
- `TestConfidenceMeetsThreshold` covers ordering + pass-through.
- E2e: `--min-confidence high` drops the low-confidence typosquatting + entropy findings while keeping high-confidence secrets.
- `go vet` + gofmt clean.

Pairs with #119 (typosquatting downgraded to low confidence): teams can now run `--min-confidence high` for a near-zero-noise gate. Part of the cluster-1 false-positive/usability series.