### PR TITLE
feat(policy): per-severity budgets for the fail gate (#146 tier 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-severity policy budgets (`policy.budget`).** The gate can now tolerate a
+  bounded amount of new debt per severity before failing — e.g. `budget: {medium:
+  5, low: 20}` fails only on the 6th new medium while still failing on any new
+  high/critical. It refines `fail_on`: a severity at/above the threshold with no
+  budget entry defaults to 0 (fail on the first, unchanged), so an empty budget
+  reproduces the previous gate exactly. Lets a team adopt a strict threshold on a
+  debt-laden repo without baselining every finding.
 - **Proof-of-offline attestation in the report.** `findings.json` meta now
   carries an `"offline"` boolean recording whether the scan ran under the
   zero-network guarantee (`nox scan --offline`: no OSV, no API, no token, no

--- a/core/config.go
+++ b/core/config.go
@@ -79,6 +79,15 @@ type PolicySettings struct {
 	BaselineMode string `yaml:"baseline_mode"`
 	BaselinePath string `yaml:"baseline_path"`
 	VEXPath      string `yaml:"vex_path"`
+	// Budget is a per-severity allowance for NEW findings: the gate tolerates
+	// up to Budget[severity] new findings of that severity before failing. It
+	// refines fail_on — a severity at/above the fail threshold with a budget of
+	// N fails only on the N+1th new finding; severities without an entry default
+	// to 0 (fail on the first, the pre-budget behaviour). Lets a team accept a
+	// bounded amount of debt ("up to 5 new mediums, zero new highs") without
+	// baselining every finding. Keys are severity names (critical/high/medium/
+	// low/info).
+	Budget map[string]int `yaml:"budget"`
 }
 
 // ComplianceSettings controls compliance framework filtering.

--- a/core/policy/policy.go
+++ b/core/policy/policy.go
@@ -26,6 +26,11 @@ type Config struct {
 	FailOn       findings.Severity `yaml:"fail_on"`
 	WarnOn       findings.Severity `yaml:"warn_on"`
 	BaselineMode BaselineMode      `yaml:"baseline_mode"`
+	// Budget is a per-severity allowance for NEW findings: the gate tolerates up
+	// to Budget[severity] new findings of that severity before failing. Absent
+	// entries default to 0 (fail on the first), so an empty Budget reproduces
+	// the pre-budget max-severity gate exactly.
+	Budget map[findings.Severity]int `yaml:"budget"`
 }
 
 // Result holds the outcome of a policy evaluation.
@@ -70,17 +75,22 @@ func Evaluate(cfg Config, all []findings.Finding) *Result {
 		}
 	}
 
-	// Check new findings against fail threshold.
-	if cfg.FailOn != "" {
-		maxNew := maxSeverity(r.New)
-		if maxNew != "" && meetsThreshold(maxNew, cfg.FailOn) {
+	// Check new findings against the fail threshold, honoring per-severity
+	// budgets. A severity is gated when there is no explicit threshold (every
+	// new finding gated) or the severity meets fail_on. A gated severity fails
+	// only once its new-finding count exceeds its budget (default 0). With an
+	// empty budget this is identical to the previous "any new finding at/above
+	// fail_on fails" gate.
+	for sev, n := range severityCounts(r.New) {
+		gated := cfg.FailOn == "" || meetsThreshold(sev, cfg.FailOn)
+		if gated && n > cfg.Budget[sev] {
 			r.Pass = false
 			r.ExitCode = 1
+			if cfg.Budget[sev] > 0 {
+				r.Warnings = append(r.Warnings, fmt.Sprintf(
+					"%d new %s finding(s) exceed the budget of %d", n, sev, cfg.Budget[sev]))
+			}
 		}
-	} else if len(r.New) > 0 {
-		// No explicit threshold: any new finding fails.
-		r.Pass = false
-		r.ExitCode = 1
 	}
 
 	// Handle baselined findings per mode.
@@ -139,6 +149,16 @@ func meetsThreshold(severity, threshold findings.Severity) bool {
 }
 
 // maxSeverity returns the most severe severity in the given findings.
+// severityCounts tallies findings by severity, so the gate can compare each
+// severity's count against its budget.
+func severityCounts(ff []findings.Finding) map[findings.Severity]int {
+	counts := make(map[findings.Severity]int)
+	for i := range ff {
+		counts[ff[i].Severity]++
+	}
+	return counts
+}
+
 func maxSeverity(ff []findings.Finding) findings.Severity {
 	best := findings.Severity("")
 	bestRank := 999

--- a/core/policy/policy_test.go
+++ b/core/policy/policy_test.go
@@ -6,6 +6,65 @@ import (
 	"github.com/nox-hq/nox/core/findings"
 )
 
+// newN returns n new findings of the given severity.
+func newN(sev findings.Severity, n int) []findings.Finding {
+	ff := make([]findings.Finding, n)
+	for i := range ff {
+		ff[i] = findings.Finding{RuleID: "SEC-001", Severity: sev, Status: findings.StatusNew}
+	}
+	return ff
+}
+
+func TestEvaluate_Budget(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      Config
+		findings []findings.Finding
+		wantPass bool
+	}{
+		{
+			name:     "within medium budget passes",
+			cfg:      Config{FailOn: findings.SeverityMedium, Budget: map[findings.Severity]int{findings.SeverityMedium: 5}},
+			findings: newN(findings.SeverityMedium, 5),
+			wantPass: true,
+		},
+		{
+			name:     "over medium budget fails",
+			cfg:      Config{FailOn: findings.SeverityMedium, Budget: map[findings.Severity]int{findings.SeverityMedium: 5}},
+			findings: newN(findings.SeverityMedium, 6),
+			wantPass: false,
+		},
+		{
+			name: "budgeted medium ok but any new high still fails (default 0)",
+			cfg:  Config{FailOn: findings.SeverityMedium, Budget: map[findings.Severity]int{findings.SeverityMedium: 5}},
+			findings: append(newN(findings.SeverityMedium, 2),
+				findings.Finding{RuleID: "SEC-002", Severity: findings.SeverityHigh, Status: findings.StatusNew}),
+			wantPass: false,
+		},
+		{
+			name:     "below fail_on is never gated regardless of budget",
+			cfg:      Config{FailOn: findings.SeverityHigh, Budget: map[findings.Severity]int{findings.SeverityMedium: 0}},
+			findings: newN(findings.SeverityMedium, 20),
+			wantPass: true,
+		},
+		{
+			name:     "empty budget reproduces the old gate (any new high fails)",
+			cfg:      Config{FailOn: findings.SeverityHigh},
+			findings: newN(findings.SeverityHigh, 1),
+			wantPass: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Evaluate(tc.cfg, tc.findings)
+			if r.Pass != tc.wantPass {
+				t.Errorf("Pass = %v, want %v (%s)", r.Pass, tc.wantPass, r.Summary)
+			}
+		})
+	}
+}
+
 func TestEvaluate_AllNewAboveThreshold(t *testing.T) {
 	cfg := Config{FailOn: findings.SeverityHigh}
 	ff := []findings.Finding{

--- a/core/scan.go
+++ b/core/scan.go
@@ -531,13 +531,21 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 // evaluatePolicy runs the configured fail-on / baseline policy gate over the
 // refined findings. It returns nil when no policy is configured. Stage 4.
 func evaluatePolicy(cfg *ScanConfig, allFindings *findings.FindingSet) *policy.Result {
-	if cfg.Policy.FailOn == "" && cfg.Policy.BaselineMode == "" {
+	if cfg.Policy.FailOn == "" && cfg.Policy.BaselineMode == "" && len(cfg.Policy.Budget) == 0 {
 		return nil
+	}
+	var budget map[findings.Severity]int
+	if len(cfg.Policy.Budget) > 0 {
+		budget = make(map[findings.Severity]int, len(cfg.Policy.Budget))
+		for sev, n := range cfg.Policy.Budget {
+			budget[findings.Severity(sev)] = n
+		}
 	}
 	policyCfg := policy.Config{
 		FailOn:       findings.Severity(cfg.Policy.FailOn),
 		WarnOn:       findings.Severity(cfg.Policy.WarnOn),
 		BaselineMode: policy.BaselineMode(cfg.Policy.BaselineMode),
+		Budget:       budget,
 	}
 	return policy.Evaluate(policyCfg, allFindings.Findings())
 }


### PR DESCRIPTION
Roadmap #146, Tier 1.3 (incremental adoption). Adds **`policy.budget`** — a per-severity allowance for new findings.

```yaml
policy:
  fail_on: medium
  budget:
    medium: 5    # tolerate up to 5 new mediums
    low: 20
```

The gate fails only once a severity's new-finding count exceeds its budget. It **refines `fail_on`** rather than replacing it: a severity at/above the threshold with no budget entry defaults to `0` (fail on the first — the pre-budget behavior), so an **empty budget reproduces the previous gate exactly** (all existing policy tests pass unchanged).

This is the adoption tool for a debt-laden repo — accept a *bounded* amount of new debt ("up to 5 new mediums, zero new highs") without baselining every finding.

## Tests
`TestEvaluate_Budget`: within budget passes, over budget fails, a budgeted medium still fails on any new high (default 0), below-`fail_on` never gated, and empty-budget backward-compat. Verified e2e via `.nox.yaml`: `budget {high:5}` passes 1 high; no budget → `policy: fail`. Full `core/...` green; lint clean.

Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom