### PR TITLE
fix(secrets): entropy detectors skip natural-language prose (closes #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Entropy secret detectors no longer flag natural-language prose (#104).**
+  The generic SEC-161 (high-entropy assignment) and SEC-163 (high-entropy hex)
+  detectors fired on long English sentences, SQL, error-message format strings,
+  and prompt templates — high *aggregate* entropy but not credentials. A compact
+  secret token (API key, hash, base64/hex blob) never contains internal
+  whitespace, so candidates with a space or tab are now rejected. On a
+  prose-heavy codebase this removes the dominant false-positive class (a real
+  case had 109 of 129 findings as prose FPs); real whitespace-free secrets are
+  still detected (the base64/hex tokenizers extract the token itself).
 - **`nox scan <file>` scans a single file.** A file target used to fail (it
   looked for `<file>/.nox.yaml` and the walker skipped its own root, finding
   nothing). Now it loads config from the file's directory and scans just that

--- a/core/rules/entropy.go
+++ b/core/rules/entropy.go
@@ -274,6 +274,19 @@ func extractRegexCandidates(line string, re *regexp.Regexp, minLen int, addFn fu
 // git SHAs, Go import paths, file paths, camelCase identifiers, version
 // strings, and other patterns that would cause false positives.
 func isLikelyNotSecret(s string) bool {
+	// Natural-language prose, SQL, error-message format strings, and prompt
+	// templates contain internal whitespace; a compact secret token — API key,
+	// token, hash, base64/hex blob — never does. This is the dominant
+	// false-positive source for the generic entropy detectors on prose-heavy
+	// codebases: a 120-char English sentence has high aggregate entropy but is
+	// not a credential (#104). Real base64/hex secrets are still caught, because
+	// the base64/hex tokenizers extract the token itself (no surrounding
+	// whitespace) — only the whole-string quoted/assignment candidates carry
+	// prose, and a real secret in a quoted string is the compact token anyway.
+	if strings.ContainsAny(s, " \t") {
+		return true
+	}
+
 	// URLs starting with http:// or https://.
 	lower := strings.ToLower(s)
 	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {

--- a/core/rules/entropy_test.go
+++ b/core/rules/entropy_test.go
@@ -1009,3 +1009,30 @@ func TestIsTokenChar(t *testing.T) {
 		})
 	}
 }
+
+// Regression for #104: the generic entropy detectors must not flag
+// natural-language prose, SQL, or format-string literals — they have high
+// aggregate entropy but internal whitespace, and are not credentials. A
+// compact secret token (no whitespace) must still be detected.
+func TestEntropyMatcher_IgnoresProse(t *testing.T) {
+	m := &EntropyMatcher{}
+	rule := Rule{MatcherType: "entropy"}
+
+	prose := []string{
+		`msg := "Risk: the finding shows the 72-hour deadline may be missed (GDPR-Art-33)."`,
+		`return "the key contractual provisions obligation (DORA-Art-30)."`,
+		`pool.Exec(ctx, "ALTER ROLE lexora_app LOGIN PASSWORD 'app_pw'")`,
+		`tmpl := "judgement was not the required JSON object {judgements: [{citation, bucket}]}"`,
+	}
+	for _, line := range prose {
+		if got := m.Match([]byte(line), &rule); len(got) != 0 {
+			t.Errorf("prose flagged as secret: %q -> %+v", line, got)
+		}
+	}
+
+	// A real compact secret (no whitespace) is still caught.
+	secret := []byte(`api_key = "aK3jR8mZ2pL5nW9xQ4vB7yD1sF6hT0c"`)
+	if got := m.Match(secret, &rule); len(got) == 0 {
+		t.Error("a real whitespace-free high-entropy secret must still be detected")
+	}
+}


### PR DESCRIPTION
Closes #104. The generic entropy detectors **SEC-161** (high-entropy assignment) and **SEC-163** (high-entropy hex) fired on long English prose, SQL, error-message format strings, and prompt templates — high *aggregate* Shannon entropy, but not credentials.

On the reporter's prose-heavy LLM/regulatory codebase: **109 of 129 findings were prose false positives**, drowning the 2 real ones. SEC-163 even flagged non-hex sentences — because the quoted-string tokenizer feeds *every* entropy rule, so the "hex" rule matched prose like `"...judgement was not the required JSON object {judgements: [...]}"`.

## Fix
A compact secret token — API key, token, hash, base64/hex blob — **never contains internal whitespace**, but prose does. `isLikelyNotSecret` (the single candidate gate shared by both rules) now rejects any candidate with a space or tab.

Real secrets are unaffected: the base64/hex tokenizers extract the token *itself* (no surrounding whitespace), and a real secret in a quoted string is the compact token anyway.

## Test
`TestEntropyMatcher_IgnoresProse` — the four exact #104 evidence lines (GDPR/DORA prose, the SQL DDL string, the JSON-shape template) produce **no** match, while a whitespace-free high-entropy secret still fires. Verified e2e:

```
var msg    = "Risk: the finding shows the 72-hour deadline..."   → clean
var tmpl   = "the key contractual provisions obligation..."      → clean
var apiKey = "aK3jR8mZ2pL5nW9xQ4vB7yD1sF6hT0c"                   → SEC-161 + SEC-163 ✓
```

Full `core/...` green; lint clean.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom