### PR TITLE
fix(discovery): scan.exclude is a hard exclude, not overridden by tracked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scan.exclude` is now a hard exclude that survives `--changed-since`.** Since
+  the tracked-file fix (#142), a file listed in `scan.exclude` that was also
+  git-tracked got re-scanned — the tracked-file override treated the config
+  exclude like a `.gitignore` pattern. So an explicit exclusion (e.g. a
+  rule-definition file full of expected-false-positive patterns) was silently
+  ignored in `--changed-since` scans, which is what failed nox's own PR gate on
+  every rule change. Config excludes are now a separate hard rule the tracked
+  override never resurrects.
 - **Unsafe-output-handling rules no longer fire on documentation.** AI-009/012/
   015/018 (eval/exec, DB query, `innerHTML`, file path from LLM output) target
   real code sinks but matched prose in docs that *quote* those sinks — most

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -315,6 +315,12 @@ type Walker struct {
 	// Empty (the default) means "no git context", so ignore rules apply as
 	// before.
 	TrackedPaths map[string]bool
+	// ExcludePatterns are hard, explicit exclusions (from `scan.exclude` in
+	// config): paths the user has said to never scan. Unlike gitignore
+	// patterns, these are NOT overridden by TrackedPaths — a tracked file that
+	// matches an exclude is still skipped, because the user asked for it
+	// (e.g. a rule-definition file full of expected-false-positive patterns).
+	ExcludePatterns []string
 }
 
 // NewWalker creates a Walker rooted at root with the DefaultClassifier
@@ -369,6 +375,17 @@ func (w *Walker) Walk() ([]Artifact, error) {
 		// Always skip .git directories.
 		if info.IsDir() && info.Name() == ".git" {
 			return filepath.SkipDir
+		}
+
+		// Hard config excludes (scan.exclude) win unconditionally — they are
+		// explicit "never scan this" rules, so the tracked-file override that
+		// applies to .gitignore does NOT apply here. Checked before gitignore
+		// and before IncludePaths so it holds even under --changed-since.
+		if len(w.ExcludePatterns) > 0 && IsIgnored(filepath.ToSlash(rel), w.ExcludePatterns) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		if w.RespectGitignore {

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -472,6 +472,40 @@ func TestLoadGitignore_WorktreeGitFile(t *testing.T) {
 	}
 }
 
+// A config `scan.exclude` (ExcludePatterns) is a HARD exclude: it must win even
+// over a tracked file, unlike a .gitignore pattern. Regression for the #142
+// tracked-override resurrecting excluded-but-tracked files (e.g. nox's own
+// rule-definition files, which are tracked and listed in scan.exclude but were
+// re-scanned under --changed-since, failing the PR gate).
+func TestWalker_ExcludePatternsWinOverTracked(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "rules.go"), "package x // excluded despite tracked")
+	mustWrite(t, filepath.Join(root, "app.go"), "package x")
+
+	w := NewWalker(root)
+	w.ExcludePatterns = []string{"rules.go"}
+	// Both files are tracked — the exclude must still drop rules.go.
+	w.TrackedPaths = map[string]bool{"rules.go": true, "app.go": true}
+
+	arts, err := w.Walk()
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	have := map[string]bool{}
+	for _, a := range arts {
+		have[a.Path] = true
+	}
+	if have["rules.go"] {
+		t.Error("scan.exclude must skip a tracked file (hard exclude wins over the tracked-file override)")
+	}
+	if !have["app.go"] {
+		t.Error("app.go should still be scanned")
+	}
+}
+
 // Regression for #142: git never ignores a *tracked* file, even when a
 // .gitignore pattern matches it. A repo that .gitignores a directory but
 // commits sources into it (pet-medical: `mobile/` ignored, ~80 tracked

--- a/core/scan.go
+++ b/core/scan.go
@@ -376,7 +376,11 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 // excluded artifact types. It is stage 1 of the scan pipeline.
 func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]discovery.Artifact, error) {
 	walker := discovery.NewWalker(target)
-	walker.IgnorePatterns = append(walker.IgnorePatterns, cfg.Scan.Exclude...)
+	// scan.exclude is a HARD exclude (explicit "never scan this"), kept separate
+	// from .gitignore so the tracked-file override does not resurrect it — a
+	// tracked file the user excluded (e.g. a rule-definition file) stays
+	// excluded, including under --changed-since.
+	walker.ExcludePatterns = cfg.Scan.Exclude
 	if opts.NoRespectGitignore {
 		walker.RespectGitignore = false
 	} else if tracked, err := git.TrackedFiles(target); err == nil {


### PR DESCRIPTION
## The bug (regression from #142, found while shipping the roadmap)

#142 added "git never ignores a tracked file, so scan it even under a `.gitignore`'d dir." But that tracked-file override was applied to **all** of `walker.IgnorePatterns` — and `scan.exclude` config patterns were appended to the *same* list. So a file the user **explicitly excluded** got re-scanned if it happened to be git-tracked.

The full scan masked it (excluded findings are in the committed baseline), but the `--changed-since` PR gate exposed it: **10 phantom net-new high/critical on `core/analyzers/ai/rules.go`** — which nox lists in `scan.exclude` but tracks. This is why nox's own advisory PR gate failed on *every* rule-editing PR (#145/#149/#151/#153).

More broadly: **anyone using `scan.exclude` on a tracked file + `--changed-since` had their exclusion silently ignored.**

## Fix

`scan.exclude` becomes a separate `Walker.ExcludePatterns`, checked as a **hard skip** before the gitignore/tracked logic and before `IncludePaths` — so it holds even under `--changed-since`. `.gitignore` keeps the #142 tracked-override; explicit config excludes always win.

## Test
`TestWalker_ExcludePatternsWinOverTracked`: a tracked file matching an exclude is skipped, a sibling is still scanned. Verified e2e: the rules.go PR gate drops from **10 → 0** net-new high/critical. Full `core/...` green. (This PR should finally make the `Nox PR Gate` pass on a rule-file change.)

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom