### PR TITLE
feat(mcp): paginate list_findings & stop truncating JSON mid-structure

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -35,6 +35,9 @@ import (
 const (
 	// maxOutputBytes is the maximum response size before truncation (1 MB).
 	maxOutputBytes = 1 << 20
+	// maxListLimit caps a single list_findings page so the response stays well
+	// under maxOutputBytes even with rule metadata enriched per finding.
+	maxListLimit = 500
 )
 
 // --- Input structs for typed tool handlers ---
@@ -57,6 +60,7 @@ type listFindingsInput struct {
 	Rule              string  `json:"rule,omitempty"`
 	File              string  `json:"file,omitempty"`
 	Limit             float64 `json:"limit,omitempty"`
+	Offset            float64 `json:"offset,omitempty"`
 	IncludeSuppressed bool    `json:"include_suppressed,omitempty"`
 }
 type baselineStatusInput struct {
@@ -236,7 +240,7 @@ func (s *Server) registerTools(srv *mcp.Server) {
 		Handler(s.handleGetFindingDetail)
 
 	srv.Tool("list_findings").
-		Description("List findings with optional severity, rule, and file filters").
+		Description("List findings with optional severity, rule, and file filters. Paginated: pass limit (default 50, max 500) and offset to page through a large result set. Returns an envelope {total, offset, limit, returned, has_more, findings} so you know how many findings exist and whether more pages remain.").
 		ReadOnly().
 		Handler(s.handleListFindings)
 
@@ -518,7 +522,21 @@ func (s *Server) handleGetFindings(_ context.Context, input getFindingsInput) (s
 		return "Error: report generation failed: " + err.Error(), nil
 	}
 
-	return truncate(string(data)), nil
+	// Never hand back a mid-structure truncation: a clipped SARIF/JSON document
+	// is unparseable and the agent has no signal that data was lost. When the
+	// full report exceeds the budget, return a structured pointer to the
+	// paginated list_findings tool instead.
+	if len(data) > maxOutputBytes {
+		notice, _ := json.MarshalIndent(map[string]any{
+			"error":       "output_too_large",
+			"total_bytes": len(data),
+			"limit_bytes": maxOutputBytes,
+			"hint":        "the full report exceeds the response budget — use list_findings with limit/offset to page through findings, or get a specific finding with get_finding_detail",
+		}, "", "  ")
+		return string(notice), nil
+	}
+
+	return string(data), nil
 }
 
 func (s *Server) handleGetSBOM(_ context.Context, input getSBOMInput) (string, error) {
@@ -607,24 +625,51 @@ func (s *Server) handleListFindings(_ context.Context, input listFindingsInput) 
 	filter.IncludeSuppressed = input.IncludeSuppressed
 
 	filtered := store.Filter(filter)
+	total := len(filtered)
 
-	// Apply limit.
+	// Apply offset + limit so an agent can page through a large result set
+	// deterministically (findings come back in a stable sorted order). Default
+	// page size 50; capped at maxListLimit to keep one response well under the
+	// MCP output budget.
 	limit := 50
 	if input.Limit > 0 {
 		limit = int(input.Limit)
 	}
-	if len(filtered) > limit {
-		filtered = filtered[:limit]
+	if limit > maxListLimit {
+		limit = maxListLimit
 	}
+	offset := 0
+	if input.Offset > 0 {
+		offset = int(input.Offset)
+	}
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	page := filtered[offset:end]
 
 	// Enrich each finding with rule metadata.
 	type findingSummary struct {
 		findings.Finding
 		Rule *catalog.RuleMeta `json:"rule,omitempty"`
 	}
-	var results []findingSummary
-	for i := range filtered {
-		f := &filtered[i]
+	// Envelope carries pagination metadata so the agent knows the total and
+	// whether more pages remain — instead of silently receiving a truncated
+	// slice with no signal.
+	type listResponse struct {
+		Total    int              `json:"total"`
+		Offset   int              `json:"offset"`
+		Limit    int              `json:"limit"`
+		Returned int              `json:"returned"`
+		HasMore  bool             `json:"has_more"`
+		Findings []findingSummary `json:"findings"`
+	}
+	results := make([]findingSummary, 0, len(page))
+	for i := range page {
+		f := &page[i]
 		fs := findingSummary{Finding: *f}
 		if meta, ok := cat[f.RuleID]; ok {
 			fs.Rule = &meta
@@ -632,12 +677,21 @@ func (s *Server) handleListFindings(_ context.Context, input listFindingsInput) 
 		results = append(results, fs)
 	}
 
-	data, err := json.MarshalIndent(results, "", "  ")
+	resp := listResponse{
+		Total:    total,
+		Offset:   offset,
+		Limit:    limit,
+		Returned: len(results),
+		HasMore:  end < total,
+		Findings: results,
+	}
+
+	data, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {
 		return "Error: marshalling findings: " + err.Error(), nil
 	}
 
-	return truncate(string(data)), nil
+	return string(data), nil
 }
 
 // Baseline handlers.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1947,3 +1947,69 @@ func TestProjectResourceDashboard_AfterScan(t *testing.T) {
 		t.Fatalf("expected HTML content")
 	}
 }
+
+func TestHandleListFindings_Pagination(t *testing.T) {
+	dir := t.TempDir()
+	// Several distinct secrets across rules → several findings to page through.
+	// AWS keys are AKIA + 16 chars from [A-Z2-7]; use two valid, distinct ones
+	// plus a private-key header.
+	writeFile(t, dir, "secrets.env",
+		"A=AKIAIOSFODNN7EXAMPLE\nB=AKIAWXYZ234567ABCDEF\n")
+	writeFile(t, dir, "id_rsa",
+		"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\n")
+
+	s := New("0.1.0", nil)
+	if r, err := s.handleScan(context.Background(), scanInput{Path: dir}); err != nil || strings.HasPrefix(r, "Error:") {
+		t.Fatalf("scan failed: %v / %s", err, r)
+	}
+
+	type page struct {
+		Total, Offset, Limit, Returned int
+		HasMore                        bool                     `json:"has_more"`
+		Findings                       []map[string]interface{} `json:"findings"`
+	}
+	get := func(limit, offset int) page {
+		out, err := s.handleListFindings(context.Background(),
+			listFindingsInput{Limit: float64(limit), Offset: float64(offset)})
+		if err != nil || strings.HasPrefix(out, "Error:") {
+			t.Fatalf("list failed: %v / %s", err, out)
+		}
+		var p page
+		if err := json.Unmarshal([]byte(out), &p); err != nil {
+			t.Fatalf("envelope not valid JSON: %v\n%s", err, out)
+		}
+		return p
+	}
+
+	first := get(2, 0)
+	if first.Total < 3 {
+		t.Fatalf("expected >=3 findings to paginate, total=%d", first.Total)
+	}
+	if first.Returned != 2 || first.Limit != 2 || first.Offset != 0 || !first.HasMore {
+		t.Fatalf("unexpected first page: %+v", first)
+	}
+
+	second := get(2, 2)
+	if second.Total != first.Total {
+		t.Errorf("total changed across pages: %d vs %d", first.Total, second.Total)
+	}
+	if second.Offset != 2 {
+		t.Errorf("expected offset 2, got %d", second.Offset)
+	}
+	// Pages must not overlap (stable order).
+	firstIDs := map[string]bool{}
+	for _, f := range first.Findings {
+		firstIDs[f["ID"].(string)] = true
+	}
+	for _, f := range second.Findings {
+		if firstIDs[f["ID"].(string)] {
+			t.Errorf("finding %v appears on both pages", f["ID"])
+		}
+	}
+
+	// Offset past the end yields an empty page, not an error.
+	beyond := get(10, 1000)
+	if beyond.Returned != 0 || beyond.HasMore {
+		t.Errorf("expected empty final page, got %+v", beyond)
+	}
+}


### PR DESCRIPTION
Two agent-hostile behaviours in the MCP server, both hit in practice (a `get_findings` call returned ~1M chars / 38k lines, clipped):

1. **`list_findings` hard-capped at 50 with no `offset`.** An agent could not enumerate findings beyond the first page, and got a bare truncated array with no signal more existed.
2. **`get_findings` / `list_findings` truncated output mid-structure.** `truncate()` clips at 1 MB and appends a text notice → **unparseable** JSON/SARIF, with no machine-readable indication that data was lost.

## Changes
- `list_findings` takes **`offset`** and returns an envelope `{total, offset, limit, returned, has_more, findings}` — deterministic paging over a stable sorted order, with the total known up front. Limit defaults to 50, capped at `maxListLimit` (500) to keep a page under budget. Tool description updated to advertise this.
- `get_findings`, when the full report exceeds the 1 MB budget, returns a structured `{error:"output_too_large", total_bytes, limit_bytes, hint}` pointing at the paginated tools — never a corrupted document.

## Verification
- `TestHandleListFindings_Pagination`: total/has_more/offset correctness, non-overlapping pages, empty page past the end.
- Existing server suite + `go vet` + gofmt clean.

First of the cluster-2 (agent/MCP ergonomics) series — a `summary` tool and `get_finding_by_fingerprint` lookup to follow.