### PR TITLE
feat(ai): model license + provenance in the AIBOM (#146 2.6)

### DIFF
--- a/core/analyzers/ai/model_inventory.go
+++ b/core/analyzers/ai/model_inventory.go
@@ -7,14 +7,24 @@ import (
 
 // ModelReference represents a reference to an ML model found in the codebase.
 type ModelReference struct {
-	Name       string `json:"name"`
-	Version    string `json:"version,omitempty"`
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+	// License is the model family's known license (SPDX-ish or a
+	// "Proprietary (<vendor>)" marker), from a curated offline lookup. Empty
+	// when the family is unrecognized — a present value is trustworthy, not a
+	// guess. This is the AIBOM's model-license/provenance answer that a
+	// dependency SBOM misses for models pulled by name.
+	License    string `json:"license,omitempty"`
 	Registry   string `json:"registry,omitempty"`
 	Hash       string `json:"hash,omitempty"`
 	Path       string `json:"path"`
 	Line       int    `json:"line,omitempty"`
 	AuthEnvVar string `json:"auth_env_var,omitempty"`
 	Endpoint   string `json:"endpoint,omitempty"`
+	// Pinned reports whether the reference is fixed to an immutable revision or
+	// digest (a hash/commit pin), so the exact weights are reproducible — the
+	// provenance signal for "which model did we actually run".
+	Pinned bool `json:"pinned"`
 }
 
 // extractModelReferences scans file content for ML model loading patterns and
@@ -36,6 +46,8 @@ func extractModelReferences(path string, content []byte) []ModelReference {
 		// Look for revision/hash on same line
 		ref.Version = extractModelVersion(text, m[0])
 		ref.Hash = extractModelHash(text, m[0])
+		ref.License = classifyModelLicense(ref.Name)
+		ref.Pinned = ref.Hash != "" || isImmutableRevision(ref.Version)
 		refs = append(refs, ref)
 	}
 
@@ -50,6 +62,7 @@ func extractModelReferences(path string, content []byte) []ModelReference {
 		refs = append(refs, ModelReference{
 			Name:     m[1],
 			Registry: classifyModelRegistry(m[1]),
+			License:  classifyModelLicense(m[1]),
 			Path:     path,
 		})
 	}
@@ -112,8 +125,8 @@ func extractModelHash(text, context string) string {
 }
 
 func containsModel(refs []ModelReference, name string) bool {
-	for _, r := range refs {
-		if r.Name == name {
+	for i := range refs {
+		if refs[i].Name == name {
 			return true
 		}
 	}

--- a/core/analyzers/ai/model_license.go
+++ b/core/analyzers/ai/model_license.go
@@ -1,0 +1,71 @@
+package ai
+
+import (
+	"regexp"
+	"strings"
+)
+
+// immutableRevisionRe matches a git-style commit SHA (7–64 hex chars). A model
+// revision that is a bare tag/branch ("main", "v1.0") is mutable; a commit hash
+// pins the exact weights.
+var immutableRevisionRe = regexp.MustCompile(`^[a-fA-F0-9]{7,64}$`)
+
+// isImmutableRevision reports whether a model revision string is a commit-hash
+// pin (reproducible) rather than a mutable tag/branch.
+func isImmutableRevision(revision string) bool {
+	return immutableRevisionRe.MatchString(strings.TrimSpace(revision))
+}
+
+// classifyModelLicense returns the best-known license for a referenced model,
+// keyed off its family. This is a deterministic, offline lookup — the AIBOM's
+// answer to "what are we actually allowed to do with this model?", which a
+// dependency SBOM never captures for models pulled by name. It is intentionally
+// conservative: an unrecognized model returns "" (omitted from output) rather
+// than a guessed license, so a present license field is trustworthy.
+//
+// Licenses reflect the model family's published terms at time of writing;
+// downstream consumers should still verify against the model card for the exact
+// checkpoint. Proprietary API models carry a "Proprietary (<vendor>)" marker so
+// governance tooling can flag "no redistribution / API-terms apply".
+func classifyModelLicense(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	// Strip a HuggingFace org prefix ("meta-llama/Llama-3-8B" -> "llama-3-8b").
+	if i := strings.LastIndex(n, "/"); i >= 0 {
+		n = n[i+1:]
+	}
+	switch {
+	// Proprietary API models — no weights, vendor terms apply.
+	case strings.HasPrefix(n, "gpt-"), strings.HasPrefix(n, "o1-"), strings.HasPrefix(n, "o3-"),
+		strings.HasPrefix(n, "o4-"), strings.HasPrefix(n, "text-embedding-"), strings.HasPrefix(n, "dall-e"):
+		return "Proprietary (OpenAI)"
+	case strings.HasPrefix(n, "claude"):
+		return "Proprietary (Anthropic)"
+	case strings.HasPrefix(n, "gemini"):
+		return "Proprietary (Google)"
+	case strings.HasPrefix(n, "command"), strings.HasPrefix(n, "cohere"):
+		return "Proprietary (Cohere)"
+
+	// Open / source-available weights.
+	case strings.HasPrefix(n, "llama"), strings.HasPrefix(n, "meta-llama"), strings.HasPrefix(n, "codellama"):
+		return "Llama Community License"
+	case strings.HasPrefix(n, "gemma"):
+		return "Gemma Terms of Use"
+	case strings.HasPrefix(n, "mistral"), strings.HasPrefix(n, "mixtral"), strings.HasPrefix(n, "ministral"):
+		return "Apache-2.0"
+	case strings.HasPrefix(n, "falcon"):
+		return "Apache-2.0"
+	case strings.HasPrefix(n, "phi-"), n == "phi":
+		return "MIT"
+	case strings.HasPrefix(n, "qwen"):
+		return "Tongyi Qianwen License"
+	case strings.HasPrefix(n, "deepseek"):
+		return "DeepSeek License"
+	case strings.HasPrefix(n, "stable-diffusion"), strings.HasPrefix(n, "sdxl"), strings.HasPrefix(n, "stabilityai"):
+		return "CreativeML Open RAIL-M"
+	case strings.HasPrefix(n, "bert"), strings.HasPrefix(n, "distilbert"), strings.HasPrefix(n, "roberta"),
+		strings.HasPrefix(n, "t5"), strings.HasPrefix(n, "gpt2"), strings.HasPrefix(n, "bart"),
+		strings.HasPrefix(n, "all-minilm"), strings.HasPrefix(n, "sentence-transformers"):
+		return "Apache-2.0"
+	}
+	return ""
+}

--- a/core/analyzers/ai/model_license_test.go
+++ b/core/analyzers/ai/model_license_test.go
@@ -1,0 +1,61 @@
+package ai
+
+import "testing"
+
+func TestClassifyModelLicense(t *testing.T) {
+	cases := map[string]string{
+		"gpt-4o":                                 "Proprietary (OpenAI)",
+		"o3-mini":                                "Proprietary (OpenAI)",
+		"claude-sonnet-4":                        "Proprietary (Anthropic)",
+		"gemini-1.5-pro":                         "Proprietary (Google)",
+		"meta-llama/Llama-3-8B":                  "Llama Community License",
+		"codellama-13b":                          "Llama Community License",
+		"mistralai/Mistral-7B-v0.3":              "Apache-2.0",
+		"google/gemma-2-9b":                      "Gemma Terms of Use",
+		"microsoft/phi-3-mini":                   "MIT",
+		"Qwen/Qwen2.5-7B":                        "Tongyi Qianwen License",
+		"sentence-transformers/all-MiniLM-L6-v2": "Apache-2.0",
+		"some-unknown-model":                     "",
+		"":                                       "",
+	}
+	for name, want := range cases {
+		if got := classifyModelLicense(name); got != want {
+			t.Errorf("classifyModelLicense(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestExtractModelReferences_LicenseAndPinned(t *testing.T) {
+	src := []byte(`
+model = AutoModel.from_pretrained("meta-llama/Llama-3-8B", revision="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+other = pipeline("gpt-4o")
+`)
+	refs := extractModelReferences("app.py", src)
+
+	byName := map[string]ModelReference{}
+	for _, r := range refs {
+		byName[r.Name] = r
+	}
+
+	llama, ok := byName["meta-llama/Llama-3-8B"]
+	if !ok {
+		t.Fatalf("expected llama model reference; got %v", refs)
+	}
+	if llama.License != "Llama Community License" {
+		t.Errorf("llama license = %q, want Llama Community License", llama.License)
+	}
+	if !llama.Pinned {
+		t.Errorf("llama pinned via revision hash should be true; hash=%q", llama.Hash)
+	}
+
+	gpt, ok := byName["gpt-4o"]
+	if !ok {
+		t.Fatalf("expected gpt-4o reference; got %v", refs)
+	}
+	if gpt.License != "Proprietary (OpenAI)" {
+		t.Errorf("gpt-4o license = %q, want Proprietary (OpenAI)", gpt.License)
+	}
+	if gpt.Pinned {
+		t.Error("gpt-4o has no revision pin; Pinned should be false")
+	}
+}


### PR DESCRIPTION
Closes the AIBOM half of #146 2.6: the AI inventory now records, per model reference:

- **License** — the family's known license (SPDX-ish, or `Proprietary (<vendor>)`) from a curated **offline** lookup that returns `""` for unrecognized families (a present value is trustworthy, not a guess). The governance answer a dependency SBOM misses for models pulled by name.
- **Pinned** — whether the reference is fixed to an **immutable revision/digest** (commit-SHA revision or hash pin) — the "which exact weights did we run" provenance signal.

`classifyModelLicense` covers OpenAI/Anthropic/Google/Cohere (proprietary), Llama, Gemma, Mistral, Falcon, Phi, Qwen, DeepSeek, Stable Diffusion, and Apache-2.0 HF classics. Table tests + end-to-end extraction test.

(Dataset lineage isn't derivable from source deterministically, so it's intentionally out of scope.)

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom