### PR TITLE
feat(discovery): scan JS/TS module + JSX variants + Kotlin/Swift/PHP (#146 tier 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Broader language coverage: JS/TS module + JSX variants, plus Kotlin, Swift,
+  PHP.** `.tsx`/`.jsx`/`.mjs`/`.cjs`/`.mts`/`.cts` are now classified as source,
+  and every rule scoped to `*.ts`/`*.js` is auto-expanded to the variants — so a
+  React/Next.js AI app's `.tsx` components (where prompts are built and the model
+  is called) are scanned instead of silently skipped. `.kt`/`.swift`/`.php` join
+  the source set too.
 - **OWASP Top 10 for Agentic Applications (ASI01–ASI10) mapping.** Findings
   against agentic surfaces now carry their `owasp-asi*` control (in SARIF
   `properties.tags` and finding metadata), the way they already carry OWASP LLM

--- a/core/analyzers/ai/agent_config_test.go
+++ b/core/analyzers/ai/agent_config_test.go
@@ -45,6 +45,36 @@ func TestASIMapping(t *testing.T) {
 	}
 }
 
+// Every rule scoped to *.ts / *.js must also cover the module + JSX variants,
+// so a React/Next.js AI app's .tsx/.jsx (where prompts are built and the model
+// is called) isn't silently skipped.
+func TestJSTSVariantExpansion(t *testing.T) {
+	pairs := map[string][]string{
+		"*.ts": {"*.tsx", "*.mts", "*.cts"},
+		"*.js": {"*.jsx", "*.mjs", "*.cjs"},
+	}
+	has := func(s []string, v string) bool {
+		for _, x := range s {
+			if x == v {
+				return true
+			}
+		}
+		return false
+	}
+	for _, r := range builtinAIRules() {
+		for base, vs := range pairs {
+			if !has(r.FilePatterns, base) {
+				continue
+			}
+			for _, v := range vs {
+				if !has(r.FilePatterns, v) {
+					t.Errorf("rule %s targets %s but not %s: %v", r.ID, base, v, r.FilePatterns)
+				}
+			}
+		}
+	}
+}
+
 func hasTag(tags []string, want string) bool {
 	for _, t := range tags {
 		if t == want {

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -1082,7 +1082,42 @@ func builtinAIRules() []*rules.Rule {
 	applyMCPProsePrecision(out)
 	applyAINoiseGlobs(out)
 	applyASIMapping(out)
+	expandJSTSFilePatterns(out)
 	return out
+}
+
+// expandJSTSFilePatterns broadens every rule that targets `*.ts` or `*.js` to
+// also match the module and JSX variants (`*.tsx`/`*.mts`/`*.cts`,
+// `*.jsx`/`*.mjs`/`*.cjs`). filepath.Match treats these as distinct globs, so a
+// rule scoped to `*.ts` would silently skip a Next.js `.tsx` component — exactly
+// where an AI app builds prompts and calls the model. Centralising the expansion
+// keeps the per-rule filePatterns lists short and guarantees new rules inherit
+// the variants. Idempotent: a rule that already lists a variant is unchanged.
+func expandJSTSFilePatterns(out []*rules.Rule) {
+	variants := map[string][]string{
+		"*.ts": {"*.tsx", "*.mts", "*.cts"},
+		"*.js": {"*.jsx", "*.mjs", "*.cjs"},
+	}
+	for _, r := range out {
+		if len(r.FilePatterns) == 0 {
+			continue // no glob → already fires on every file
+		}
+		have := make(map[string]bool, len(r.FilePatterns))
+		for _, p := range r.FilePatterns {
+			have[p] = true
+		}
+		for base, vs := range variants {
+			if !have[base] {
+				continue
+			}
+			for _, v := range vs {
+				if !have[v] {
+					r.FilePatterns = append(r.FilePatterns, v)
+					have[v] = true
+				}
+			}
+		}
+	}
 }
 
 // applyASIMapping tags rules with their OWASP Top 10 for Agentic Applications

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -109,18 +109,25 @@ var containerNames = map[string]bool{
 
 // sourceExtensions maps file extensions to the Source artifact type.
 var sourceExtensions = map[string]bool{
-	".go":   true,
-	".py":   true,
-	".js":   true,
-	".ts":   true,
-	".rb":   true,
-	".java": true,
-	".rs":   true,
-	".c":    true,
-	".cpp":  true,
-	".h":    true,
-	".cs":   true,
-	".sh":   true,
+	".go": true,
+	".py": true,
+	// JavaScript / TypeScript and their module + JSX variants. The React/Next
+	// AI-app frontend keeps its LLM calls and prompt construction in .tsx/.jsx,
+	// so omitting them left that code unclassified (and unscanned by
+	// source-gated rules).
+	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
+	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
+	".rb":    true,
+	".java":  true,
+	".kt":    true,
+	".swift": true,
+	".php":   true,
+	".rs":    true,
+	".c":     true,
+	".cpp":   true,
+	".h":     true,
+	".cs":    true,
+	".sh":    true,
 }
 
 // configExtensions maps file extensions to the Config artifact type.


### PR DESCRIPTION
Roadmap #146, Tier 4 (language coverage). Two gaps left React/Next.js AI apps under-scanned:

1. **Classification** — `.tsx`/`.jsx`/`.mjs`/`.cjs`/`.mts`/`.cts` weren't in `sourceExtensions`, so they classified as `Unknown` (dropped from the source set the secrets/data analyzers and inventory consider). Added them, plus `.kt`/`.swift`/`.php`.
2. **Rule scoping** — ~21 AI rules gate on `*.ts`/`*.js`, and `filepath.Match` treats `*.tsx` as a *distinct* glob, so those rules silently skipped `.tsx` — exactly where an AI app builds prompts and calls the model. A centralized `expandJSTSFilePatterns()` broadens any `*.ts`/`*.js` rule to its module + JSX variants (idempotent; future rules inherit it).

## Tests
`TestJSTSVariantExpansion` asserts the invariant: every `*.ts`-scoped rule also covers `*.tsx`/`*.mts`/`*.cts` (and `*.js` → `*.jsx`/`*.mjs`/`*.cjs`). Verified e2e — a `.tsx` component is now scanned. Full `core/...` green.

Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom