### PR TITLE
feat(cli): nox baseline init + adoption guide (#146 tier 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nox baseline init` — one-command adoption for a debt-laden repo.** Scans,
+  records every current finding as accepted baseline debt (reported by
+  severity), and prints the "gate the change, not the history" policy to add
+  (`fail_on` + `baseline_mode: warn`). Refuses to clobber an existing baseline
+  (use `update`, or `--force`). See the new `docs/adoption.md`, which ties
+  together `baseline init`, per-severity budgets, `--tracked-only`, and
+  `--offline` into a five-minute adoption path.
 - **Broader language coverage: JS/TS module + JSX variants, plus Kotlin, Swift,
   PHP.** `.tsx`/`.jsx`/`.mjs`/`.cjs`/`.mts`/`.cts` are now classified as source,
   and every rule scoped to `*.ts`/`*.js` is auto-expanded to the variants — so a

--- a/cli/baseline_cmd.go
+++ b/cli/baseline_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	nox "github.com/nox-hq/nox/core"
@@ -14,7 +15,7 @@ import (
 
 func runBaseline(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show|migrate> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <init|write|update|add|diff|show|migrate> [path]")
 		return 2
 	}
 
@@ -22,6 +23,8 @@ func runBaseline(args []string) int {
 	remaining := args[1:]
 
 	switch subcommand {
+	case "init":
+		return baselineInit(remaining)
 	case "write":
 		return baselineWrite(remaining)
 	case "update":
@@ -36,7 +39,7 @@ func runBaseline(args []string) int {
 		return baselineMigrate(remaining)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown baseline subcommand: %s\n", subcommand)
-		fmt.Fprintln(os.Stderr, "Usage: nox baseline <write|update|add|diff|show|migrate> [path]")
+		fmt.Fprintln(os.Stderr, "Usage: nox baseline <init|write|update|add|diff|show|migrate> [path]")
 		return 2
 	}
 }
@@ -181,6 +184,90 @@ func pruneNote(prune bool, unmatched int) string {
 		return " (kept; use --prune to drop)"
 	}
 	return ""
+}
+
+// baselineInit is the one-command adoption entry point for a repo with existing
+// security debt: it scans, records every current finding as accepted baseline
+// debt, and prints the "gate the change, not the history" policy to add. Unlike
+// `write`, it refuses to clobber an existing baseline (use `update`), and it
+// reports the debt by severity so the operator sees what they're accepting.
+func baselineInit(args []string) int {
+	fs := flag.NewFlagSet("baseline init", flag.ContinueOnError)
+	var outputPath string
+	var force bool
+	fs.StringVar(&outputPath, "output", "", "baseline file path (default: .nox/baseline.json)")
+	fs.BoolVar(&force, "force", false, "recreate the baseline even if one already exists")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	target := "."
+	if fs.NArg() > 0 {
+		target = fs.Arg(0)
+	}
+	if outputPath == "" {
+		outputPath = baseline.DefaultPath(target)
+	}
+
+	if !force {
+		if _, err := os.Stat(outputPath); err == nil {
+			fmt.Fprintf(os.Stderr, "baseline already exists at %s — use `nox baseline update` to refresh it, or `--force` to recreate.\n", outputPath)
+			return 2
+		}
+	}
+
+	result, err := nox.RunScan(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: scan failed: %v\n", err)
+		return 2
+	}
+
+	ff := result.Findings.Findings()
+	bl := &baseline.Baseline{}
+	entries := baseline.FromFindings(ff)
+	for i := range entries {
+		bl.Add(&entries[i])
+	}
+	if err := bl.Save(outputPath); err != nil {
+		fmt.Fprintf(os.Stderr, "error: writing baseline: %v\n", err)
+		return 2
+	}
+
+	counts := map[findings.Severity]int{}
+	for i := range ff {
+		counts[ff[i].Severity]++
+	}
+	fmt.Printf("baseline: recorded %d existing findings as accepted debt in %s\n", bl.Len(), outputPath)
+	if bd := severityBreakdown(counts); bd != "" {
+		fmt.Printf("  by severity: %s\n", bd)
+	}
+	fmt.Print(`
+Next — gate the change, not the history. Add to .nox.yaml:
+
+  policy:
+    fail_on: high        # new high/critical findings fail the gate
+    baseline_mode: warn  # the recorded debt above only warns, never fails
+
+Commit the baseline so CI shares it. From now on, new findings gate; the
+existing debt does not. Burn it down with ` + "`nox baseline update`" + ` as you fix.
+`)
+	return 0
+}
+
+// severityBreakdown formats per-severity counts in severity order, e.g.
+// "2 critical, 11 high, 40 medium".
+func severityBreakdown(counts map[findings.Severity]int) string {
+	order := []findings.Severity{
+		findings.SeverityCritical, findings.SeverityHigh,
+		findings.SeverityMedium, findings.SeverityLow, findings.SeverityInfo,
+	}
+	var parts []string
+	for _, s := range order {
+		if n := counts[s]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, s))
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 func baselineWrite(args []string) int {

--- a/cli/baseline_cmd_test.go
+++ b/cli/baseline_cmd_test.go
@@ -24,6 +24,34 @@ func TestRunBaseline_UnknownSubcommand(t *testing.T) {
 	}
 }
 
+func TestRunBaseline_Init(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.env"), []byte("AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+	blPath := filepath.Join(dir, "bl.json")
+
+	if code := runBaseline([]string{"init", "--output", blPath, dir}); code != 0 {
+		t.Fatalf("init exit code = %d, want 0", code)
+	}
+	bl, err := baseline.Load(blPath)
+	if err != nil {
+		t.Fatalf("loading baseline: %v", err)
+	}
+	if bl.Len() == 0 {
+		t.Fatal("expected init to record findings as baseline debt")
+	}
+
+	// A second init must refuse rather than clobber an existing baseline.
+	if code := runBaseline([]string{"init", "--output", blPath, dir}); code == 0 {
+		t.Error("second init should refuse when a baseline already exists")
+	}
+	// --force recreates it.
+	if code := runBaseline([]string{"init", "--force", "--output", blPath, dir}); code != 0 {
+		t.Errorf("init --force exit code = %d, want 0", code)
+	}
+}
+
 func TestRunBaseline_Write(t *testing.T) {
 	dir := t.TempDir()
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,92 @@
+# Adopting nox on a repo with existing debt
+
+A scanner that fails the build on every pre-existing finding gets turned off on
+day one. nox is built to **gate the change, not the history**: record today's
+findings as accepted debt, then fail only on *new* ones. This guide is the
+five-minute path from "we've never scanned this repo" to a green, enforcing CI.
+
+## One command to start
+
+```bash
+nox baseline init
+```
+
+`baseline init` scans the repo, records every current finding as accepted debt
+in `.nox/baseline.json`, and prints the policy to add. It reports what you're
+accepting, by severity:
+
+```
+baseline: recorded 640 existing findings as accepted debt in .nox/baseline.json
+  by severity: 2 critical, 37 high, 218 medium, 383 low
+
+Next — gate the change, not the history. Add to .nox.yaml:
+
+  policy:
+    fail_on: high        # new high/critical findings fail the gate
+    baseline_mode: warn  # the recorded debt above only warns, never fails
+```
+
+Commit both `.nox/baseline.json` and `.nox.yaml`. From now on a **new** high or
+critical fails CI; the recorded debt only warns. `init` refuses to overwrite an
+existing baseline — use `nox baseline update` to refresh it, or `--force` to
+recreate.
+
+## Tightening the gate over time
+
+**Accept a bounded amount of new debt** instead of zero, with per-severity
+budgets — useful while a team ramps up:
+
+```yaml
+policy:
+  fail_on: medium
+  budget:
+    medium: 5   # tolerate up to 5 new mediums
+    low: 20     # ...and 20 new lows — but any new high/critical still fails
+```
+
+A severity at/above `fail_on` with no budget entry defaults to zero, so
+high/critical always gate. An empty budget behaves exactly like the plain
+threshold.
+
+**Burn the debt down** as you fix it — re-baseline so resolved findings drop out
+and don't mask a regression:
+
+```bash
+nox baseline update      # add nothing new; prune findings you've fixed
+nox baseline diff        # preview what update would change first
+```
+
+## Reproducible CI
+
+Two flags keep the gate deterministic and honest:
+
+- **`nox scan --tracked-only`** — scan exactly what git tracks, ignoring
+  untracked scratch files, build output, and un-added drafts. CI sees the same
+  set a reviewer sees, and a developer's local scratch file never trips the gate.
+- **`nox scan --offline`** — the zero-network guarantee: no OSV lookups, no API,
+  no token, no telemetry. `findings.json` records `"offline": true` so a reviewer
+  can confirm from the artifact that the scan never touched the network. Backed
+  by an enforced egress test, not a promise.
+
+## Adopting a stricter linter on the *changed* code only
+
+To hold *new* code to a higher bar without a big-bang cleanup, scope the gate to
+the diff:
+
+```bash
+nox scan --changed-since origin/main --severity-threshold high
+```
+
+This scans only files changed since the base ref, so a PR is gated on what it
+introduced — not the whole backlog. It composes with the baseline and budgets
+above.
+
+## The whole flow
+
+```bash
+nox baseline init                 # 1. record existing debt, get the policy
+git add .nox/baseline.json .nox.yaml && git commit -m "chore: adopt nox"
+#    2. add the printed policy block to .nox.yaml
+nox scan --tracked-only           # 3. CI gates new findings; debt only warns
+nox baseline update               # 4. re-baseline as you fix, to keep it honest
+```


### PR DESCRIPTION
Roadmap #146, Tier 1.3 — completes the incremental-adoption story and ties together everything shipped in Tier 1.

## `nox baseline init`

The one-command entry point for a repo with existing debt:

```
$ nox baseline init
baseline: recorded 640 existing findings as accepted debt in .nox/baseline.json
  by severity: 2 critical, 37 high, 218 medium, 383 low

Next — gate the change, not the history. Add to .nox.yaml:

  policy:
    fail_on: high        # new high/critical findings fail the gate
    baseline_mode: warn  # the recorded debt above only warns, never fails
```

Scans, records current findings as accepted debt (reported by severity), and prints the policy to add. Unlike `write`, it **refuses to clobber** an existing baseline (use `update`, or `--force`).

## `docs/adoption.md`

A five-minute path from never-scanned to a green, enforcing CI, tying together the Tier-1 work: `baseline init` → `policy.budget` (per-severity budgets) → `--tracked-only` (reproducible CI) → `--offline` (zero-network) → `baseline update` (burn the debt down).

## Test
`TestRunBaseline_Init`: records debt; a second init refuses; `--force` recreates. Full `cli/` suite green.

Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom