### PR TITLE
feat(scan): --tracked-only scan mode (#146 tier 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nox scan --tracked-only`.** Restricts the scan to git-tracked files
+  (`git ls-files`), excluding untracked working-tree files (scratch files, build
+  output, un-added drafts) and submodule contents. Scans exactly what is
+  committed — the same set a reviewer sees — so a CI gate is reproducible and
+  doesn't flag a developer's local scratch file. Ignored outside a git repo.
 - **Agent-config artifact scanning (`AGENT-001..004`).** The files that steer a
   coding agent are an execution surface, not just docs — a poisoned rule file or
   an over-broad permission grant silently changes what the agent runs, reads, and

--- a/cli/main.go
+++ b/cli/main.go
@@ -280,6 +280,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		noCacheFlag           bool
 		changedSinceFlag      string
 		noRespectGitignoreFlg bool
+		trackedOnlyFlag       bool
 		noAutoInstallFlg      bool
 		failOnUnwaivedFlg     bool
 		offlineFlag           bool
@@ -289,6 +290,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "disable incremental scan cache")
 	scanFS.StringVar(&changedSinceFlag, "changed-since", "", "scan only files changed since the given git ref")
 	scanFS.BoolVar(&noRespectGitignoreFlg, "no-respect-gitignore", false, "scan paths matched by .gitignore (default: skip them)")
+	scanFS.BoolVar(&trackedOnlyFlag, "tracked-only", false, "scan only git-tracked files (git ls-files); exclude untracked working-tree files and submodule contents")
 	scanFS.BoolVar(&noAutoInstallFlg, "no-auto-install", false, "skip auto-installing plugins listed in .nox.yaml plugins.required")
 	scanFS.BoolVar(&failOnUnwaivedFlg, "fail-on-unwaived", false, "with --vex: only exit non-zero on findings NOT covered by an OpenVEX waiver")
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
@@ -384,6 +386,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			NoCache:            noCacheFlag,
 			ChangedSince:       changedSinceFlag,
 			NoRespectGitignore: noRespectGitignoreFlg,
+			TrackedOnly:        trackedOnlyFlag,
 		}
 		result, err = nox.RunScanWithOptions(target, opts)
 	}

--- a/core/scan.go
+++ b/core/scan.go
@@ -102,6 +102,13 @@ type ScanOptions struct {
 	// NoRespectGitignore disables .gitignore handling. When true, every
 	// file under the target is walked regardless of ignore rules.
 	NoRespectGitignore bool
+
+	// TrackedOnly restricts the scan to files git tracks (`git ls-files`),
+	// excluding untracked working-tree files (scratch files, build output,
+	// un-added drafts) and submodule contents. Use it to scan exactly what is
+	// committed — the same set a reviewer sees — for reproducible CI gates.
+	// Ignored outside a git repository.
+	TrackedOnly bool
 }
 
 // RunScan executes the full scan pipeline against the given target path.
@@ -383,9 +390,23 @@ func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]disc
 		}
 	}
 
+	// --tracked-only: restrict the walk to git-tracked files by seeding the
+	// allow-list with `git ls-files`. Untracked working-tree files and
+	// submodule contents (gitlinks, not listed) are excluded. Best-effort:
+	// outside a git repo this errors and the full walk proceeds.
+	if opts.TrackedOnly {
+		if tracked, err := git.TrackedFiles(target); err == nil {
+			walker.IncludePaths = make(map[string]bool, len(tracked))
+			for _, f := range tracked {
+				walker.IncludePaths[f] = true
+			}
+		}
+	}
+
 	// When --changed-since is set, resolve the diff and wire it into the
 	// walker as an allow-list BEFORE walking. Pushing this down avoids walking
-	// unchanged subtrees in large monorepos.
+	// unchanged subtrees in large monorepos. (Changed files are a subset of
+	// tracked files, so this correctly narrows a --tracked-only scan further.)
 	if opts.ChangedSince != "" {
 		changed, err := git.ChangedFilesSince(target, opts.ChangedSince)
 		if err != nil {

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -1862,6 +1862,52 @@ const apiKey = "AKIAIOSFODNN7EXAMPLE"
 
 // initGitRepo creates a git repo with an initial commit containing the given
 // files. Each key in files is a relative path and each value is the content.
+// TestRunScanWithOptions_TrackedOnly verifies that --tracked-only scans only
+// git-tracked files: an untracked working-tree file (scratch, build output, an
+// un-added draft) is excluded, while committed files are still scanned. This
+// makes a CI gate reproducible — it sees exactly what a reviewer sees.
+func TestRunScanWithOptions_TrackedOnly(t *testing.T) {
+	t.Parallel()
+
+	const secret = "package main\nconst key = \"AKIAIOSFODNN7EXAMPLE\"\n"
+	dir := initGitRepo(t, map[string]string{"tracked.go": secret})
+
+	// An untracked working-tree file with its own secret.
+	if err := os.WriteFile(filepath.Join(dir, "untracked.go"), []byte(secret), 0o644); err != nil {
+		t.Fatalf("writing untracked file: %v", err)
+	}
+
+	scanned := func(res *ScanResult, name string) bool {
+		for _, f := range res.Findings.Findings() {
+			if strings.HasSuffix(f.Location.FilePath, name) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// A default scan sees both the tracked and the untracked file.
+	full, err := RunScanWithOptions(dir, ScanOptions{})
+	if err != nil {
+		t.Fatalf("full scan: %v", err)
+	}
+	if !scanned(full, "untracked.go") {
+		t.Fatal("default scan should include the untracked file (sanity check)")
+	}
+
+	// --tracked-only drops the untracked file but keeps the tracked one.
+	tracked, err := RunScanWithOptions(dir, ScanOptions{TrackedOnly: true})
+	if err != nil {
+		t.Fatalf("tracked-only scan: %v", err)
+	}
+	if scanned(tracked, "untracked.go") {
+		t.Error("tracked-only scan must exclude the untracked working-tree file")
+	}
+	if !scanned(tracked, "tracked.go") {
+		t.Error("tracked-only scan must still include the tracked file")
+	}
+}
+
 func initGitRepo(t *testing.T, files map[string]string) string {
 	t.Helper()
 


### PR DESCRIPTION
Roadmap #146, Tier 1.2 (git-native scan set).

Adds `nox scan --tracked-only` — restrict the scan to git-tracked files (`git ls-files`), excluding **untracked working-tree files** (scratch, build output, un-added drafts) and **submodule contents** (gitlinks aren't listed). Scans exactly what's committed — the same set a reviewer sees — so a CI gate is reproducible and never flags a developer's local scratch file.

Implemented by seeding the walker's existing `IncludePaths` allow-list with the tracked set (reuses the `--changed-since` machinery), so the flags compose: `--changed-since X --tracked-only` narrows to changed-and-tracked. Best-effort outside a git repo (full walk).

**Test:** `TestRunScanWithOptions_TrackedOnly` — an untracked file with a secret is excluded, the committed file still scanned. Verified e2e:

```
default        → [tracked.js, untracked.js]
--tracked-only → [tracked.js]
```

Full `core/...` + `cli/...` green. Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom