### PR TITLE
fix(ai): output-handling rules skip docs (unbreaks the PR gate on changelog edits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unsafe-output-handling rules no longer fire on documentation.** AI-009/012/
+  015/018 (eval/exec, DB query, `innerHTML`, file path from LLM output) target
+  real code sinks but matched prose in docs that *quote* those sinks — most
+  visibly nox's own CHANGELOG entry `cursor.execute("SELECT " + completion)`,
+  which tripped AI-012 (high) and failed the PR gate on every change that edited
+  the changelog. A markdown file can't execute, so these rules now skip docs and
+  test files (joining the existing prose/logging noise-glob set); real source is
+  unaffected.
 - **Tracked files under a gitignored directory are now scanned.** git never
   ignores a file it already tracks, even when a `.gitignore` pattern matches it
   — but nox applied ignore patterns purely from the filesystem and skipped them,

--- a/core/analyzers/ai/agent_config_test.go
+++ b/core/analyzers/ai/agent_config_test.go
@@ -2,6 +2,36 @@ package ai
 
 import "testing"
 
+// The unsafe-output-handling rules (AI-009/012/015/018) target real code sinks,
+// but they must not fire on documentation that *quotes* those sinks — a
+// markdown file can't execute. Regression for the AI-012 false positive on
+// nox's own CHANGELOG (`cursor.execute("SELECT " + completion)`), which failed
+// the PR gate on every change that touched the changelog.
+func TestOutputHandlingRules_SkipDocsNotCode(t *testing.T) {
+	a := NewAnalyzer()
+	const sink = "result = cursor.execute(\"SELECT \" + completion)\n"
+
+	// Real Python code: AI-012 must still fire.
+	code, err := a.ScanFile("db.py", []byte(sink))
+	if err != nil {
+		t.Fatalf("ScanFile(code): %v", err)
+	}
+	if findingWithRule(code, "AI-012") == nil {
+		t.Error("AI-012 must still fire on a real code sink")
+	}
+
+	// Same text quoted in a changelog: no output-handling rule may fire.
+	doc, err := a.ScanFile("CHANGELOG.md", []byte("- Fixed: `"+sink+"` patterns still fire.\n"))
+	if err != nil {
+		t.Fatalf("ScanFile(doc): %v", err)
+	}
+	for _, id := range []string{"AI-009", "AI-012", "AI-015", "AI-018"} {
+		if findingWithRule(doc, id) != nil {
+			t.Errorf("%s fired on markdown prose quoting a code sink (false positive)", id)
+		}
+	}
+}
+
 // The AGENT-* family scans agent-configuration artifacts (Cursor/Cline rules,
 // CLAUDE.md/AGENTS.md, Claude Code skills, and the settings that grant tool
 // permissions). Each rule must fire on a malicious sample in a real

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -1085,14 +1085,23 @@ func builtinAIRules() []*rules.Rule {
 }
 
 // applyAINoiseGlobs adds test-file and documentation ignore globs to the AI
-// prose / logging / model-selection rules. Scanning the top public MCP servers
-// showed these rules firing on test fixtures, README/SKILL docs, and JSDoc —
-// never on real production AI code. Generated/vendored files are handled
-// separately by the scan.generated_paths filter.
+// prose / logging / model-selection rules, plus the unsafe-output-handling
+// rules. Scanning the top public MCP servers showed the prose/logging rules
+// firing on test fixtures, README/SKILL docs, and JSDoc; and the
+// output-handling rules (AI-009/012/015/018 — eval/exec, DB query, innerHTML,
+// file path from LLM output) fire on documentation that *quotes* those code
+// sinks. A markdown file can't execute, so a match there is always a doc
+// example, never a real vulnerability — most visibly nox's own CHANGELOG entry
+// `cursor.execute("SELECT " + completion)` tripping AI-012 on every PR that
+// edits it. Generated/vendored files are handled separately by the
+// scan.generated_paths filter.
 func applyAINoiseGlobs(out []*rules.Rule) {
 	noisy := map[string]bool{
 		"AI-006": true, "AI-008": true, "AI-026": true, "AI-030": true,
 		"AI-036": true, "AI-039": true, "AI-042": true,
+		// Unsafe-output-handling rules: real code sinks, but they match prose
+		// in docs that quote the sink. Skip docs/tests, keep real source.
+		"AI-009": true, "AI-012": true, "AI-015": true, "AI-018": true,
 	}
 	globs := []string{
 		"*_test.go", "*_test.py", "*.test.ts", "*.test.js", "*.spec.ts", "*.spec.js", "testdata/*",

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -1091,10 +1091,10 @@ func builtinAIRules() []*rules.Rule {
 // output-handling rules (AI-009/012/015/018 — eval/exec, DB query, innerHTML,
 // file path from LLM output) fire on documentation that *quotes* those code
 // sinks. A markdown file can't execute, so a match there is always a doc
-// example, never a real vulnerability — most visibly nox's own CHANGELOG entry
-// `cursor.execute("SELECT " + completion)` tripping AI-012 on every PR that
-// edits it. Generated/vendored files are handled separately by the
-// scan.generated_paths filter.
+// example, never a real vulnerability — most visibly nox's own CHANGELOG prose
+// (which quotes a SQL-execute sink when documenting a past AI-012 precision
+// fix) tripped AI-012 on every PR that edits the changelog. Generated/vendored
+// files are handled separately by the scan.generated_paths filter.
 func applyAINoiseGlobs(out []*rules.Rule) {
 	noisy := map[string]bool{
 		"AI-006": true, "AI-008": true, "AI-026": true, "AI-030": true,


### PR DESCRIPTION
## The bug (found while shipping the tier roadmap)

AI-009/012/015/018 — the unsafe-output-handling rules (eval/exec, DB query, `innerHTML`, file path from LLM output) — target real code sinks but fire on **documentation that quotes those sinks**. nox's own CHANGELOG has `` `cursor.execute("SELECT " + completion)` `` (prose from an earlier AI-012 precision fix), which trips **AI-012 (high)**.

Because editing the changelog pulls the whole file into the `--changed-since` set, this **failed the `Nox PR Gate` on essentially every nox PR** that touches CHANGELOG.md (observed on #145/#147/#148).

## Fix

A markdown file can't execute — a match there is always a quoted example, never a vulnerability. These four rules now join the existing prose/logging noise-glob set (AI-006/008/026/…), so they skip `*.md`/`*.mdx`/`*.rst` and test files while still firing on real source.

## Test

`TestOutputHandlingRules_SkipDocsNotCode`: AI-012 still fires on `db.py`; none of AI-009/012/015/018 fire on the same sink quoted in a CHANGELOG line. Full `core/...` green.

Lands in `[Unreleased]`. This should be merged first — it unblocks the gate for the other in-flight tier PRs.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom