### PR TITLE
feat(sast): per-language SAST depth strategy (deep/standard/off)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -479,6 +479,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			r := report.NewJSONReporter(version)
 			r.Offline = offlineFlag
 			r.Prioritize = sortFlag == "priority"
+			r.SASTLanguages = result.SASTProfile
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2

--- a/core/config.go
+++ b/core/config.go
@@ -128,6 +128,21 @@ type ScanSettings struct {
 	OSV                  OSVConfig               `yaml:"osv"`
 	Entropy              EntropyConfig           `yaml:"entropy"`
 	GeneratedPaths       GeneratedPathsConfig    `yaml:"generated_paths"`
+	SAST                 SASTConfig              `yaml:"sast"`
+}
+
+// SASTConfig declares the per-language SAST depth strategy. nox targets ~15
+// languages but shouldn't invest equal analysis depth everywhere: Python and
+// JS/TS — where AI apps and the worst false positives concentrate — earn deep
+// analysis; the rest get standard pattern coverage; a repo can turn a language
+// off entirely.
+//
+// Languages maps a canonical language name (see LanguageForExtension) to a
+// depth level: "deep" | "standard" | "off". Unlisted languages fall back to
+// DefaultLanguageDepth. See docs/sast-language-strategy.md for the rationale
+// and how each depth maps to behavior today and in future.
+type SASTConfig struct {
+	Languages map[string]string `yaml:"languages"`
 }
 
 // GeneratedPathsConfig controls the built-in noise filter that stops the

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -47,6 +47,13 @@ type Meta struct {
 	// the artifact — "this report was produced without the scanner touching the
 	// network" — backed by the enforced egress test, not just a claim.
 	Offline bool `json:"offline"`
+	// SASTLanguages records the resolved per-language SAST depth applied to the
+	// scan (language name → deep|standard|off). It makes the depth strategy
+	// auditable straight from the artifact: a reviewer can see that, say,
+	// `go` was scanned at standard and `rust` was turned off, without
+	// re-deriving defaults from config. Omitted from JSON when empty (a scan
+	// run without a profile, e.g. history scans).
+	SASTLanguages map[string]string `json:"sast_languages,omitempty"`
 }
 
 // JSONReport is the top-level structure serialized to JSON. It pairs report
@@ -66,6 +73,10 @@ type JSONReporter struct {
 	// confidence) instead of the canonical deterministic order — the most
 	// actionable findings first, likely-false-positive unreachable vulns last.
 	Prioritize bool
+	// SASTLanguages is the resolved per-language SAST depth for this scan,
+	// recorded verbatim in the report Meta. Set it from ScanResult.SASTProfile
+	// before Generate to make the depth strategy auditable in the artifact.
+	SASTLanguages map[string]string
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -99,6 +110,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			ToolName:      "nox",
 			ToolVersion:   r.ToolVersion,
 			Offline:       r.Offline,
+			SASTLanguages: r.SASTLanguages,
 		},
 		Findings: f,
 	}

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -133,6 +133,37 @@ func TestGenerateOfflineAttestation(t *testing.T) {
 	}
 }
 
+func TestGenerateSASTLanguagesMeta(t *testing.T) {
+	// Default: no profile set, so the field is omitted from the artifact rather
+	// than emitting a null/empty object.
+	def, err := NewJSONReporter("1.0.0").Generate(sampleFindingSet())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if bytes.Contains(def, []byte("sast_languages")) {
+		t.Errorf("empty profile must be omitted from meta; got: %s", def)
+	}
+
+	// With a resolved profile, the depth strategy is recorded so a reviewer can
+	// audit which languages were scanned at which depth straight from the report.
+	r := NewJSONReporter("1.0.0")
+	r.SASTLanguages = map[string]string{"python": "deep", "go": "standard", "rust": "off"}
+	data, err := r.Generate(sampleFindingSet())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if report.Meta.SASTLanguages["python"] != "deep" {
+		t.Errorf("meta sast_languages[python] = %q, want deep", report.Meta.SASTLanguages["python"])
+	}
+	if report.Meta.SASTLanguages["rust"] != "off" {
+		t.Errorf("meta sast_languages[rust] = %q, want off", report.Meta.SASTLanguages["rust"])
+	}
+}
+
 func TestGenerateSortsFindingsDeterministically(t *testing.T) {
 	r := NewJSONReporter("0.1.0")
 	// Findings are added in reverse order (rule-002 before rule-001).

--- a/core/sast.go
+++ b/core/sast.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+)
+
+// SASTDepth is a per-language SAST analysis depth level. The strategy is
+// "depth where the moat is": invest deep analysis in the languages where AI
+// apps and false-positive hotspots concentrate, standard pattern coverage
+// elsewhere, and nothing for languages a repo doesn't care about.
+type SASTDepth string
+
+const (
+	// SASTDeep marks a language for the deepest analysis nox can offer. Today
+	// deep is behaviorally identical to standard (both run the pattern rules) —
+	// it reserves a home for future AST/taint analysis without a config break.
+	SASTDeep SASTDepth = "deep"
+	// SASTStandard runs the current pattern-based rule analysis. It is the
+	// default for every language not explicitly listed.
+	SASTStandard SASTDepth = "standard"
+	// SASTOff skips a language entirely: its source files contribute no
+	// findings to the pattern analyzers. Use it for languages a repo does not
+	// care to scan.
+	SASTOff SASTDepth = "off"
+)
+
+// DefaultLanguageDepth is the depth applied to a language with no explicit
+// entry in SASTConfig.Languages. Python/JS/TS default to deep (see
+// deepByDefaultLanguages); everything else is standard.
+func DefaultLanguageDepth(language string) SASTDepth {
+	if deepByDefaultLanguages[language] {
+		return SASTDeep
+	}
+	return SASTStandard
+}
+
+// deepByDefaultLanguages is the set of languages that default to deep analysis:
+// Python and JavaScript/TypeScript. These are where AI applications are built
+// and where the pattern rules produce the worst false positives, so they earn
+// the deepest analysis and are the first targets for future AST/taint work.
+var deepByDefaultLanguages = map[string]bool{
+	"python":     true,
+	"javascript": true,
+	"typescript": true,
+}
+
+// validSASTDepths is the set of accepted depth strings, used by validation.
+var validSASTDepths = map[SASTDepth]bool{
+	SASTDeep:     true,
+	SASTStandard: true,
+	SASTOff:      true,
+}
+
+// extensionLanguages maps a source-file extension to its canonical language
+// name for SAST-profile lookup. It mirrors discovery.sourceExtensions (the set
+// of extensions classified as Source) so every scannable source file resolves
+// to a language. Config/lockfile/container artifacts carry no source language
+// and are never subject to the language profile.
+var extensionLanguages = map[string]string{
+	".go":    "go",
+	".py":    "python",
+	".js":    "javascript",
+	".jsx":   "javascript",
+	".mjs":   "javascript",
+	".cjs":   "javascript",
+	".ts":    "typescript",
+	".tsx":   "typescript",
+	".mts":   "typescript",
+	".cts":   "typescript",
+	".rb":    "ruby",
+	".java":  "java",
+	".kt":    "kotlin",
+	".swift": "swift",
+	".php":   "php",
+	".rs":    "rust",
+	".c":     "c",
+	".cpp":   "cpp",
+	".h":     "c",
+	".cs":    "csharp",
+	".sh":    "shell",
+}
+
+// LanguageForExtension returns the canonical language name for a file path
+// based on its extension, or "" when the extension maps to no known source
+// language. The lookup is case-insensitive on the extension.
+func LanguageForExtension(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	return extensionLanguages[ext]
+}
+
+// ResolveDepth returns the effective SAST depth for a canonical language name,
+// applying the explicit config entry when present and DefaultLanguageDepth
+// otherwise. Language names are matched case-insensitively so `Python` and
+// `python` resolve the same. An empty or unknown-depth entry is treated as
+// absent (defaulting), since Validate rejects unknown depths before a scan.
+func (c SASTConfig) ResolveDepth(language string) SASTDepth {
+	if language == "" {
+		return SASTStandard
+	}
+	lang := strings.ToLower(language)
+	if raw, ok := c.lookup(lang); ok {
+		d := SASTDepth(strings.ToLower(raw))
+		if validSASTDepths[d] {
+			return d
+		}
+	}
+	return DefaultLanguageDepth(lang)
+}
+
+// lookup finds a configured depth for a language, matching keys
+// case-insensitively so config authors can write `Python` or `python`.
+func (c SASTConfig) lookup(lang string) (string, bool) {
+	if c.Languages == nil {
+		return "", false
+	}
+	if v, ok := c.Languages[lang]; ok {
+		return v, true
+	}
+	for k, v := range c.Languages {
+		if strings.EqualFold(k, lang) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// Validate rejects unknown depth values so a typo (e.g. `depe`) fails the scan
+// loudly at config load instead of silently defaulting. Language names are not
+// validated — an unknown language simply never matches a source file — but its
+// depth string still must be one of deep|standard|off.
+func (c SASTConfig) Validate() error {
+	// Sort keys so the error message is deterministic across runs.
+	langs := make([]string, 0, len(c.Languages))
+	for lang := range c.Languages {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		d := SASTDepth(strings.ToLower(c.Languages[lang]))
+		if !validSASTDepths[d] {
+			return fmt.Errorf("scan.sast.languages: invalid depth %q for %q (want deep|standard|off)", c.Languages[lang], lang)
+		}
+	}
+	return nil
+}
+
+// ResolvedProfile returns the effective depth for every language nox knows how
+// to classify, merged with any explicitly configured entries (including
+// languages nox has no extension mapping for, which a config may still list).
+// The result is the auditable record written to the report meta — it answers
+// "what depth did this scan apply to each language?" without the reader having
+// to re-derive defaults. Keys are canonical, lowercased language names; values
+// are the string form of the resolved depth.
+func (c SASTConfig) ResolvedProfile() map[string]string {
+	profile := make(map[string]string)
+	for _, lang := range extensionLanguages {
+		profile[lang] = string(c.ResolveDepth(lang))
+	}
+	for lang := range c.Languages {
+		l := strings.ToLower(lang)
+		profile[l] = string(c.ResolveDepth(l))
+	}
+	return profile
+}
+
+// FilterArtifactsByLanguageProfile drops source artifacts whose resolved SAST
+// depth is "off" so they reach no pattern analyzer and contribute no findings.
+// Non-source artifacts (config, lockfiles, containers, AI components) carry no
+// source language and always pass through — turning off a language must not
+// silence dependency, IaC, or secret scanning of unrelated files. Source files
+// whose extension maps to no known language also pass through (they cannot be
+// addressed by the language profile). The input order is preserved so the scan
+// stays deterministic.
+func FilterArtifactsByLanguageProfile(artifacts []discovery.Artifact, cfg SASTConfig) []discovery.Artifact {
+	filtered := make([]discovery.Artifact, 0, len(artifacts))
+	for _, a := range artifacts {
+		if a.Type == discovery.Source {
+			if lang := LanguageForExtension(a.Path); lang != "" && cfg.ResolveDepth(lang) == SASTOff {
+				continue
+			}
+		}
+		filtered = append(filtered, a)
+	}
+	return filtered
+}

--- a/core/sast_test.go
+++ b/core/sast_test.go
@@ -1,0 +1,314 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+)
+
+func TestLanguageForExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"go", "main.go", "go"},
+		{"python", "app.py", "python"},
+		{"js", "index.js", "javascript"},
+		{"jsx", "App.jsx", "javascript"},
+		{"mjs", "esm.mjs", "javascript"},
+		{"ts", "server.ts", "typescript"},
+		{"tsx", "Page.tsx", "typescript"},
+		{"rust", "lib.rs", "rust"},
+		{"c header maps to c", "foo.h", "c"},
+		{"uppercase extension", "MAIN.GO", "go"},
+		{"nested path", "src/pkg/handler.py", "python"},
+		{"config file has no language", "config.yaml", ""},
+		{"no extension", "Makefile", ""},
+		{"unknown source", "query.sql", ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := LanguageForExtension(tt.path); got != tt.want {
+				t.Errorf("LanguageForExtension(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultLanguageDepth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		language string
+		want     SASTDepth
+	}{
+		{"python", SASTDeep},
+		{"javascript", SASTDeep},
+		{"typescript", SASTDeep},
+		{"go", SASTStandard},
+		{"rust", SASTStandard},
+		{"java", SASTStandard},
+		{"unlisted-language", SASTStandard},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.language, func(t *testing.T) {
+			t.Parallel()
+			if got := DefaultLanguageDepth(tt.language); got != tt.want {
+				t.Errorf("DefaultLanguageDepth(%q) = %q, want %q", tt.language, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSASTConfig_ResolveDepth(t *testing.T) {
+	t.Parallel()
+
+	cfg := SASTConfig{Languages: map[string]string{
+		"go":         "deep",     // override the default (standard) upward
+		"python":     "off",      // override the default (deep) to off
+		"typescript": "standard", // override the default (deep) downward
+		"Ruby":       "off",      // uppercase key must match lowercase lookup
+	}}
+
+	tests := []struct {
+		name     string
+		language string
+		want     SASTDepth
+	}{
+		{"explicit deep on a standard-default language", "go", SASTDeep},
+		{"explicit off overrides deep default", "python", SASTOff},
+		{"explicit standard overrides deep default", "typescript", SASTStandard},
+		{"case-insensitive language lookup", "ruby", SASTOff},
+		{"query language name case-insensitively", "PYTHON", SASTOff},
+		{"unlisted deep-default language keeps deep", "javascript", SASTDeep},
+		{"unlisted standard-default language keeps standard", "rust", SASTStandard},
+		{"empty language resolves standard", "", SASTStandard},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cfg.ResolveDepth(tt.language); got != tt.want {
+				t.Errorf("ResolveDepth(%q) = %q, want %q", tt.language, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSASTConfig_ResolveDepth_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	var cfg SASTConfig // Languages is nil
+	if got := cfg.ResolveDepth("python"); got != SASTDeep {
+		t.Errorf("ResolveDepth(python) with nil config = %q, want deep (default)", got)
+	}
+	if got := cfg.ResolveDepth("go"); got != SASTStandard {
+		t.Errorf("ResolveDepth(go) with nil config = %q, want standard (default)", got)
+	}
+}
+
+func TestSASTConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		langs   map[string]string
+		wantErr bool
+	}{
+		{"nil config is valid", nil, false},
+		{"empty config is valid", map[string]string{}, false},
+		{
+			name:  "all valid depths",
+			langs: map[string]string{"python": "deep", "go": "standard", "rust": "off"},
+		},
+		{
+			name:  "mixed case depth is normalized and valid",
+			langs: map[string]string{"go": "Deep", "python": "OFF"},
+		},
+		{
+			name:    "unknown depth is rejected",
+			langs:   map[string]string{"go": "shallow"},
+			wantErr: true,
+		},
+		{
+			name:    "typo depth is rejected",
+			langs:   map[string]string{"python": "depe"},
+			wantErr: true,
+		},
+		{
+			name:    "empty depth string is rejected",
+			langs:   map[string]string{"go": ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := SASTConfig{Languages: tt.langs}.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestSASTConfig_ResolvedProfile(t *testing.T) {
+	t.Parallel()
+
+	cfg := SASTConfig{Languages: map[string]string{
+		"go":        "off",
+		"terraform": "standard", // language with no extension mapping, still recorded
+	}}
+	profile := cfg.ResolvedProfile()
+
+	// Defaults are materialized for known languages.
+	if profile["python"] != "deep" {
+		t.Errorf("profile[python] = %q, want deep", profile["python"])
+	}
+	if profile["javascript"] != "deep" {
+		t.Errorf("profile[javascript] = %q, want deep", profile["javascript"])
+	}
+	// Explicit override wins.
+	if profile["go"] != "off" {
+		t.Errorf("profile[go] = %q, want off", profile["go"])
+	}
+	// An explicitly configured language with no extension mapping is still
+	// recorded so the audit trail is complete.
+	if profile["terraform"] != "standard" {
+		t.Errorf("profile[terraform] = %q, want standard", profile["terraform"])
+	}
+}
+
+func TestFilterArtifactsByLanguageProfile(t *testing.T) {
+	t.Parallel()
+
+	artifacts := []discovery.Artifact{
+		{Path: "main.go", Type: discovery.Source},
+		{Path: "app.py", Type: discovery.Source},
+		{Path: "index.ts", Type: discovery.Source},
+		{Path: "config.yaml", Type: discovery.Config},           // no source language
+		{Path: "package-lock.json", Type: discovery.Lockfile},   // deps must still scan
+		{Path: "prompts/agent.md", Type: discovery.AIComponent}, // AI must still scan
+		{Path: "query.sql", Type: discovery.Source},             // unknown source language
+	}
+
+	cfg := SASTConfig{Languages: map[string]string{
+		"go":     "off",
+		"python": "standard",
+	}}
+
+	got := FilterArtifactsByLanguageProfile(artifacts, cfg)
+
+	var gotPaths []string
+	for _, a := range got {
+		gotPaths = append(gotPaths, a.Path)
+	}
+
+	// main.go dropped (go=off); everything else survives.
+	want := []string{"app.py", "index.ts", "config.yaml", "package-lock.json", "prompts/agent.md", "query.sql"}
+	if len(gotPaths) != len(want) {
+		t.Fatalf("filtered paths = %v, want %v", gotPaths, want)
+	}
+	for i := range want {
+		if gotPaths[i] != want[i] {
+			t.Errorf("filtered[%d] = %q, want %q (order must be preserved)", i, gotPaths[i], want[i])
+		}
+	}
+}
+
+func TestFilterArtifactsByLanguageProfile_NoOffLanguages(t *testing.T) {
+	t.Parallel()
+
+	artifacts := []discovery.Artifact{
+		{Path: "main.go", Type: discovery.Source},
+		{Path: "app.py", Type: discovery.Source},
+	}
+	// Default profile turns nothing off, so nothing is filtered.
+	got := FilterArtifactsByLanguageProfile(artifacts, SASTConfig{})
+	if len(got) != len(artifacts) {
+		t.Errorf("filtered %d artifacts with default profile, want %d (no drops)", len(got), len(artifacts))
+	}
+}
+
+func TestLoadScanConfig_SASTLanguages(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `scan:
+  sast:
+    languages:
+      python: deep
+      javascript: deep
+      typescript: deep
+      go: standard
+      rust: off
+`
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadScanConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.Scan.SAST.ResolveDepth("python"); got != SASTDeep {
+		t.Errorf("python depth = %q, want deep", got)
+	}
+	if got := cfg.Scan.SAST.ResolveDepth("go"); got != SASTStandard {
+		t.Errorf("go depth = %q, want standard", got)
+	}
+	if got := cfg.Scan.SAST.ResolveDepth("rust"); got != SASTOff {
+		t.Errorf("rust depth = %q, want off", got)
+	}
+	// A language absent from config still gets its default.
+	if got := cfg.Scan.SAST.ResolveDepth("ruby"); got != SASTStandard {
+		t.Errorf("ruby depth = %q, want standard (default)", got)
+	}
+
+	if err := cfg.Scan.SAST.Validate(); err != nil {
+		t.Errorf("Validate() on parsed config = %v, want nil", err)
+	}
+}
+
+func TestLoadScanConfig_SASTLanguages_Absent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `scan:
+  exclude:
+    - "vendor/"
+`
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadScanConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Scan.SAST.Languages != nil {
+		t.Errorf("expected nil Languages when sast block absent, got %v", cfg.Scan.SAST.Languages)
+	}
+	// Defaults still apply through the nil config.
+	if got := cfg.Scan.SAST.ResolveDepth("python"); got != SASTDeep {
+		t.Errorf("python depth with no sast block = %q, want deep", got)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -60,6 +60,11 @@ type ScanResult struct {
 	Rules        *rules.RuleSet
 	Graphs       []graph.Graph         // relationship graphs from plugins
 	Enrichments  []findings.Enrichment // finding annotations from plugins
+	// SASTProfile records the resolved per-language SAST depth applied to this
+	// scan (language name → deep|standard|off). It is the auditable answer to
+	// "what depth did this scan give each language?" and is copied into the
+	// report meta so the decision is visible in the artifact, not just in config.
+	SASTProfile map[string]string
 }
 
 // ScanOptions holds optional parameters for RunScanWithOptions. The zero
@@ -149,11 +154,24 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
+	// Fail loudly on an invalid SAST depth (e.g. a typo) instead of silently
+	// defaulting — a misconfigured `off` that scanned anyway would be a silent
+	// security surprise.
+	if err := cfg.Scan.SAST.Validate(); err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
 	// Stage 1: Discover artifacts.
 	artifacts, err := discoverArtifacts(target, cfg, opts)
 	if err != nil {
 		return nil, err
 	}
+
+	// Apply the per-language SAST profile: source files of a language set to
+	// "off" are dropped here, before any analyzer sees them, so they contribute
+	// no findings. Non-source artifacts always pass through. This runs on the
+	// discovered set (deterministic, input order preserved).
+	artifacts = FilterArtifactsByLanguageProfile(artifacts, cfg.Scan.SAST)
 
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -420,6 +438,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		AIInventory:  aiInventory,
 		PolicyResult: policyResult,
 		Rules:        allRules,
+		SASTProfile:  cfg.Scan.SAST.ResolvedProfile(),
 	}, nil
 }
 

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -139,6 +139,80 @@ const apiKey = "` + awsKey + `"
 	}
 }
 
+func TestRunScan_SASTOffSkipsLanguage(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Turn Go off; Python stays at its default (deep). Both files carry the same
+	// detectable secret, so only the Python finding must survive.
+	configContent := `scan:
+  sast:
+    languages:
+      go: off
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".nox.yaml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	awsKey := "AKIAIOSFODNN7EXAMPLE"
+	goFile := "package main\n\nconst apiKey = \"" + awsKey + "\"\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(goFile), 0o644); err != nil {
+		t.Fatalf("failed to write go file: %v", err)
+	}
+	pyFile := "api_key = \"" + awsKey + "\"\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "app.py"), []byte(pyFile), 0o644); err != nil {
+		t.Fatalf("failed to write py file: %v", err)
+	}
+
+	result, err := RunScan(tmpDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var goFindings, pyFindings int
+	for _, f := range result.Findings.Findings() {
+		switch f.Location.FilePath {
+		case "main.go":
+			goFindings++
+		case "app.py":
+			pyFindings++
+		}
+	}
+	if goFindings != 0 {
+		t.Errorf("go=off must yield zero findings on main.go, got %d", goFindings)
+	}
+	if pyFindings == 0 {
+		t.Error("python (default deep) must still produce findings on app.py, got none")
+	}
+
+	// The resolved profile is recorded for audit.
+	if result.SASTProfile["go"] != "off" {
+		t.Errorf("result.SASTProfile[go] = %q, want off", result.SASTProfile["go"])
+	}
+	if result.SASTProfile["python"] != "deep" {
+		t.Errorf("result.SASTProfile[python] = %q, want deep", result.SASTProfile["python"])
+	}
+}
+
+func TestRunScan_SASTInvalidDepthFailsScan(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configContent := `scan:
+  sast:
+    languages:
+      go: shallow
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".nox.yaml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	_, err := RunScan(tmpDir)
+	if err == nil {
+		t.Fatal("expected error for invalid SAST depth, got nil")
+	}
+}
+
 func TestRunScan_NonExistentDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/docs/sast-language-strategy.md
+++ b/docs/sast-language-strategy.md
@@ -1,0 +1,129 @@
+# Per-language SAST depth strategy
+
+nox targets roughly fifteen languages, but it does **not** invest equal
+static-analysis depth in all of them. This document explains *why* the depth is
+uneven, how to configure it in `.nox.yaml`, and how each depth level maps to
+scanner behavior — today and as the SAST engine grows.
+
+## Depth where the moat is
+
+Security tooling has finite engineering attention. Spreading it evenly across
+every language produces mediocre coverage everywhere and a defensible advantage
+nowhere. nox concentrates depth where it pays off:
+
+- **Python and JavaScript/TypeScript get `deep`.** This is where AI applications
+  are built — LLM orchestration, prompt construction, agent frameworks, MCP
+  servers and clients — so it is where nox's AI-security rules matter most. It is
+  also where the pattern rules generate the **worst false positives** (dynamic
+  string building, template literals, notebook-style code), so it is the first
+  place richer analysis earns its keep. These languages are the moat; they get
+  the deepest analysis and are the first targets for future AST/taint work.
+
+- **Everything else gets `standard`.** Go, Rust, Java, Ruby, C/C++, C#, PHP,
+  Kotlin, Swift, shell, and friends receive solid pattern-based coverage. This
+  is the sensible default: real coverage without over-investing where the
+  marginal security return is lower.
+
+- **A repo can turn any language `off`.** A Go-only backend that vendors a
+  handful of generated JS assets, or a Python service with a throwaway `scripts/`
+  tree in another language, can silence a language it does not care to scan.
+  `off` means those source files contribute **no findings** at all.
+
+## Configuration
+
+The strategy lives under `scan.sast.languages` in `.nox.yaml`. Keys are
+language names; values are one of `deep`, `standard`, or `off`:
+
+```yaml
+scan:
+  sast:
+    languages:
+      python: deep
+      javascript: deep
+      typescript: deep
+      go: standard
+      rust: off
+      # any language not listed uses its default (see below)
+```
+
+**Defaults.** You do not need to list a language to get sensible behavior:
+
+| Language                         | Default depth |
+| -------------------------------- | ------------- |
+| `python`, `javascript`, `typescript` | `deep`    |
+| every other language             | `standard`    |
+
+So the block above is equivalent to listing only the overrides you care about
+(`rust: off`); `python`/`javascript`/`typescript` are already `deep` and `go` is
+already `standard` by default.
+
+**Validation.** An unknown depth value fails the scan immediately with a clear
+error rather than silently defaulting — a misconfigured `off` that quietly kept
+scanning (or a typo'd `deep`) would be a silent security surprise:
+
+```
+scan.sast.languages: invalid depth "shallow" for "go" (want deep|standard|off)
+```
+
+Language names are matched case-insensitively (`Python` and `python` are the
+same). Unknown *language* names are not an error — they simply never match a
+source file — but their depth value must still be valid.
+
+## How depth maps to behavior
+
+| Depth      | Behavior today                                   | Intended future behavior                          |
+| ---------- | ------------------------------------------------ | ------------------------------------------------- |
+| `deep`     | Current pattern-based rule analysis              | Pattern rules **plus** AST / taint / dataflow     |
+| `standard` | Current pattern-based rule analysis              | Pattern rules only                                |
+| `off`      | Source files of the language are **skipped** — no analyzer sees them, so they produce zero findings | Unchanged: still skipped |
+
+### `deep` and `standard` are identical *today* — on purpose
+
+Be honest about the current state: `deep` and `standard` run **exactly the same
+analysis right now** (the existing pattern rules). The value shipped today is the
+*config surface* and the *`off` skip*, not a behavioral split between deep and
+standard.
+
+Why ship the distinction before the behavior exists? Because it gives the future
+AST/taint work a stable home. When deeper analysis lands, it switches on for
+languages already marked `deep` with **no config migration** for users — a repo
+that set `python: deep` today automatically gets the richer engine when it
+arrives. The strategy is declared once; the engine grows into it.
+
+### What `off` actually does
+
+`off` is the one depth that changes behavior today, and it is deliberately
+scoped:
+
+- It drops **source** artifacts of that language (files whose extension maps to
+  the language) *before any analyzer runs*, so they contribute no findings from
+  the pattern analyzers (secrets, AI, IaC, data, slop, variants, …).
+- It does **not** touch non-source artifacts. Lockfiles, configuration files,
+  container definitions, and AI-component files are never gated by the language
+  profile — turning off a language must not silently disable dependency-CVE,
+  IaC, or secret scanning of unrelated files. In particular, dependency scanning
+  still reads `package-lock.json` even with `javascript: off`.
+- The filter is applied on the discovered artifact set with input order
+  preserved, so scans stay **deterministic**.
+
+## Auditability
+
+The resolved per-language depth for a scan is recorded in the JSON report meta
+under `sast_languages`, so a reviewer can see exactly which languages were
+scanned at which depth without re-deriving defaults from config:
+
+```json
+{
+  "meta": {
+    "schema_version": "1.0.0",
+    "tool_name": "nox",
+    "sast_languages": {
+      "python": "deep",
+      "go": "standard",
+      "rust": "off"
+    }
+  }
+}
+```
+
+The field is omitted when no profile applies (for example, git-history scans).


### PR DESCRIPTION
## Summary

nox targets ~15 languages but shouldn't spend equal SAST depth everywhere. This makes "depth where the moat is" a real, configurable strategy: **Python + JS/TS** (where AI apps and the worst false positives live) default to **deep**, everything else to **standard**, and any language can be turned **off**.

## Config surface

```yaml
scan:
  sast:
    languages:
      python: deep
      javascript: deep
      typescript: deep
      go: standard
      rust: off
      # unlisted languages: python/js/ts -> deep, everything else -> standard
```

Depth levels: `deep` | `standard` | `off`. An unknown depth (typo) fails the scan at config load with a clear error. Language names match case-insensitively.

## What each level does *today*

- **`off`** — source files of that language are dropped **before any analyzer runs**, so they produce zero findings. Non-source artifacts (lockfiles, config, containers, AI components) always pass through, so turning off a language never silences dependency-CVE / IaC / secret scanning of unrelated files. Applied deterministically, input order preserved.
- **`standard`** — current pattern-based rule analysis.
- **`deep`** — **behaviorally identical to `standard` right now**, on purpose. It reserves a home for future AST/taint analysis so `python: deep` set today gets the richer engine when it lands, with no config migration.

## Plumbing

- Ext→language map mirroring `discovery` source extensions (`core/sast.go`).
- `FilterArtifactsByLanguageProfile` filters the discovered set in `core/scan.go` before analyzers run; config validated at scan start.
- Resolved per-language profile recorded on `ScanResult.SASTProfile` and emitted in the JSON report meta as `sast_languages` (omitted when empty) for auditability.

## Docs

`docs/sast-language-strategy.md` — rationale, config, and the depth→behavior mapping (honest that deep == standard today).

## Tests

Table-tested defaulting, validation, parsing, ext→lang, artifact filtering, report meta, plus an end-to-end test proving `go: off` yields zero Go findings while Python still scans. `go build ./...` and `go test ./core/...` green; `golangci-lint` clean on changed files.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom