### PR TITLE
feat(ai): OWASP Top 10 for Agentic Applications (ASI) mapping (#146 tier 2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OWASP Top 10 for Agentic Applications (ASI01–ASI10) mapping.** Findings
+  against agentic surfaces now carry their `owasp-asi*` control (in SARIF
+  `properties.tags` and finding metadata), the way they already carry OWASP LLM
+  and MCP Top 10 tags. Mapped: ASI01 Agent Goal Hijack (AGENT-001/004, prompt-
+  injection rules), ASI02 Tool Misuse (AGENT-002/003, tool-exposure rules), ASI03
+  Identity & Privilege Abuse (MCP authz/SSRF), ASI04 Agentic Supply Chain (MCP
+  tool-poisoning, rug-pull, shadow servers, model supply chain), ASI05 Unexpected
+  Code Execution. Runtime/multi-agent categories nox can't statically detect
+  (ASI06/07/08) are deliberately left unmapped rather than over-claimed.
 - **Per-severity policy budgets (`policy.budget`).** The gate can now tolerate a
   bounded amount of new debt per severity before failing — e.g. `budget: {medium:
   5, low: 20}` fails only on the 6th new medium while still failing on any new

--- a/core/analyzers/ai/agent_config_test.go
+++ b/core/analyzers/ai/agent_config_test.go
@@ -1,6 +1,58 @@
 package ai
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// The AGENT/AI/MCP rules that map to the OWASP Top 10 for Agentic Applications
+// must carry the corresponding owasp-asi* tag (flows into SARIF for Code
+// Scanning + GRC). Spot-check one rule per mapped category.
+func TestASIMapping(t *testing.T) {
+	rs := builtinAIRules()
+	byID := map[string][]string{}
+	for _, r := range rs {
+		byID[r.ID] = r.Tags
+	}
+
+	want := map[string]string{
+		"AGENT-001": "owasp-asi01", // Agent Goal Hijack
+		"AGENT-003": "owasp-asi02", // Tool Misuse
+		"MCP-018":   "owasp-asi03", // Identity & Privilege Abuse (SSRF)
+		"MCP-009":   "owasp-asi04", // Agentic Supply Chain (tool poisoning)
+		"AI-009":    "owasp-asi05", // Unexpected Code Execution
+	}
+	for id, tag := range want {
+		tags, ok := byID[id]
+		if !ok {
+			t.Errorf("rule %s not found", id)
+			continue
+		}
+		if !hasTag(tags, tag) {
+			t.Errorf("rule %s missing %s tag; got %v", id, tag, tags)
+		}
+	}
+
+	// A non-agentic rule must not be force-tagged with an ASI category.
+	for _, r := range rs {
+		if r.ID == "AI-006" { // insecure logging — not a category we map
+			for _, tg := range r.Tags {
+				if strings.HasPrefix(tg, "owasp-asi") {
+					t.Errorf("AI-006 should not carry an ASI tag, got %q", tg)
+				}
+			}
+		}
+	}
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, t := range tags {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
 
 // The unsafe-output-handling rules (AI-009/012/015/018) target real code sinks,
 // but they must not fire on documentation that *quotes* those sinks — a

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -1081,7 +1081,45 @@ func builtinAIRules() []*rules.Rule {
 
 	applyMCPProsePrecision(out)
 	applyAINoiseGlobs(out)
+	applyASIMapping(out)
 	return out
+}
+
+// applyASIMapping tags rules with their OWASP Top 10 for Agentic Applications
+// (ASI01–ASI10, Dec 2025) category, so findings against agentic surfaces carry
+// the agentic-security control the way they already carry OWASP LLM / MCP Top
+// 10 tags. The tag flows into SARIF `properties.tags` for Code Scanning and
+// downstream GRC. Only the categories nox has defensible static coverage for
+// are mapped — memory poisoning, inter-agent comms, and cascading failures
+// (ASI06/07/08) are runtime/multi-agent concerns nox doesn't statically detect,
+// so they are deliberately left unmapped rather than over-claimed.
+func applyASIMapping(out []*rules.Rule) {
+	asi := map[string]string{
+		// ASI01 Agent Goal Hijack — prompt injection / instruction manipulation.
+		"AGENT-001": "owasp-asi01", "AGENT-004": "owasp-asi01",
+		"AI-001": "owasp-asi01", "AI-002": "owasp-asi01", "AI-003": "owasp-asi01",
+		"AI-010":    "owasp-asi01",
+		"AI-PI-001": "owasp-asi01", "AI-PI-002": "owasp-asi01", "AI-PI-003": "owasp-asi01",
+		"AI-PI-004": "owasp-asi01", "AI-PI-005": "owasp-asi01", "AI-PI-006": "owasp-asi01",
+		// ASI02 Tool Misuse & Exploitation — unsafe / over-broad tool use.
+		"AGENT-002": "owasp-asi02", "AGENT-003": "owasp-asi02",
+		"AI-004": "owasp-asi02", "AI-005": "owasp-asi02", "AI-011": "owasp-asi02",
+		// ASI03 Identity & Privilege Abuse — authz, tokens, sessions, SSRF.
+		"MCP-016": "owasp-asi03", "MCP-017": "owasp-asi03", "MCP-018": "owasp-asi03",
+		"MCP-019": "owasp-asi03", "MCP-020": "owasp-asi03", "MCP-021": "owasp-asi03",
+		// ASI04 Agentic Supply Chain — poisoned tools, servers, models.
+		"AI-008": "owasp-asi04", "MCP-007": "owasp-asi04",
+		"MCP-009": "owasp-asi04", "MCP-010": "owasp-asi04", "MCP-011": "owasp-asi04",
+		"MCP-012": "owasp-asi04", "MCP-013": "owasp-asi04", "MCP-014": "owasp-asi04",
+		"MCP-022": "owasp-asi04",
+		// ASI05 Unexpected Code Execution — LLM output → code/shell execution.
+		"AI-009": "owasp-asi05", "MCP-001": "owasp-asi05",
+	}
+	for _, r := range out {
+		if tag, ok := asi[r.ID]; ok {
+			r.Tags = append(r.Tags, tag)
+		}
+	}
 }
 
 // applyAINoiseGlobs adds test-file and documentation ignore globs to the AI

--- a/core/mcppin/mcppin.go
+++ b/core/mcppin/mcppin.go
@@ -278,6 +278,7 @@ func driftFinding(path, server, oldHash, newHash string) findings.Finding {
 			"old_hash":    oldHash,
 			"new_hash":    newHash,
 			"owasp-mcp":   "MCP04",
+			"owasp-asi":   "ASI04",
 			"detector":    "rug-pull",
 			"remediation": "Diff the MCP server definition against its approved state. Confirm the command, arguments, environment, and any embedded tool definitions are still what you reviewed. Re-approve only after verifying the change is legitimate.",
 		},

--- a/core/mcpshadow/mcpshadow.go
+++ b/core/mcpshadow/mcpshadow.go
@@ -113,6 +113,7 @@ func detectServerShadowing(servers []Server) []findings.Finding {
 					"cwe":       "CWE-300",
 					"server":    name,
 					"owasp-mcp": "MCP09",
+					"owasp-asi": "ASI04",
 					"detector":  "server-shadowing",
 				},
 			})
@@ -159,6 +160,7 @@ func detectToolShadowing(servers []Server) []findings.Finding {
 					"cwe":       "CWE-300",
 					"tool":      tool,
 					"owasp-mcp": "MCP09",
+					"owasp-asi": "ASI04",
 					"detector":  "tool-shadowing",
 				},
 			})


### PR DESCRIPTION
Roadmap #146, Tier 2.5. Closes the gap where nox tagged findings with OWASP LLM + MCP Top 10 but had **no OWASP Agentic (ASI) Top 10** mapping — a table some competitors mark and nox didn't.

Findings against agentic surfaces now carry their **OWASP Top 10 for Agentic Applications** (ASI01–ASI10, Dec 2025) control as an `owasp-asi*` tag, flowing into SARIF `properties.tags` (Code Scanning + GRC) and, for the relational MCP rules, into finding metadata.

Centralised in one `applyASIMapping()`:

| ASI | Rules |
|---|---|
| **ASI01** Agent Goal Hijack | AGENT-001/004, AI-001/002/003/010, AI-PI-001..006 |
| **ASI02** Tool Misuse | AGENT-002/003, AI-004/005/011 |
| **ASI03** Identity & Privilege Abuse | MCP-016..021 |
| **ASI04** Agentic Supply Chain | AI-008, MCP-007/009..014/022, MCP-015, MCP-023/024 |
| **ASI05** Unexpected Code Execution | AI-009, MCP-001 |

**Honest scoping:** ASI06 (memory poisoning), ASI07 (inter-agent comms), ASI08 (cascading failures) are runtime/multi-agent concerns nox doesn't statically detect — left **unmapped rather than over-claimed**.

## Test
`TestASIMapping` spot-checks one rule per mapped category and asserts a non-agentic rule (AI-006) carries no ASI tag. Verified e2e: `AGENT-001` emits `owasp-asi01` in SARIF `properties.tags`. Full `core/...` green.

Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom
