### PR TITLE
docs(sotw): bi-weekly queue dates anchored on today's post

### DIFF
--- a/docs/scan-of-the-week-queue.txt
+++ b/docs/scan-of-the-week-queue.txt
@@ -18,12 +18,12 @@
 # Refill via PR when this list runs short.
 
 # ── Q3 2026 ─────────────────────────────────────────────────────
-# DONE 2026-05-04: modelcontextprotocol/python-sdk — series opener; 427 findings + 6-repo bench (anthropic-sdk-python, openai-python, agent-go, …); 0 disclosable
-# DONE 2026-05-09: anthropics/anthropic-cookbook — 1.95M findings (mostly RAG-corpus FPs); precision-tuning post
-# DONE 2026-05-22: deepset-ai/haystack — 12,367 findings (94% docs-website noise); 1 real low-sev (unredacted prompt log); fixed AI-009 ast.literal_eval FP
-# DONE 2026-05-29: huggingface/smolagents — 323 findings (65% from one example dir); 0 true positives; fixed VULN-002 PEP503 typosquat FP
-# DONE 2026-06-05: langchain-ai/langgraph — 134,614 findings (99.8% examples/ notebook image data + lockfile hashes); 0 true positives; fixed AI-019 DB-pipeline FP; MCP-011 docstring FP tracked
-# DONE 2026-06-15: microsoft/autogen — 304,629 findings (99.5% SVG/lock/notebook FPs); 1 low-sev AI-019 model-hash gap; fixed 10 broad-pattern SEC rules missing \b+secretShape
+# DONE 2026-04-26: modelcontextprotocol/python-sdk — series opener; 427 findings + 6-repo bench (anthropic-sdk-python, openai-python, agent-go, …); 0 disclosable
+# DONE 2026-05-10: anthropics/anthropic-cookbook — 1.95M findings (mostly RAG-corpus FPs); precision-tuning post
+# DONE 2026-05-24: deepset-ai/haystack — 12,367 findings (94% docs-website noise); 1 real low-sev (unredacted prompt log); fixed AI-009 ast.literal_eval FP
+# DONE 2026-06-07: huggingface/smolagents — 323 findings (65% from one example dir); 0 true positives; fixed VULN-002 PEP503 typosquat FP
+# DONE 2026-06-21: langchain-ai/langgraph — 134,614 findings (99.8% examples/ notebook image data + lockfile hashes); 0 true positives; fixed AI-019 DB-pipeline FP; MCP-011 docstring FP tracked
+# DONE 2026-07-05: microsoft/autogen — 304,629 findings (99.5% SVG/lock/notebook FPs); 1 low-sev AI-019 model-hash gap; fixed 10 broad-pattern SEC rules missing \b+secretShape
 modelcontextprotocol/servers
 openai/openai-agents-python
 phidatahq/phidata


### PR DESCRIPTION
Matches [nox-hq.dev#7](https://github.com/nox-hq/nox-hq.dev/pull/7): 14-day steps back from today's post (autogen 2026-07-05). The DONE log is now a clean bi-weekly record — 04-26, 05-10, 05-24, 06-07, 06-21, 07-05.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom