### PR TITLE
feat(editors): JetBrains plugin over the nox language server

### DIFF
--- a/editors/jetbrains/.gitignore
+++ b/editors/jetbrains/.gitignore
@@ -1,0 +1,4 @@
+.gradle/
+build/
+.idea/
+*.iml

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -1,0 +1,45 @@
+# nox for JetBrains
+
+Surfaces [nox](https://github.com/nox-hq/nox) security findings inline in
+JetBrains IDEs — squiggly underlines on the offending line, hover for the rule
+and message, entries in the Problems view. **Deterministic and offline**: it
+runs the local `nox` binary; no code leaves your machine and no model is called.
+
+It's a thin client over the `nox lsp` language server (JSON-RPC over stdio): on
+open and save, the server scans that file and publishes diagnostics — the same
+findings as `nox scan`, mapped to IDE severities.
+
+## Requirements
+
+- `nox` on your `PATH` (`brew install nox`), or set the `NOX_PATH` environment
+  variable to the binary.
+- A JetBrains IDE with the **platform LSP API**: IntelliJ IDEA **Ultimate**,
+  GoLand, PyCharm **Professional**, WebStorm, RubyMine, PhpStorm, CLion, or
+  Rider, **2023.2 or newer**.
+
+### Community editions (IntelliJ IDEA / PyCharm Community)
+
+The platform LSP API isn't available in the free Community editions. Install the
+[LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin and register a
+new language server with the command `nox lsp` — the diagnostics are identical.
+
+## Build from source
+
+```bash
+cd editors/jetbrains
+./gradlew buildPlugin      # produces build/distributions/nox-jetbrains-*.zip
+./gradlew runIde           # launch a sandbox IDE with the plugin loaded
+```
+
+Install the built ZIP via **Settings → Plugins → ⚙ → Install Plugin from Disk**.
+
+> Note: this module is not built in nox's Go CI (it needs the JetBrains/IntelliJ
+> SDK, which Gradle downloads on first build). It mirrors the
+> [VS Code extension](../vscode) one-to-one over the same `nox lsp` server.
+
+## What you get
+
+Diagnostics mirror `nox scan`: severity maps to Error (critical/high), Warning
+(medium), Weak Warning (low), Information (info); the rule ID is the diagnostic
+code and `nox` is the source. Findings update on save (the server re-scans the
+saved file).

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -1,0 +1,38 @@
+// nox JetBrains plugin — a thin LSP client over `nox lsp`.
+//
+// The plugin uses the IntelliJ Platform LSP API (com.intellij.platform.lsp),
+// available in paid JetBrains IDEs (IntelliJ IDEA Ultimate, PyCharm
+// Professional, GoLand, WebStorm, etc.) from 2023.2 onward. For the free
+// Community editions, install the LSP4IJ plugin and point it at `nox lsp`
+// (see README).
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.9.24"
+    id("org.jetbrains.intellij") version "1.17.4"
+}
+
+group = "dev.nox"
+version = "1.6.0"
+
+repositories {
+    mavenCentral()
+}
+
+// Target GoLand as the base IDE: it ships the platform LSP API and is a natural
+// home for scanning Go/AI projects. The plugin also loads in IDEA Ultimate,
+// PyCharm Professional, WebStorm, etc.
+intellij {
+    version.set("2024.1")
+    type.set("GO")
+    plugins.set(listOf())
+}
+
+tasks {
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+    }
+    patchPluginXml {
+        sinceBuild.set("232") // 2023.2 — first release with the platform LSP API
+        untilBuild.set("")
+    }
+}

--- a/editors/jetbrains/settings.gradle.kts
+++ b/editors/jetbrains/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "nox-jetbrains"

--- a/editors/jetbrains/src/main/kotlin/dev/nox/lsp/NoxLspServerSupportProvider.kt
+++ b/editors/jetbrains/src/main/kotlin/dev/nox/lsp/NoxLspServerSupportProvider.kt
@@ -1,0 +1,58 @@
+package dev.nox.lsp
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.LspServerSupportProvider
+import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+
+// The languages nox scans. The client only starts the server for files of these
+// types, so `nox lsp` is invoked on files it understands.
+private val SUPPORTED_EXTENSIONS = setOf(
+    "go", "py", "pyi",
+    "js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts",
+    "rb", "java", "kt", "rs", "c", "cc", "cpp", "cs", "php",
+    "sh", "bash", "yaml", "yml", "json", "tf", "dockerfile",
+)
+
+private fun isSupported(file: VirtualFile): Boolean {
+    val ext = file.extension?.lowercase()
+    if (ext != null && ext in SUPPORTED_EXTENSIONS) return true
+    // Dockerfiles and a handful of agent-config files have no telling extension.
+    return file.name.equals("Dockerfile", ignoreCase = true) ||
+        file.name in setOf(".cursorrules", ".clinerules", ".windsurfrules",
+            "CLAUDE.md", "AGENTS.md", "GEMINI.md", "mcp.json", "manifest.json", "agent.json")
+}
+
+/**
+ * Registers the nox language server with the IntelliJ Platform LSP API. When a
+ * supported file is opened, the platform starts (or reuses) one `nox lsp`
+ * process per project and surfaces its diagnostics inline, in the Problems view,
+ * and in the gutter. Deterministic and offline: it runs the local `nox` binary;
+ * no code leaves the machine and no model is called.
+ */
+class NoxLspServerSupportProvider : LspServerSupportProvider {
+    override fun fileOpened(
+        project: Project,
+        file: VirtualFile,
+        serverStarter: LspServerSupportProvider.LspServerStarter,
+    ) {
+        if (isSupported(file)) {
+            serverStarter.ensureServerStarted(NoxLspServerDescriptor(project))
+        }
+    }
+}
+
+private class NoxLspServerDescriptor(project: Project) :
+    ProjectWideLspServerDescriptor(project, "nox") {
+
+    override fun isSupportedFile(file: VirtualFile): Boolean = isSupported(file)
+
+    // `nox lsp` speaks JSON-RPC 2.0 over stdio. The binary is resolved from the
+    // PATH; override with the NOX_PATH environment variable if it lives
+    // elsewhere.
+    override fun createCommandLine(): GeneralCommandLine {
+        val exe = System.getenv("NOX_PATH")?.takeIf { it.isNotBlank() } ?: "nox"
+        return GeneralCommandLine(exe, "lsp")
+    }
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,28 @@
+<idea-plugin>
+    <id>dev.nox.jetbrains</id>
+    <name>nox</name>
+    <vendor url="https://github.com/nox-hq/nox">nox</vendor>
+
+    <description><![CDATA[
+        Surfaces <a href="https://github.com/nox-hq/nox">nox</a> security findings
+        inline in JetBrains IDEs — squiggly underlines on the offending line,
+        hover for the rule and message, and entries in the Problems view.
+        <br/><br/>
+        <b>Deterministic and offline.</b> It runs the local <code>nox</code> binary
+        over the <code>nox lsp</code> language server (JSON-RPC over stdio); no code
+        leaves your machine and no model is called. On open and save the server
+        scans that file and publishes diagnostics.
+        <br/><br/>
+        Requires the <code>nox</code> binary on your PATH (<code>brew install nox</code>),
+        or set the <code>NOX_PATH</code> environment variable.
+    ]]></description>
+
+    <!-- The platform LSP API lives in the paid IDEs. -->
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.lsp</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <platform.lsp.serverSupportProvider
+            implementation="dev.nox.lsp.NoxLspServerSupportProvider"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
## What
A thin JetBrains/IntelliJ client for `nox lsp`, mirroring the [VS Code extension](../vscode) one-to-one. On open/save the platform starts one `nox lsp` process per project and surfaces its diagnostics inline, in the Problems view, and in the gutter. **Deterministic and offline** — runs the local `nox` binary; no code leaves the machine, no model is called.

- IntelliJ Platform LSP API (`com.intellij.platform.lsp`, 2023.2+) — available in the paid IDEs (IDEA Ultimate, GoLand, PyCharm Pro, WebStorm, …). README documents the free-Community path via LSP4IJ.
- Binary resolved from PATH, overridable via `NOX_PATH`.
- Gradle + `gradle-intellij-plugin`; `plugin.xml` registers the `serverSupportProvider`.

## Note
Not built in the Go CI (needs the JetBrains/IntelliJ SDK that Gradle downloads on first build). The Kotlin is written against the current platform LSP API; verify locally with `./gradlew runIde`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom