### PR TITLE
fix(actions): SHA-pin mutable tag refs, not just outdated ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-03
+
+### Changed
+
+- **`nox fix --actions` now SHA-pins mutable tag refs, not just outdated ones.**
+  A `uses: owner/action@v7` that already tracks the latest release is still a
+  mutable ref — a supply-chain risk and a frequent PR-review flag. `--actions`
+  now rewrites any tag ref to `@<sha> # <tag>`, pinning to the same-major latest
+  release (or to the tag's own commit when a newer major is being held back).
+  Already-SHA-pinned, up-to-date refs remain untouched, so remediation PRs are
+  no longer blocked by "still using a mutable tag" review comments. Behavior for
+  the dependency pass (default `nox fix`) is unchanged.
+
 ## [1.4.0] - 2026-07-03
 
 ### Added

--- a/cli/fix_actions.go
+++ b/cli/fix_actions.go
@@ -134,10 +134,11 @@ func runActionsFix(root string, dryRun, includeMajor bool, r actionResolver) (ap
 			continue
 		}
 
-		// A mutable ref (a tag like @v7, not a 40-hex SHA) must be pinned to a
-		// SHA even when it already tracks the latest version — that is the
-		// whole point of pinning (supply-chain immutability). An already-SHA
-		// ref only needs touching when it is genuinely outdated.
+		// A mutable ref (a tag like @v7, i.e. not a hex commit SHA per isSHA)
+		// must be pinned to a SHA even when it already tracks the latest
+		// version — that is the whole point of pinning (supply-chain
+		// immutability). An already-SHA ref only needs touching when it is
+		// genuinely outdated.
 		mutable := !isSHA(p.ref)
 		outdated := versionLess(cur, l.tag)
 		sameMajor := majorComponent(cur) == majorComponent(l.tag)

--- a/cli/fix_actions.go
+++ b/cli/fix_actions.go
@@ -69,10 +69,11 @@ func isSHA(ref string) bool {
 }
 
 // actionResolver returns the latest release tag and its commit SHA for an
-// action repo. Injected so the planning/rewrite logic is testable without
-// the network.
+// action repo, and the commit SHA a specific tag resolves to. Injected so the
+// planning/rewrite logic is testable without the network.
 type actionResolver interface {
 	latest(repo string) (tag, sha string, err error)
+	tagSHA(repo, tag string) (sha string, err error)
 }
 
 // runActionsFix scans workflows under root, rewrites outdated action pins to
@@ -84,7 +85,7 @@ func runActionsFix(root string, dryRun, includeMajor bool, r actionResolver) (ap
 		return 0, 0, 0
 	}
 
-	// Resolve each unique repo once.
+	// Resolve each unique repo's latest release once.
 	type latest struct {
 		tag, sha string
 		ok       bool
@@ -102,6 +103,22 @@ func runActionsFix(root string, dryRun, includeMajor bool, r actionResolver) (ap
 		cache[repo] = l
 		return l
 	}
+	// Resolve a specific tag's commit SHA once (for SHA-pinning a mutable tag
+	// in place when the latest release is a major we won't jump to).
+	tagCache := map[string]string{}
+	resolveTag := func(repo, tag string) string {
+		key := repo + "@" + tag
+		if s, seen := tagCache[key]; seen {
+			return s
+		}
+		sha, err := r.tagSHA(repo, tag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: resolve %s@%s: %v\n", repo, tag, err)
+			sha = ""
+		}
+		tagCache[key] = sha
+		return sha
+	}
 
 	// Group rewrites per file so each file is read/written once.
 	perFile := map[string][]rewrite{}
@@ -116,18 +133,60 @@ func runActionsFix(root string, dryRun, includeMajor bool, r actionResolver) (ap
 			skipped++
 			continue
 		}
-		if !versionLess(cur, l.tag) {
-			skipped++ // already latest (or ahead)
-			continue
-		}
-		if !includeMajor && majorComponent(cur) != majorComponent(l.tag) {
+
+		// A mutable ref (a tag like @v7, not a 40-hex SHA) must be pinned to a
+		// SHA even when it already tracks the latest version — that is the
+		// whole point of pinning (supply-chain immutability). An already-SHA
+		// ref only needs touching when it is genuinely outdated.
+		mutable := !isSHA(p.ref)
+		outdated := versionLess(cur, l.tag)
+		sameMajor := majorComponent(cur) == majorComponent(l.tag)
+
+		var tag, sha, why string
+		switch {
+		case outdated && (includeMajor || sameMajor):
+			// Upgrade to the latest release, SHA-pinned.
+			tag, sha, why = l.tag, l.sha, fmt.Sprintf("%s -> %s", cur, l.tag)
+		case outdated && mutable:
+			// Newer major exists but we won't jump it; still SHA-pin the
+			// mutable tag in place at its current major.
+			if s := resolveTag(p.repo, p.ref); s != "" {
+				tag, sha, why = p.ref, s, fmt.Sprintf("pin %s (major %d held; latest %s)", p.ref, majorComponent(cur), l.tag)
+			} else {
+				fmt.Printf("skip (major): %s %s -> %s (use --include-major)\n", p.full, cur, l.tag)
+				skipped++
+				continue
+			}
+		case outdated:
+			// Already SHA-pinned, newer major available — hold without flag.
 			fmt.Printf("skip (major): %s %s -> %s (use --include-major)\n", p.full, cur, l.tag)
 			skipped++
 			continue
+		case mutable && sameMajor:
+			// Up to date but mutable → SHA-pin to the same-major latest.
+			tag, sha, why = l.tag, l.sha, fmt.Sprintf("pin %s", cur)
+		case mutable:
+			// Up to date, mutable, latest is a different (older) major line —
+			// pin the tag to its own SHA without changing the version.
+			if s := resolveTag(p.repo, p.ref); s != "" {
+				tag, sha, why = p.ref, s, fmt.Sprintf("pin %s", p.ref)
+			} else {
+				skipped++
+				continue
+			}
+		default:
+			// Already SHA-pinned and up to date — nothing to do.
+			skipped++
+			continue
 		}
-		newLine := fmt.Sprintf("%s@%s # %s", p.full, l.sha, l.tag)
+
+		if sha == p.ref {
+			skipped++ // already pinned to this exact SHA
+			continue
+		}
+		newLine := fmt.Sprintf("%s@%s # %s", p.full, sha, tag)
 		perFile[p.file] = append(perFile[p.file], rewrite{lineNo: p.lineNo, prefix: p.prefix, newRest: newLine})
-		fmt.Printf("plan: %s %s -> %s (%s)\n", p.full, cur, l.tag, short(l.sha))
+		fmt.Printf("plan: %s %s (%s)\n", p.full, why, short(sha))
 	}
 
 	if dryRun {

--- a/cli/fix_actions_test.go
+++ b/cli/fix_actions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // fakeResolver returns scripted latest tag/sha per repo. tagSHA resolves an
-// arbitrary tag to a deterministic pseudo-SHA (tag "vN" -> "shaOf-vN...").
+// arbitrary tag to a deterministic 40-hex SHA (its digits, 'a'-padded).
 type fakeResolver map[string][2]string // repo -> {tag, sha}
 
 func (f fakeResolver) latest(repo string) (tag, sha string, err error) {
@@ -23,9 +23,14 @@ func (f fakeResolver) tagSHA(repo, tag string) (sha string, err error) {
 	if _, ok := f[repo]; !ok {
 		return "", os.ErrNotExist
 	}
-	// 40-hex deterministic SHA derived from the tag name.
-	base := "shaof" + strings.NewReplacer(".", "", "v", "").Replace(tag)
-	return (base + strings.Repeat("0", 40))[:40], nil
+	// Deterministic, valid 40-hex SHA from the tag's digits, 'a'-padded.
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, tag)
+	return (digits + strings.Repeat("a", 40))[:40], nil
 }
 
 func writeWFPin(t *testing.T, root, name, body string) string {

--- a/cli/fix_actions_test.go
+++ b/cli/fix_actions_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// fakeResolver returns scripted latest tag/sha per repo.
+// fakeResolver returns scripted latest tag/sha per repo. tagSHA resolves an
+// arbitrary tag to a deterministic pseudo-SHA (tag "vN" -> "shaOf-vN...").
 type fakeResolver map[string][2]string // repo -> {tag, sha}
 
 func (f fakeResolver) latest(repo string) (tag, sha string, err error) {
@@ -15,6 +17,15 @@ func (f fakeResolver) latest(repo string) (tag, sha string, err error) {
 		return "", "", os.ErrNotExist
 	}
 	return v[0], v[1], nil
+}
+
+func (f fakeResolver) tagSHA(repo, tag string) (sha string, err error) {
+	if _, ok := f[repo]; !ok {
+		return "", os.ErrNotExist
+	}
+	// 40-hex deterministic SHA derived from the tag name.
+	base := "shaof" + strings.NewReplacer(".", "", "v", "").Replace(tag)
+	return (base + strings.Repeat("0", 40))[:40], nil
 }
 
 func writeWFPin(t *testing.T, root, name, body string) string {
@@ -83,12 +94,12 @@ func TestRunActionsFix_RewritesOutdated(t *testing.T) {
 func TestRunActionsFix_SkipsUpToDateAndMajor(t *testing.T) {
 	root := t.TempDir()
 	writeWFPin(t, root, "ci.yml", `steps:
-  - uses: actions/checkout@sha11111111111111111111111111111111111111 # v4.3.0
-  - uses: actions/setup-go@sha22222222222222222222222222222222222222 # v5.0.0
+  - uses: actions/checkout@1111111111111111111111111111111111111111 # v4.3.0
+  - uses: actions/setup-go@2222222222222222222222222222222222222222 # v5.0.0
 `)
 	res := fakeResolver{
-		"actions/checkout": {"v4.3.0", "same"},     // already latest → skip
-		"actions/setup-go": {"v6.0.0", "newmajor"}, // major jump → skip w/o flag
+		"actions/checkout": {"v4.3.0", "1111111111111111111111111111111111111111"}, // SHA-pinned + latest → skip
+		"actions/setup-go": {"v6.0.0", "3333333333333333333333333333333333333333"}, // major jump → skip w/o flag
 	}
 	applied, skipped, failed := runActionsFix(root, true, false, res)
 	if applied != 0 || failed != 0 || skipped != 2 {
@@ -98,6 +109,37 @@ func TestRunActionsFix_SkipsUpToDateAndMajor(t *testing.T) {
 	applied, _, _ = runActionsFix(root, true, true, res)
 	if applied != 1 {
 		t.Errorf("with --include-major want applied=1, got %d", applied)
+	}
+}
+
+func TestRunActionsFix_PinsMutableTags(t *testing.T) {
+	root := t.TempDir()
+	p := writeWFPin(t, root, "ci.yml", `steps:
+  - uses: actions/checkout@v7
+  - uses: actions/setup-node@v6
+  - uses: octo/legacy@v2
+`)
+	res := fakeResolver{
+		// same major as the pinned mutable tag → pin to the latest release SHA
+		"actions/checkout":   {"v7.0.0", "1111111111111111111111111111111111111111"},
+		"actions/setup-node": {"v6.4.0", "2222222222222222222222222222222222222222"},
+		// newer major than the pin → hold the major, but SHA-pin @v2 in place
+		"octo/legacy": {"v4.0.0", "9999999999999999999999999999999999999999"},
+	}
+	applied, skipped, failed := runActionsFix(root, false, false, res)
+	if applied != 3 || failed != 0 {
+		t.Fatalf("applied=%d skipped=%d failed=%d, want applied=3", applied, skipped, failed)
+	}
+	got, _ := os.ReadFile(p)
+	// octo/legacy@v2 keeps the v2 comment but is now pinned to v2's own SHA.
+	legacySHA, _ := res.tagSHA("octo/legacy", "v2")
+	want := `steps:
+  - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0
+  - uses: actions/setup-node@2222222222222222222222222222222222222222 # v6.4.0
+  - uses: octo/legacy@` + legacySHA + ` # v2
+`
+	if string(got) != want {
+		t.Errorf("mutable-tag pinning wrong:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
`nox fix --actions` (released in v1.4.0) only rewrote **outdated** action pins. A pin that already tracks the latest release but uses a **mutable tag** (`uses: owner/action@v7`) was left alone — but a mutable ref is still a supply-chain risk, and code reviewers (incl. GitHub Copilot) flag it, which was blocking the automated nox-remediate PRs on repos that require conversation resolution.

## Change
`--actions` now SHA-pins **any** tag ref to `@<sha> # <tag>`:
- Mutable tag, same major as latest → pin to the same-major latest release SHA.
- Mutable tag, newer major held back (no `--include-major`) → pin to the tag's **own** commit SHA, version unchanged.
- Already SHA-pinned + up to date → untouched.
- Default `nox fix` (dependency pass) → **unchanged**.

## Tests
- New `TestRunActionsFix_PinsMutableTags` (same-major upgrade, major-held in-place pin).
- Existing tests updated to use valid-hex SHA fixtures.
- `go build/vet/test ./...` green; gofmt + golangci clean on changed files.

Cut as v1.4.1 after merge.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom