### PR TITLE
feat(lsp): nox lsp — inline, offline, deterministic diagnostics (#146 tier 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nox lsp` — Language Server for editor diagnostics.** Runs a minimal LSP
+  server over stdio (JSON-RPC 2.0 with `Content-Length` framing) that scans the
+  active file on open/save and publishes nox findings as
+  `textDocument/publishDiagnostics`. Deterministic and fully offline — it just
+  runs the scanner on the one file, maps each finding's location/severity/RuleID
+  onto an LSP diagnostic (critical/high→Error, medium→Warning, low→Information,
+  info→Hint), and sorts them stably by line, column, then rule id. Hand-rolled
+  JSON-RPC (no third-party LSP library, no network); `didClose` clears
+  diagnostics and scan errors publish an empty set instead of crashing.
 - **`nox scan --sort priority` — reachability-aware finding prioritization.**
   Orders findings.json by what's most actionable — severity first, then
   reachability, then confidence — instead of the default rule/path/line order

--- a/cli/lsp/diagnostics.go
+++ b/cli/lsp/diagnostics.go
@@ -53,7 +53,7 @@ func severityToLSP(s findings.Severity) int {
 // nox locations use 1-based lines and 0-based columns; LSP uses 0-based for
 // both. Negative coordinates are clamped to 0, and a non-positive-width column
 // span is widened to a single character so editors always render a mark.
-func findingToDiagnostic(f findings.Finding) Diagnostic {
+func findingToDiagnostic(f *findings.Finding) Diagnostic {
 	loc := f.Location
 
 	startLine := loc.StartLine - 1
@@ -96,7 +96,7 @@ func findingToDiagnostic(f findings.Finding) Diagnostic {
 func findingsToDiagnostics(fs []findings.Finding) []Diagnostic {
 	diags := make([]Diagnostic, 0, len(fs))
 	for i := range fs {
-		diags = append(diags, findingToDiagnostic(fs[i]))
+		diags = append(diags, findingToDiagnostic(&fs[i]))
 	}
 	sort.SliceStable(diags, func(i, j int) bool {
 		a, b := diags[i], diags[j]

--- a/cli/lsp/diagnostics.go
+++ b/cli/lsp/diagnostics.go
@@ -1,0 +1,112 @@
+package lsp
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Position is a zero-based line/character offset in a text document.
+type Position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+// Range is a half-open [start, end) span in a text document.
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+// Diagnostic is an LSP diagnostic derived from a nox finding.
+type Diagnostic struct {
+	Range    Range  `json:"range"`
+	Severity int    `json:"severity"`
+	Code     string `json:"code"`
+	Source   string `json:"source"`
+	Message  string `json:"message"`
+}
+
+// LSP DiagnosticSeverity values.
+const (
+	severityError       = 1
+	severityWarning     = 2
+	severityInformation = 3
+	severityHint        = 4
+)
+
+// severityToLSP maps a nox severity onto an LSP DiagnosticSeverity.
+func severityToLSP(s findings.Severity) int {
+	switch s {
+	case findings.SeverityCritical, findings.SeverityHigh:
+		return severityError
+	case findings.SeverityMedium:
+		return severityWarning
+	case findings.SeverityLow:
+		return severityInformation
+	default: // info and anything unrecognised
+		return severityHint
+	}
+}
+
+// findingToDiagnostic converts a single nox finding into an LSP diagnostic.
+// nox locations use 1-based lines and 0-based columns; LSP uses 0-based for
+// both. Negative coordinates are clamped to 0, and a non-positive-width column
+// span is widened to a single character so editors always render a mark.
+func findingToDiagnostic(f findings.Finding) Diagnostic {
+	loc := f.Location
+
+	startLine := loc.StartLine - 1
+	if startLine < 0 {
+		startLine = 0
+	}
+
+	endLineBase := loc.StartLine
+	if loc.EndLine > endLineBase {
+		endLineBase = loc.EndLine
+	}
+	endLine := endLineBase - 1
+	if endLine < 0 {
+		endLine = 0
+	}
+
+	startChar := loc.StartColumn
+	if startChar < 0 {
+		startChar = 0
+	}
+	endChar := loc.EndColumn
+	if endChar <= startChar {
+		endChar = startChar + 1
+	}
+
+	return Diagnostic{
+		Range: Range{
+			Start: Position{Line: startLine, Character: startChar},
+			End:   Position{Line: endLine, Character: endChar},
+		},
+		Severity: severityToLSP(f.Severity),
+		Code:     f.RuleID,
+		Source:   "nox",
+		Message:  f.Message,
+	}
+}
+
+// findingsToDiagnostics converts and stably sorts a set of findings into
+// diagnostics ordered by start line, then start column, then rule id.
+func findingsToDiagnostics(fs []findings.Finding) []Diagnostic {
+	diags := make([]Diagnostic, 0, len(fs))
+	for i := range fs {
+		diags = append(diags, findingToDiagnostic(fs[i]))
+	}
+	sort.SliceStable(diags, func(i, j int) bool {
+		a, b := diags[i], diags[j]
+		if a.Range.Start.Line != b.Range.Start.Line {
+			return a.Range.Start.Line < b.Range.Start.Line
+		}
+		if a.Range.Start.Character != b.Range.Start.Character {
+			return a.Range.Start.Character < b.Range.Start.Character
+		}
+		return a.Code < b.Code
+	})
+	return diags
+}

--- a/cli/lsp/diagnostics_test.go
+++ b/cli/lsp/diagnostics_test.go
@@ -32,7 +32,7 @@ func TestFindingToDiagnosticClamping(t *testing.T) {
 			StartColumn: 5, EndColumn: 5, // zero-width -> widen to StartColumn+1
 		},
 	}
-	d := findingToDiagnostic(f)
+	d := findingToDiagnostic(&f)
 	if d.Range.Start.Line != 0 || d.Range.End.Line != 0 {
 		t.Errorf("lines = %d..%d, want 0..0", d.Range.Start.Line, d.Range.End.Line)
 	}
@@ -53,7 +53,7 @@ func TestFindingToDiagnosticNegativeClampAndMultiline(t *testing.T) {
 			StartColumn: -3, EndColumn: 2, // start clamps to 0, end 2 > 0 kept
 		},
 	}
-	d := findingToDiagnostic(f)
+	d := findingToDiagnostic(&f)
 	if d.Range.Start.Line != 0 {
 		t.Errorf("start line = %d, want 0", d.Range.Start.Line)
 	}

--- a/cli/lsp/diagnostics_test.go
+++ b/cli/lsp/diagnostics_test.go
@@ -1,0 +1,85 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+func TestSeverityToLSP(t *testing.T) {
+	cases := map[findings.Severity]int{
+		findings.SeverityCritical: severityError,
+		findings.SeverityHigh:     severityError,
+		findings.SeverityMedium:   severityWarning,
+		findings.SeverityLow:      severityInformation,
+		findings.SeverityInfo:     severityHint,
+		findings.Severity("wat"):  severityHint,
+	}
+	for sev, want := range cases {
+		if got := severityToLSP(sev); got != want {
+			t.Errorf("severityToLSP(%q) = %d, want %d", sev, got, want)
+		}
+	}
+}
+
+func TestFindingToDiagnosticClamping(t *testing.T) {
+	f := findings.Finding{
+		RuleID:   "SEC-001",
+		Severity: findings.SeverityHigh,
+		Message:  "boom",
+		Location: findings.Location{
+			StartLine: 1, EndLine: 0, // 1-based; EndLine defaults below StartLine
+			StartColumn: 5, EndColumn: 5, // zero-width -> widen to StartColumn+1
+		},
+	}
+	d := findingToDiagnostic(f)
+	if d.Range.Start.Line != 0 || d.Range.End.Line != 0 {
+		t.Errorf("lines = %d..%d, want 0..0", d.Range.Start.Line, d.Range.End.Line)
+	}
+	if d.Range.Start.Character != 5 || d.Range.End.Character != 6 {
+		t.Errorf("chars = %d..%d, want 5..6", d.Range.Start.Character, d.Range.End.Character)
+	}
+	if d.Code != "SEC-001" || d.Source != "nox" || d.Message != "boom" {
+		t.Errorf("unexpected fields: %+v", d)
+	}
+}
+
+func TestFindingToDiagnosticNegativeClampAndMultiline(t *testing.T) {
+	f := findings.Finding{
+		RuleID:   "X-1",
+		Severity: findings.SeverityLow,
+		Location: findings.Location{
+			StartLine: 0, EndLine: 4, // StartLine-1 = -1 -> clamp to 0; end uses max(0,4)-1=3
+			StartColumn: -3, EndColumn: 2, // start clamps to 0, end 2 > 0 kept
+		},
+	}
+	d := findingToDiagnostic(f)
+	if d.Range.Start.Line != 0 {
+		t.Errorf("start line = %d, want 0", d.Range.Start.Line)
+	}
+	if d.Range.End.Line != 3 {
+		t.Errorf("end line = %d, want 3", d.Range.End.Line)
+	}
+	if d.Range.Start.Character != 0 || d.Range.End.Character != 2 {
+		t.Errorf("chars = %d..%d, want 0..2", d.Range.Start.Character, d.Range.End.Character)
+	}
+}
+
+func TestFindingsToDiagnosticsSortStable(t *testing.T) {
+	fs := []findings.Finding{
+		{RuleID: "B", Severity: findings.SeverityHigh, Location: findings.Location{StartLine: 3, StartColumn: 1, EndColumn: 2}},
+		{RuleID: "A", Severity: findings.SeverityHigh, Location: findings.Location{StartLine: 1, StartColumn: 4, EndColumn: 5}},
+		{RuleID: "C", Severity: findings.SeverityHigh, Location: findings.Location{StartLine: 1, StartColumn: 4, EndColumn: 5}},
+		{RuleID: "A2", Severity: findings.SeverityHigh, Location: findings.Location{StartLine: 1, StartColumn: 2, EndColumn: 3}},
+	}
+	got := findingsToDiagnostics(fs)
+	wantOrder := []string{"A2", "A", "C", "B"} // line1 col2, line1 col4 (A<C), line3
+	if len(got) != len(wantOrder) {
+		t.Fatalf("len = %d, want %d", len(got), len(wantOrder))
+	}
+	for i, code := range wantOrder {
+		if got[i].Code != code {
+			t.Errorf("order[%d] = %q, want %q (full: %+v)", i, got[i].Code, code, got)
+		}
+	}
+}

--- a/cli/lsp/lsp.go
+++ b/cli/lsp/lsp.go
@@ -1,0 +1,313 @@
+// Package lsp implements a minimal Language Server Protocol (LSP) server for
+// nox. It speaks JSON-RPC 2.0 over stdio (with Content-Length framing) and
+// publishes nox scan findings as editor diagnostics.
+//
+// The server is deliberately small and offline: on didOpen/didSave it runs the
+// nox scanner against the single opened file and pushes the resulting findings
+// back to the editor as textDocument/publishDiagnostics notifications. There is
+// no dependency on any third-party LSP library — the JSON-RPC framing is
+// hand-rolled on top of encoding/json and bufio.
+package lsp
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// ScanFunc scans a single file path and returns the findings for it. It is a
+// seam that lets tests drive the server without invoking the real scanner.
+type ScanFunc func(path string) ([]findings.Finding, error)
+
+// defaultScan runs the real nox scanner against a single file.
+func defaultScan(path string) ([]findings.Finding, error) {
+	result, err := nox.RunScan(path)
+	if err != nil {
+		return nil, err
+	}
+	return result.Findings.Findings(), nil
+}
+
+// Server is a stdio LSP server instance.
+type Server struct {
+	reader  *bufio.Reader
+	writer  io.Writer
+	version string
+	scan    ScanFunc
+}
+
+// NewServer builds a Server that reads JSON-RPC messages from r and writes
+// responses/notifications to w. version is reported back in the initialize
+// response's serverInfo.
+func NewServer(r io.Reader, w io.Writer, version string) *Server {
+	return &Server{
+		reader:  bufio.NewReader(r),
+		writer:  w,
+		version: version,
+		scan:    defaultScan,
+	}
+}
+
+// --- Wire types ---------------------------------------------------------------
+
+// incomingMessage is a decoded JSON-RPC request or notification. Requests carry
+// an id; notifications do not.
+type incomingMessage struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// isRequest reports whether the message expects a response (i.e. it has an id).
+func (m *incomingMessage) isRequest() bool {
+	return len(m.ID) > 0 && string(m.ID) != "null"
+}
+
+type responseMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type notificationMessage struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// --- Framing ------------------------------------------------------------------
+
+// writeMessage marshals v to JSON and writes it framed with a Content-Length
+// header, per the LSP base protocol.
+func writeMessage(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Content-Length: %d\r\n\r\n", len(data)); err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// readMessage parses one framed message: it reads header lines until the blank
+// separator, then reads exactly Content-Length bytes of body. It returns
+// io.EOF when the stream is cleanly exhausted before a header.
+func readMessage(r *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+	sawHeader := false
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF && !sawHeader && line == "" {
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+		sawHeader = true
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break // blank line terminates the header block
+		}
+		if idx := strings.IndexByte(line, ':'); idx >= 0 {
+			name := strings.TrimSpace(line[:idx])
+			value := strings.TrimSpace(line[idx+1:])
+			if strings.EqualFold(name, "Content-Length") {
+				n, err := strconv.Atoi(value)
+				if err != nil {
+					return nil, fmt.Errorf("lsp: invalid Content-Length %q: %w", value, err)
+				}
+				contentLength = n
+			}
+		}
+	}
+	if contentLength < 0 {
+		return nil, errors.New("lsp: message missing Content-Length header")
+	}
+	buf := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// --- Serve loop ---------------------------------------------------------------
+
+// Serve runs the read/dispatch loop until an `exit` notification is received or
+// the input stream reaches EOF. It returns nil on a clean shutdown.
+func (s *Server) Serve() error {
+	for {
+		body, err := readMessage(s.reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		var msg incomingMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			// Malformed frame: skip it rather than tearing down the session.
+			continue
+		}
+		exit, err := s.handle(&msg)
+		if err != nil {
+			return err
+		}
+		if exit {
+			return nil
+		}
+	}
+}
+
+// handle dispatches a single decoded message. It returns exit=true when the
+// serve loop should terminate (on `exit`).
+func (s *Server) handle(msg *incomingMessage) (exit bool, err error) {
+	switch msg.Method {
+	case "initialize":
+		return false, s.reply(msg.ID, s.initializeResult())
+	case "initialized":
+		return false, nil // notification, no-op
+	case "textDocument/didOpen", "textDocument/didSave":
+		return false, s.scanAndPublish(msg.Params)
+	case "textDocument/didClose":
+		return false, s.clearDiagnostics(msg.Params)
+	case "shutdown":
+		// Respond with null result per the LSP spec.
+		return false, s.reply(msg.ID, nil)
+	case "exit":
+		return true, nil
+	default:
+		if msg.isRequest() {
+			return false, s.replyError(msg.ID, -32601, "method not found: "+msg.Method)
+		}
+		return false, nil // unknown notification: ignore
+	}
+}
+
+func (s *Server) initializeResult() interface{} {
+	return map[string]interface{}{
+		"capabilities": map[string]interface{}{
+			// 1 == TextDocumentSyncKind.Full
+			"textDocumentSync": 1,
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "nox-lsp",
+			"version": s.version,
+		},
+	}
+}
+
+// textDocumentParams captures the { textDocument: { uri } } shape shared by the
+// didOpen/didSave/didClose notifications.
+type textDocumentParams struct {
+	TextDocument struct {
+		URI string `json:"uri"`
+	} `json:"textDocument"`
+}
+
+func parseURI(params json.RawMessage) (string, error) {
+	var p textDocumentParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return "", err
+	}
+	if p.TextDocument.URI == "" {
+		return "", errors.New("lsp: missing textDocument.uri")
+	}
+	return p.TextDocument.URI, nil
+}
+
+// scanAndPublish resolves the document URI to a path, scans that single file,
+// and pushes diagnostics for the URI. On any scan error it publishes an empty
+// diagnostics array so a stale set is cleared and the server never crashes.
+func (s *Server) scanAndPublish(params json.RawMessage) error {
+	uri, err := parseURI(params)
+	if err != nil {
+		return nil // cannot publish without a URI; ignore quietly
+	}
+	diags := []Diagnostic{}
+	if path, err := uriToPath(uri); err == nil {
+		if found, scanErr := s.scan(path); scanErr == nil {
+			diags = findingsToDiagnostics(found)
+		}
+	}
+	return s.publishDiagnostics(uri, diags)
+}
+
+// clearDiagnostics publishes an empty diagnostics array for a closed document.
+func (s *Server) clearDiagnostics(params json.RawMessage) error {
+	uri, err := parseURI(params)
+	if err != nil {
+		return nil
+	}
+	return s.publishDiagnostics(uri, []Diagnostic{})
+}
+
+type publishDiagnosticsParams struct {
+	URI         string       `json:"uri"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+func (s *Server) publishDiagnostics(uri string, diags []Diagnostic) error {
+	return writeMessage(s.writer, notificationMessage{
+		JSONRPC: "2.0",
+		Method:  "textDocument/publishDiagnostics",
+		Params: publishDiagnosticsParams{
+			URI:         uri,
+			Diagnostics: diags,
+		},
+	})
+}
+
+func (s *Server) reply(id json.RawMessage, result interface{}) error {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return writeMessage(s.writer, responseMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  json.RawMessage(data),
+	})
+}
+
+func (s *Server) replyError(id json.RawMessage, code int, message string) error {
+	return writeMessage(s.writer, responseMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: message},
+	})
+}
+
+// uriToPath converts a file:// URI to a local filesystem path. Percent-encoding
+// is decoded by url.Parse. A leading-slash Windows drive path (/C:/x) is
+// normalised to C:/x.
+func uriToPath(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("lsp: unsupported URI scheme %q", u.Scheme)
+	}
+	path := u.Path
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:] // strip leading slash before a drive letter
+	}
+	return filepath.FromSlash(path), nil
+}

--- a/cli/lsp/lsp_test.go
+++ b/cli/lsp/lsp_test.go
@@ -1,0 +1,293 @@
+package lsp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// TestFramingRoundTrip verifies that a value written with writeMessage can be
+// read back byte-for-byte with readMessage (Content-Length framing).
+func TestFramingRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	original := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "textDocument/didOpen",
+		"params":  map[string]interface{}{"n": 42, "s": "héllo, wörld"},
+	}
+	if err := writeMessage(&buf, original); err != nil {
+		t.Fatalf("writeMessage: %v", err)
+	}
+
+	// The frame must start with the header and a CRLFCRLF separator.
+	if !bytes.Contains(buf.Bytes(), []byte("\r\n\r\n")) {
+		t.Fatalf("frame missing CRLFCRLF separator: %q", buf.String())
+	}
+
+	r := bufio.NewReader(&buf)
+	body, err := readMessage(r)
+	if err != nil {
+		t.Fatalf("readMessage: %v", err)
+	}
+
+	want, _ := json.Marshal(original)
+	if !bytes.Equal(body, want) {
+		t.Fatalf("round-trip mismatch:\n got %s\nwant %s", body, want)
+	}
+}
+
+// outMessage is a loosely-typed decode of anything the server writes back.
+type outMessage struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+	Params struct {
+		URI         string       `json:"uri"`
+		Diagnostics []Diagnostic `json:"diagnostics"`
+	} `json:"params"`
+}
+
+// drainMessages reads every framed message out of buf until EOF.
+func drainMessages(t *testing.T, buf *bytes.Buffer) []outMessage {
+	t.Helper()
+	r := bufio.NewReader(buf)
+	var msgs []outMessage
+	for {
+		body, err := readMessage(r)
+		if err != nil {
+			break // EOF or exhausted
+		}
+		var m outMessage
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("decode out message %q: %v", body, err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+// TestServeFullFlow drives initialize -> didOpen -> shutdown -> exit against
+// in-memory streams and asserts a publishDiagnostics with a real AI-009
+// finding (from `eval(response)` in a temp .py file).
+func TestServeFullFlow(t *testing.T) {
+	dir := t.TempDir()
+	pyPath := filepath.Join(dir, "vuln.py")
+	src := "import x\nresponse = get()\ndata = eval(response)\n"
+	if err := os.WriteFile(pyPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write temp py: %v", err)
+	}
+	uri := (&url.URL{Scheme: "file", Path: pyPath}).String()
+
+	var in bytes.Buffer
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]interface{}{},
+	})
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]interface{}{
+			"textDocument": map[string]interface{}{"uri": uri, "text": src},
+		},
+	})
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "id": 2, "method": "shutdown",
+	})
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "method": "exit",
+	})
+
+	var out bytes.Buffer
+	srv := NewServer(&in, &out, "test")
+	if err := srv.Serve(); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	msgs := drainMessages(t, &out)
+
+	// initialize response must advertise Full sync and serverInfo.
+	init := findByID(t, msgs, "1")
+	var initResult struct {
+		Capabilities struct {
+			TextDocumentSync int `json:"textDocumentSync"`
+		} `json:"capabilities"`
+		ServerInfo struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(init.Result, &initResult); err != nil {
+		t.Fatalf("decode initialize result: %v", err)
+	}
+	if initResult.Capabilities.TextDocumentSync != 1 {
+		t.Errorf("textDocumentSync = %d, want 1 (Full)", initResult.Capabilities.TextDocumentSync)
+	}
+	if initResult.ServerInfo.Name == "" || initResult.ServerInfo.Version != "test" {
+		t.Errorf("unexpected serverInfo: %+v", initResult.ServerInfo)
+	}
+
+	// publishDiagnostics for the URI with an AI-009 error diagnostic.
+	var pub *outMessage
+	for i := range msgs {
+		if msgs[i].Method == "textDocument/publishDiagnostics" {
+			pub = &msgs[i]
+			break
+		}
+	}
+	if pub == nil {
+		t.Fatalf("no publishDiagnostics notification; got %d messages", len(msgs))
+	}
+	if pub.Params.URI != uri {
+		t.Errorf("publishDiagnostics uri = %q, want %q", pub.Params.URI, uri)
+	}
+	if len(pub.Params.Diagnostics) < 1 {
+		t.Fatalf("expected >=1 diagnostic, got %d", len(pub.Params.Diagnostics))
+	}
+	var found *Diagnostic
+	for i := range pub.Params.Diagnostics {
+		if pub.Params.Diagnostics[i].Code == "AI-009" {
+			found = &pub.Params.Diagnostics[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no AI-009 diagnostic in %+v", pub.Params.Diagnostics)
+	}
+	if found.Severity != severityError {
+		t.Errorf("AI-009 severity = %d, want %d (Error)", found.Severity, severityError)
+	}
+	if found.Source != "nox" {
+		t.Errorf("diagnostic source = %q, want nox", found.Source)
+	}
+	// eval(response) is on the 3rd line (0-based line 2).
+	if found.Range.Start.Line != 2 {
+		t.Errorf("AI-009 start line = %d, want 2", found.Range.Start.Line)
+	}
+
+	// shutdown response must be a JSON null result.
+	sh := findByID(t, msgs, "2")
+	if string(sh.Result) != "null" {
+		t.Errorf("shutdown result = %q, want null", sh.Result)
+	}
+}
+
+// TestShutdownExitReturns confirms the serve loop returns cleanly on exit and
+// that shutdown yields a null result.
+func TestShutdownExitReturns(t *testing.T) {
+	var in bytes.Buffer
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "id": 7, "method": "shutdown"})
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	srv := NewServer(&in, &out, "test")
+	if err := srv.Serve(); err != nil {
+		t.Fatalf("Serve should return nil on exit, got %v", err)
+	}
+
+	msgs := drainMessages(t, &out)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 response (shutdown), got %d", len(msgs))
+	}
+	if string(msgs[0].Result) != "null" {
+		t.Errorf("shutdown result = %q, want null", msgs[0].Result)
+	}
+}
+
+// TestUnknownRequestError verifies an unknown request gets a -32601 error and
+// an unknown notification is silently ignored.
+func TestUnknownRequestError(t *testing.T) {
+	var in bytes.Buffer
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "method": "$/setTrace"}) // notification: ignored
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "id": 9, "method": "totally/unknown"})
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	if err := NewServer(&in, &out, "test").Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message (error for the request only), got %d", len(msgs))
+	}
+	if msgs[0].Error == nil || msgs[0].Error.Code != -32601 {
+		t.Fatalf("expected -32601 error, got %+v", msgs[0].Error)
+	}
+}
+
+// TestDidCloseClearsDiagnostics verifies didClose publishes an empty array.
+func TestDidCloseClearsDiagnostics(t *testing.T) {
+	uri := "file:///tmp/whatever.py"
+	var in bytes.Buffer
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "method": "textDocument/didClose",
+		"params": map[string]interface{}{
+			"textDocument": map[string]interface{}{"uri": uri},
+		},
+	})
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	if err := NewServer(&in, &out, "test").Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) != 1 || msgs[0].Method != "textDocument/publishDiagnostics" {
+		t.Fatalf("expected 1 publishDiagnostics, got %+v", msgs)
+	}
+	if msgs[0].Params.URI != uri {
+		t.Errorf("uri = %q, want %q", msgs[0].Params.URI, uri)
+	}
+	if len(msgs[0].Params.Diagnostics) != 0 {
+		t.Errorf("expected empty diagnostics, got %d", len(msgs[0].Params.Diagnostics))
+	}
+}
+
+// TestScanErrorPublishesEmpty verifies a failing scan yields an empty
+// diagnostics array rather than crashing the loop.
+func TestScanErrorPublishesEmpty(t *testing.T) {
+	var in bytes.Buffer
+	mustWrite(t, &in, map[string]interface{}{
+		"jsonrpc": "2.0", "method": "textDocument/didSave",
+		"params": map[string]interface{}{
+			"textDocument": map[string]interface{}{"uri": "file:///tmp/x.py"},
+		},
+	})
+	mustWrite(t, &in, map[string]interface{}{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	srv := NewServer(&in, &out, "test")
+	srv.scan = func(string) ([]findings.Finding, error) {
+		return nil, os.ErrNotExist // simulate a scan failure
+	}
+	if err := srv.Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) != 1 || len(msgs[0].Params.Diagnostics) != 0 {
+		t.Fatalf("expected 1 message with empty diagnostics, got %+v", msgs)
+	}
+}
+
+func mustWrite(t *testing.T, w *bytes.Buffer, v interface{}) {
+	t.Helper()
+	if err := writeMessage(w, v); err != nil {
+		t.Fatalf("writeMessage: %v", err)
+	}
+}
+
+func findByID(t *testing.T, msgs []outMessage, id string) outMessage {
+	t.Helper()
+	for _, m := range msgs {
+		if string(m.ID) == id {
+			return m
+		}
+	}
+	t.Fatalf("no response with id=%s among %d messages", id, len(msgs))
+	return outMessage{}
+}

--- a/cli/lsp_cmd.go
+++ b/cli/lsp_cmd.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/nox-hq/nox/cli/lsp"
+)
+
+// runLSP starts the nox Language Server over stdio. It speaks JSON-RPC 2.0 and
+// publishes nox findings as editor diagnostics on didOpen/didSave. It takes no
+// positional arguments; unknown flags cause a usage error.
+func runLSP(args []string) int {
+	fs := flag.NewFlagSet("lsp", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: nox lsp")
+		fmt.Fprintln(os.Stderr, "\nRun the nox Language Server on stdio (JSON-RPC 2.0).")
+		fmt.Fprintln(os.Stderr, "Editors connect to publish nox findings as diagnostics.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	srv := lsp.NewServer(os.Stdin, os.Stdout, version)
+	if err := srv.Serve(); err != nil {
+		fmt.Fprintf(os.Stderr, "nox lsp: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -149,6 +149,7 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "  uri <uri>        Handle nox:// URI (install action). Use `uri register` to wire OS URL handler\n")
 		fmt.Fprintf(os.Stderr, "  completion <sh>  Generate shell completions\n") // nox:ignore AI-006 -- CLI help text
 		fmt.Fprintf(os.Stderr, "  serve            Start MCP server on stdio\n")
+		fmt.Fprintf(os.Stderr, "  lsp              Start LSP server on stdio (publishes findings as editor diagnostics)\n")
 		fmt.Fprintf(os.Stderr, "  registry         Manage plugin registries\n")
 		fmt.Fprintf(os.Stderr, "  plugin           Manage and invoke plugins\n")
 		fmt.Fprintf(os.Stderr, "  version          Print version and exit\n\n")
@@ -185,6 +186,8 @@ func run(args []string) int {
 		return runBadge(remaining[1:])
 	case "serve":
 		return runServe(remaining[1:])
+	case "lsp":
+		return runLSP(remaining[1:])
 	case "registry":
 		return runRegistry(remaining[1:])
 	case "plugin":


### PR DESCRIPTION
Roadmap #146, Tier 4 — `nox lsp`, unblocked by the single-file scan fix (#156). A Language Server that publishes nox findings as **inline editor diagnostics** — deterministic and offline, the anti-LLM-assistant angle (no code leaves the machine, no model call).

## What
`nox lsp` runs an LSP server over stdio (hand-rolled JSON-RPC 2.0 with `Content-Length` framing — no third-party LSP library, no network):
- `initialize` → advertises `textDocumentSync: 1` (Full) + serverInfo
- `didOpen`/`didSave` → scans that one file (`RunScan`) and publishes diagnostics for its URI
- `didClose` → clears diagnostics · `shutdown`/`exit` → clean lifecycle · unknown request → `-32601`
- Finding → Diagnostic: 0-based range from the finding's line/column (clamped, non-empty), severity critical/high→Error, medium→Warning, low→Information, info→Hint; `code`=RuleID, `source`=nox. Diagnostics sorted stably.

Structure: logic in `cli/lsp` (framing + server + conversion), a thin `runLSP` command, one dispatch line + help entry.

## Tests
Framing round-trip; a full `initialize→didOpen→shutdown→exit` flow over in-memory streams asserting a real **AI-009 Error** diagnostic; shutdown/exit loop return; unknown-method `-32601`; didClose clears; scan-error → empty (no crash); plus conversion/clamp/sort unit tests. Build + vet + `cli/` + `cli/lsp` all green, gofmt clean.

**Reviewed and re-verified end-to-end**: piped a framed `initialize`/`didOpen`/`shutdown`/`exit` session through the built `nox lsp` binary — returns capabilities and an `AI-009` diagnostic (severity 1, source `nox`, correct 0-based line), exits 0.

Built in an isolated worktree in parallel with the ai-eval OWASP mapping (#159). Lands in `[Unreleased]`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom