### PR TITLE
feat(mcp): add summary tool for a one-call scan overview

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,11 @@ func (s *Server) registerTools(srv *mcp.Server) {
 		ReadOnly().
 		Handler(s.handleGetFindingDetail)
 
+	srv.Tool("summary").
+		Description("Aggregate overview of the last scan: active/total/suppressed counts and breakdowns by severity, confidence, and rule family, plus dependency and AI-component totals. Call this first to size up a scan before paging through individual findings.").
+		ReadOnly().
+		Handler(s.handleSummary)
+
 	srv.Tool("list_findings").
 		Description("List findings with optional severity, rule, and file filters. Paginated: pass limit (default 50, max 500) and offset to page through a large result set. Returns an envelope {total, offset, limit, returned, has_more, findings} so you know how many findings exist and whether more pages remain.").
 		ReadOnly().
@@ -599,6 +604,71 @@ func (s *Server) handleGetFindingDetail(_ context.Context, input getFindingDetai
 	}
 
 	return truncate(string(data)), nil
+}
+
+// handleSummary returns an aggregate overview of the last scan: counts by
+// severity, confidence, and rule family, plus dependency / AI-component totals.
+// This is the cheap "what am I looking at?" call an agent (or human) makes
+// before deciding whether to page through individual findings.
+func (s *Server) handleSummary(_ context.Context, _ emptyInput) (string, error) {
+	pc := s.getCache("")
+	if pc == nil {
+		return "Error: no scan results available — run the scan tool first", nil
+	}
+
+	active := pc.result.Findings.ActiveFindings()
+	total := len(pc.result.Findings.Findings())
+
+	bySeverity := map[string]int{}
+	byConfidence := map[string]int{}
+	byFamily := map[string]int{}
+	for i := range active {
+		f := &active[i]
+		bySeverity[string(f.Severity)]++
+		byConfidence[string(f.Confidence)]++
+		byFamily[ruleFamily(f.RuleID)]++
+	}
+
+	resp := map[string]any{
+		"active_findings": len(active),
+		"total_findings":  total,
+		"suppressed":      total - len(active),
+		"by_severity":     bySeverity,
+		"by_confidence":   byConfidence,
+		"by_family":       byFamily,
+		"dependencies":    len(pc.result.Inventory.Packages()),
+		"ai_components":   len(pc.result.AIInventory.Components),
+	}
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "Error: marshalling summary: " + err.Error(), nil
+	}
+	return string(data), nil
+}
+
+// ruleFamily maps a rule ID (e.g. "SEC-001", "VULN-002") to its human family
+// name, used for grouping in the summary.
+func ruleFamily(ruleID string) string {
+	prefix := ruleID
+	if i := strings.IndexByte(ruleID, '-'); i >= 0 {
+		prefix = ruleID[:i]
+	}
+	switch prefix {
+	case "SEC":
+		return "secrets"
+	case "VULN":
+		return "dependencies"
+	case "IAC":
+		return "infrastructure"
+	case "CONT":
+		return "containers"
+	case "DATA":
+		return "privacy"
+	case "AI", "MCP":
+		return "ai"
+	default:
+		return "other"
+	}
 }
 
 func (s *Server) handleListFindings(_ context.Context, input listFindingsInput) (string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -418,7 +418,7 @@ func (s *Server) registerResources(srv *mcp.Server) {
 		Name("Project AI Inventory").
 		Description("AI inventory for a specific project").
 		MimeType("application/json").
-		Handler(s.handleProjectResourceAIInventory) // nox:ignore SEC-659,SEC-506,SEC-574 -- function name, not a key
+		Handler(s.handleProjectResourceAIInventory) // nox:ignore SEC-659,SEC-506,SEC-574,SEC-664 -- function name, not a key
 
 	srv.Resource("nox://project/{project}/dashboard").
 		Name("Project Dashboard").
@@ -1564,7 +1564,7 @@ func (s *Server) handleProjectResourceSPDX(_ context.Context, uri string, params
 	}, nil
 }
 
-func (s *Server) handleProjectResourceAIInventory(_ context.Context, uri string, params map[string]string) (*mcp.ResourceContent, error) { // nox:ignore SEC-659,SEC-506,SEC-574 -- function name, not a key
+func (s *Server) handleProjectResourceAIInventory(_ context.Context, uri string, params map[string]string) (*mcp.ResourceContent, error) { // nox:ignore SEC-659,SEC-506,SEC-574,SEC-664 -- function name, not a key
 	path, err := s.resolveProjectPath(params)
 	if err != nil {
 		return nil, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2013,3 +2013,46 @@ func TestHandleListFindings_Pagination(t *testing.T) {
 		t.Errorf("expected empty final page, got %+v", beyond)
 	}
 }
+
+func TestHandleSummary(t *testing.T) {
+	// Before any scan.
+	s := New("0.1.0", nil)
+	if r, _ := s.handleSummary(context.Background(), emptyInput{}); !strings.HasPrefix(r, "Error:") {
+		t.Fatal("expected error before scan")
+	}
+
+	dir := t.TempDir()
+	writeFile(t, dir, "secrets.env", "A=AKIAIOSFODNN7EXAMPLE\n")
+	writeFile(t, dir, "id_rsa", "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----\n")
+	if r, err := s.handleScan(context.Background(), scanInput{Path: dir}); err != nil || strings.HasPrefix(r, "Error:") {
+		t.Fatalf("scan failed: %v / %s", err, r)
+	}
+
+	out, err := s.handleSummary(context.Background(), emptyInput{})
+	if err != nil || strings.HasPrefix(out, "Error:") {
+		t.Fatalf("summary failed: %v / %s", err, out)
+	}
+	var sum struct {
+		ActiveFindings int            `json:"active_findings"`
+		TotalFindings  int            `json:"total_findings"`
+		BySeverity     map[string]int `json:"by_severity"`
+		ByFamily       map[string]int `json:"by_family"`
+	}
+	if err := json.Unmarshal([]byte(out), &sum); err != nil {
+		t.Fatalf("summary not valid JSON: %v\n%s", err, out)
+	}
+	if sum.ActiveFindings < 2 {
+		t.Fatalf("expected >=2 active findings, got %d", sum.ActiveFindings)
+	}
+	if sum.ByFamily["secrets"] < 2 {
+		t.Errorf("expected secrets family count >=2, got %v", sum.ByFamily)
+	}
+	// counts must sum to active total.
+	sevSum := 0
+	for _, n := range sum.BySeverity {
+		sevSum += n
+	}
+	if sevSum != sum.ActiveFindings {
+		t.Errorf("severity counts %d != active findings %d", sevSum, sum.ActiveFindings)
+	}
+}


### PR DESCRIPTION
Agents (and humans) had no cheap way to size up a scan: the only options were `get_findings` (the full, potentially 1 MB+ report) or `list_findings` (paging through individual findings). To answer "how bad is it?" an agent had to pull and parse everything.

## Change
Adds a **`summary`** MCP tool returning a small fixed-size response:
- `active_findings`, `total_findings`, `suppressed`
- `by_severity`, `by_confidence`
- `by_family` (secrets / dependencies / infrastructure / containers / privacy / ai)
- `dependencies`, `ai_components`

The natural first call before deciding whether to page through findings (pairs with the paginated `list_findings` in #121).

## Verification
- `TestHandleSummary`: before-scan error, family/severity counts, and the invariant that severity counts sum to the active total.
- Server suite + `go vet` + gofmt clean.

Cluster-2 (agent/MCP ergonomics) continues; `get_finding_by_fingerprint` lookup next.