### PR TITLE
fix(discovery): scan tracked files under a gitignored directory (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tracked files under a gitignored directory are now scanned.** git never
+  ignores a file it already tracks, even when a `.gitignore` pattern matches it
+  — but nox applied ignore patterns purely from the filesystem and skipped them,
+  a scanner blind spot for any repo that gitignores a directory yet commits
+  sources into it (e.g. pet-medical ignores `mobile/` but tracks ~80 files under
+  it, none of which were scanned — a committed secret there would go undetected).
+  The scan now consults `git ls-files`: a tracked path is scanned even under an
+  ignored directory, while genuinely-ignored (untracked) files stay skipped.
+  Outside a git repo, behavior is unchanged. Note: repos with tracked files
+  under ignored directories will see new findings on the next scan and should
+  refresh their baseline. (#142)
+
 ## [1.4.2] - 2026-07-04
 
 ### Fixed

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -232,6 +232,26 @@ func dirContainsAnyIncluded(relDir string, include map[string]bool) bool {
 	return false
 }
 
+// dirContainsAnyTracked reports whether any tracked path is at or under the
+// given directory (relative, slash-separated). Used to keep the walker from
+// pruning an ignored directory that still holds git-tracked files. The root
+// ("" / ".") contains every tracked path.
+func dirContainsAnyTracked(relDir string, tracked map[string]bool) bool {
+	if len(tracked) == 0 {
+		return false
+	}
+	if relDir == "" || relDir == "." {
+		return true
+	}
+	prefix := relDir + "/"
+	for p := range tracked {
+		if p == relDir || strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Walker recursively discovers and classifies files under Root.
 type Walker struct {
 	// Root is the directory to walk.
@@ -251,6 +271,13 @@ type Walker struct {
 	// also short-circuits directory descent when no included path lives
 	// under the current directory.
 	IncludePaths map[string]bool
+	// TrackedPaths holds the files git tracks (relative to Root, slash-
+	// separated). git never ignores a tracked file, so a path in this set
+	// is scanned even when a .gitignore pattern matches it — and an ignored
+	// directory is still descended into when it contains a tracked file.
+	// Empty (the default) means "no git context", so ignore rules apply as
+	// before.
+	TrackedPaths map[string]bool
 }
 
 // NewWalker creates a Walker rooted at root with the DefaultClassifier
@@ -315,10 +342,19 @@ func (w *Walker) Walk() ([]Artifact, error) {
 			}
 
 			if w.isIgnored(absRoot, path, rel, nestedPatterns) {
+				relSlash := filepath.ToSlash(rel)
 				if info.IsDir() {
-					return filepath.SkipDir
+					// Prune an ignored directory — unless it holds a tracked
+					// file. git never ignores a tracked file, so we must
+					// descend to reach one (e.g. a repo that .gitignores
+					// `mobile/` but commits sources into it).
+					if !dirContainsAnyTracked(relSlash, w.TrackedPaths) {
+						return filepath.SkipDir
+					}
+				} else if !w.TrackedPaths[relSlash] {
+					// Skip an ignored file unless it is tracked.
+					return nil
 				}
-				return nil
 			}
 		}
 

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -472,6 +472,77 @@ func TestLoadGitignore_WorktreeGitFile(t *testing.T) {
 	}
 }
 
+// Regression for #142: git never ignores a *tracked* file, even when a
+// .gitignore pattern matches it. A repo that .gitignores a directory but
+// commits sources into it (pet-medical: `mobile/` ignored, ~80 tracked
+// files under it) must still have those tracked files scanned. The walker
+// honors TrackedPaths: a tracked file under an ignored dir is scanned, the
+// ignored dir is descended into to reach it, but a genuinely-ignored
+// (untracked) sibling stays skipped and an ignored dir with no tracked
+// descendant is still pruned.
+func TestWalker_ScansTrackedFilesUnderIgnoredDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("mobile/\nbuild/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// mobile/ is ignored but two files under it are tracked; a third is not.
+	mustWrite(t, filepath.Join(root, "mobile", "app.go"), "package m")         // tracked
+	mustWrite(t, filepath.Join(root, "mobile", "sub", "util.go"), "package s") // tracked (nested)
+	mustWrite(t, filepath.Join(root, "mobile", "generated.go"), "package m")   // ignored + untracked
+	// build/ is ignored and holds no tracked files → must stay pruned.
+	mustWrite(t, filepath.Join(root, "build", "out.go"), "package b")
+	// a normal tracked file outside any ignore.
+	mustWrite(t, filepath.Join(root, "src", "main.go"), "package main")
+
+	w := NewWalker(root)
+	w.TrackedPaths = map[string]bool{
+		"mobile/app.go":      true,
+		"mobile/sub/util.go": true,
+		"src/main.go":        true,
+	}
+	arts, err := w.Walk()
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	have := map[string]bool{}
+	for _, a := range arts {
+		have[a.Path] = true
+	}
+
+	for _, want := range []string{"mobile/app.go", "mobile/sub/util.go", "src/main.go"} {
+		if !have[want] {
+			t.Errorf("tracked file %q under an ignored dir should be scanned; got %v", want, keys(have))
+		}
+	}
+	if have["mobile/generated.go"] {
+		t.Error("mobile/generated.go is ignored and untracked — it should not be scanned")
+	}
+	if have["build/out.go"] {
+		t.Error("build/ is ignored with no tracked files — it should stay pruned")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // Regression for #83: --changed-since must short-circuit the file
 // walk, not just filter the artifact list afterwards. The walker now
 // accepts an IncludePaths allow-list and skips directories that don't

--- a/core/git/git.go
+++ b/core/git/git.go
@@ -92,6 +92,22 @@ func StagedContent(repoRoot, path string) ([]byte, error) {
 	return []byte(out), nil
 }
 
+// TrackedFiles returns the paths of every file tracked by git under dir,
+// relative to dir and slash-separated. These are the files git considers part
+// of the repository — and git never ignores a tracked file, even when a
+// .gitignore pattern matches it. Callers use this so the scanner still covers
+// sources committed into an otherwise-ignored directory (e.g. a repo that
+// .gitignores `mobile/` but commits code into it). `-z` avoids git's path
+// quoting so names with special characters round-trip. Best-effort: returns an
+// error when dir is not a git working tree.
+func TrackedFiles(dir string) ([]string, error) {
+	out, err := runGit(dir, "ls-files", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+	return splitZero(out), nil
+}
+
 func runGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
@@ -108,4 +124,14 @@ func splitLines(s string) []string {
 		return nil
 	}
 	return strings.Split(s, "\n")
+}
+
+// splitZero splits NUL-separated git output (from `-z`) into paths, dropping
+// the trailing empty element after the final NUL.
+func splitZero(s string) []string {
+	s = strings.TrimRight(s, "\x00")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\x00")
 }

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -174,6 +174,50 @@ func TestStagedContent_SubDir(t *testing.T) {
 	}
 }
 
+func TestTrackedFiles(t *testing.T) {
+	dir := setupGitRepo(t) // starts with a tracked README.md
+
+	// A directory ignored by .gitignore, but with a file force-added (tracked).
+	writeFile(t, filepath.Join(dir, ".gitignore"), "mobile/\n")
+	if err := os.MkdirAll(filepath.Join(dir, "mobile"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "mobile", "app.go"), "package m")
+	writeFile(t, filepath.Join(dir, "mobile", "ignored.go"), "package m")
+	run(t, dir, "git", "add", ".gitignore", "README.md")
+	run(t, dir, "git", "add", "-f", "mobile/app.go") // force-track despite ignore
+	run(t, dir, "git", "commit", "-m", "add tracked file under ignored dir")
+
+	tracked, err := TrackedFiles(dir)
+	if err != nil {
+		t.Fatalf("TrackedFiles: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range tracked {
+		got[f] = true
+	}
+	// The force-added file is tracked even though mobile/ is gitignored —
+	// this is exactly what git ls-files reports, and why the scanner must
+	// cover it (#142).
+	if !got["mobile/app.go"] {
+		t.Errorf("expected tracked mobile/app.go, got %v", tracked)
+	}
+	if !got[".gitignore"] || !got["README.md"] {
+		t.Errorf("expected .gitignore and README.md tracked, got %v", tracked)
+	}
+	if got["mobile/ignored.go"] {
+		t.Error("mobile/ignored.go was never added — it must not be tracked")
+	}
+}
+
+func TestTrackedFiles_InvalidRepo(t *testing.T) {
+	dir := t.TempDir()
+	_, err := TrackedFiles(dir)
+	if err == nil {
+		t.Fatal("expected error for non-git directory, got nil")
+	}
+}
+
 // setupGitRepo creates a temp dir with a git repo and an initial commit.
 func setupGitRepo(t *testing.T) string {
 	t.Helper()

--- a/core/scan.go
+++ b/core/scan.go
@@ -372,6 +372,15 @@ func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]disc
 	walker.IgnorePatterns = append(walker.IgnorePatterns, cfg.Scan.Exclude...)
 	if opts.NoRespectGitignore {
 		walker.RespectGitignore = false
+	} else if tracked, err := git.TrackedFiles(target); err == nil {
+		// git never ignores a tracked file, so a source committed into an
+		// otherwise-ignored directory (e.g. `mobile/` in .gitignore) must still
+		// be scanned. Best-effort: outside a git repo this errors and the walker
+		// applies ignore rules as before.
+		walker.TrackedPaths = make(map[string]bool, len(tracked))
+		for _, f := range tracked {
+			walker.TrackedPaths[f] = true
+		}
 	}
 
 	// When --changed-since is set, resolve the diff and wire it into the


### PR DESCRIPTION
## Problem

git never ignores a file it already **tracks**, even when a `.gitignore` pattern matches it. nox applied ignore patterns purely from the filesystem, so it silently **skipped tracked sources committed into an otherwise-ignored directory** — a scanner blind spot.

Real-world: `pet-medical` gitignores `mobile/` but tracks ~80 files under it. None were scanned, so a committed secret under `mobile/` would go undetected.

```sh
git init repo && cd repo
printf 'mobile/\n' > .gitignore
mkdir -p mobile && printf 'const k="AKIAIOSFODNN7EXAMPLE"\n' > mobile/app.js
git add -f mobile/app.js .gitignore && git commit -m init
git check-ignore mobile/app.js   # empty — git does NOT ignore a tracked file
nox scan .                        # before: misses mobile/app.js
```

## Fix

The scan now consults `git ls-files` (new `core/git.TrackedFiles`) and passes the tracked set to the walker:

- a **tracked** path is scanned even under an ignored directory (and the ignored dir is descended into to reach it);
- a **genuinely-ignored, untracked** file stays skipped;
- an ignored dir with **no tracked descendant** is still pruned (no traversal-cost regression on `node_modules/` etc.);
- outside a git repo the tracked set is empty and ignore rules apply exactly as before.

This is the git-faithful counterpart to #140: after #140 dir and worktree scans *agreed*, but both under-reported; now both scan tracked-under-ignored files **consistently**. Verified end-to-end — dir and worktree both scan `mobile/app.js` and both skip an untracked sibling.

## Tests

- `git.TrackedFiles` incl. a force-added file under a gitignored dir, plus the non-git error path.
- `TestWalker_ScansTrackedFilesUnderIgnoredDir`: tracked-scanned / untracked-skipped / empty-ignored-dir-pruned.
- Full `core/...` suite green; no new lint.

## Heads-up

Repos with tracked files under ignored dirs will see **new findings** on the next scan and should refresh their baseline (changelog notes this). This lands in `[Unreleased]` — not in v1.4.2 (already tagged) — since it changes scan scope.

Closes #142

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom