### PR TITLE
feat(mcp): add get_finding_by_fingerprint lookup

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -63,6 +63,9 @@ type listFindingsInput struct {
 	Offset            float64 `json:"offset,omitempty"`
 	IncludeSuppressed bool    `json:"include_suppressed,omitempty"`
 }
+type findingByFingerprintInput struct {
+	Fingerprint string `json:"fingerprint"`
+}
 type baselineStatusInput struct {
 	Path string `json:"path"`
 }
@@ -248,6 +251,11 @@ func (s *Server) registerTools(srv *mcp.Server) {
 		Description("List findings with optional severity, rule, and file filters. Paginated: pass limit (default 50, max 500) and offset to page through a large result set. Returns an envelope {total, offset, limit, returned, has_more, findings} so you know how many findings exist and whether more pages remain.").
 		ReadOnly().
 		Handler(s.handleListFindings)
+
+	srv.Tool("get_finding_by_fingerprint").
+		Description("Look up a single finding by fingerprint (full or 12-char prefix) and report its current status (new / baselined / suppressed / vex_*). Use this when you already hold a fingerprint (from a prior scan or baseline entry) and just need to know whether it is still active. Returns {found:false, fingerprint} if no match.").
+		ReadOnly().
+		Handler(s.handleFindingByFingerprint)
 
 	srv.Tool("baseline_status").
 		Description("Show baseline statistics: total entries, expired count, per-severity breakdown").
@@ -669,6 +677,59 @@ func ruleFamily(ruleID string) string {
 	default:
 		return "other"
 	}
+}
+
+// handleFindingByFingerprint looks up a single finding by its fingerprint and
+// reports its current status (new / baselined / suppressed / vex_*). This is
+// the O(1)-style call an agent makes when it already holds a fingerprint (from
+// a prior scan or a baseline entry) and wants to know whether that finding is
+// still active — without pulling and searching the full findings list. Accepts
+// a full fingerprint or a unique prefix (the 12-char form used in finding IDs).
+func (s *Server) handleFindingByFingerprint(_ context.Context, input findingByFingerprintInput) (string, error) {
+	if strings.TrimSpace(input.Fingerprint) == "" {
+		return "Error: missing required argument: fingerprint", nil
+	}
+	pc := s.getCache("")
+	if pc == nil {
+		return "Error: no scan results available — run the scan tool first", nil
+	}
+
+	fp := strings.TrimSpace(input.Fingerprint)
+	all := pc.result.Findings.Findings()
+	for i := range all {
+		f := &all[i]
+		if f.Fingerprint == fp || strings.HasPrefix(f.Fingerprint, fp) {
+			resp := map[string]any{
+				"found":       true,
+				"id":          f.ID,
+				"fingerprint": f.Fingerprint,
+				"rule_id":     f.RuleID,
+				"severity":    f.Severity,
+				"confidence":  f.Confidence,
+				"status":      statusOrNew(f.Status),
+				"message":     f.Message,
+				"location":    f.Location,
+			}
+			data, err := json.MarshalIndent(resp, "", "  ")
+			if err != nil {
+				return "Error: marshalling finding: " + err.Error(), nil
+			}
+			return string(data), nil
+		}
+	}
+	data, _ := json.MarshalIndent(map[string]any{
+		"found":       false,
+		"fingerprint": fp,
+	}, "", "  ")
+	return string(data), nil
+}
+
+// statusOrNew reports a finding's status, defaulting an empty status to "new".
+func statusOrNew(st findings.Status) findings.Status {
+	if st == "" {
+		return findings.StatusNew
+	}
+	return st
 }
 
 func (s *Server) handleListFindings(_ context.Context, input listFindingsInput) (string, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2056,3 +2056,60 @@ func TestHandleSummary(t *testing.T) {
 		t.Errorf("severity counts %d != active findings %d", sevSum, sum.ActiveFindings)
 	}
 }
+
+func TestHandleFindingByFingerprint(t *testing.T) {
+	s := New("0.1.0", nil)
+	// Missing arg.
+	if r, _ := s.handleFindingByFingerprint(context.Background(), findingByFingerprintInput{}); !strings.HasPrefix(r, "Error:") {
+		t.Fatal("expected error for empty fingerprint")
+	}
+
+	dir := t.TempDir()
+	writeFile(t, dir, "config.env", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n")
+	if r, err := s.handleScan(context.Background(), scanInput{Path: dir}); err != nil || strings.HasPrefix(r, "Error:") {
+		t.Fatalf("scan failed: %v / %s", err, r)
+	}
+
+	// Pull one finding's fingerprint via list_findings.
+	listOut, _ := s.handleListFindings(context.Background(), listFindingsInput{})
+	var env struct {
+		Findings []struct {
+			Fingerprint string `json:"Fingerprint"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &env); err != nil || len(env.Findings) == 0 {
+		t.Fatalf("could not get a fingerprint: %v\n%s", err, listOut)
+	}
+	fp := env.Findings[0].Fingerprint
+
+	// Full fingerprint → found.
+	out, err := s.handleFindingByFingerprint(context.Background(), findingByFingerprintInput{Fingerprint: fp})
+	if err != nil {
+		t.Fatalf("lookup error: %v", err)
+	}
+	var found struct {
+		Found  bool   `json:"found"`
+		Status string `json:"status"`
+		RuleID string `json:"rule_id"`
+	}
+	if err := json.Unmarshal([]byte(out), &found); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !found.Found || found.Status != "new" {
+		t.Errorf("expected found+new, got %+v", found)
+	}
+
+	// 12-char prefix → also found.
+	if len(fp) >= 12 {
+		out2, _ := s.handleFindingByFingerprint(context.Background(), findingByFingerprintInput{Fingerprint: fp[:12]})
+		if !strings.Contains(out2, `"found": true`) {
+			t.Errorf("prefix lookup should find the finding: %s", out2)
+		}
+	}
+
+	// Unknown fingerprint → found:false.
+	out3, _ := s.handleFindingByFingerprint(context.Background(), findingByFingerprintInput{Fingerprint: "deadbeefdeadbeef"})
+	if !strings.Contains(out3, `"found": false`) {
+		t.Errorf("expected found:false for unknown fp: %s", out3)
+	}
+}


### PR DESCRIPTION
An agent that already holds a fingerprint (from a prior scan or a baseline entry) had no direct way to ask "is this finding still active?" — it had to pull the full findings list and search.

## Change
Adds **`get_finding_by_fingerprint`**, matching a full fingerprint or a 12-char prefix (the form used in finding IDs). Returns `{found, id, fingerprint, rule_id, severity, confidence, status, message, location}`, or `{found:false, fingerprint}` when there's no match. The `status` field disambiguates `new / baselined / suppressed / vex_*` so the agent can tell active findings from waived ones.

## Verification
- `TestHandleFindingByFingerprint`: full + prefix match, not-found, empty-argument error.
- Server suite + `go vet` + gofmt + the repo's own Nox PR gate clean.

Completes the cluster-2 (agent/MCP ergonomics) set: pagination (#121), summary (#122), and now fingerprint lookup.