### PR TITLE
feat(findings): reachability-aware priority sort (nox scan --sort priority) (#146 tier 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nox scan --sort priority` — reachability-aware finding prioritization.**
+  Orders findings.json by what's most actionable — severity first, then
+  reachability, then confidence — instead of the default rule/path/line order
+  that buries criticals. Paired with the reachability plugin (which enriches
+  VULN findings with a `reachable` flag), a confirmed-reachable vuln rises and a
+  likely-false-positive *unreachable* one sinks to the bottom, so the report
+  leads with real risk. Deterministic (stable location tiebreak); the default
+  order is unchanged, preserving baselines and diffs.
 - **`nox fix --content` — deterministic patches for mechanical misconfigurations.**
   Reads `findings.json` and rewrites the flagged line to its one unambiguous
   secure value: Kubernetes hardening flips (`privileged: true`→`false`,

--- a/cli/main.go
+++ b/cli/main.go
@@ -284,6 +284,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		noAutoInstallFlg      bool
 		failOnUnwaivedFlg     bool
 		offlineFlag           bool
+		sortFlag              string
 	)
 	scanFS.BoolVar(&historyFlag, "history", false, "scan git history for secrets in past commits")
 	scanFS.IntVar(&historyDepthFlag, "history-depth", 0, "max number of commits to scan (0 = unlimited)")
@@ -294,6 +295,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.BoolVar(&noAutoInstallFlg, "no-auto-install", false, "skip auto-installing plugins listed in .nox.yaml plugins.required")
 	scanFS.BoolVar(&failOnUnwaivedFlg, "fail-on-unwaived", false, "with --vex: only exit non-zero on findings NOT covered by an OpenVEX waiver")
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
+	scanFS.StringVar(&sortFlag, "sort", "deterministic", "findings.json order: 'deterministic' (rule/path/line) or 'priority' (severity, then reachability, then confidence — most actionable first)")
 	var fingerprintVersionFlag string
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
 	positionals, err := parseInterspersed(scanFS, args)
@@ -471,6 +473,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			path := filepath.Join(outputDir, "findings.json")
 			r := report.NewJSONReporter(version)
 			r.Offline = offlineFlag
+			r.Prioritize = sortFlag == "priority"
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -215,6 +215,64 @@ func (fs *FindingSet) SortDeterministic() {
 	})
 }
 
+// severityPriorityRank orders severities from most to least urgent.
+var severityPriorityRank = map[Severity]int{
+	SeverityCritical: 0, SeverityHigh: 1, SeverityMedium: 2, SeverityLow: 3, SeverityInfo: 4,
+}
+
+// confidencePriorityRank orders confidence from most to least certain.
+var confidencePriorityRank = map[Confidence]int{
+	ConfidenceHigh: 0, ConfidenceMedium: 1, ConfidenceLow: 2,
+}
+
+// reachabilityRank ranks a finding by the reachability plugin's `reachable`
+// enrichment: a confirmed-reachable finding is the most actionable, an
+// unreachable one is a likely false positive and sinks. Findings never analyzed
+// for reachability (no metadata) rank in the neutral middle, so enabling the
+// reachability plugin only ever demotes likely-FPs — it never buries a normal
+// finding beneath one.
+func reachabilityRank(f Finding) int {
+	switch f.Metadata["reachable"] {
+	case "true":
+		return 0
+	case "false":
+		return 2
+	default: // "undetermined" or absent
+		return 1
+	}
+}
+
+// SortByPriority orders findings for a human reading top-down: active findings
+// before suppressed/baselined ones, then by severity, then by reachability
+// (confirmed-reachable up, likely-false-positive unreachable down — see the
+// reachability plugin), then confidence, then a stable location tiebreak. Use
+// it for display/reporting; SortDeterministic remains the canonical order for
+// baselines and diffs.
+func (fs *FindingSet) SortByPriority() {
+	sort.SliceStable(fs.items, func(i, j int) bool {
+		a, b := fs.items[i], fs.items[j]
+		if av, bv := a.Status.IsActive(), b.Status.IsActive(); av != bv {
+			return av // active first
+		}
+		if ar, br := severityPriorityRank[a.Severity], severityPriorityRank[b.Severity]; ar != br {
+			return ar < br
+		}
+		if ar, br := reachabilityRank(a), reachabilityRank(b); ar != br {
+			return ar < br
+		}
+		if ac, bc := confidencePriorityRank[a.Confidence], confidencePriorityRank[b.Confidence]; ac != bc {
+			return ac < bc
+		}
+		if a.Location.FilePath != b.Location.FilePath {
+			return a.Location.FilePath < b.Location.FilePath
+		}
+		if a.Location.StartLine != b.Location.StartLine {
+			return a.Location.StartLine < b.Location.StartLine
+		}
+		return a.RuleID < b.RuleID
+	})
+}
+
 // RemoveByRuleIDs removes all findings whose RuleID matches any of the given IDs.
 func (fs *FindingSet) RemoveByRuleIDs(ids []string) {
 	if len(ids) == 0 {

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -231,7 +231,7 @@ var confidencePriorityRank = map[Confidence]int{
 // for reachability (no metadata) rank in the neutral middle, so enabling the
 // reachability plugin only ever demotes likely-FPs — it never buries a normal
 // finding beneath one.
-func reachabilityRank(f Finding) int {
+func reachabilityRank(f *Finding) int {
 	switch f.Metadata["reachable"] {
 	case "true":
 		return 0
@@ -257,7 +257,7 @@ func (fs *FindingSet) SortByPriority() {
 		if ar, br := severityPriorityRank[a.Severity], severityPriorityRank[b.Severity]; ar != br {
 			return ar < br
 		}
-		if ar, br := reachabilityRank(a), reachabilityRank(b); ar != br {
+		if ar, br := reachabilityRank(&a), reachabilityRank(&b); ar != br {
 			return ar < br
 		}
 		if ac, bc := confidencePriorityRank[a.Confidence], confidencePriorityRank[b.Confidence]; ac != bc {

--- a/core/findings/findings_test.go
+++ b/core/findings/findings_test.go
@@ -940,3 +940,35 @@ func TestNewFinding_AndValidate(t *testing.T) {
 		t.Error("invalid severity must fail validation")
 	}
 }
+
+// TestSortByPriority orders the most actionable findings first: severity, then
+// reachability (confirmed-reachable up, likely-false-positive unreachable
+// down), then confidence, with a stable location tiebreak.
+func TestSortByPriority(t *testing.T) {
+	fs := NewFindingSet()
+	mk := func(id string, sev Severity, reachable string) Finding {
+		f := Finding{RuleID: id, Severity: sev, Confidence: ConfidenceHigh, Status: StatusNew,
+			Location: Location{FilePath: "a.go", StartLine: 1}, Message: id}
+		if reachable != "" {
+			f.Metadata = map[string]string{"reachable": reachable}
+		}
+		return f
+	}
+	// Added out of priority order on purpose.
+	fs.Add(mk("VULN-low", SeverityLow, ""))
+	fs.Add(mk("VULN-crit-unreach", SeverityCritical, "false"))
+	fs.Add(mk("VULN-crit-reach", SeverityCritical, "true"))
+	fs.Add(mk("VULN-high", SeverityHigh, ""))
+
+	fs.SortByPriority()
+	got := make([]string, 0, 4)
+	for _, f := range fs.Findings() {
+		got = append(got, f.RuleID)
+	}
+	want := []string{"VULN-crit-reach", "VULN-crit-unreach", "VULN-high", "VULN-low"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("priority order = %v, want %v", got, want)
+		}
+	}
+}

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -46,6 +46,10 @@ type JSONReporter struct {
 	// Offline is recorded in the report Meta as the proof-of-offline
 	// attestation. Set it to the scan's `--offline` state before Generate.
 	Offline bool
+	// Prioritize orders findings by priority (severity, then reachability, then
+	// confidence) instead of the canonical deterministic order — the most
+	// actionable findings first, likely-false-positive unreachable vulns last.
+	Prioritize bool
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -58,7 +62,11 @@ func NewJSONReporter(version string) *JSONReporter {
 // pretty-printed JSON with 2-space indentation. The output is stable across
 // runs given the same input findings (aside from the GeneratedAt timestamp).
 func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
-	fs.SortDeterministic()
+	if r.Prioritize {
+		fs.SortByPriority()
+	} else {
+		fs.SortDeterministic()
+	}
 
 	f := fs.Findings()
 


### PR DESCRIPTION
Roadmap #146, Tier 4 — reachability-as-prioritization. The reachability plugin (core-analysis) already classifies VULN findings and **enriches them with a `reachable` flag** — but nothing consumed it. Findings always sorted by RuleID, so criticals were buried and likely-false-positive *unreachable* vulns sat among real ones.

## What

`FindingSet.SortByPriority()`, wired into the JSON reporter via **`nox scan --sort priority`**. Order:
1. active before suppressed/baselined
2. **severity** (critical → info)
3. **reachability** — confirmed-reachable up, likely-FP **unreachable down** (from the plugin's `reachable` metadata)
4. confidence
5. stable location tiebreak (deterministic)

```
default:         AI-008 (medium), AI-009 (critical)   ← critical buried
--sort priority: AI-009 (critical), AI-008 (medium)   ← most actionable first
```

Paired with the reachability plugin, a confirmed-reachable vuln rises and an unreachable one sinks. Findings **never analyzed** for reachability rank in the neutral middle, so enabling the plugin only ever demotes likely-FPs — it never buries a normal finding beneath one.

## Safety
The **default order is unchanged** (rule/path/line), so baselines, diffs, and golden output are unaffected — `--sort priority` is purely a display/report opt-in.

## Test
`TestSortByPriority`: crit-reachable > crit-unreachable > high > low. Verified e2e. Full `core/...` + `cli/...` green.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom