### PR TITLE
feat(editors): VS Code extension over the nox language server (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VS Code extension (`editors/vscode`).** A thin client over the `nox lsp`
+  language server: surfaces nox findings inline (squiggles, hover, Problems
+  panel) as you open and save files. Deterministic and offline — it runs the
+  local `nox` binary, no code leaves the machine. Delivers the editor-integration
+  half of #47 on top of `nox lsp`; a JetBrains plugin is the same shape.
 - **Post-scan plugins run automatically in `nox scan`.** Plugins whose tools
   need the findings the scan just produced — those declaring
   `requires_scan_context` — now run as part of the pipeline (before refinement,

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,38 @@
+# nox for VS Code
+
+Surfaces [nox](https://github.com/nox-hq/nox) security findings inline — squiggly
+underlines on the offending line, hover for the rule and message, in the Problems
+panel. **Deterministic and offline**: it runs the local `nox` binary; no code
+leaves your machine and no model is called.
+
+It's a thin client over the `nox lsp` language server (JSON-RPC over stdio): on
+open and save, the server scans that file and publishes diagnostics.
+
+## Requirements
+
+- `nox` on your `PATH` (`brew install nox`, or set `nox.path`).
+
+## Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `nox.path` | `nox` | Path to the nox executable. |
+| `nox.enable` | `true` | Enable the language server. |
+
+## Build from source
+
+```bash
+cd editors/vscode
+npm install
+npm run compile      # tsc → out/extension.js
+```
+
+Then press F5 in VS Code (Extension Development Host) to try it, or package with
+`npx vsce package`.
+
+## What you get
+
+Diagnostics mirror `nox scan`: severity maps to Error (critical/high), Warning
+(medium), Information (low), Hint (info); the rule ID is the diagnostic code and
+`nox` is the source. Findings update on save (the server re-scans the saved
+file).

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,140 @@
+{
+  "name": "nox",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nox",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.75.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "nox",
+  "displayName": "nox — AI application security",
+  "description": "Inline nox security findings in your editor, via the nox language server. Deterministic and offline — no code leaves your machine.",
+  "version": "0.1.0",
+  "publisher": "nox-hq",
+  "license": "Apache-2.0",
+  "repository": { "type": "git", "url": "https://github.com/nox-hq/nox" },
+  "engines": { "vscode": "^1.75.0" },
+  "categories": ["Linters", "Programming Languages"],
+  "activationEvents": [
+    "onLanguage:go",
+    "onLanguage:python",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:ruby",
+    "onLanguage:java",
+    "onLanguage:kotlin",
+    "onLanguage:rust",
+    "onLanguage:c",
+    "onLanguage:cpp",
+    "onLanguage:csharp",
+    "onLanguage:php",
+    "onLanguage:shellscript",
+    "onLanguage:yaml",
+    "onLanguage:json",
+    "onLanguage:dockerfile"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "nox",
+      "properties": {
+        "nox.path": {
+          "type": "string",
+          "default": "nox",
+          "description": "Path to the nox executable (must be on PATH, or an absolute path)."
+        },
+        "nox.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the nox language server."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run compile"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.75.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+// The languages nox scans; the client only forwards documents of these types to
+// the server, so nox is invoked on files it understands.
+const documentSelector: { scheme: string; language: string }[] = [
+  "go",
+  "python",
+  "javascript",
+  "javascriptreact",
+  "typescript",
+  "typescriptreact",
+  "ruby",
+  "java",
+  "kotlin",
+  "rust",
+  "c",
+  "cpp",
+  "csharp",
+  "php",
+  "shellscript",
+  "yaml",
+  "json",
+  "dockerfile",
+].map((language) => ({ scheme: "file", language }));
+
+export function activate(context: vscode.ExtensionContext): void {
+  const config = vscode.workspace.getConfiguration("nox");
+  if (!config.get<boolean>("enable", true)) {
+    return;
+  }
+
+  // The server is `nox lsp` over stdio: deterministic, offline, no network.
+  const command = config.get<string>("path", "nox");
+  const serverOptions: ServerOptions = {
+    run: { command, args: ["lsp"], transport: TransportKind.stdio },
+    debug: { command, args: ["lsp"], transport: TransportKind.stdio },
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector,
+    diagnosticCollectionName: "nox",
+  };
+
+  client = new LanguageClient(
+    "nox",
+    "nox",
+    serverOptions,
+    clientOptions,
+  );
+  client.start();
+  context.subscriptions.push({ dispose: () => void client?.stop() });
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
Delivers the editor-integration half of #47, built on `nox lsp` (#160).

A thin VS Code extension (`editors/vscode/`) that spawns `nox lsp` over stdio and surfaces findings inline — squiggles on the offending line, hover for the rule/message, entries in the Problems panel — updated on open and save. **Deterministic and offline**: it runs the local `nox` binary; no code leaves the machine, no model call (the anti-LLM-assistant angle vs. Snyk/Semgrep/Copilot).

## What's here
- `package.json` — manifest: `documentSelector` scoped to the languages nox scans, a `nox.path` setting + `nox.enable` toggle, `Linters` category.
- `src/extension.ts` — standard `vscode-languageclient` client: `serverOptions = { command: nox.path, args: ["lsp"], stdio }`.
- `tsconfig.json`, `README.md`, `.gitignore`.

The heavy lifting (protocol, per-file scan, finding→diagnostic mapping, severity/range) lives in the `nox lsp` server, which is unit-tested and e2e-verified. A JetBrains plugin is the same shape against the same server.

## Verification
`npm install && npm run compile` → clean `tsc` build (`out/extension.js`). Full in-editor validation needs VS Code itself, which I can't launch here — but the client is standard boilerplate and the server side is already tested (#160). Honest about that limit.

Partially addresses #47 (VS Code done; JetBrains + quick-fix action for #42 remain).

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom