### PR TITLE
chore(registry): mark policy-gate + baseline-mgmt deprecated

### DIFF
--- a/registry-scaffold/index.json
+++ b/registry-scaffold/index.json
@@ -794,7 +794,7 @@
     },
     {
       "name": "nox/policy-gate",
-      "description": "Policy evaluation and CI gate (pass/fail) \u2014 severity thresholds, rule allowlists, finding budgets (5 rules)",
+      "description": "[DEPRECATED] Policy evaluation and CI gate (pass/fail) \u2014 severity thresholds, rule allowlists, finding budgets (5 rules)",
       "homepage": "https://github.com/Nox-HQ/nox-plugin-policy-gate",
       "repository": "https://github.com/Nox-HQ/nox-plugin-policy-gate",
       "license": "Apache-2.0",
@@ -871,11 +871,13 @@
             }
           ]
         }
-      ]
+      ],
+      "deprecated": true,
+      "deprecation_note": "Superseded by core: policy.fail_on / --severity-threshold / --fail-on-unwaived"
     },
     {
       "name": "nox/baseline-mgmt",
-      "description": "Finding baseline snapshots, diff, triage \u2014 brownfield migration enabler (4 rules)",
+      "description": "[DEPRECATED] Finding baseline snapshots, diff, triage \u2014 brownfield migration enabler (4 rules)",
       "homepage": "https://github.com/Nox-HQ/nox-plugin-baseline-mgmt",
       "repository": "https://github.com/Nox-HQ/nox-plugin-baseline-mgmt",
       "license": "Apache-2.0",
@@ -953,7 +955,9 @@
             }
           ]
         }
-      ]
+      ],
+      "deprecated": true,
+      "deprecation_note": "Superseded by core: nox baseline write/update/diff/migrate + nox vex"
     },
     {
       "name": "nox/depconfusion",


### PR DESCRIPTION
Consolidation follow-up. policy-gate + baseline-mgmt are redundant with nox core (policy gating + `nox baseline`/VEX); their repos are archived. This flags them `deprecated` in the registry index (with a pointer to the core feature) while keeping the entries so existing installs keep working.