### PR TITLE
feat(scan): auto-run post-scan (reachability) plugins in nox scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Post-scan plugins run automatically in `nox scan`.** Plugins whose tools
+  need the findings the scan just produced — those declaring
+  `requires_scan_context` — now run as part of the pipeline (before refinement,
+  so their findings are deduped, suppressed, and policy-gated). The reachability
+  plugin is the motivating case: listed in `plugins.required`, it now classifies
+  the scan's vulnerabilities as reachable / unreachable / undetermined without a
+  separate manual `nox plugin call`, feeding the `--sort priority` deprioritization
+  of likely-false-positive unreachable vulns.
 - **`nox lsp` — Language Server for editor diagnostics.** Runs a minimal LSP
   server over stdio (JSON-RPC 2.0 with `Content-Length` framing) that scans the
   active file on open/save and publishes nox findings as

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -16,6 +16,75 @@ import (
 // so the CLI wires the implementation here.
 func init() {
 	core.ScanPluginHook = runScanPlugins
+	core.PostScanPluginHook = runPostScanPlugins
+}
+
+// installedPluginBinaries resolves each required plugin name to its installed
+// binary path. Missing or not-yet-installed plugins are skipped (scan-time
+// auto-install may have been disabled or failed) rather than aborting the scan.
+func installedPluginBinaries(required []string) ([]string, error) {
+	st, err := LoadState(DefaultStatePath())
+	if err != nil {
+		return nil, fmt.Errorf("loading plugin state: %w", err)
+	}
+	var binaries []string
+	for _, name := range required {
+		ip := st.FindPlugin(name)
+		if ip == nil {
+			continue
+		}
+		if _, statErr := os.Stat(ip.BinaryPath); statErr != nil {
+			continue
+		}
+		binaries = append(binaries, ip.BinaryPath)
+	}
+	return binaries, nil
+}
+
+// runPostScanPlugins invokes the post-scan (scan-context) tools of every
+// installed plugin named in .nox.yaml plugins.required — those declaring
+// requires_scan_context=true, notably reachability — passing them the findings
+// the core scan just produced and merging their results into result in place.
+// Missing plugins are skipped; failures surface as diagnostics and never abort
+// the scan.
+func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target string, required []string) error {
+	if len(required) == 0 || result == nil {
+		return nil
+	}
+
+	binaries, err := installedPluginBinaries(required)
+	if err != nil {
+		return err
+	}
+	if len(binaries) == 0 {
+		return nil
+	}
+
+	absTarget, absErr := filepath.Abs(target)
+	if absErr != nil {
+		absTarget = target
+	}
+
+	policy := plugin.DefaultPolicy()
+	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
+		policy = cfg.PluginPolicy.ToPolicy()
+	}
+
+	host := plugin.NewHost(plugin.WithPolicy(&policy))
+	defer func() { _ = host.Close() }()
+	for _, bin := range binaries {
+		if regErr := host.RegisterBinary(ctx, bin, nil); regErr != nil {
+			return fmt.Errorf("registering plugin %q: %w", bin, regErr)
+		}
+	}
+
+	if invErr := host.InvokePostScan(ctx, result, absTarget); invErr != nil {
+		return fmt.Errorf("post-scan plugins: %w", invErr)
+	}
+	for _, d := range host.Diagnostics() {
+		fmt.Fprintf(os.Stderr, "[plugin %s] %s: %s\n", d.Severity, d.Source, d.Message)
+	}
+	return nil
 }
 
 // runScanPlugins runs the `scan` tool of every installed plugin named in
@@ -28,24 +97,9 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 		return nil, nil
 	}
 
-	st, err := LoadState(DefaultStatePath())
+	binaries, err := installedPluginBinaries(required)
 	if err != nil {
-		return nil, fmt.Errorf("loading plugin state: %w", err)
-	}
-
-	// Resolve each required plugin name to its installed binary. Missing or
-	// not-yet-installed plugins are skipped (scan-time auto-install may have
-	// been disabled or failed) rather than aborting the scan.
-	var binaries []string
-	for _, name := range required {
-		ip := st.FindPlugin(name)
-		if ip == nil {
-			continue
-		}
-		if _, statErr := os.Stat(ip.BinaryPath); statErr != nil {
-			continue
-		}
-		binaries = append(binaries, ip.BinaryPath)
+		return nil, err
 	}
 
 	policy := plugin.DefaultPolicy()

--- a/core/plugin_hook.go
+++ b/core/plugin_hook.go
@@ -30,3 +30,15 @@ type PluginScanOutput struct {
 // nil, nil) and must never panic: a plugin failure is reported as a non-fatal
 // error and the built-in scan still completes.
 var ScanPluginHook func(ctx context.Context, target string, required []string) (*PluginScanOutput, error)
+
+// PostScanPluginHook runs the "post-scan" plugin tools — those declaring
+// requires_scan_context=true — which need the findings the core scan just
+// produced. The reachability plugin is the canonical case: it classifies the
+// VULN findings against the workspace's imports (reachable / unreachable /
+// undetermined). Implementations enrich the given ScanResult IN PLACE (adding
+// findings and enrichments) using the plugin host's InvokePostScan.
+//
+// It runs before refinement so its findings are deduped, suppressed, and
+// policy-gated like any other. Same import-cycle rationale, nil-safety, and
+// non-fatal-failure contract as ScanPluginHook; the CLI registers it.
+var PostScanPluginHook func(ctx context.Context, result *ScanResult, target string, required []string) error

--- a/core/scan.go
+++ b/core/scan.go
@@ -353,6 +353,18 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		}
 	}
 
