### PR TITLE
docs(ci): add GitLab CI example + fix SARIF-as-SAST guidance

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1058,16 +1058,36 @@ jobs:
 
 ```yaml
 nox-scan:
-  image: golang:1.25
+  stage: security
+  image:
+    name: ghcr.io/nox-hq/nox:v1.2.0  # pin a release tag, not :latest
+    entrypoint: [""]
+  variables:
+    GIT_DEPTH: "0"  # full history so --changed-since can diff the target branch
   script:
-    - go install github.com/nox-hq/nox/cli@latest
-    - nox scan . --format sarif,json --output results/
+    - |
+      ARGS="--format sarif,json --output nox-out --severity-threshold high"
+      [ -f vex.json ] && ARGS="$ARGS --vex vex.json --fail-on-unwaived"
+      if [ -n "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" ]; then
+        git fetch --depth=50 origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+        ARGS="$ARGS --changed-since origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+      fi
+      nox scan $ARGS .
   artifacts:
+    when: always
     paths:
-      - results/
-    reports:
-      sast: results/results.sarif
+      - nox-out/results.sarif
+      - nox-out/findings.json
 ```
+
+> **Note:** publish the SARIF as a plain artifact, not via
+> `artifacts:reports:sast`. GitLab's SAST report widget expects GitLab's own
+> JSON schema, not SARIF, so pointing it at `results.sarif` does not populate
+> the MR security widget. Download the artifact or feed the SARIF to a viewer.
+
+A complete, copy-paste-ready version (merge-request-scoped scanning, VEX
+waivers, gating) lives in
+[`examples/gitlab-ci/`](../examples/gitlab-ci/).
 
 ### Generic CI
 

--- a/examples/gitlab-ci/.gitlab-ci.yml
+++ b/examples/gitlab-ci/.gitlab-ci.yml
@@ -1,0 +1,44 @@
+# nox security scan for GitLab CI/CD.
+#
+# Runs the nox container image, fails the pipeline on high+ findings, and
+# publishes the SARIF + JSON reports as artifacts. On merge requests it scans
+# only the diff against the target branch for fast feedback; on the default
+# branch it scans the whole repo.
+#
+# Pin the image to a release tag (e.g. ghcr.io/nox-hq/nox:v1.2.0) rather than
+# :latest for reproducible runs.
+
+stages:
+  - security
+
+nox-scan:
+  stage: security
+  image:
+    name: ghcr.io/nox-hq/nox:latest
+    entrypoint: [""]
+  variables:
+    # Full git history so --changed-since can diff against the target branch.
+    GIT_DEPTH: "0"
+  script:
+    - |
+      ARGS="--format sarif,json --output nox-out --severity-threshold high"
+      # Honour a committed OpenVEX waiver document if present.
+      if [ -f vex.json ]; then
+        ARGS="$ARGS --vex vex.json --fail-on-unwaived"
+      fi
+      # On a merge request, scan only the changed files vs the target branch.
+      if [ -n "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" ]; then
+        git fetch --depth=50 origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+        ARGS="$ARGS --changed-since origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+      fi
+      nox scan $ARGS .
+  artifacts:
+    when: always
+    paths:
+      - nox-out/results.sarif
+      - nox-out/findings.json
+    expire_in: 1 week
+  rules:
+    # Run on merge requests and on the default branch.
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/examples/gitlab-ci/README.md
+++ b/examples/gitlab-ci/README.md
@@ -1,0 +1,50 @@
+# Example: GitLab CI/CD
+
+Run nox in a GitLab pipeline — gate on high-severity findings, scan only
+the merge-request diff for fast feedback, and publish SARIF + JSON reports
+as artifacts.
+
+## Files
+
+- `.gitlab-ci.yml` — a `security` stage that runs the nox container image,
+  fails the pipeline on high+ findings, applies an OpenVEX waiver document
+  when one is committed, and scans only the diff against the target branch
+  on merge requests.
+
+## How to use this in your repo
+
+1. Copy `.gitlab-ci.yml` into your repository root (or merge the `nox-scan`
+   job into your existing pipeline).
+2. Pin the image to a release tag for reproducible runs, e.g.
+   `ghcr.io/nox-hq/nox:v1.2.0` instead of `:latest`.
+3. (Optional) Bootstrap waivers so legacy findings don't block new commits:
+   ```sh
+   nox scan . --output nox-out
+   nox vex init --input nox-out/findings.json --output vex.json
+   ```
+   Edit `vex.json` — set `status: not_affected` for reviewed findings, leave
+   the rest as `under_investigation` — then commit it. The job picks it up
+   automatically (`--vex vex.json --fail-on-unwaived`), so only new or
+   unwaived high-severity findings fail.
+
+## Why this shape
+
+- **`--severity-threshold high`** — only blocking findings fail the pipeline;
+  everything still lands in the SARIF/JSON artifacts for visibility.
+- **`--changed-since origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME`** — MR
+  pipelines scan the diff, not the whole repo. `GIT_DEPTH: "0"` gives nox the
+  history it needs to compute that diff.
+- **`--vex vex.json --fail-on-unwaived`** — committed waivers carry the team's
+  prior decisions across runs.
+- **`artifacts.when: always`** — reports are kept even when the job fails, so
+  you can inspect the findings that blocked the pipeline.
+
+## Notes
+
+- The reports are published as plain artifacts (`results.sarif`,
+  `findings.json`). GitLab's native **SAST report** widget
+  (`artifacts:reports:sast`) expects GitLab's own JSON schema, not SARIF, so
+  it is not wired here; download the artifact or feed the SARIF to a viewer.
+- For a non-containerised runner you can install nox directly instead of using
+  the image — `go install github.com/nox-hq/nox/cli@v1.2.0` — and drop the
+  `image:` block.


### PR DESCRIPTION
nox ships a GitHub Action and several examples but **no GitLab template**, and the GitLab snippet in `usage.md` pointed `artifacts:reports:sast` at the SARIF file — GitLab's SAST report widget expects GitLab's **own JSON schema, not SARIF**, so that line silently does nothing.

## Changes
- **`examples/gitlab-ci/`** (`.gitlab-ci.yml` + README): containerised nox scan, high-severity gating, **merge-request-scoped `--changed-since`** for fast feedback, optional committed VEX waivers (`--fail-on-unwaived`), SARIF + JSON published as plain artifacts, pinned image tag.
- **`docs/usage.md`**: replaced the GitLab snippet with the corrected version and documented the SARIF-vs-GitLab-SAST-format caveat + a pointer to the example.

Docs/example only — no code changes. `.gitlab-ci.yml` validated as YAML.

Part of cluster 3 (CI/CD). Pure-docs, independent of #124 (V2 fingerprints).