### PR TITLE
feat(report): proof-of-offline attestation in findings.json (#146 tier 1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Proof-of-offline attestation in the report.** `findings.json` meta now
+  carries an `"offline"` boolean recording whether the scan ran under the
+  zero-network guarantee (`nox scan --offline`: no OSV, no API, no token, no
+  telemetry). A reviewer or CISO can confirm straight from the artifact that the
+  scanner never touched the network — backed by the enforced egress test
+  (`TestOSVDisabled_NoNetworkEgress`), not just a claim. `--offline` also prints
+  an `[offline]` confirmation line. This is the differentiator vs. LLM-powered
+  scanners that ship your code to a model provider.
 - **Agent-config artifact scanning (`AGENT-001..004`).** The files that steer a
   coding agent are an execution surface, not just docs — a poisoned rule file or
   an over-broad permission grant silently changes what the agent runs, reads, and

--- a/cli/main.go
+++ b/cli/main.go
@@ -451,6 +451,9 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		if summary := familySummary(activeFindings); summary != "" {
 			fmt.Printf("[families] %s\n", summary)
 		}
+		if offlineFlag {
+			fmt.Println("[offline] zero-network guarantee: no OSV, no API, no token, no telemetry (recorded in findings.json meta)")
+		}
 	}
 
 	// Generate reports.
@@ -464,6 +467,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		case "json":
 			path := filepath.Join(outputDir, "findings.json")
 			r := report.NewJSONReporter(version)
+			r.Offline = offlineFlag
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -25,6 +25,12 @@ type Meta struct {
 	GeneratedAt   string `json:"generated_at"`
 	ToolName      string `json:"tool_name"`
 	ToolVersion   string `json:"tool_version"`
+	// Offline records whether the scan ran under the zero-network guarantee
+	// (`nox scan --offline`): no OSV lookups, no API, no token, no telemetry.
+	// It is the proof-of-offline attestation a reviewer can read straight from
+	// the artifact — "this report was produced without the scanner touching the
+	// network" — backed by the enforced egress test, not just a claim.
+	Offline bool `json:"offline"`
 }
 
 // JSONReport is the top-level structure serialized to JSON. It pairs report
@@ -37,6 +43,9 @@ type JSONReport struct {
 // JSONReporter produces deterministic JSON output from a FindingSet.
 type JSONReporter struct {
 	ToolVersion string
+	// Offline is recorded in the report Meta as the proof-of-offline
+	// attestation. Set it to the scan's `--offline` state before Generate.
+	Offline bool
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -65,6 +74,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
 			ToolName:      "nox",
 			ToolVersion:   r.ToolVersion,
+			Offline:       r.Offline,
 		},
 		Findings: f,
 	}

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -98,6 +98,41 @@ func TestGenerateContainsCorrectMeta(t *testing.T) {
 	}
 }
 
+func TestGenerateOfflineAttestation(t *testing.T) {
+	// Default: a reporter records offline=false, so an artifact never over-claims
+	// a zero-network scan that wasn't one.
+	def, err := NewJSONReporter("1.0.0").Generate(sampleFindingSet())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var defReport JSONReport
+	if err := json.Unmarshal(def, &defReport); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if defReport.Meta.Offline {
+		t.Error("default reporter must record offline=false")
+	}
+
+	// With Offline set, the attestation appears in the artifact so a reviewer
+	// can confirm the scan touched no network straight from findings.json.
+	r := NewJSONReporter("1.0.0")
+	r.Offline = true
+	data, err := r.Generate(sampleFindingSet())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !report.Meta.Offline {
+		t.Error("offline reporter must record offline=true in meta")
+	}
+	if !bytes.Contains(data, []byte(`"offline": true`)) {
+		t.Errorf("findings.json meta must carry the offline attestation; got: %s", data)
+	}
+}
+
 func TestGenerateSortsFindingsDeterministically(t *testing.T) {
 	r := NewJSONReporter("0.1.0")
 	// Findings are added in reverse order (rule-002 before rule-001).


### PR DESCRIPTION
Roadmap #146, Tier 1.1. nox's headline differentiator vs. the LLM-powered scanners in this space is that **it never sends your code anywhere**. This makes that verifiable from the artifact instead of a README claim.

## What

- `findings.json` meta gains `"offline": <bool>`, set from the scan's `--offline` state (the zero-network umbrella: no OSV, no API, no token, no telemetry).
- `nox scan --offline` prints an `[offline]` confirmation line.
- Default is `offline=false` — a report never over-claims a network-free scan.

```json
"meta": { "schema_version": "1.0.0", "tool_name": "nox", "offline": true }
```

Backed by the enforced egress test (`TestOSVDisabled_NoNetworkEgress`) — the code *can't* egress in offline mode — so the attestation is trustworthy, not a self-claim.

## Tests

`TestGenerateOfflineAttestation` (default false; `--offline` surfaces the field + the literal in the JSON). Reporter determinism already covered by `TestGenerateIsDeterministic`. Full `core/...` + `cli/...` green. Verified e2e: `--offline` → `meta.offline=true` + `[offline]` line; without → `false`.

Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom