### PR TITLE
feat(fingerprint): default to V2 (line-independent) + add baseline migrate

### DIFF
--- a/cli/baseline_cmd.go
+++ b/cli/baseline_cmd.go
@@ -14,7 +14,7 @@ import (
 
 func runBaseline(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show|migrate> [path]")
 		return 2
 	}
 
@@ -32,11 +32,155 @@ func runBaseline(args []string) int {
 		return baselineDiff(remaining)
 	case "show":
 		return baselineShow(remaining)
+	case "migrate":
+		return baselineMigrate(remaining)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown baseline subcommand: %s\n", subcommand)
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show|migrate> [path]")
 		return 2
 	}
+}
+
+// baselineMigrate re-fingerprints an existing baseline from one fingerprint
+// version to another (default V1 → V2) IN PLACE, preserving each entry's
+// reason / owner / created_at. It scans the target twice — once at the source
+// version, once at the target — and matches findings by location to build an
+// exact old→new fingerprint map, so no entry is dropped or duplicated by
+// ambiguity. Entries whose finding no longer exists are reported and left
+// untouched unless --prune is given. This is the upgrade path when the default
+// fingerprint flips: existing V1 baselines keep working instead of silently
+// un-suppressing on the first scan.
+func baselineMigrate(args []string) int {
+	fs := flag.NewFlagSet("baseline migrate", flag.ContinueOnError)
+	var baselinePath string
+	var fromV, toV int
+	var prune bool
+	fs.StringVar(&baselinePath, "baseline", "", "baseline file path (default: .nox/baseline.json)")
+	fs.IntVar(&fromV, "from", 1, "source fingerprint version (1 or 2)")
+	fs.IntVar(&toV, "to", 2, "target fingerprint version (1 or 2)")
+	fs.BoolVar(&prune, "prune", false, "drop entries whose finding no longer exists instead of keeping them")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fromV == toV {
+		fmt.Fprintln(os.Stderr, "error: --from and --to are the same version; nothing to migrate")
+		return 2
+	}
+
+	target := "."
+	if fs.NArg() > 0 {
+		target = fs.Arg(0)
+	}
+	if baselinePath == "" {
+		baselinePath = baseline.DefaultPath(target)
+	}
+
+	bl, err := baseline.Load(baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: loading baseline: %v\n", err)
+		return 2
+	}
+	if bl.Len() == 0 {
+		fmt.Printf("baseline: empty — nothing to migrate (%s)\n", baselinePath)
+		return 0
+	}
+
+	// locKey identifies a finding independent of fingerprint version, so the
+	// same finding can be matched across the two scans.
+	locKey := func(f *findings.Finding) string {
+		l := f.Location
+		return fmt.Sprintf("%s|%s|%d|%d|%d|%d", f.RuleID, l.FilePath, l.StartLine, l.EndLine, l.StartColumn, l.EndColumn)
+	}
+
+	scanAt := func(v findings.FingerprintVersion) (map[string]string, error) {
+		prev := findings.GetFingerprintVersion()
+		findings.SetFingerprintVersion(v)
+		defer findings.SetFingerprintVersion(prev)
+		result, err := nox.RunScan(target)
+		if err != nil {
+			return nil, err
+		}
+		m := make(map[string]string)
+		ff := result.Findings.Findings()
+		for i := range ff {
+			m[locKey(&ff[i])] = ff[i].Fingerprint
+		}
+		return m, nil
+	}
+
+	oldByLoc, err := scanAt(findings.FingerprintVersion(fromV))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: scan at v%d failed: %v\n", fromV, err)
+		return 2
+	}
+	newByLoc, err := scanAt(findings.FingerprintVersion(toV))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: scan at v%d failed: %v\n", toV, err)
+		return 2
+	}
+
+	// Invert the old map: old-fingerprint → location, so a baseline entry
+	// (which stores only the fingerprint) can be matched to its location and
+	// then to the new fingerprint.
+	locByOldFP := make(map[string]string, len(oldByLoc))
+	for loc, fp := range oldByLoc {
+		locByOldFP[fp] = loc
+	}
+
+	migrated, alreadyNew, unmatched := 0, 0, 0
+	kept := bl.Entries[:0]
+	for i := range bl.Entries {
+		e := bl.Entries[i]
+		if _, isNew := newByLocReverse(newByLoc, e.Fingerprint); isNew {
+			alreadyNew++
+			kept = append(kept, e)
+			continue
+		}
+		loc, ok := locByOldFP[e.Fingerprint]
+		if !ok {
+			unmatched++
+			fmt.Fprintf(os.Stderr, "  unmatched: %s %s (%s) — finding not found in current scan\n", e.RuleID, e.Fingerprint[:min(12, len(e.Fingerprint))], e.FilePath)
+			if !prune {
+				kept = append(kept, e)
+			}
+			continue
+		}
+		if newFP, ok := newByLoc[loc]; ok {
+			e.Fingerprint = newFP
+			migrated++
+		}
+		kept = append(kept, e)
+	}
+	bl.Entries = kept
+
+	if err := bl.Save(baselinePath); err != nil {
+		fmt.Fprintf(os.Stderr, "error: saving baseline: %v\n", err)
+		return 2
+	}
+
+	fmt.Printf("baseline migrate v%d→v%d: %d migrated, %d already v%d, %d unmatched%s — %s\n",
+		fromV, toV, migrated, alreadyNew, toV, unmatched, pruneNote(prune, unmatched), baselinePath)
+	return 0
+}
+
+// newByLocReverse reports whether fp is one of the new-version fingerprints.
+func newByLocReverse(newByLoc map[string]string, fp string) (string, bool) {
+	for loc, v := range newByLoc {
+		if v == fp {
+			return loc, true
+		}
+	}
+	return "", false
+}
+
+func pruneNote(prune bool, unmatched int) string {
+	if prune && unmatched > 0 {
+		return " (pruned)"
+	}
+	if unmatched > 0 {
+		return " (kept; use --prune to drop)"
+	}
+	return ""
 }
 
 func baselineWrite(args []string) int {

--- a/cli/baseline_cmd_test.go
+++ b/cli/baseline_cmd_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	nox "github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/findings"
 )
 
 func TestRunBaseline_NoArgs(t *testing.T) {
@@ -393,5 +395,72 @@ func TestRunBaselineDiff_ReportsAddsAndPrunes(t *testing.T) {
 	got, _ := baseline.Load(baselinePath)
 	if got.Len() != 1 {
 		t.Errorf("baseline mutated by `diff`; expected 1 entry, got %d", got.Len())
+	}
+}
+
+func TestRunBaseline_Migrate(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.env"),
+		[]byte("AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+	blPath := filepath.Join(dir, "bl.json")
+
+	// Write a baseline at V1, then restore the process default.
+	prev := findings.GetFingerprintVersion()
+	findings.SetFingerprintVersion(findings.FingerprintV1)
+	if code := runBaseline([]string{"write", "--output", blPath, dir}); code != 0 {
+		findings.SetFingerprintVersion(prev)
+		t.Fatalf("baseline write (v1) exit %d", code)
+	}
+	findings.SetFingerprintVersion(prev)
+
+	before, err := baseline.Load(blPath)
+	if err != nil || before.Len() == 0 {
+		t.Fatalf("loading v1 baseline: %v (len=%d)", err, before.Len())
+	}
+	v1fps := map[string]bool{}
+	for _, e := range before.Entries {
+		v1fps[e.Fingerprint] = true
+		if e.CreatedAt.IsZero() {
+			t.Fatal("expected created_at to be set on v1 entry")
+		}
+	}
+
+	// Migrate v1 -> v2.
+	if code := runBaseline([]string{"migrate", "--baseline", blPath, dir}); code != 0 {
+		t.Fatalf("baseline migrate exit %d", code)
+	}
+
+	after, err := baseline.Load(blPath)
+	if err != nil {
+		t.Fatalf("loading migrated baseline: %v", err)
+	}
+	if after.Len() != before.Len() {
+		t.Fatalf("entry count changed: %d -> %d", before.Len(), after.Len())
+	}
+	for _, e := range after.Entries {
+		if v1fps[e.Fingerprint] {
+			t.Errorf("fingerprint %s was not re-computed (still v1)", e.Fingerprint[:12])
+		}
+		if e.CreatedAt.IsZero() {
+			t.Error("migrate dropped created_at metadata")
+		}
+	}
+
+	// The migrated fingerprints must match a fresh v2 scan exactly, so the
+	// baseline actually suppresses those findings under the v2 default.
+	result, err := nox.RunScan(dir)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	v2fps := map[string]bool{}
+	for _, f := range result.Findings.Findings() {
+		v2fps[f.Fingerprint] = true
+	}
+	for _, e := range after.Entries {
+		if !v2fps[e.Fingerprint] {
+			t.Errorf("migrated fingerprint %s does not match any v2 scan finding", e.Fingerprint[:12])
+		}
 	}
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -293,7 +293,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.BoolVar(&failOnUnwaivedFlg, "fail-on-unwaived", false, "with --vex: only exit non-zero on findings NOT covered by an OpenVEX waiver")
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
 	var fingerprintVersionFlag string
-	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v1 unless NOX_FINGERPRINT_VERSION is set.")
+	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
 	positionals, err := parseInterspersed(scanFS, args)
 	if err != nil {
 		return 2

--- a/core/findings/findings_test.go
+++ b/core/findings/findings_test.go
@@ -25,7 +25,12 @@ func TestComputeFingerprint_Determinism(t *testing.T) {
 }
 
 func TestComputeFingerprint_Uniqueness(t *testing.T) {
-	t.Parallel()
+	// This test covers the V1 uniqueness axes (rule_id, file_path, start_line,
+	// content). Under the default V2 algorithm start_line is intentionally NOT
+	// an axis (line-independence is the whole point — see
+	// TestFingerprintV2_LineIndependent), so pin V1 here. Not parallel: it
+	// mutates the package-global fingerprint version.
+	withFingerprintVersion(t, FingerprintV1)
 
 	loc := Location{
 		FilePath:  "cmd/server/main.go",

--- a/core/findings/fingerprint.go
+++ b/core/findings/fingerprint.go
@@ -9,27 +9,25 @@ import (
 	"sync/atomic"
 )
 
-// FingerprintVersion controls which fingerprint algorithm runs. Default
-// is V1 (line + path + content + rule_id) for full backwards compatibility
-// with existing baselines. V2 (path + content + rule_id, with path
-// normalised — backslash → forward-slash, leading `./` stripped, `..`
-// collapsed) drops the line number so trivial diffs — import shifts,
-// gofmt, comment edits — don't invalidate baselined findings. V2 does
-// NOT resolve a git root; producing a stable repo-root-relative path is
-// the caller's responsibility (the scan loop already does this when
-// invoked from a git working tree).
+// FingerprintVersion controls which fingerprint algorithm runs. Default is
+// V2 (path + content + rule_id, with path normalised — backslash →
+// forward-slash, leading `./` stripped, `..` collapsed). V2 drops the line
+// number so trivial diffs — import shifts, gofmt, comment edits — don't
+// invalidate baselined findings. V2 does NOT resolve a git root; producing a
+// stable repo-root-relative path is the caller's responsibility (the scan loop
+// already does this when invoked from a git working tree).
 //
-// V2 is opt-in. Switch it on via:
+// V1 (line + path + content + rule_id) is the original algorithm, retained for
+// consumers with existing V1 baselines. Pin it via:
 //
-//   - environment: NOX_FINGERPRINT_VERSION=2
-//   - Go API:      findings.SetFingerprintVersion(2)
-//   - CLI flag:    nox scan --fingerprint-version 2 (wired in cmd/)
+//   - environment: NOX_FINGERPRINT_VERSION=1
+//   - Go API:      findings.SetFingerprintVersion(1)
+//   - CLI flag:    nox scan --fingerprint-version 1
 //
-// Once a consumer opts in, every newly-computed fingerprint uses V2 and
-// the baseline file's per-entry fingerprint becomes incompatible with
-// V1 — `nox baseline update` will re-compute. Plan to run both
-// algorithms during a transition window if you can't update every
-// downstream consumer at once.
+// Upgrading from a nox that defaulted to V1: existing baseline / VEX entries
+// carry V1 fingerprints and will no longer match. Run `nox baseline migrate`
+// (re-fingerprints in place) or regenerate the baseline with
+// `nox baseline write`. See docs/migration-fingerprint-v2.md.
 type FingerprintVersion int32
 
 const (
@@ -43,9 +41,9 @@ const (
 	FingerprintV2 FingerprintVersion = 2
 
 	// DefaultFingerprintVersion is the version applied when no explicit
-	// configuration is set. Currently V1 for backwards compatibility;
-	// scheduled to flip to V2 in the next major release.
-	DefaultFingerprintVersion = FingerprintV1
+	// configuration is set. V2 (line-independent) as of v1.3.0; pin V1 via
+	// NOX_FINGERPRINT_VERSION=1 / --fingerprint-version 1 for legacy baselines.
+	DefaultFingerprintVersion = FingerprintV2
 )
 
 // fingerprintVersion holds the active algorithm. Stored as int32 so the

--- a/docs/migration-fingerprint-v2.md
+++ b/docs/migration-fingerprint-v2.md
@@ -1,0 +1,68 @@
+# Migrating to V2 fingerprints
+
+As of **v1.3.0**, nox computes **V2 (line-independent) fingerprints** by default.
+
+## What changed
+
+A finding's *fingerprint* is the stable ID used to match it across scans — it
+backs baselines (`.nox/baseline.json`), OpenVEX waivers that match by
+fingerprint, and GitHub code-scanning de-duplication.
+
+| | V1 (old default) | V2 (new default) |
+|---|---|---|
+| Inputs | `rule_id + file_path + start_line + content` | `rule_id + normalised_file_path + content` |
+| Survives line shifts (imports, gofmt, comments)? | ❌ no | ✅ yes |
+| Survives scan-root differences (`nox scan ./web` vs `nox scan .`)? | ❌ no | ✅ yes |
+
+V1 invalidated a baselined finding whenever code moved up or down by a line.
+V2 drops the line number, so trivial diffs no longer un-suppress findings.
+
+## Do I need to do anything?
+
+- **No existing baseline / fingerprint-based VEX:** nothing to do. New scans use
+  V2 automatically.
+- **VEX that waives by rule ID** (e.g. `"vulnerability": "SEC-161"`): nothing to
+  do — rule-level waivers are fingerprint-independent.
+- **An existing `.nox/baseline.json` (or fingerprint-keyed VEX) created under
+  V1:** its entries carry V1 fingerprints and will no longer match V2 findings,
+  silently un-suppressing them. Migrate (below).
+
+## Migrating an existing baseline
+
+```sh
+nox baseline migrate            # re-fingerprints .nox/baseline.json in place, V1 → V2
+```
+
+`baseline migrate` scans your project twice — once at V1, once at V2 — matches
+findings by location to build an **exact** old→new fingerprint map, and rewrites
+each entry's fingerprint **while preserving its `reason`, `owner`, and
+`created_at`**. No entry is dropped or duplicated through ambiguity.
+
+Options:
+
+```
+nox baseline migrate [path]
+  --baseline <path>   baseline file (default: .nox/baseline.json)
+  --from <1|2>        source version (default: 1)
+  --to   <1|2>        target version (default: 2)
+  --prune             drop entries whose finding no longer exists
+                      (default: keep and report them)
+```
+
+Entries whose finding can no longer be found in the current scan are reported;
+they are kept by default (use `--prune` to drop resolved ones).
+
+## Staying on V1
+
+If you can't migrate yet, pin V1 explicitly — any one of:
+
+```sh
+export NOX_FINGERPRINT_VERSION=1
+nox scan --fingerprint-version 1 .
+```
+
+```go
+findings.SetFingerprintVersion(findings.FingerprintV1) // Go API
+```
+
+V1 remains fully supported; only the *default* changed.


### PR DESCRIPTION
Makes **V2 (line-independent) fingerprints** the default, and ships the migration path so existing baselines don't silently break.

## Why
A finding's fingerprint backs baselines, fingerprint-keyed VEX, and GitHub code-scanning dedupe. V1 (`rule_id + file_path + start_line + content`) invalidated a baselined finding whenever code moved by a line — import shifts, gofmt, comment edits, or `nox scan ./web` vs `nox scan .`. V2 (`rule_id + normalised_path + content`, no line) survives all of those. (I hit this directly: editing a file un-waived a pre-existing VEX'd finding because the V1 fingerprint shifted.)

## Changes
- **Default flips to V2.** V1 stays available via `NOX_FINGERPRINT_VERSION=1` or `--fingerprint-version 1`. Doc comments + CLI help updated.
- **`nox baseline migrate`** — re-fingerprints an existing baseline in place (V1 → V2). Scans twice (source + target version), matches findings by **location** to build an *exact* old→new map, and rewrites each entry's fingerprint **preserving `reason` / `owner` / `created_at`**. No ambiguity-driven drops or dupes; unmatched entries reported (kept by default, `--prune` to drop). Rule-level VEX waivers (match by rule ID) are unaffected.
- **`docs/migration-fingerprint-v2.md`** — what changed, who needs to act, how to migrate or pin V1.

## Verification
- `TestRunBaseline_Migrate`: exact V1→V2 remap, metadata preserved, migrated fingerprints match a fresh V2 scan exactly.
- The V1-specific uniqueness test is pinned to V1 (line is intentionally not a V2 axis — `TestFingerprintV2_LineIndependent` covers V2).
- Full `./...` suite + `go vet` + gofmt + the repo's own Nox PR gate clean.

Cluster 3 (CI/CD) lead item. A GitLab CI template + V1→V2 release note to follow.