+	// Post-scan (context) plugins — e.g. reachability — need the findings the
+	// scan just produced, so they run here, after the built-in analyzers and
+	// the scan-tool plugins but before refinement, so their findings and
+	// enrichments are deduped, suppressed, and policy-gated like any other.
+	if PostScanPluginHook != nil && len(cfg.Plugins.Required) > 0 {
+		postResult := &ScanResult{Findings: allFindings, Inventory: inventory, AIInventory: aiInventory}
+		if hookErr := PostScanPluginHook(ctx, postResult, target, cfg.Plugins.Required); hookErr != nil {
+			slog.WarnContext(ctx, "post-scan plugins failed; continuing with findings so far", "error", hookErr)
+		}
+		pluginEnrichments = append(pluginEnrichments, postResult.Enrichments...)
+	}
+
 	// Stage 3: Refine findings — apply rule config, generated/noise filters,
 	// conditional severity, dedup, inline suppressions, terraform plan,
 	// baseline matching, and VEX.

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2246,3 +2246,52 @@ func TestConfidenceMeetsThreshold(t *testing.T) {
 		}
 	}
 }
+
+// TestRunScan_PostScanPluginHook verifies the post-scan hook (which runs
+// context-requiring plugins like reachability that need the scan's findings)
+// fires when plugins are required, and that a finding it adds flows through the
+// rest of the pipeline into the result.
+func TestRunScan_PostScanPluginHook(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"),
+		[]byte("plugins:\n  required:\n    - nox/reachability\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	var gotRequired []string
+	PostScanPluginHook = func(_ context.Context, result *ScanResult, _ string, required []string) error {
+		called = true
+		gotRequired = required
+		result.Findings.Add(findings.Finding{
+			RuleID: "REACH-001", Severity: findings.SeverityInfo, Confidence: findings.ConfidenceHigh,
+			Message: "unreachable (test)", Location: findings.Location{FilePath: "app.py", StartLine: 1},
+			Metadata: map[string]string{"reachable": "false"},
+		})
+		return nil
+	}
+	defer func() { PostScanPluginHook = nil }()
+
+	res, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+	if !called {
+		t.Fatal("post-scan hook was not called despite plugins.required being set")
+	}
+	if len(gotRequired) != 1 || gotRequired[0] != "nox/reachability" {
+		t.Errorf("hook got required=%v, want [nox/reachability]", gotRequired)
+	}
+	found := false
+	for _, f := range res.Findings.Findings() {
+		if f.RuleID == "REACH-001" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("finding added by the post-scan hook did not reach the result")
+	}
+}


### PR DESCRIPTION
Circling back to a gap I flagged when I shipped `--sort priority` (#158): the reachability plugin **enriches VULN findings with a `reachable` flag, but it never runs during `nox scan`** — it declares `analyze_reachability` (`requires_scan_context=true`), not the `scan` tool the pipeline invokes. So the prioritization couldn't actually deprioritize unreachable vulns out of the box.

## What
The plugin host already had `InvokePostScan` (builds a `ScanContext` from the current findings, invokes every `requires_scan_context` tool, merges results) — it just wasn't wired in. This adds a `PostScanPluginHook`, registered by the CLI next to `ScanPluginHook`, and calls it **after the built-in analyzers + scan-tool plugins but before refinement**, so post-scan findings/enrichments are deduped, suppressed, and policy-gated like everything else.

Now, with the reachability plugin in `plugins.required`, `nox scan` classifies its vulnerabilities reachable / unreachable / undetermined automatically — feeding `--sort priority`'s demotion of likely-false-positive unreachable vulns. Extracted `installedPluginBinaries()` so the scan-tool and post-scan paths share plugin resolution.

## Test
`TestRunScan_PostScanPluginHook`: with `plugins.required` set, the hook fires with the required list and a finding it adds flows into the result. Full core + cli suites green; no new lint.

**Honest scope**: the plugin-level e2e (real reachability binary reclassifying a real vuln) needs the plugin installed + a vulnerable dependency, which I can't stand up here; this PR covers the wiring + hook contract, relying on the pre-existing `InvokePostScan` + host tests for the invocation mechanism. A natural follow-up is a design note on how the separate `reachable` **enrichment** (kept off the immutable finding by design) should correlate to its VULN in the priority sort — today the sort keys on finding metadata, so it fully orders the REACH-* findings but doesn't yet re-rank the VULN via its enrichment.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom