### PR TITLE
fix(registry): verify checksums.txt not the bundle for .sigstore.json; cosign version guard

### DIFF
--- a/registry/oci/store_test.go
+++ b/registry/oci/store_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -322,6 +323,131 @@ func TestStoreFetchTrustVerification(t *testing.T) {
 	// Digest should match.
 	if !installed.VerifyResult.DigestMatch {
 		t.Error("DigestMatch should be true")
+	}
+}
+
+// fakeCosign installs a stub `cosign` binary on PATH that records the
+// final positional argument (the artifact-to-verify path) cosign was
+// invoked with, into recordPath. It always exits 0. Returns a cleanup
+// that restores PATH (handled by t.Setenv).
+//
+// This lets store-level tests assert WHICH bytes nox handed to cosign
+// without depending on a real keyless verification (network, Rekor,
+// trusted-root). The bug this guards against is nox passing the bundle
+// file itself as the artifact instead of the signed checksums.txt —
+// cosign then reports "invalid signature when validating ASN.1 encoded
+// signature" and the plugin is rejected as unverified.
+func fakeCosign(t *testing.T, recordArtifactArg string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cosign shim uses a POSIX shell script")
+	}
+	binDir := t.TempDir()
+	// The shim copies its last argument (the artifact path cosign is
+	// asked to verify) to recordArtifactArg, then exits 0.
+	script := "#!/bin/sh\n" +
+		"for last; do :; done\n" +
+		"cp \"$last\" \"" + recordArtifactArg + "\"\n" +
+		"exit 0\n"
+	cosignPath := filepath.Join(binDir, "cosign")
+	if err := os.WriteFile(cosignPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake cosign: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestStoreFetchCosignBundleVerifiesChecksums is a regression test for
+// the taint-analysis plugin signature-verification failure: nox shipped
+// a registry entry whose CosignBundleURL ended in ".sigstore.json"
+// (cosign v3.10+/v4 bundle naming). The buggy deriveChecksumsURL only
+// stripped ".sig.bundle", so nox downloaded the bundle and handed it to
+// `cosign verify-blob` AS THE ARTIFACT — cosign then verified the
+// signature against the bundle's own bytes and failed with "invalid
+// signature when validating ASN.1 encoded signature", leaving the
+// plugin at trust level "unverified" and breaking `nox scan` CI.
+//
+// This test exercises the full Fetch path with a ".sigstore.json"
+// bundle URL and a fake cosign that records the artifact it was asked to
+// verify. It asserts the artifact handed to cosign is the signed
+// checksums.txt (not the bundle), and that the artifact is promoted to
+// community trust.
+func TestStoreFetchCosignBundleVerifiesChecksums(t *testing.T) {
+	tarGzData := buildTarGz(t, map[string]string{"plugin": "plugin binary"})
+	digest := sha256Digest(tarGzData)
+
+	artifactName := "plugin_linux_amd64.tar.gz"
+	// GoReleaser-style checksums.txt listing the artifact with its digest.
+	checksumsContent := strings.TrimPrefix(digest, "sha256:") + "  " + artifactName + "\n"
+	// A distinctive marker so the test can prove cosign was NOT handed
+	// the bundle file (which would reproduce the original bug).
+	bundleContent := `{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","sentinel":"BUNDLE-NOT-CHECKSUMS"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/"+artifactName):
+			_, _ = w.Write(tarGzData)
+		case strings.HasSuffix(r.URL.Path, "checksums.txt.sigstore.json"):
+			_, _ = w.Write([]byte(bundleContent))
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			_, _ = w.Write([]byte(checksumsContent))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	recordPath := filepath.Join(t.TempDir(), "cosign-artifact-arg.bin")
+	fakeCosign(t, recordPath)
+
+	store := NewStore(
+		WithCacheDir(t.TempDir()),
+		WithHTTPClient(srv.Client()),
+		WithVerifier(trust.NewVerifier()),
+	)
+
+	ve := registry.VersionEntry{
+		Version:    "0.6.6",
+		APIVersion: "v1",
+		Artifacts: []registry.PlatformArtifact{
+			{
+				OS:     "linux",
+				Arch:   "amd64",
+				URL:    srv.URL + "/" + artifactName,
+				Size:   int64(len(tarGzData)),
+				Digest: digest,
+				// cosign v3.10+/v4 bundle naming — the exact shape that
+				// broke nox <= v1.1.0.
+				CosignBundleURL:          srv.URL + "/checksums.txt.sigstore.json",
+				CosignCertIdentityRegexp: "(?i)https://github.com/nox-hq/nox-plugin-taint-analysis/.github/workflows/release.yml@.*",
+				CosignOIDCIssuer:         "https://token.actions.githubusercontent.com",
+			},
+		},
+	}
+
+	installed, err := store.FetchFor(context.Background(), "nox/taint-analysis", &ve, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// cosign must have been handed the signed checksums.txt, NOT the
+	// bundle. If deriveChecksumsURL regresses on ".sigstore.json", the
+	// recorded artifact will be the bundle JSON and this fails.
+	got, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("fake cosign did not record an artifact arg (cosign not invoked?): %v", err)
+	}
+	if strings.Contains(string(got), "BUNDLE-NOT-CHECKSUMS") {
+		t.Fatalf("cosign was handed the BUNDLE as the artifact-to-verify; "+
+			"deriveChecksumsURL failed to strip the .sigstore.json suffix.\nGot:\n%s", got)
+	}
+	if strings.TrimSpace(string(got)) != strings.TrimSpace(checksumsContent) {
+		t.Fatalf("cosign artifact = %q, want the checksums.txt content %q", got, checksumsContent)
+	}
+
+	// Verification + checksums binding both passed -> promoted to community.
+	if installed.VerifyResult.Level < trust.TrustCommunity {
+		t.Errorf("TrustLevel = %v, want >= %v; violations: %+v",
+			installed.VerifyResult.Level, trust.TrustCommunity, installed.VerifyResult.Violations)
 	}
 }
 

--- a/registry/trust/cosign.go
+++ b/registry/trust/cosign.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -79,7 +81,20 @@ func CosignVerifyBlob(ctx context.Context, p CosignVerifyParams) error {
 		"--certificate-oidc-issuer", issuer,
 	}
 	if p.BundlePath != "" {
-		// New bundle format — required by cosign v4, supported by v3.10+.
+		// nox publishes plugin signatures as Sigstore v0.3 bundles
+		// (GoReleaser/cosign sign-blob --bundle). Verifying them requires
+		// `--new-bundle-format`, a flag added in cosign v2.4.0. Older
+		// cosign reads the bundle as the legacy Rekor-bundle format and
+		// fails with opaque errors ("bundle does not contain cert",
+		// "invalid signature when validating ASN.1 encoded signature").
+		// Detect that case and return an actionable error instead so an
+		// operator with a stale cosign on PATH isn't left guessing.
+		if majVal, minVal, ok := cosignVersion(ctx); ok && !supportsNewBundleFormat(majVal, minVal) {
+			return fmt.Errorf(
+				"cosign v%d.%d is too old to verify Sigstore bundles: nox requires cosign >= v2.4.0 (which added --new-bundle-format). Upgrade cosign (brew upgrade cosign, or sigstore/cosign-installer)",
+				majVal, minVal)
+		}
+		// New bundle format — required by cosign v4, supported by v2.4.0+.
 		args = append(args, "--bundle", p.BundlePath, "--new-bundle-format")
 	} else {
 		// Legacy --signature path. Cosign v4 rejects this; falls
@@ -102,4 +117,48 @@ func CosignVerifyBlob(ctx context.Context, p CosignVerifyParams) error {
 func CosignAvailable() bool {
 	_, err := exec.LookPath("cosign")
 	return err == nil
+}
+
+// cosignVersionRe extracts the GitVersion line from `cosign version`
+// output, e.g. "GitVersion:    v3.0.6" -> major 3, minor 0.
+var cosignVersionRe = regexp.MustCompile(`(?m)^GitVersion:\s*v?(\d+)\.(\d+)`)
+
+// cosignVersion shells out to `cosign version` and parses the major and
+// minor numbers. ok is false when cosign isn't on PATH, the command
+// fails, or the version can't be parsed — callers must treat !ok as
+// "unknown" and proceed (never block verification on a parse miss).
+func cosignVersion(ctx context.Context) (major, minor int, ok bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	vctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(vctx, "cosign", "version").CombinedOutput()
+	if err != nil {
+		return 0, 0, false
+	}
+	m := cosignVersionRe.FindStringSubmatch(string(out))
+	if len(m) != 3 {
+		return 0, 0, false
+	}
+	majVal, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	minVal, err := strconv.Atoi(m[2])
+	if err != nil {
+		return 0, 0, false
+	}
+	return majVal, minVal, true
+}
+
+// supportsNewBundleFormat reports whether a cosign version understands
+// the `--new-bundle-format` flag (added in v2.4.0). nox signs and
+// publishes Sigstore v0.3 bundles, so verification needs this flag.
+func supportsNewBundleFormat(major, minor int) bool {
+	if major > 2 {
+		return true
+	}
+	return major == 2 && minor >= 4
 }

--- a/registry/trust/cosign_test.go
+++ b/registry/trust/cosign_test.go
@@ -3,7 +3,10 @@ package trust
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -38,5 +41,72 @@ func TestCosignAvailable_HonoursPath(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	if CosignAvailable() {
 		t.Error("expected cosign unavailable with empty PATH")
+	}
+}
+
+func TestSupportsNewBundleFormat(t *testing.T) {
+	tests := []struct {
+		major, minor int
+		want         bool
+	}{
+		{1, 13, false}, // legacy cosign v1
+		{2, 0, false},  // v2.0 — before --new-bundle-format
+		{2, 3, false},  // v2.3 — still before
+		{2, 4, true},   // v2.4.0 introduced --new-bundle-format
+		{2, 6, true},
+		{3, 0, true}, // cosign v3 (what cosign-installer v4.1.2 installs)
+		{3, 1, true},
+		{4, 0, true}, // future cosign v4
+	}
+	for _, tt := range tests {
+		if got := supportsNewBundleFormat(tt.major, tt.minor); got != tt.want {
+			t.Errorf("supportsNewBundleFormat(%d,%d) = %v, want %v", tt.major, tt.minor, got, tt.want)
+		}
+	}
+}
+
+// fakeCosignVersion installs a stub `cosign` on PATH whose `version`
+// subcommand prints the given GitVersion line.
+func fakeCosignVersion(t *testing.T, gitVersion string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = version ]; then\n" +
+		"  echo 'GitVersion:    " + gitVersion + "'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "cosign"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake cosign: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestCosignVersion_Parses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cosign shim uses a POSIX shell script")
+	}
+	fakeCosignVersion(t, "v3.0.6")
+	majVal, minVal, ok := cosignVersion(context.Background())
+	if !ok {
+		t.Fatal("expected version parse to succeed")
+	}
+	if majVal != 3 || minVal != 0 {
+		t.Errorf("cosignVersion = v%d.%d, want v3.0", majVal, minVal)
+	}
+}
+
+func TestCosignVerifyBlob_RejectsOldCosignForBundle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cosign shim uses a POSIX shell script")
+	}
+	fakeCosignVersion(t, "v2.2.4") // pre --new-bundle-format
+	err := CosignVerifyBlob(context.Background(), CosignVerifyParams{
+		ArtifactPath:              filepath.Join(t.TempDir(), "checksums.txt"),
+		BundlePath:                filepath.Join(t.TempDir(), "checksums.txt.sigstore.json"),
+		CertificateIdentityRegexp: "https://github.com/x/y/.github/workflows/release.yml@.*",
+	})
+	if err == nil || !strings.Contains(err.Error(), "too old") {
+		t.Fatalf("expected too-old cosign error, got %v", err)
 	}
 }


### PR DESCRIPTION
Regression test locking the deriveChecksumsURL fix (cosign must receive checksums.txt, not the .sigstore.json bundle — passing the bundle as the artifact caused 'invalid signature when validating ASN.1 encoded signature' and left plugins unverified). Adds cosign version detection that returns an actionable 'cosign too old' error (< v2.4.0, before --new-bundle-format) instead of opaque failures. No SDK added (still shells to cosign). No trust policy change.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9