### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-05
+
 ### Added
 
 - **VS Code extension (`editors/vscode`).** A thin client over the `nox lsp`


### PR DESCRIPTION
Cuts the v1.5.0 changelog ahead of tagging. Everything from #145–#163 moves under the 1.5.0 heading.

Highlights: agent-config artifact scanning (AGENT-*), OWASP ASI Top 10 mapping, EU AI Act / ISO 42001 / NIST AI RMF frameworks, per-severity policy budgets, proof-of-offline attestation, `--tracked-only` + single-file scan, deterministic `nox fix --content`, `nox baseline init`, reachability-aware `--sort priority` + post-scan plugin auto-run, `nox lsp` + VS Code extension, broader language coverage; plus FP fixes (docs, prose entropy #104, scan.exclude regression).

Merge → tag `v1.5.0` → goreleaser publishes the release + bumps the Homebrew formula.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom