### PR TITLE
feat(core): reproducible output (SOURCE_DATE_EPOCH) + submodule-aware tracked scans

### DIFF
--- a/core/determinism_test.go
+++ b/core/determinism_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/report"
+)
+
+// TestScanDeterminism is the run-to-run identity proof: the same tree scanned
+// twice must produce byte-identical output. This exercises the whole pipeline —
+// parallel analyzers (whose goroutine completion order varies), dedup,
+// fingerprinting, and the deterministic sort — and, with SOURCE_DATE_EPOCH
+// frozen, the report metadata too. A regression here means nox stopped being
+// reproducible, which breaks CI caching, baseline diffs, and the offline moat.
+func TestScanDeterminism(t *testing.T) {
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+
+	dir := t.TempDir()
+	writeFixtureTree(t, dir, map[string]string{
+		// Multiple analyzers, several findings each, so ordering matters.
+		"Dockerfile":       "FROM ubuntu:latest\nRUN echo hi\n",
+		"requirements.txt": "flask\nrequests\n",
+		"app.py": `import os
+import flask
+import quantum_flux_helper
+prompt = f"Answer this: {user_input}"
+model = "gpt-4"
+`,
+		"infra/main.tf": `resource "aws_s3_bucket" "b" {
+  acl = "public-read"
+}
+`,
+	})
+
+	gen := func() []byte {
+		res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		b, err := report.NewJSONReporter("test").Generate(res.Findings)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		return b
+	}
+
+	first := gen()
+	// A meaningful test needs the fixture to actually produce findings; an empty
+	// scan is trivially "deterministic".
+	if res, _ := RunScanWithOptions(dir, ScanOptions{Offline: true}); len(res.Findings.Findings()) == 0 {
+		t.Fatal("fixture produced no findings; determinism test would be vacuous")
+	}
+	for i := 0; i < 3; i++ {
+		if again := gen(); !bytes.Equal(first, again) {
+			t.Fatalf("scan output not byte-identical on run %d\n--- first ---\n%s\n--- again ---\n%s", i+2, first, again)
+		}
+	}
+}
+
+func writeFixtureTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		abs := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/core/git/git.go
+++ b/core/git/git.go
@@ -101,7 +101,12 @@ func StagedContent(repoRoot, path string) ([]byte, error) {
 // quoting so names with special characters round-trip. Best-effort: returns an
 // error when dir is not a git working tree.
 func TrackedFiles(dir string) ([]string, error) {
-	out, err := runGit(dir, "ls-files", "-z")
+	// --recurse-submodules lists tracked files inside initialized submodules too,
+	// with paths relative to the superproject. Without it, tracked-only scans
+	// would skip submodule content that a normal filesystem walk does traverse
+	// (the walker only skips `.git` directories, and a submodule root carries a
+	// `.git` *file*), leaving the two scan sets inconsistent.
+	out, err := runGit(dir, "ls-files", "-z", "--recurse-submodules")
 	if err != nil {
 		return nil, fmt.Errorf("git ls-files: %w", err)
 	}

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -210,6 +210,38 @@ func TestTrackedFiles(t *testing.T) {
 	}
 }
 
+// TestTrackedFiles_Submodules verifies tracked-only scans reach into an
+// initialized submodule (roadmap 1.2). Without --recurse-submodules, git
+// ls-files reports the submodule only as a gitlink, so its scannable content
+// would be invisible to a tracked-only scan even though a normal walk sees it.
+func TestTrackedFiles_Submodules(t *testing.T) {
+	// A separate repo that will become the submodule.
+	subRemote := t.TempDir()
+	run(t, subRemote, "git", "init", "-b", "main")
+	run(t, subRemote, "git", "config", "user.email", "test@test.com")
+	run(t, subRemote, "git", "config", "user.name", "Test")
+	writeFile(t, filepath.Join(subRemote, "lib.go"), "package lib")
+	run(t, subRemote, "git", "add", ".")
+	run(t, subRemote, "git", "commit", "-m", "sub initial")
+
+	super := setupGitRepo(t)
+	// Local submodule add needs protocol.file.allow=always on modern git.
+	run(t, super, "git", "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "vendor/sub")
+	run(t, super, "git", "commit", "-m", "add submodule")
+
+	tracked, err := TrackedFiles(super)
+	if err != nil {
+		t.Fatalf("TrackedFiles: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range tracked {
+		got[f] = true
+	}
+	if !got["vendor/sub/lib.go"] {
+		t.Errorf("expected submodule file vendor/sub/lib.go in tracked set, got %v", tracked)
+	}
+}
+
 func TestTrackedFiles_InvalidRepo(t *testing.T) {
 	dir := t.TempDir()
 	_, err := TrackedFiles(dir)

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -6,10 +6,26 @@ package report
 import (
 	"encoding/json"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/nox-hq/nox/core/findings"
 )
+
+// GeneratedAt returns the report timestamp. It honors SOURCE_DATE_EPOCH (the
+// reproducible-builds standard: a Unix timestamp in seconds) so a scan can
+// produce byte-identical output across runs — the proof-of-determinism a
+// reviewer or CI cache can rely on. Without it, the current time is used.
+// Shared by the JSON and SBOM reporters so every timestamped artifact honors
+// the same reproducibility switch.
+func GeneratedAt() string {
+	if e := os.Getenv("SOURCE_DATE_EPOCH"); e != "" {
+		if secs, err := strconv.ParseInt(e, 10, 64); err == nil {
+			return time.Unix(secs, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
 
 // Reporter defines the contract for serializing a FindingSet into a byte
 // representation. Each output format (JSON, SARIF, SBOM, etc.) implements
@@ -79,7 +95,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 	report := JSONReport{
 		Meta: Meta{
 			SchemaVersion: "1.0.0",
-			GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+			GeneratedAt:   GeneratedAt(),
 			ToolName:      "nox",
 			ToolVersion:   r.ToolVersion,
 			Offline:       r.Offline,

--- a/core/report/sbom/sbom.go
+++ b/core/report/sbom/sbom.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/nox-hq/nox/core/analyzers/deps"
+	"github.com/nox-hq/nox/core/report"
 )
 
 // ---------------------------------------------------------------------------
@@ -185,13 +185,13 @@ func (r *CycloneDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, 
 		}
 	}
 
-	report := CDXReport{
+	doc := CDXReport{
 		BOMFormat:    "CycloneDX",
 		SpecVersion:  "1.5",
 		SerialNumber: "urn:uuid:nox-scan",
 		Version:      1,
 		Metadata: CDXMetadata{
-			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Timestamp: report.GeneratedAt(),
 			Tools: []CDXTool{
 				{
 					Vendor:  "nox",
@@ -204,7 +204,7 @@ func (r *CycloneDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, 
 		Vulnerabilities: cdxVulns,
 	}
 
-	return json.MarshalIndent(report, "", "  ")
+	return json.MarshalIndent(doc, "", "  ")
 }
 
 // WriteToFile generates the CycloneDX report and writes it to the given path.
@@ -369,7 +369,7 @@ func (r *SPDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, error
 		Name:              "nox-scan",
 		DocumentNamespace: "https://github.com/nox-hq/nox/scans",
 		CreationInfo: SPDXCreationInfo{
-			Created:  time.Now().UTC().Format(time.RFC3339),
+			Created:  report.GeneratedAt(),
 			Creators: []string{fmt.Sprintf("Tool: nox-%s", r.ToolVersion)},
 		},
 		Packages:      spdxPkgs,


### PR DESCRIPTION
Closes two Tier-1 gaps from #146.

### 1.1 — Determinism / proof-of-offline
- JSON + SBOM reporters honor **`SOURCE_DATE_EPOCH`** (reproducible-builds standard) for `generated_at`, so scans produce **byte-identical** artifacts across runs. SARIF is already timestamp-free; the SBOM serial number is a fixed urn.
- **`TestScanDeterminism`** scans a multi-analyzer fixture 4× (parallel analyzers → varying goroutine order) and asserts byte-identical output — a regression guard for dedup + fingerprinting + deterministic sort.

### 1.2 — Git submodule traversal
- `TrackedFiles` now uses `git ls-files --recurse-submodules`, so **tracked-only scans reach into initialized submodules**, consistent with the normal walk (which already descends — it only skips `.git` *dirs*, and submodule roots carry a `.git` *file*). **`TestTrackedFiles_Submodules`** sets up a real local submodule and asserts coverage.

`go test ./core/...` green; `golangci-lint` clean on changed packages.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom