### PR TITLE
feat(provenance): unverifiable dependency provenance (PROV-001/002)

### DIFF
--- a/cli/ux.go
+++ b/cli/ux.go
@@ -25,6 +25,8 @@ func familyOf(ruleID string) string {
 		return "Dependencies"
 	case strings.HasPrefix(ruleID, "VARIANT-"):
 		return "CVE Variants"
+	case strings.HasPrefix(ruleID, "PROV-"):
+		return "Provenance"
 	case strings.HasPrefix(ruleID, "LIC-"):
 		return "License"
 	case strings.HasPrefix(ruleID, "MCP-"):

--- a/core/analyzers/provenance/provenance.go
+++ b/core/analyzers/provenance/provenance.go
@@ -1,0 +1,241 @@
+// Package provenance flags dependencies whose origin cannot be verified against
+// a signed package registry — the deterministic, offline half of supply-chain
+// provenance (OWASP ASI04 / SLSA). It reports two shapes that a version-based
+// SCA misses because there is no CVE, only an unverifiable source:
+//
+//   - PROV-001: a dependency pulled from a VCS, raw URL, or tarball instead of
+//     a signed registry, so no integrity hash or publisher attestation backs it.
+//   - PROV-002: a VCS dependency pinned to a mutable ref (branch/tag) rather than
+//     an immutable commit SHA, so the code can change under you.
+//
+// Live signature verification (sigstore/cosine, SLSA attestation fetch) needs
+// the network and is intentionally left to an opt-in plugin; this analyzer never
+// makes a network call.
+package provenance
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// Analyzer detects unverifiable dependency provenance.
+type Analyzer struct{}
+
+// NewAnalyzer returns a provenance analyzer.
+func NewAnalyzer() *Analyzer { return &Analyzer{} }
+
+// Rules returns the rule set for the provenance analyzer.
+func (a *Analyzer) Rules() *rules.RuleSet {
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID:          "PROV-001",
+		Version:     "1.0",
+		Description: "Dependency from a non-registry source (VCS/URL/tarball) — provenance cannot be verified",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"dependency", "supply-chain", "provenance", "slsa", "owasp-asi04"},
+		Remediation: "This dependency is pulled from a VCS repository, raw URL, or tarball rather than a signed package registry, so no integrity hash or publisher attestation backs it. Prefer the registry-published package. If a non-registry source is unavoidable, pin it to an immutable commit SHA and vendor or hash-lock the artifact (npm: commit-ish; pip: --hash or #sha256=).",
+		References:  []string{"https://slsa.dev/", "https://genai.owasp.org/llmrisk/llm03-supply-chain/"},
+		Metadata:    map[string]string{"cwe": "CWE-1357"},
+	})
+	rs.Add(&rules.Rule{
+		ID:          "PROV-002",
+		Version:     "1.0",
+		Description: "VCS dependency pinned to a mutable ref instead of an immutable commit SHA",
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"dependency", "supply-chain", "provenance", "slsa", "owasp-asi04"},
+		Remediation: "This VCS dependency is pinned to a branch or tag, both of which are mutable — the referenced code can be force-pushed or re-tagged after review. Pin to the full 40-character commit SHA so the exact tree is immutable and reproducible.",
+		References:  []string{"https://slsa.dev/spec/v1.0/requirements", "https://genai.owasp.org/llmrisk/llm03-supply-chain/"},
+		Metadata:    map[string]string{"cwe": "CWE-829"},
+	})
+	return rs
+}
+
+// ScanArtifacts inspects dependency manifests for unverifiable provenance.
+func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
+	fs := findings.NewFindingSet()
+	for i := range artifacts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		art := artifacts[i]
+		base := strings.ToLower(filepath.Base(art.Path))
+		content, err := os.ReadFile(art.AbsPath)
+		if err != nil {
+			continue
+		}
+		switch {
+		case base == "package.json":
+			scanPackageJSON(fs, art.Path, content)
+		case base == "requirements.txt" || (strings.HasPrefix(base, "requirements") && strings.HasSuffix(base, ".txt")):
+			scanRequirements(fs, art.Path, content)
+		}
+	}
+	return fs, nil
+}
+
+var shaRe = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
+func addFinding(fs *findings.FindingSet, ruleID, path string, line int, sev findings.Severity, msg string) {
+	fs.Add(findings.Finding{
+		RuleID:     ruleID,
+		Severity:   sev,
+		Confidence: findings.ConfidenceMedium,
+		Location:   findings.Location{FilePath: path, StartLine: line, EndLine: line},
+		Message:    msg,
+	})
+}
+
+// classifyNPMSpec classifies a package.json dependency version spec. It returns
+// the rule ID to raise ("" when the source is a normal registry spec) plus a
+// human-readable reason.
+func classifyNPMSpec(spec string) (ruleID, reason string) {
+	s := strings.TrimSpace(spec)
+	low := strings.ToLower(s)
+	switch {
+	case s == "", strings.HasPrefix(low, "file:"), strings.HasPrefix(low, "link:"),
+		strings.HasPrefix(low, "workspace:"), strings.HasPrefix(low, "portal:"),
+		strings.HasPrefix(low, "npm:"), strings.HasPrefix(s, "."), strings.HasPrefix(s, "/"):
+		return "", "" // local / registry alias — not a provenance concern here
+	}
+	isVCS := strings.HasPrefix(low, "git+") || strings.HasPrefix(low, "git://") ||
+		strings.HasPrefix(low, "github:") || strings.HasPrefix(low, "gitlab:") ||
+		strings.HasPrefix(low, "bitbucket:") || strings.HasPrefix(low, "gist:")
+	// Shorthand "owner/repo" or "owner/repo#ref": a slash, no protocol, not a range.
+	if !isVCS && looksLikeGitHubShorthand(s) {
+		isVCS = true
+	}
+	if isVCS {
+		if ref, ok := vcsRef(s); ok && shaRe.MatchString(ref) {
+			return "PROV-001", "VCS dependency (pinned to a commit, but not from a signed registry)"
+		}
+		return "PROV-002", "VCS dependency pinned to a mutable ref (branch/tag) or no ref"
+	}
+	// Raw URL tarball.
+	if (strings.HasPrefix(low, "http://") || strings.HasPrefix(low, "https://")) &&
+		(strings.Contains(low, ".tgz") || strings.Contains(low, ".tar")) {
+		return "PROV-001", "dependency fetched from a raw tarball URL (no registry integrity)"
+	}
+	return "", "" // semver range, tag, "*", "latest" — registry source
+}
+
+func looksLikeGitHubShorthand(s string) bool {
+	if strings.Contains(s, "://") || strings.ContainsAny(s, "^~<>= ") {
+		return false
+	}
+	base := s
+	if i := strings.IndexAny(base, "#"); i >= 0 {
+		base = base[:i]
+	}
+	if base == "" || strings.HasPrefix(base, "@") { // @scope/name is a registry name, not a value
+		return false
+	}
+	parts := strings.Split(base, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+}
+
+func vcsRef(s string) (string, bool) {
+	if i := strings.LastIndex(s, "#"); i >= 0 {
+		return s[i+1:], true
+	}
+	return "", false
+}
+
+func scanPackageJSON(fs *findings.FindingSet, path string, content []byte) {
+	var pkg struct {
+		Dependencies         map[string]string `json:"dependencies"`
+		DevDependencies      map[string]string `json:"devDependencies"`
+		OptionalDependencies map[string]string `json:"optionalDependencies"`
+	}
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return
+	}
+	text := string(content)
+	for _, deps := range []map[string]string{pkg.Dependencies, pkg.DevDependencies, pkg.OptionalDependencies} {
+		for name, spec := range deps {
+			ruleID, reason := classifyNPMSpec(spec)
+			if ruleID == "" {
+				continue
+			}
+			sev := findings.SeverityMedium
+			if ruleID == "PROV-002" {
+				sev = findings.SeverityHigh
+			}
+			addFinding(fs, ruleID, path, lineOfKey(text, name), sev,
+				"Dependency \""+name+"\" ("+spec+"): "+reason+".")
+		}
+	}
+}
+
+// lineOfKey returns the 1-based line where a JSON key first appears, so the
+// finding points at the offending dependency. Falls back to line 1.
+func lineOfKey(text, key string) int {
+	needle := "\"" + key + "\""
+	if i := strings.Index(text, needle); i >= 0 {
+		return 1 + strings.Count(text[:i], "\n")
+	}
+	return 1
+}
+
+func scanRequirements(fs *findings.FindingSet, path string, content []byte) {
+	for i, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Editable installs: strip the -e/--editable flag and evaluate the rest.
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "--editable"), "-e"))
+		low := strings.ToLower(line)
+		isVCS := strings.HasPrefix(low, "git+") || strings.HasPrefix(low, "hg+") ||
+			strings.HasPrefix(low, "svn+") || strings.HasPrefix(low, "bzr+")
+		isURL := (strings.HasPrefix(low, "http://") || strings.HasPrefix(low, "https://")) &&
+			(strings.Contains(low, ".whl") || strings.Contains(low, ".tar") || strings.Contains(low, ".zip"))
+		switch {
+		case isVCS:
+			ref, ok := pyVCSRef(line)
+			if ok && shaRe.MatchString(ref) {
+				addFinding(fs, "PROV-001", path, i+1, findings.SeverityMedium,
+					"Dependency from VCS ("+truncate(line)+"): pinned to a commit but not from a signed registry.")
+			} else {
+				addFinding(fs, "PROV-002", path, i+1, findings.SeverityHigh,
+					"Dependency from VCS ("+truncate(line)+"): pinned to a mutable ref or no ref — pin to a commit SHA.")
+			}
+		case isURL:
+			if strings.Contains(low, "#sha256=") || strings.Contains(low, "#md5=") {
+				continue // hash-verified direct URL
+			}
+			addFinding(fs, "PROV-001", path, i+1, findings.SeverityMedium,
+				"Dependency from a direct URL ("+truncate(line)+"): no registry integrity or hash.")
+		}
+	}
+}
+
+// pyVCSRef extracts the ref from a pip VCS requirement of the form
+// git+https://host/repo@<ref>#egg=name. Returns ok=false when no @ref present.
+func pyVCSRef(line string) (string, bool) {
+	// Consider only the part before any #egg / fragment.
+	main := line
+	if i := strings.IndexByte(main, '#'); i >= 0 {
+		main = main[:i]
+	}
+	if i := strings.LastIndex(main, "@"); i >= 0 {
+		return main[i+1:], true
+	}
+	return "", false
+}
+
+func truncate(s string) string {
+	if len(s) > 60 {
+		return s[:57] + "..."
+	}
+	return s
+}

--- a/core/analyzers/provenance/provenance_test.go
+++ b/core/analyzers/provenance/provenance_test.go
@@ -1,0 +1,110 @@
+package provenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+)
+
+func TestClassifyNPMSpec(t *testing.T) {
+	cases := []struct {
+		spec string
+		want string
+	}{
+		{"^4.18.2", ""},
+		{"1.2.3", ""},
+		{"latest", ""},
+		{"*", ""},
+		{"npm:@scope/pkg@1.0.0", ""},
+		{"file:../local", ""},
+		{"workspace:*", ""},
+		{"git+https://github.com/o/r.git#0123456789abcdef0123456789abcdef01234567", "PROV-001"},
+		{"git+https://github.com/o/r.git#main", "PROV-002"},
+		{"git+ssh://git@github.com/o/r.git", "PROV-002"},
+		{"github:owner/repo#v1.2.3", "PROV-002"},
+		{"owner/repo#abcdef1", "PROV-001"},
+		{"owner/repo", "PROV-002"},
+		{"https://example.com/pkg.tgz", "PROV-001"},
+	}
+	for _, c := range cases {
+		got, _ := classifyNPMSpec(c.spec)
+		if got != c.want {
+			t.Errorf("classifyNPMSpec(%q) = %q, want %q", c.spec, got, c.want)
+		}
+	}
+}
+
+func scanFile(t *testing.T, name, body string) []string {
+	t.Helper()
+	dir := t.TempDir()
+	abs := filepath.Join(dir, name)
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	art := discovery.Artifact{Path: name, AbsPath: abs, Type: discovery.Lockfile}
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(), []discovery.Artifact{art})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	items := fs.Findings()
+	for i := range items {
+		ids = append(ids, items[i].RuleID)
+	}
+	return ids
+}
+
+func has(ids []string, id string) bool {
+	for _, x := range ids {
+		if x == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPackageJSONProvenance(t *testing.T) {
+	body := `{
+		"dependencies": {
+			"express": "^4.18.2",
+			"internal-lib": "git+https://github.com/acme/internal.git#main",
+			"pinned-fork": "git+https://github.com/acme/fork.git#0123456789abcdef0123456789abcdef01234567",
+			"tarball": "https://cdn.example.com/pkg-1.0.0.tgz"
+		}
+	}`
+	ids := scanFile(t, "package.json", body)
+	if !has(ids, "PROV-002") {
+		t.Errorf("expected PROV-002 for mutable git ref; got %v", ids)
+	}
+	if !has(ids, "PROV-001") {
+		t.Errorf("expected PROV-001 for pinned git + tarball; got %v", ids)
+	}
+	// express (registry) must not raise anything.
+	if len(ids) != 3 {
+		t.Errorf("expected exactly 3 findings (not express), got %d: %v", len(ids), ids)
+	}
+}
+
+func TestRequirementsProvenance(t *testing.T) {
+	body := "flask==2.0.1\n" +
+		"requests>=2.0\n" +
+		"-e git+https://github.com/acme/tool.git@main#egg=tool\n" +
+		"git+https://github.com/acme/lib.git@0123456789abcdef0123456789abcdef01234567#egg=lib\n" +
+		"https://example.com/wheels/foo-1.0-py3-none-any.whl\n" +
+		"https://example.com/wheels/bar-1.0.whl#sha256=deadbeef\n"
+	ids := scanFile(t, "requirements.txt", body)
+	if !has(ids, "PROV-002") {
+		t.Errorf("expected PROV-002 for git @main; got %v", ids)
+	}
+	if !has(ids, "PROV-001") {
+		t.Errorf("expected PROV-001 for git @sha and plain wheel URL; got %v", ids)
+	}
+	// flask/requests (registry, versioned) and the #sha256 wheel must not fire.
+	// Expected: git@main (PROV-002), git@sha (PROV-001), plain wheel (PROV-001) = 3.
+	if len(ids) != 3 {
+		t.Errorf("expected exactly 3 findings, got %d: %v", len(ids), ids)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/data"
 	"github.com/nox-hq/nox/core/analyzers/deps"
 	"github.com/nox-hq/nox/core/analyzers/iac"
+	"github.com/nox-hq/nox/core/analyzers/provenance"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
 	"github.com/nox-hq/nox/core/analyzers/variants"
 	"github.com/nox-hq/nox/core/baseline"
@@ -177,6 +178,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	}
 	depsAnalyzer := deps.NewAnalyzer(depsOpts...)
 	variantsAnalyzer := variants.NewAnalyzer()
+	provenanceAnalyzer := provenance.NewAnalyzer()
 
 	// Per-analyzer result collectors.
 	var (
@@ -254,6 +256,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			addFindings(fs)
 			return nil
 		},
+		func(c context.Context) error {
+			fs, err := provenanceAnalyzer.ScanArtifacts(c, artifacts)
+			if err != nil {
+				return err
+			}
+			addFindings(fs)
+			return nil
+		},
 	}
 	if err := runAnalyzerTasks(ctx, tasks, opts.Sequential); err != nil {
 		return nil, err
@@ -302,6 +312,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		allRules.Add(r)
 	}
 	for _, r := range variantsAnalyzer.Rules().Rules() {
+		allRules.Add(r)
+	}
+	for _, r := range provenanceAnalyzer.Rules().Rules() {
 		allRules.Add(r)
 	}
 
@@ -927,6 +940,8 @@ func analyzerRulePatterns(analyzer string) []string {
 		return []string{"VULN-*", "CONT-*", "LIC-*"}
 	case "variants":
 		return []string{"VARIANT-*"}
+	case "provenance":
+		return []string{"PROV-*"}
 	default:
 		return nil
 	}


### PR DESCRIPTION
> Stacked on #170 (feat/cve-variants) — review after it merges; base will retarget to main.

## What
Deterministic, offline analyzer (`core/analyzers/provenance`) for the supply-chain provenance gap a version-based SCA can't see (OWASP ASI04 / SLSA):

- **PROV-001** (medium) — dependency from a **VCS repo / raw URL / tarball** instead of a signed registry: no integrity hash or publisher attestation.
- **PROV-002** (high) — VCS dependency pinned to a **mutable ref** (branch/tag) instead of an immutable commit SHA.

Parses `package.json` (deps/devDeps/optionalDeps) and `requirements*.txt` (incl. `-e git+` and direct-URL wheels). Registry ranges and `#sha256=` URLs never fire; a git dep pinned to a full commit SHA downgrades PROV-002→PROV-001.

Live sigstore/SLSA attestation verification needs the network and is intentionally left to an **opt-in plugin** — this analyzer makes no network call.

## Tests
`classifyNPMSpec` table + end-to-end `package.json`/`requirements.txt` scans incl. exact finding-count assertions. `go test ./core/... ./cli/...` green; lint clean.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom