### PR TITLE
feat(fix): deterministic content-rule patches (nox fix --content) (#146 tier 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nox fix --content` — deterministic patches for mechanical misconfigurations.**
+  Reads `findings.json` and rewrites the flagged line to its one unambiguous
+  secure value: Kubernetes hardening flips (`privileged: true`→`false`,
+  `runAsNonRoot: false`→`true`, hostNetwork/hostPID/hostIPC/allowPrivilegeEscalation/
+  automountServiceAccountToken, readOnlyRootFilesystem), Terraform
+  (`storage_encrypted`/`enable_https_traffic_only`, `protocol "HTTP"`→`"HTTPS"`,
+  `acl "public-read"`→`"private"`), CI (`continue-on-error: true`→`false`), and
+  Dockerfile `ADD`→`COPY`. Template-free and no LLM — only rules with a single
+  correct answer are fixed; anything needing a choice (a UID, a pinned digest, an
+  allowlist, a rotated secret) is deliberately never touched. Previews the diff
+  by default and applies nothing; `--content --write` applies.
 - **`nox baseline init` — one-command adoption for a debt-laden repo.** Scans,
   records every current finding as accepted baseline debt (reported by
   severity), and prints the "gate the change, not the history" policy to add

--- a/cli/fix_cmd.go
+++ b/cli/fix_cmd.go
@@ -29,6 +29,8 @@ func runFix(args []string) int {
 		manifestRoot string
 		doActions    bool
 		onlyActions  bool
+		doContent    bool
+		write        bool
 	)
 	fs.StringVar(&inputPath, "input", "findings.json", "path to findings.json from a previous scan")
 	fs.BoolVar(&dryRun, "dry-run", false, "print actions without applying them")
@@ -36,8 +38,16 @@ func runFix(args []string) int {
 	fs.StringVar(&manifestRoot, "root", ".", "directory containing the project's manifest (go.mod)")
 	fs.BoolVar(&doActions, "actions", false, "also upgrade outdated GitHub Actions pins in .github/workflows (needs GITHUB_TOKEN)")
 	fs.BoolVar(&onlyActions, "actions-only", false, "only upgrade GitHub Actions pins; skip the package-dependency pass")
+	fs.BoolVar(&doContent, "content", false, "generate deterministic patches for mechanical IAC misconfigurations (previews the diff; add --write to apply)")
+	fs.BoolVar(&write, "write", false, "with --content: apply the patches instead of only previewing them")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+
+	// Content-rule fixing is a distinct mode: it reads findings.json and
+	// rewrites the flagged lines with their one unambiguous secure value.
+	if doContent {
+		return runContentFix(inputPath, write)
 	}
 
 	// GitHub Actions remediation runs independently of findings.json — it

--- a/cli/fix_content.go
+++ b/cli/fix_content.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// contentFix is a deterministic, template-free line transform for a rule whose
+// remediation is mechanical and unambiguous — a hardening boolean flip or an
+// exact value swap. re matches the insecure token on the finding's line; repl
+// is the replacement, using $1/$2 capture-group backrefs to preserve the
+// surrounding indentation, keys, and quotes.
+type contentFix struct {
+	re      *regexp.Regexp
+	repl    string
+	summary string
+}
+
+// contentFixes maps a rule ID to its deterministic fix. Only rules whose
+// remediation has ONE correct, judgment-free answer are listed — a secure
+// default flip or a safe value swap. Rules that need a choice (a non-root UID,
+// a pinned image digest, an explicit tool allowlist, a rotated secret) are
+// deliberately absent: nox never guesses a value.
+var contentFixes = map[string]contentFix{
+	// Kubernetes: disable a dangerous flag.
+	"IAC-007": {regexp.MustCompile(`(?i)(privileged\s*:\s*)true`), "${1}false", "privileged: true → false"},
+	"IAC-008": {regexp.MustCompile(`(?i)(hostNetwork\s*:\s*)true`), "${1}false", "hostNetwork: true → false"},
+	"IAC-009": {regexp.MustCompile(`(?i)(allowPrivilegeEscalation\s*:\s*)true`), "${1}false", "allowPrivilegeEscalation: true → false"},
+	"IAC-026": {regexp.MustCompile(`(?i)(hostPID\s*:\s*)true`), "${1}false", "hostPID: true → false"},
+	"IAC-027": {regexp.MustCompile(`(?i)(hostIPC\s*:\s*)true`), "${1}false", "hostIPC: true → false"},
+	"IAC-030": {regexp.MustCompile(`(?i)(automountServiceAccountToken\s*:\s*)true`), "${1}false", "automountServiceAccountToken: true → false"},
+	// Kubernetes: enable a protective flag.
+	"IAC-035": {regexp.MustCompile(`(?i)(runAsNonRoot\s*:\s*)false`), "${1}true", "runAsNonRoot: false → true"},
+	"IAC-029": {regexp.MustCompile(`(?i)(readOnlyRootFilesystem\s*:\s*)false`), "${1}true", "readOnlyRootFilesystem: false → true"},
+	// CI: fail on error instead of swallowing it.
+	"IAC-018": {regexp.MustCompile(`(?i)(continue-on-error\s*:\s*)true`), "${1}false", "continue-on-error: true → false"},
+	// Terraform: enable encryption / TLS-only transport.
+	"IAC-037": {regexp.MustCompile(`(?i)(storage_encrypted\s*=\s*)false`), "${1}true", "storage_encrypted = false → true"},
+	"IAC-042": {regexp.MustCompile(`(?i)(enable_https_traffic_only\s*=\s*)false`), "${1}true", "enable_https_traffic_only = false → true"},
+	// Terraform: HTTPS listener, private ACL.
+	"IAC-041": {regexp.MustCompile(`(?i)(protocol\s*=\s*["'])HTTP(["'])`), "${1}HTTPS${2}", `protocol "HTTP" → "HTTPS"`},
+	"IAC-040": {regexp.MustCompile(`(?i)(acl\s*=\s*["'])(?:public-read|public-read-write)(["'])`), "${1}private${2}", `acl "public-read" → "private"`},
+	// Dockerfile: COPY instead of ADD (ADD's implicit fetch/extract is a footgun).
+	"IAC-003": {regexp.MustCompile(`(?im)(^\s*)ADD(\s+)`), "${1}COPY${2}", "ADD → COPY"},
+}
+
+// runContentFix reads findings.json and, for each finding whose rule has a
+// deterministic fix, computes the patched line. By default it previews the
+// diff and applies nothing (nox never auto-rewrites code); --write applies.
+func runContentFix(inputPath string, write bool) int {
+	raw, err := os.ReadFile(inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: reading %s: %v\n", inputPath, err)
+		return 2
+	}
+	var doc struct {
+		Findings []findings.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "error: parsing %s: %v\n", inputPath, err)
+		return 2
+	}
+
+	// Collect fixable findings per file, preserving rule + line.
+	type edit struct {
+		line   int
+		ruleID string
+	}
+	byFile := map[string][]edit{}
+	for i := range doc.Findings {
+		f := doc.Findings[i]
+		if _, ok := contentFixes[f.RuleID]; !ok {
+			continue
+		}
+		byFile[f.Location.FilePath] = append(byFile[f.Location.FilePath], edit{line: f.Location.StartLine, ruleID: f.RuleID})
+	}
+	if len(byFile) == 0 {
+		fmt.Println("fix: no findings with a deterministic fix (content fixes cover the mechanical IAC misconfigurations)")
+		return 0
+	}
+
+	files := make([]string, 0, len(byFile))
+	for f := range byFile {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+
+	available, applied := 0, 0
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  skip %s: %v\n", file, err)
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		edits := byFile[file]
+		sort.Slice(edits, func(i, j int) bool { return edits[i].line < edits[j].line })
+
+		changed := false
+		for _, e := range edits {
+			idx := e.line - 1
+			if idx < 0 || idx >= len(lines) {
+				continue
+			}
+			fx := contentFixes[e.ruleID]
+			old := lines[idx]
+			newLine := fx.re.ReplaceAllString(old, fx.repl)
+			if newLine == old {
+				continue // already fixed, or the line moved since the scan
+			}
+			available++
+			fmt.Printf("%s:%d  %s (%s)\n", file, e.line, fx.summary, e.ruleID)
+			fmt.Printf("  - %s\n", strings.TrimSpace(old))
+			fmt.Printf("  + %s\n", strings.TrimSpace(newLine))
+			if write {
+				lines[idx] = newLine
+				changed = true
+				applied++
+			}
+		}
+		if write && changed {
+			if err := os.WriteFile(file, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "  error writing %s: %v\n", file, err)
+				return 2
+			}
+		}
+	}
+
+	if write {
+		fmt.Printf("fix: applied %d change(s)\n", applied)
+	} else if available > 0 {
+		fmt.Printf("fix: %d deterministic change(s) available — re-run with --content --write to apply\n", available)
+	}
+	return 0
+}

--- a/cli/fix_content_test.go
+++ b/cli/fix_content_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// runContentFix previews by default (never rewrites) and applies only with
+// write=true, flipping each flagged line to its one secure value.
+func TestRunContentFix(t *testing.T) {
+	dir := t.TempDir()
+	deploy := filepath.Join(dir, "deploy.yaml")
+	const before = "spec:\n  securityContext:\n    privileged: true\n    runAsNonRoot: false\n"
+	if err := os.WriteFile(deploy, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// findings.json referencing the two fixable lines.
+	findingsJSON := `{"findings":[
+	  {"RuleID":"IAC-007","Severity":"critical","Location":{"FilePath":"` + deploy + `","StartLine":3}},
+	  {"RuleID":"IAC-035","Severity":"high","Location":{"FilePath":"` + deploy + `","StartLine":4}}
+	]}`
+	inputPath := filepath.Join(dir, "findings.json")
+	if err := os.WriteFile(inputPath, []byte(findingsJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Preview must not modify the file.
+	if code := runContentFix(inputPath, false); code != 0 {
+		t.Fatalf("preview exit = %d", code)
+	}
+	if got, _ := os.ReadFile(deploy); string(got) != before {
+		t.Fatalf("preview modified the file:\n%s", got)
+	}
+
+	// --write applies the secure flips.
+	if code := runContentFix(inputPath, true); code != 0 {
+		t.Fatalf("write exit = %d", code)
+	}
+	const after = "spec:\n  securityContext:\n    privileged: false\n    runAsNonRoot: true\n"
+	if got, _ := os.ReadFile(deploy); string(got) != after {
+		t.Fatalf("write produced:\n%s\nwant:\n%s", got, after)
+	}
+}
+
+// A finding whose rule has no deterministic fix is left alone.
+func TestRunContentFix_NoFixForRule(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "findings.json")
+	// SEC-001 (a secret) has no mechanical fix — nox never guesses a value.
+	if err := os.WriteFile(inputPath, []byte(`{"findings":[{"RuleID":"SEC-001","Location":{"FilePath":"x","StartLine":1}}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := runContentFix(inputPath, true); code != 0 {
+		t.Fatalf("exit = %d, want 0 (no-op)", code)
+	}
+}


### PR DESCRIPTION
Roadmap #146, Tier 4 — deterministic fix-patch generation. Extends `nox fix` (today: deps + GitHub Actions) to the **mechanical IAC misconfigurations**: rules whose remediation has exactly **one** correct, judgment-free answer.

```
$ nox fix --content
Dockerfile:2  ADD → COPY (IAC-003)
  - ADD . /app
  + COPY . /app
deploy.yaml:3  privileged: true → false (IAC-007)
  - privileged: true
  + privileged: false
fix: 3 deterministic change(s) available — re-run with --content --write to apply
```

## What it fixes (template-free, no LLM)
- **Kubernetes**: `privileged`/`hostNetwork`/`hostPID`/`hostIPC`/`allowPrivilegeEscalation`/`automountServiceAccountToken` `true`→`false`; `runAsNonRoot`/`readOnlyRootFilesystem` `false`→`true`
- **Terraform**: `storage_encrypted`/`enable_https_traffic_only` `false`→`true`; `protocol "HTTP"`→`"HTTPS"`; `acl "public-read"`→`"private"`
- **CI**: `continue-on-error: true`→`false`
- **Dockerfile**: `ADD`→`COPY`

## What it deliberately does NOT touch
Anything needing a **choice** — a non-root UID, a pinned image digest, a tool allowlist, a rotated secret. nox never guesses a value. This is the deterministic, reviewable counterpart to the LLM "auto-fix" that competitors ship.

## Safety
Previews the diff and applies **nothing** by default; `--content --write` applies. (Config code is never rewritten without an explicit flag — stricter than the deps pass.)

## Tests
`TestRunContentFix` (preview is a no-op; `--write` flips both lines) + `TestRunContentFix_NoFixForRule`. Verified e2e across YAML + Dockerfile. Full `cli/` green.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom