### PR TITLE
feat(ai-eval): map runtime findings to OWASP LLM/ASI controls (#146 tier 3.7)

### DIFF
--- a/plugins/nox-plugin-ai-eval/CHANGELOG.md
+++ b/plugins/nox-plugin-ai-eval/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **OWASP control mappings on runtime findings.** Each successful attack now
+  carries the OWASP LLM Top 10 (2025) and OWASP Agentic Security Initiative
+  (ASI) Top 10 controls it demonstrates, attached via an `owasp` metadata key
+  (comma-joined `owasp-llm*` / `owasp-asi*` tags, mirroring the static AI
+  analyzer rules). Mapping: jailbreak & role-confusion → `owasp-llm01`
+  (Prompt Injection) + `owasp-asi01` (Agent Goal Hijack); system-prompt leak →
+  `owasp-llm07` (System Prompt Leakage); tool misuse → `owasp-asi02`
+  (Tool Misuse) + `owasp-llm06` (Excessive Agency). This makes nox's
+  deterministic runtime red-team lane first-class and consistent with the
+  static lane. A new deterministic `owaspTags(AttackKind)` is the single source
+  of truth (unknown/zero kind → no mapping, never guessed).
+- `TestOWASPTags` and `TestOWASPTags_EveryCorpusKindMapped` covering the kind →
+  control mapping, plus `TestHandleAIEval_AttachesOWASPMetadata` asserting the
+  metadata reaches an emitted finding.

--- a/plugins/nox-plugin-ai-eval/corpus.go
+++ b/plugins/nox-plugin-ai-eval/corpus.go
@@ -24,6 +24,31 @@ const (
 	AttackToolMisuse    AttackKind = "tool_misuse"
 )
 
+// owaspTags returns the OWASP control tags for an attack kind, mapping
+// each runtime attack class onto the OWASP LLM Top 10 (2025) and the
+// OWASP Agentic Security Initiative (ASI) Top 10. The tag strings mirror
+// the ones the static AI analyzer rules attach (owasp-llm* / owasp-asi*)
+// so nox's deterministic runtime red-team lane is first-class and
+// consistent with the static lane.
+//
+// An unknown or zero kind returns nil — we never guess a mapping.
+func owaspTags(kind AttackKind) []string {
+	switch kind {
+	case AttackJailbreak, AttackRoleConfusion:
+		// Instruction override / persona hijack: LLM01 Prompt Injection
+		// + ASI01 Agent Goal Hijack (Memory & Context Manipulation).
+		return []string{"owasp-llm01", "owasp-asi01"}
+	case AttackSystemLeak:
+		// System-prompt extraction: LLM07 System Prompt Leakage.
+		return []string{"owasp-llm07"}
+	case AttackToolMisuse:
+		// Coerced/unauthorised tool invocation: ASI02 Tool Misuse +
+		// LLM06 Excessive Agency.
+		return []string{"owasp-asi02", "owasp-llm06"}
+	}
+	return nil
+}
+
 // CorpusEntry is one adversarial prompt + the markers that identify
 // a successful attack in the response.
 type CorpusEntry struct {

--- a/plugins/nox-plugin-ai-eval/corpus_test.go
+++ b/plugins/nox-plugin-ai-eval/corpus_test.go
@@ -2,6 +2,59 @@ package main
 
 import "testing"
 
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOWASPTags(t *testing.T) {
+	cases := []struct {
+		name string
+		kind AttackKind
+		want []string
+	}{
+		{"jailbreak", AttackJailbreak, []string{"owasp-llm01", "owasp-asi01"}},
+		{"role_confusion", AttackRoleConfusion, []string{"owasp-llm01", "owasp-asi01"}},
+		{"system_leak", AttackSystemLeak, []string{"owasp-llm07"}},
+		{"tool_misuse", AttackToolMisuse, []string{"owasp-asi02", "owasp-llm06"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := owaspTags(tc.kind)
+			if len(got) != len(tc.want) {
+				t.Fatalf("kind %s: got %v, want %v", tc.kind, got, tc.want)
+			}
+			for _, w := range tc.want {
+				if !contains(got, w) {
+					t.Errorf("kind %s: missing tag %q (got %v)", tc.kind, w, got)
+				}
+			}
+		})
+	}
+
+	// Unknown / zero kind must never guess a mapping.
+	if got := owaspTags(AttackKind("")); got != nil {
+		t.Errorf("zero kind: expected nil, got %v", got)
+	}
+	if got := owaspTags(AttackKind("nonsense")); got != nil {
+		t.Errorf("unknown kind: expected nil, got %v", got)
+	}
+}
+
+func TestOWASPTags_EveryCorpusKindMapped(t *testing.T) {
+	// Every kind used by the shipped corpus must carry OWASP tags so no
+	// emitted finding lacks a control mapping.
+	for _, e := range Corpus() {
+		if len(owaspTags(e.Kind)) == 0 {
+			t.Errorf("corpus entry %s (kind %s) has no OWASP mapping", e.ID, e.Kind)
+		}
+	}
+}
+
 func TestCorpus_Nonempty(t *testing.T) {
 	c := Corpus()
 	if len(c) < 10 {

--- a/plugins/nox-plugin-ai-eval/main.go
+++ b/plugins/nox-plugin-ai-eval/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"github.com/nox-hq/nox/sdk"
@@ -134,6 +135,13 @@ func handleAIEval(ctx context.Context, req sdk.ToolRequest) (*pluginv1.InvokeToo
 		fb.WithMetadata("http_status", fmt.Sprintf("%d", v.Status))
 		fb.WithMetadata("response_excerpt", v.Body)
 		fb.WithMetadata("cwe", cwe)
+		// OWASP LLM/ASI control tags, comma-joined under a single
+		// `owasp` metadata key (the convention used by the AI analyzer
+		// findings in core). Mirrors the static rules so a runtime
+		// finding surfaces the same owasp-llm* / owasp-asi* controls.
+		if tags := owaspTags(v.Entry.Kind); len(tags) > 0 {
+			fb.WithMetadata("owasp", strings.Join(tags, ","))
+		}
 		fb.Done()
 	}
 

--- a/plugins/nox-plugin-ai-eval/main_test.go
+++ b/plugins/nox-plugin-ai-eval/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/sdk"
+)
+
+// TestHandleAIEval_AttachesOWASPMetadata drives the tool handler end to
+// end against a stub endpoint that succumbs to a jailbreak marker, then
+// asserts the emitted finding carries the OWASP LLM/ASI control tags.
+func TestHandleAIEval_AttachesOWASPMetadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always concede the DAN jailbreak marker (AI-EVAL-J01).
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"DAN ready"}}]}`))
+	}))
+	defer srv.Close()
+
+	req := sdk.ToolRequest{
+		ToolName: "ai_eval",
+		Input: map[string]any{
+			"endpoint":          srv.URL,
+			"authorize":         true,
+			"authorized_target": srv.URL,
+		},
+	}
+
+	resp, err := handleAIEval(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleAIEval returned error: %v", err)
+	}
+
+	findings := resp.GetFindings()
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding, got none")
+	}
+
+	var checked bool
+	for _, f := range findings {
+		md := f.GetMetadata()
+		if md["attack_kind"] != string(AttackJailbreak) {
+			continue
+		}
+		checked = true
+		owasp := md["owasp"]
+		if !strings.Contains(owasp, "owasp-llm01") || !strings.Contains(owasp, "owasp-asi01") {
+			t.Errorf("jailbreak finding owasp metadata = %q, want owasp-llm01 and owasp-asi01", owasp)
+		}
+	}
+	if !checked {
+		t.Fatal("no jailbreak finding emitted to assert OWASP metadata on")
+	}
+}


### PR DESCRIPTION
Roadmap #146, Tier 3.7 — I made the runtime-testing call: **own it deterministically** rather than cede to LLM-judged tools. The `nox-plugin-ai-eval` already runs a bundled adversarial corpus (jailbreak / system-leak / role-confusion / tool-misuse) against a chat endpoint behind a consent gate — a deterministic runtime red-team lane. This makes it **first-class**: its findings now carry the same OWASP controls as the static scanner (#151).

## What
`owaspTags(AttackKind)` — single source of truth:
- jailbreak, role-confusion → `owasp-llm01` (Prompt Injection) + `owasp-asi01` (Agent Goal Hijack)
- system-leak → `owasp-llm07` (System Prompt Leakage)
- tool-misuse → `owasp-asi02` (Tool Misuse) + `owasp-llm06` (Excessive Agency)
- unknown/zero kind → nil (never guessed)

`handleAIEval` attaches them under the `owasp` metadata key (comma-joined) — the convention the core AI analyzer uses. So a runtime finding and its static counterpart map to the same controls, all the way through to GRC evidence.

## Tests
`TestOWASPTags` (per-kind + unknown→nil), `TestOWASPTags_EveryCorpusKindMapped` (no shipped corpus kind is unmapped), `TestHandleAIEval_AttachesOWASPMetadata` (finding-level, via httptest stub). Build + vet + tests + gofmt all clean in the plugin module. Reviewed and re-verified.

Lands in the plugin's `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom