### PR TITLE
ci: docs PRs mergeable + v1.4.2 changelog (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
+    # No paths-ignore here: branch protection requires the reusable CI's
+    # status checks (Lint/Test/Build/Security), and a docs-only PR that skips
+    # the whole workflow never reports them — so the PR is unmergeable forever
+    # (the required checks never arrive). Running CI on docs PRs is cheap (no
+    # code changed → cache hits) and keeps them mergeable without an admin
+    # override. push-to-main below still skips docs, saving minutes on merges.
   # Weekly dependency-CVE audit — replaces Dependabot security scanning with
   # nox's own OSV lookups. Catches newly-disclosed CVEs in existing deps that
   # the PR gate (changed-files only) would miss.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-07-04
+
+### Fixed
+
+- **`.gitignore` is now honored when scanning from inside a git worktree.** In a
+  linked worktree (and submodule) `.git` is a gitdir-pointer *file*, not a
+  directory, so loading `.git/info/exclude` failed with `ENOTDIR` — an error
+  that discarded every pattern already read from `.gitignore`, leaving the
+  walker with zero ignore rules. A scan run from a worktree therefore found
+  strictly more than the same HEAD scanned from the real checkout (a
+  `mobile/`-ignored subtree reappeared: 721 vs 640 findings), so a baseline
+  written from a plain directory never matched a worktree rescan. `info/exclude`
+  is now resolved via the worktree's commondir (git shares it across worktrees),
+  and a non-directory path component contributes no patterns instead of nuking
+  the set. Dir and worktree scans of the same HEAD are now identical. (#140)
+
 ## [1.4.1] - 2026-07-03
 
 ### Changed


### PR DESCRIPTION
Follow-through after the #140 fix merged.

## 1. Docs PRs can't merge (required checks never run)

`pull_request` had `paths-ignore: ['**.md','docs/**','LICENSE']`, but branch protection requires the reusable CI contexts (`Lint`, `Test`, `Build`, `Security`). A docs-only PR skips the whole workflow, so those required checks never report and the PR is `BLOCKED` forever — exactly what a CHANGELOG-only release PR would hit. Removing `paths-ignore` from the PR trigger makes docs PRs run CI (cheap — no code changed, cache hits) and merge normally. `push`-to-main keeps `paths-ignore`, so docs merges still skip CI and save minutes on the frequent path.

## 2. v1.4.2 changelog

Cuts the changelog section for the worktree-gitignore fix (#140, merged in #141), ahead of tagging `v1.4.2`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom