### PR TITLE
fix(scan): support single-file targets (nox scan <file>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`nox scan <file>` scans a single file.** A file target used to fail (it
+  looked for `<file>/.nox.yaml` and the walker skipped its own root, finding
+  nothing). Now it loads config from the file's directory and scans just that
+  file — the basis for fast pre-commit hooks and editor integrations.
 - **`scan.exclude` is now a hard exclude that survives `--changed-since`.** Since
   the tracked-file fix (#142), a file listed in `scan.exclude` that was also
   git-tracked got re-scanned — the tracked-file override treated the config

--- a/core/config.go
+++ b/core/config.go
@@ -252,6 +252,12 @@ type ExplainSettings struct {
 // LoadScanConfig reads .nox.yaml from root and returns the parsed config.
 // If the file does not exist, a zero-value ScanConfig is returned with no error.
 func LoadScanConfig(root string) (*ScanConfig, error) {
+	// A single-file target loads config from the file's directory, so
+	// `nox scan path/to/file.py` finds the project .nox.yaml instead of
+	// looking for `file.py/.nox.yaml`.
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		root = filepath.Dir(root)
+	}
 	path := filepath.Join(root, ".nox.yaml")
 
 	data, err := os.ReadFile(path)

--- a/core/scan.go
+++ b/core/scan.go
@@ -139,7 +139,8 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		return nil, err
 	}
 
-	// Load project config.
+	// Load project config (LoadScanConfig resolves a single-file target to its
+	// directory, so `nox scan path/file.py` finds the project .nox.yaml).
 	cfg, err := LoadScanConfig(target)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
@@ -375,6 +376,13 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 // optionally restricting to files changed since a git ref, and filtering out
 // excluded artifact types. It is stage 1 of the scan pipeline.
 func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]discovery.Artifact, error) {
+	// A single-file target scans exactly that file — the walker skips its own
+	// root, so pointing it at a file would yield nothing. The user named the
+	// file explicitly, so gitignore/scan.exclude do not apply.
+	if info, err := os.Stat(target); err == nil && !info.IsDir() {
+		return singleFileArtifacts(target, cfg)
+	}
+
 	walker := discovery.NewWalker(target)
 	// scan.exclude is a HARD exclude (explicit "never scan this"), kept separate
 	// from .gitignore so the tracked-file override does not resurrect it — a
@@ -427,11 +435,41 @@ func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]disc
 		return nil, err
 	}
 
-	var excludeArtifactTypes []string
+	return filterArtifactsByType(artifacts, excludeArtifactTypes(cfg)), nil
+}
+
+// excludeArtifactTypes flattens the configured artifact-type exclusions.
+func excludeArtifactTypes(cfg *ScanConfig) []string {
+	var out []string
 	for _, et := range cfg.Scan.ExcludeArtifactTypes {
-		excludeArtifactTypes = append(excludeArtifactTypes, et.ArtifactTypes...)
+		out = append(out, et.ArtifactTypes...)
 	}
-	return filterArtifactsByType(artifacts, excludeArtifactTypes), nil
+	return out
+}
+
+// singleFileArtifacts classifies one explicitly-named file into a single
+// artifact for `nox scan <file>` (fast pre-commit hooks, editor integrations).
+// The user named the file, so gitignore and scan.exclude do not apply; only the
+// configured artifact-type exclusions do.
+func singleFileArtifacts(path string, cfg *ScanConfig) ([]discovery.Artifact, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	reg := discovery.NewClassifierRegistry()
+	reg.Register(&discovery.DefaultClassifier{})
+	rel := filepath.Base(path)
+	art := discovery.Artifact{
+		Path:    filepath.ToSlash(rel),
+		AbsPath: abs,
+		Type:    reg.Classify(rel, info),
+		Size:    info.Size(),
+	}
+	return filterArtifactsByType([]discovery.Artifact{art}, excludeArtifactTypes(cfg)), nil
 }
 
 // refineFindings applies all post-analysis transformations to the merged

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -1908,6 +1908,39 @@ func TestRunScanWithOptions_TrackedOnly(t *testing.T) {
 	}
 }
 
+// TestRunScan_SingleFileTarget verifies `nox scan path/to/file` scans just that
+// file — loading config from the file's directory (not `file/.nox.yaml`) and
+// producing findings for the file. This is the basis for fast pre-commit hooks
+// and editor integrations. Previously a file target failed on config loading
+// and the walker skipped its own root, yielding nothing.
+func TestRunScan_SingleFileTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "app.py")
+	if err := os.WriteFile(file, []byte("import os\neval(response)\nkey = \"AKIAIOSFODNN7EXAMPLE\"\n"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+	// A sibling file that must NOT be scanned when a single file is targeted.
+	if err := os.WriteFile(filepath.Join(dir, "other.py"), []byte("key = \"AKIAIOSFODNN7EXAMPLE\"\n"), 0o644); err != nil {
+		t.Fatalf("writing sibling: %v", err)
+	}
+
+	result, err := RunScan(file)
+	if err != nil {
+		t.Fatalf("RunScan(file): %v", err)
+	}
+	ff := result.Findings.Findings()
+	if len(ff) == 0 {
+		t.Fatal("expected findings for the single file")
+	}
+	for _, f := range ff {
+		if strings.Contains(f.Location.FilePath, "other.py") {
+			t.Errorf("single-file scan must not include the sibling other.py: %s", f.Location.FilePath)
+		}
+	}
+}
+
 func initGitRepo(t *testing.T, files map[string]string) string {
 	t.Helper()
 


### PR DESCRIPTION
`nox scan path/to/file.py` was broken two ways:
1. Config loading looked for `file.py/.nox.yaml` → `ENOTDIR`.
2. The walker skips its own root, so pointing it at a file yielded **no artifacts**.

## Fix
- `LoadScanConfig` resolves a file target to its directory (fixes the CLI plugin-auto-install load *and* the core scan load in one place).
- `discoverArtifacts` detects a file target and classifies it into a single artifact directly. The user named the file explicitly, so gitignore/`scan.exclude` don't apply; artifact-type exclusions still do.

## Why it matters
Independently useful — **fast pre-commit hooks and editor integrations** scan one file instead of the whole tree — and it's the groundwork for a future `nox lsp` (which needs per-file diagnostics).

## Test
`TestRunScan_SingleFileTarget`: scans the file, produces findings (AI-009 + SEC-001), and excludes a sibling. Full `core/...` green; directory scans unchanged.

Verified e2e: `nox scan app.py` → `AI-009 L2`, `SEC-001 L3`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom