### PR TITLE
feat(bench): SAST precision/recall harness

### DIFF
--- a/cli/bench_cmd.go
+++ b/cli/bench_cmd.go
@@ -38,6 +38,15 @@ var curatedAutoCorpus = []struct {
 // set into a temp directory and runs the same harness against it —
 // reproducible numbers without manual setup.
 func runBench(args []string) int {
+	// `nox bench --precision <corpus>` is a distinct mode: instead of
+	// fire-rates over many projects, it scores one labeled corpus for
+	// precision/recall/F1 against inline `nox-expect` ground truth. It is
+	// routed early so it can own its own flag set without colliding with the
+	// fire-rate flags (e.g. --min-precision, --json).
+	if hasFlag(args, "precision") {
+		return runBenchPrecision(args)
+	}
+
 	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
 	var (
 		corpusDir  string
@@ -132,12 +141,12 @@ func runBench(args []string) int {
 // BenchReport is the top-level bench output. Stable JSON shape so
 // downstream tooling can join across runs.
 type BenchReport struct {
-	StartedAt   string           `json:"started_at"`
-	FinishedAt  string           `json:"finished_at"`
-	NoxBinary   string           `json:"nox_binary"`
-	Projects    []ProjectSummary `json:"projects"`
-	Failed      []FailedProject  `json:"failed,omitempty"`
-	RuleFireRate map[string]int  `json:"rule_fire_rate,omitempty"`
+	StartedAt    string           `json:"started_at"`
+	FinishedAt   string           `json:"finished_at"`
+	NoxBinary    string           `json:"nox_binary"`
+	Projects     []ProjectSummary `json:"projects"`
+	Failed       []FailedProject  `json:"failed,omitempty"`
+	RuleFireRate map[string]int   `json:"rule_fire_rate,omitempty"`
 }
 
 type ProjectSummary struct {

--- a/cli/bench_precision_cmd.go
+++ b/cli/bench_precision_cmd.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/bench"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// hasFlag reports whether args contains the named flag in any accepted form
+// (-name, --name, -name=..., --name=...). Used to route `nox bench --precision`
+// before the fire-rate flag set parses, so the two modes never share a flag
+// namespace.
+func hasFlag(args []string, name string) bool {
+	for _, a := range args {
+		trimmed := strings.TrimLeft(a, "-")
+		if trimmed == name || strings.HasPrefix(trimmed, name+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// runBenchPrecision scores a labeled corpus for SAST precision/recall/F1.
+//
+// It scans the corpus offline (the corpus is ground truth, not a live target —
+// determinism matters more than dependency lookups), parses the inline
+// `nox-expect` annotations into expectations, and hands both to the pure
+// bench.Score function. The table is sorted worst-precision-first so the rules
+// most in need of attention are impossible to miss. With --min-precision set,
+// any rule that scored (TP+FP > 0) below the threshold makes the command exit
+// non-zero, turning the harness into a CI gate against precision regressions.
+func runBenchPrecision(args []string) int {
+	fs := flag.NewFlagSet("bench --precision", flag.ContinueOnError)
+	var (
+		corpusDir    string
+		jsonOut      bool
+		minPrecision float64
+	)
+	fs.StringVar(&corpusDir, "precision", "", "path to a labeled precision corpus (directory of samples with inline nox-expect annotations)")
+	fs.BoolVar(&jsonOut, "json", false, "emit the report as JSON instead of a table")
+	fs.Float64Var(&minPrecision, "min-precision", -1, "fail (exit 1) if any rule that fired scores below this precision (0..1); default off")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	// Allow `nox bench --precision <dir>` (positional) as well as
+	// `--precision=<dir>`: if the flag consumed nothing, take the first
+	// positional argument.
+	if corpusDir == "" {
+		if fs.NArg() > 0 {
+			corpusDir = fs.Arg(0)
+		} else {
+			fmt.Fprintln(os.Stderr, "usage: nox bench --precision <corpus-dir> [--json] [--min-precision F]")
+			return 2
+		}
+	}
+
+	expectations, err := bench.ParseCorpus(corpusDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: parsing corpus: %v\n", err)
+		return 2
+	}
+
+	scanFindings, err := scanCorpusFindings(corpusDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: scanning corpus: %v\n", err)
+		return 2
+	}
+
+	report := bench.Score(scanFindings, expectations)
+
+	if jsonOut {
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: marshalling report: %v\n", err)
+			return 2
+		}
+		fmt.Println(string(out))
+	} else {
+		fmt.Print(renderPrecisionTable(corpusDir, &report))
+	}
+
+	if minPrecision >= 0 {
+		if failed := rulesBelowPrecision(&report, minPrecision); len(failed) > 0 {
+			fmt.Fprintf(os.Stderr, "\nprecision gate FAILED: %s below --min-precision %.2f\n",
+				strings.Join(failed, ", "), minPrecision)
+			return 1
+		}
+	}
+	return 0
+}
+
+// scanCorpusFindings runs an offline scan over the corpus and returns its
+// findings with file paths made relative to the corpus root, so they line up
+// with the corpus-relative paths ParseCorpus produces. Scanning offline keeps
+// the score reproducible: no network, no OSV lookups, no LLM.
+func scanCorpusFindings(corpusDir string) ([]findings.Finding, error) {
+	result, err := nox.RunScanWithOptions(corpusDir, nox.ScanOptions{Offline: true})
+	if err != nil {
+		return nil, err
+	}
+	all := result.Findings.Findings()
+	out := make([]findings.Finding, 0, len(all))
+	for i := range all {
+		f := all[i]
+		f.Location.FilePath = relToCorpus(corpusDir, f.Location.FilePath)
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// relToCorpus normalises a finding path to be relative to the corpus root.
+// Scan findings may carry absolute or corpus-relative paths depending on how
+// the analyzer recorded them; normalising both sides to corpus-relative slash
+// paths lets the scorer compare them directly.
+func relToCorpus(corpusDir, path string) string {
+	if rel, err := filepath.Rel(corpusDir, path); err == nil && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(path)
+}
+
+// rulesBelowPrecision returns the IDs of rules that actually fired (TP+FP > 0)
+// and scored below threshold. Rules that never fired are exempt: they have no
+// false positives to penalise, and gating on them would fail CI for rules a
+// corpus simply doesn't exercise.
+func rulesBelowPrecision(report *bench.Report, threshold float64) []string {
+	var failed []string
+	for i := range report.Rules {
+		r := &report.Rules[i]
+		if r.TP+r.FP == 0 {
+			continue
+		}
+		if r.Precision() < threshold {
+			failed = append(failed, r.RuleID)
+		}
+	}
+	sort.Strings(failed)
+	return failed
+}
+
+// renderPrecisionTable formats the per-rule metrics (worst precision first) and
+// the overall roll-up as an aligned text table. It returns the rendered text so
+// the caller owns the single Print — building into a strings.Builder keeps this
+// pure and sidesteps unhandled-write errors from writing straight to a file.
+func renderPrecisionTable(corpusDir string, report *bench.Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Precision/recall for corpus %s\n\n", corpusDir)
+
+	tw := tabwriter.NewWriter(&b, 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "RULE\tTP\tFP\tFN\tPRECISION\tRECALL\tF1")
+	for i := range report.Rules {
+		r := &report.Rules[i]
+		_, _ = fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\n",
+			r.RuleID, r.TP, r.FP, r.FN, r.Precision(), r.Recall(), r.F1())
+	}
+	_, _ = fmt.Fprintln(tw, "\t\t\t\t\t\t")
+	o := &report.Overall
+	_, _ = fmt.Fprintf(tw, "OVERALL\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\n",
+		o.TP, o.FP, o.FN, o.Precision(), o.Recall(), o.F1())
+	_ = tw.Flush() //nolint:errcheck // strings.Builder never errors on write
+	return b.String()
+}

--- a/cli/bench_precision_cmd_test.go
+++ b/cli/bench_precision_cmd_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/bench"
+)
+
+// corpusPath resolves the shipped labeled corpus relative to the repo root.
+// The CLI package lives in ./cli, so the corpus is one directory up.
+func corpusPath() string {
+	return filepath.Join("..", "testdata", "precision-corpus")
+}
+
+// TestPrecisionCorpusBaseline is a guard test: the shipped corpus is curated to
+// score a perfect 1.0/1.0/1.0. If a rule change makes nox miss a labeled
+// finding (recall drops) or fire on a clean sample (precision drops), this test
+// fails and forces the corpus or the rule to be reconciled — which is exactly
+// the regression signal the harness exists to provide.
+func TestPrecisionCorpusBaseline(t *testing.T) {
+	dir := corpusPath()
+
+	expectations, err := bench.ParseCorpus(dir)
+	if err != nil {
+		t.Fatalf("ParseCorpus(%s): %v", dir, err)
+	}
+	if len(expectations) == 0 {
+		t.Fatal("corpus has no expectations; a labeled corpus must declare some")
+	}
+
+	scanFindings, err := scanCorpusFindings(dir)
+	if err != nil {
+		t.Fatalf("scanCorpusFindings(%s): %v", dir, err)
+	}
+
+	report := bench.Score(scanFindings, expectations)
+
+	if report.Overall.FP != 0 {
+		t.Errorf("shipped corpus produced %d false positive(s); precision baseline broken:\n%s",
+			report.Overall.FP, renderPrecisionTable(dir, &report))
+	}
+	if report.Overall.FN != 0 {
+		t.Errorf("shipped corpus produced %d false negative(s); recall baseline broken:\n%s",
+			report.Overall.FN, renderPrecisionTable(dir, &report))
+	}
+	if report.Overall.TP == 0 {
+		t.Error("shipped corpus produced zero true positives; the samples no longer fire")
+	}
+}
+
+// TestRunBenchPrecisionExitCodes exercises the CLI entry point end to end,
+// including the --min-precision gate.
+func TestRunBenchPrecisionExitCodes(t *testing.T) {
+	dir := corpusPath()
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"table mode succeeds", []string{"bench", "--precision", dir}, 0},
+		{"json mode succeeds", []string{"bench", "--precision", dir, "--json"}, 0},
+		{"positional corpus arg", []string{"bench", "--precision=" + dir}, 0},
+		{"gate passes at achievable threshold", []string{"bench", "--precision", dir, "--min-precision", "0.9"}, 0},
+		{"gate fails at impossible threshold", []string{"bench", "--precision", dir, "--min-precision", "1.1"}, 1},
+		{"missing corpus errors", []string{"bench", "--precision", filepath.Join(t.TempDir(), "nope")}, 2},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := run(tt.args); got != tt.want {
+				t.Errorf("run(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -143,7 +143,7 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "  fix              Apply OSV dep upgrades (--actions also bumps GitHub Actions pins)\n")
 		fmt.Fprintf(os.Stderr, "  doctor           Report environment, plugin state, config sanity\n")
 		fmt.Fprintf(os.Stderr, "  agent-graph      Render agent capability lattice (mermaid/dot)\n")
-		fmt.Fprintf(os.Stderr, "  bench            Scan a corpus directory; report rule fire-rates\n")
+		fmt.Fprintf(os.Stderr, "  bench            Scan a corpus directory; report rule fire-rates (--precision <dir> scores P/R/F1 against a labeled corpus)\n")
 		fmt.Fprintf(os.Stderr, "  calibrate        Suggest severity overrides from a bench report\n")
 		fmt.Fprintf(os.Stderr, "  install          Install plugins listed in .nox.yaml plugins.required\n")
 		fmt.Fprintf(os.Stderr, "  uri <uri>        Handle nox:// URI (install action). Use `uri register` to wire OS URL handler\n")

--- a/core/bench/corpus.go
+++ b/core/bench/corpus.go
@@ -1,0 +1,130 @@
+package bench
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// expectMarker is the inline annotation keyword. A line containing
+// `nox-expect: <RuleID>[, <RuleID>...]` declares that the listed rules are
+// expected to fire on that line. The keyword is matched case-insensitively so
+// authors can shout it if they like. We deliberately require the annotation to
+// live on the same line as the code that should fire — this keeps each sample
+// self-contained and makes the ground truth impossible to misread: the
+// expectation sits exactly where the finding should land.
+var expectMarker = regexp.MustCompile(`(?i)nox-expect\s*:\s*(.*)$`)
+
+// docExtensions are treated as documentation, not samples. The corpus README
+// explains the annotation format and would otherwise be parsed as if its
+// examples were real expectations. Documentation is never scanned as a sample,
+// so any `nox-expect` text inside it must be ignored.
+var docExtensions = map[string]bool{
+	".md":       true,
+	".mdx":      true,
+	".markdown": true,
+	".rst":      true,
+	".txt":      true,
+}
+
+// ParseCorpus walks a labeled-corpus directory and returns every declared
+// expectation. Each source file is read line by line; any line carrying a
+// `nox-expect: <RuleID>` annotation yields one Expectation per listed rule,
+// anchored to that line number (1-based). Files with no annotations contribute
+// nothing — they are "clean" samples whose only role is to catch false
+// positives at scan time.
+//
+// FilePath in every returned Expectation is relative to dir, matching the
+// relative paths that findings.Location carries after a scan of the same
+// directory, so the scorer can compare them directly.
+func ParseCorpus(dir string) ([]Expectation, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("bench: corpus dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("bench: corpus path %q is not a directory", dir)
+	}
+
+	var expectations []Expectation
+	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if docExtensions[strings.ToLower(filepath.Ext(path))] {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		fileExpectations, err := parseFileExpectations(path, filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		expectations = append(expectations, fileExpectations...)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("bench: walking corpus: %w", walkErr)
+	}
+	return expectations, nil
+}
+
+// parseFileExpectations reads one source file and extracts its annotations.
+// relPath is the corpus-relative path stored on each Expectation.
+func parseFileExpectations(absPath, relPath string) ([]Expectation, error) {
+	f, err := os.Open(absPath) //nolint:gosec // corpus paths are operator-supplied, not user input
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only file; close error is not actionable
+
+	var out []Expectation
+	scanner := bufio.NewScanner(f)
+	// Allow long lines (minified JS, base64 blobs) without tripping the default
+	// 64KiB token limit — corpus samples intentionally include such lines.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		for _, ruleID := range parseExpectationRuleIDs(scanner.Text()) {
+			out = append(out, Expectation{RuleID: ruleID, FilePath: relPath, Line: lineNo})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// parseExpectationRuleIDs returns the rule IDs declared by a `nox-expect`
+// annotation on the line, or nil if the line has none. Rule IDs may be
+// separated by commas and/or whitespace. Tokens are returned verbatim (after
+// trimming) so a typo'd rule ID surfaces as a never-matched expectation rather
+// than being silently dropped.
+func parseExpectationRuleIDs(line string) []string {
+	m := expectMarker.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+	// Split the remainder on commas and whitespace. filepath-style tokens are
+	// preserved; empty tokens (from doubled separators) are dropped.
+	fields := strings.FieldsFunc(m[1], func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+	var ids []string
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			ids = append(ids, f)
+		}
+	}
+	return ids
+}

--- a/core/bench/corpus_test.go
+++ b/core/bench/corpus_test.go
@@ -1,0 +1,102 @@
+package bench
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestParseExpectationsFromLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want []string // rule IDs, in order
+	}{
+		{"no annotation", `x = 1`, nil},
+		{"python comment", `secret = "..."  # nox-expect: SEC-001`, []string{"SEC-001"}},
+		{"js line comment", `const p = a + b; // nox-expect: AI-002`, []string{"AI-002"}},
+		{"go comment", `os.System(x) // nox-expect: SEC-078`, []string{"SEC-078"}},
+		{"multiple rules comma-separated", `y // nox-expect: SEC-001, SEC-508`, []string{"SEC-001", "SEC-508"}},
+		{"multiple rules space-separated", `y # nox-expect: AI-002 AI-003`, []string{"AI-002", "AI-003"}},
+		{"extra whitespace tolerated", `z   #   nox-expect:    SEC-081   `, []string{"SEC-081"}},
+		{"annotation without comment marker still parses", `nox-expect: SEC-001`, []string{"SEC-001"}},
+		{"case-insensitive keyword", `q # NOX-EXPECT: SEC-001`, []string{"SEC-001"}},
+		{"ignores trailing prose after rule ids is not supported; rule tokens only", `a # nox-expect: SEC-001 because reasons`, []string{"SEC-001", "because", "reasons"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseExpectationRuleIDs(tt.line)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseExpectationRuleIDs(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCorpus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A sample with two annotated lines.
+	writeFile(t, dir, "secret.py", `import os
+AWS_KEY = "AKIA..."  # nox-expect: SEC-001
+password = "hunter2"  # nox-expect: SEC-081
+clean = 1
+`)
+	// A clean sample: no annotations at all.
+	writeFile(t, dir, "clean.py", `x = 2
+y = 3
+`)
+	// The corpus README must be ignored, not parsed as a sample.
+	writeFile(t, dir, "README.md", "# nox-expect: SEC-999 (this is documentation, must be ignored)\n")
+
+	got, err := ParseCorpus(dir)
+	if err != nil {
+		t.Fatalf("ParseCorpus: %v", err)
+	}
+
+	// Paths are relative to the corpus dir so the report is portable.
+	want := []Expectation{
+		{RuleID: "SEC-001", FilePath: "secret.py", Line: 2},
+		{RuleID: "SEC-081", FilePath: "secret.py", Line: 3},
+	}
+	sortExpectations(got)
+	sortExpectations(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseCorpus = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseCorpusMissingDir(t *testing.T) {
+	t.Parallel()
+	if _, err := ParseCorpus(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("expected error for missing corpus dir, got nil")
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+func sortExpectations(es []Expectation) {
+	sort.Slice(es, func(i, j int) bool {
+		if es[i].FilePath != es[j].FilePath {
+			return es[i].FilePath < es[j].FilePath
+		}
+		if es[i].Line != es[j].Line {
+			return es[i].Line < es[j].Line
+		}
+		return es[i].RuleID < es[j].RuleID
+	})
+}

--- a/core/bench/precision.go
+++ b/core/bench/precision.go
@@ -1,0 +1,218 @@
+// Package bench provides a precision/recall scorer for nox's SAST rules.
+//
+// nox already reports rule fire-rates (how often each rule triggers across a
+// corpus), but fire-rate says nothing about *quality*: a rule that fires on
+// every file might be all noise. To improve precision you must be able to
+// measure it, and to measure it you need ground truth. This package supplies
+// that missing measurement layer.
+//
+// Ground truth comes from a labeled corpus (see corpus.go): every finding a
+// scan *should* produce is declared inline in the sample source with a
+// `nox-expect: <RuleID>` annotation on the line that should fire. Score then
+// compares an actual scan's findings against those expectations and computes,
+// per rule and overall, true positives (TP), false positives (FP), false
+// negatives (FN), and the derived precision, recall, and F1.
+//
+// The scorer is deliberately a pure function of (findings, expectations) so it
+// is fully unit-testable without running a scan — the scan is I/O, the scoring
+// is arithmetic, and keeping them separate is what makes the quality number
+// trustworthy and reproducible.
+package bench
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Expectation is a single declared ground-truth finding: rule RuleID is
+// expected to fire at FilePath:Line. It is produced by parsing `nox-expect`
+// annotations out of the corpus (see ParseCorpus). Line is 1-based to match
+// findings.Location.StartLine.
+type Expectation struct {
+	RuleID   string
+	FilePath string
+	Line     int
+}
+
+// RuleMetrics holds the confusion-matrix counts for one rule (or, when RuleID
+// is empty, the overall totals) plus the derived precision/recall/F1.
+//
+// The counts are the source of truth; Precision/Recall/F1 are computed on
+// demand so callers can trust them to always agree with TP/FP/FN.
+type RuleMetrics struct {
+	RuleID string `json:"rule_id,omitempty"`
+	TP     int    `json:"tp"`
+	FP     int    `json:"fp"`
+	FN     int    `json:"fn"`
+	// Precision, Recall, F1 are serialized for JSON consumers so downstream
+	// tooling doesn't have to recompute them. They are always recomputed from
+	// the counts by Score.
+	PrecisionValue float64 `json:"precision"`
+	RecallValue    float64 `json:"recall"`
+	F1Value        float64 `json:"f1"`
+}
+
+// Precision is TP / (TP + FP): of the findings this rule reported, the fraction
+// that were real. A rule that reports nothing (TP+FP == 0) has no false
+// positives, so precision is defined as the perfect 1.0 — this avoids a rule
+// that never fires being scored as "bad" and keeps overall averages sane.
+func (m *RuleMetrics) Precision() float64 {
+	den := m.TP + m.FP
+	if den == 0 {
+		return 1.0
+	}
+	return float64(m.TP) / float64(den)
+}
+
+// Recall is TP / (TP + FN): of the findings that should have fired, the
+// fraction that did. With no expectations (TP+FN == 0) recall is defined as
+// 1.0 — nothing was missed because nothing was owed.
+func (m *RuleMetrics) Recall() float64 {
+	den := m.TP + m.FN
+	if den == 0 {
+		return 1.0
+	}
+	return float64(m.TP) / float64(den)
+}
+
+// F1 is the harmonic mean of precision and recall. When both are zero (e.g. a
+// rule with only false positives, or only false negatives) F1 is 0.
+func (m *RuleMetrics) F1() float64 {
+	p, r := m.Precision(), m.Recall()
+	if p+r == 0 {
+		return 0
+	}
+	return 2 * p * r / (p + r)
+}
+
+// Report is the full scoring result: one RuleMetrics per rule that appeared in
+// either the findings or the expectations, plus an Overall roll-up. Rules is
+// sorted worst-precision-first (ties broken by rule ID) so the CLI can render
+// the rules most in need of attention at the top without re-sorting.
+type Report struct {
+	Rules   []RuleMetrics `json:"rules"`
+	Overall RuleMetrics   `json:"overall"`
+}
+
+// expectationKey identifies a distinct ground-truth slot. Two expectations
+// with the same rule/file/line are the same slot and can only be satisfied
+// once.
+type expectationKey struct {
+	rule string
+	file string
+	line int
+}
+
+// Score compares actual scan findings against declared expectations and
+// returns per-rule and overall precision/recall/F1.
+//
+// Matching rule: a finding is a true positive when there is an unsatisfied
+// expectation for the same RuleID and FilePath whose anchor line falls within
+// the finding's [StartLine, EndLine] range. Each expectation can be satisfied
+// by at most one finding; a second finding matching an already-satisfied
+// expectation is a false positive (so duplicate findings are penalised, which
+// is the honest behaviour — duplicates are noise to a human triager). A finding
+// with no matching expectation is a false positive. An expectation left
+// unsatisfied after all findings are considered is a false negative.
+//
+// Score is pure: it does no I/O and does not mutate its arguments.
+func Score(scanFindings []findings.Finding, expectations []Expectation) Report {
+	// Index expectations by key and track which have been satisfied. Using a
+	// count lets several identical expectations (unusual, but possible) each be
+	// matched once.
+	remaining := make(map[expectationKey]int, len(expectations))
+	for _, e := range expectations {
+		remaining[expectationKey{e.RuleID, e.FilePath, e.Line}]++
+	}
+
+	// Per-rule counters. We seed every rule that appears in either input so a
+	// rule with only FNs (never fired) still shows up in the report.
+	tp := map[string]int{}
+	fp := map[string]int{}
+	fn := map[string]int{}
+	seen := map[string]struct{}{}
+	seenRule := func(id string) { seen[id] = struct{}{} }
+
+	for _, e := range expectations {
+		seenRule(e.RuleID)
+	}
+
+	for i := range scanFindings {
+		f := &scanFindings[i]
+		seenRule(f.RuleID)
+
+		if key, ok := matchExpectation(f, remaining); ok {
+			remaining[key]--
+			tp[f.RuleID]++
+			continue
+		}
+		fp[f.RuleID]++
+	}
+
+	// Anything still remaining is a false negative.
+	for key, count := range remaining {
+		if count > 0 {
+			fn[key.rule] += count
+		}
+	}
+
+	report := Report{}
+	for rule := range seen {
+		m := RuleMetrics{RuleID: rule, TP: tp[rule], FP: fp[rule], FN: fn[rule]}
+		fillDerived(&m)
+		report.Rules = append(report.Rules, m)
+		report.Overall.TP += m.TP
+		report.Overall.FP += m.FP
+		report.Overall.FN += m.FN
+	}
+	fillDerived(&report.Overall)
+
+	sortWorstPrecisionFirst(report.Rules)
+	return report
+}
+
+// matchExpectation finds an unsatisfied expectation that the finding satisfies:
+// same rule and file, with the expectation's anchor line inside the finding's
+// line range. Returns the matched key so the caller can decrement it. A finding
+// whose EndLine is zero (unset) is treated as a single line at StartLine.
+func matchExpectation(f *findings.Finding, remaining map[expectationKey]int) (expectationKey, bool) {
+	start := f.Location.StartLine
+	end := f.Location.EndLine
+	if end < start {
+		end = start
+	}
+	for line := start; line <= end; line++ {
+		key := expectationKey{f.RuleID, f.Location.FilePath, line}
+		if remaining[key] > 0 {
+			return key, true
+		}
+	}
+	return expectationKey{}, false
+}
+
+// fillDerived recomputes the precision/recall/F1 fields from the counts so the
+// serialized values can never drift from TP/FP/FN.
+func fillDerived(m *RuleMetrics) {
+	m.PrecisionValue = m.Precision()
+	m.RecallValue = m.Recall()
+	m.F1Value = m.F1()
+}
+
+// sortWorstPrecisionFirst orders rules so the least precise rule is first — the
+// rules most worth fixing surface at the top of the CLI table. Ties in
+// precision are broken by more false positives first (louder = higher
+// priority), then by rule ID for determinism.
+func sortWorstPrecisionFirst(rules []RuleMetrics) {
+	sort.Slice(rules, func(i, j int) bool {
+		a, b := &rules[i], &rules[j]
+		pa, pb := a.Precision(), b.Precision()
+		if pa != pb {
+			return pa < pb
+		}
+		if a.FP != b.FP {
+			return a.FP > b.FP
+		}
+		return a.RuleID < b.RuleID
+	})
+}

--- a/core/bench/precision_test.go
+++ b/core/bench/precision_test.go
@@ -1,0 +1,226 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// finding is a tiny helper that builds a findings.Finding at a given
+// rule/file/line so the table cases below stay readable.
+func finding(ruleID, file string, line int) findings.Finding {
+	return findings.Finding{
+		RuleID: ruleID,
+		Location: findings.Location{
+			FilePath:  file,
+			StartLine: line,
+			EndLine:   line,
+		},
+	}
+}
+
+// expect builds an Expectation for the table cases.
+func expect(ruleID, file string, line int) Expectation {
+	return Expectation{RuleID: ruleID, FilePath: file, Line: line}
+}
+
+func TestScore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		findings     []findings.Finding
+		expectations []Expectation
+		// wantRule maps ruleID -> expected {TP, FP, FN}. Overall is checked
+		// separately from the sum so a bug in aggregation is visible.
+		wantRule    map[string][3]int
+		wantOverall [3]int
+	}{
+		{
+			name:         "empty corpus, no findings",
+			findings:     nil,
+			expectations: nil,
+			wantRule:     map[string][3]int{},
+			wantOverall:  [3]int{0, 0, 0},
+		},
+		{
+			name:         "single true positive",
+			findings:     []findings.Finding{finding("SEC-001", "a.py", 3)},
+			expectations: []Expectation{expect("SEC-001", "a.py", 3)},
+			wantRule:     map[string][3]int{"SEC-001": {1, 0, 0}},
+			wantOverall:  [3]int{1, 0, 0},
+		},
+		{
+			name:         "false positive on a clean line (no expectation)",
+			findings:     []findings.Finding{finding("SEC-001", "clean.py", 5)},
+			expectations: nil,
+			wantRule:     map[string][3]int{"SEC-001": {0, 1, 0}},
+			wantOverall:  [3]int{0, 1, 0},
+		},
+		{
+			name:         "false negative: expectation with no finding",
+			findings:     nil,
+			expectations: []Expectation{expect("AI-002", "p.py", 2)},
+			wantRule:     map[string][3]int{"AI-002": {0, 0, 1}},
+			wantOverall:  [3]int{0, 0, 1},
+		},
+		{
+			name: "same rule fires on wrong line: one FP + one FN, not a TP",
+			findings: []findings.Finding{
+				finding("SEC-001", "a.py", 9),
+			},
+			expectations: []Expectation{expect("SEC-001", "a.py", 3)},
+			wantRule:     map[string][3]int{"SEC-001": {0, 1, 1}},
+			wantOverall:  [3]int{0, 1, 1},
+		},
+		{
+			name: "finding within a multi-line expectation range counts as TP",
+			findings: []findings.Finding{
+				// Finding spans lines 4-4 but the expectation is declared on
+				// line 3 which opens a 3..6 range; a match on any covered line
+				// is a TP. We model the expectation as a single anchor line and
+				// match findings whose StartLine equals it OR whose range
+				// covers it.
+				{RuleID: "SEC-510", Location: findings.Location{FilePath: "a.py", StartLine: 3, EndLine: 6}},
+			},
+			expectations: []Expectation{expect("SEC-510", "a.py", 3)},
+			wantRule:     map[string][3]int{"SEC-510": {1, 0, 0}},
+			wantOverall:  [3]int{1, 0, 0},
+		},
+		{
+			name: "different rule at the expected line is FP + FN",
+			findings: []findings.Finding{
+				finding("SEC-081", "a.py", 3),
+			},
+			expectations: []Expectation{expect("SEC-001", "a.py", 3)},
+			wantRule: map[string][3]int{
+				"SEC-001": {0, 0, 1},
+				"SEC-081": {0, 1, 0},
+			},
+			wantOverall: [3]int{0, 1, 1},
+		},
+		{
+			name: "two findings of the same rule at the same line satisfy one expectation; the duplicate is a FP",
+			findings: []findings.Finding{
+				finding("SEC-001", "a.py", 3),
+				finding("SEC-001", "a.py", 3),
+			},
+			expectations: []Expectation{expect("SEC-001", "a.py", 3)},
+			wantRule:     map[string][3]int{"SEC-001": {1, 1, 0}},
+			wantOverall:  [3]int{1, 1, 0},
+		},
+		{
+			name: "mixed corpus with several rules",
+			findings: []findings.Finding{
+				finding("SEC-001", "secret.py", 1), // TP
+				finding("SEC-508", "secret.py", 1), // FP (no expectation)
+				finding("AI-002", "prompt.py", 2),  // TP
+				finding("AI-002", "clean.py", 10),  // FP
+			},
+			expectations: []Expectation{
+				expect("SEC-001", "secret.py", 1),
+				expect("AI-002", "prompt.py", 2),
+				expect("SEC-510", "secret.py", 2), // FN: never found
+			},
+			wantRule: map[string][3]int{
+				"SEC-001": {1, 0, 0},
+				"SEC-508": {0, 1, 0},
+				"AI-002":  {1, 1, 0},
+				"SEC-510": {0, 0, 1},
+			},
+			wantOverall: [3]int{2, 2, 1},
+		},
+		{
+			name: "file path is compared verbatim: a match on a different file is FP + FN",
+			findings: []findings.Finding{
+				finding("SEC-001", "other.py", 3),
+			},
+			expectations: []Expectation{expect("SEC-001", "a.py", 3)},
+			wantRule: map[string][3]int{
+				"SEC-001": {0, 1, 1},
+			},
+			wantOverall: [3]int{0, 1, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			report := Score(tt.findings, tt.expectations)
+
+			// Per-rule assertions.
+			gotRule := map[string][3]int{}
+			for i := range report.Rules {
+				r := report.Rules[i]
+				gotRule[r.RuleID] = [3]int{r.TP, r.FP, r.FN}
+			}
+			if len(gotRule) != len(tt.wantRule) {
+				t.Fatalf("rule count: got %d rules %v, want %d %v",
+					len(gotRule), gotRule, len(tt.wantRule), tt.wantRule)
+			}
+			for rule, want := range tt.wantRule {
+				got, ok := gotRule[rule]
+				if !ok {
+					t.Errorf("rule %s missing from report", rule)
+					continue
+				}
+				if got != want {
+					t.Errorf("rule %s: got TP/FP/FN %v, want %v", rule, got, want)
+				}
+			}
+
+			// Overall assertions.
+			gotOverall := [3]int{report.Overall.TP, report.Overall.FP, report.Overall.FN}
+			if gotOverall != tt.wantOverall {
+				t.Errorf("overall: got TP/FP/FN %v, want %v", gotOverall, tt.wantOverall)
+			}
+		})
+	}
+}
+
+func TestMetricsPrecisionRecallF1(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		tp, fp, fn    int
+		wantPrecision float64
+		wantRecall    float64
+		wantF1        float64
+	}{
+		{"perfect", 10, 0, 0, 1.0, 1.0, 1.0},
+		{"half precision", 5, 5, 0, 0.5, 1.0, 2.0 / 3.0},
+		{"half recall", 5, 0, 5, 1.0, 0.5, 2.0 / 3.0},
+		{"no findings, no expectations: precision undefined -> 1.0", 0, 0, 0, 1.0, 1.0, 1.0},
+		{"only false positives: precision 0, recall undefined -> 1.0", 0, 3, 0, 0.0, 1.0, 0.0},
+		{"only false negatives: recall 0, precision undefined -> 1.0", 0, 0, 4, 1.0, 0.0, 0.0},
+		{"mixed", 8, 2, 4, 0.8, 8.0 / 12.0, 2 * 0.8 * (8.0 / 12.0) / (0.8 + 8.0/12.0)},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := RuleMetrics{RuleID: "X", TP: tt.tp, FP: tt.fp, FN: tt.fn}
+			if got := m.Precision(); !almostEqual(got, tt.wantPrecision) {
+				t.Errorf("precision: got %v, want %v", got, tt.wantPrecision)
+			}
+			if got := m.Recall(); !almostEqual(got, tt.wantRecall) {
+				t.Errorf("recall: got %v, want %v", got, tt.wantRecall)
+			}
+			if got := m.F1(); !almostEqual(got, tt.wantF1) {
+				t.Errorf("f1: got %v, want %v", got, tt.wantF1)
+			}
+		})
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}

--- a/testdata/precision-corpus/README.md
+++ b/testdata/precision-corpus/README.md
@@ -1,0 +1,79 @@
+# Precision corpus
+
+A **labeled corpus** for measuring nox's SAST precision and recall. Each file is
+a small source sample; every finding a scan *should* produce is declared inline,
+on the line that should fire, so the ground truth lives right next to the code it
+describes.
+
+Run the scorer with:
+
+```
+nox bench --precision testdata/precision-corpus
+nox bench --precision testdata/precision-corpus --json
+nox bench --precision testdata/precision-corpus --min-precision 0.9   # exit 1 if any rule scores below
+```
+
+## The annotation format
+
+Put a `nox-expect` annotation in a comment **on the same line** that should
+produce the finding. The keyword is followed by one or more rule IDs, separated
+by commas and/or spaces:
+
+```python
+access_key = "<your-aws-access-key-id>"  # nox-expect: SEC-001 SEC-508
+```
+
+```javascript
+const p = system + userInput;  // nox-expect: AI-002
+```
+
+Rules:
+
+- **Same-line anchoring.** The annotation must sit on the line the finding
+  targets. The scorer matches a finding to an expectation when the rule IDs and
+  file paths agree and the expectation's line falls within the finding's
+  `[StartLine, EndLine]` range.
+- **List every rule that should fire on that line.** One line can trip several
+  overlapping detectors (an AWS key id fires two AWS-key rules). List them all;
+  a rule that fires but isn't listed counts as a false positive.
+- **Clean samples carry no annotations.** A file with zero `nox-expect`
+  annotations asserts that a scan produces **no findings** on it. Any finding on
+  a clean file is a false positive. Use clean samples to pin down precision on
+  patterns a naive rule might over-flag (e.g. a base64 blob that looks
+  high-entropy but is public image data).
+- **Documentation is ignored.** `.md`, `.mdx`, `.markdown`, `.rst`, and `.txt`
+  files (including this README) are never parsed as samples, so annotation
+  examples in prose don't leak into the ground truth.
+
+## How scoring works
+
+For each rule the scorer computes, comparing scan findings against expectations:
+
+- **TP** (true positive) — a finding that matches an expectation.
+- **FP** (false positive) — a finding with no matching expectation (including a
+  duplicate finding for an already-satisfied expectation).
+- **FN** (false negative) — an expectation no finding satisfied.
+
+From those: `precision = TP/(TP+FP)`, `recall = TP/(TP+FN)`, and
+`F1 = 2·P·R/(P+R)`. The per-rule table is sorted worst-precision-first so the
+rules most worth fixing surface at the top; an overall roll-up sums every rule.
+
+## The samples
+
+| File | Kind | Expected |
+|---|---|---|
+| `hardcoded_secret.py` | true positive | SEC-001, SEC-508 (hardcoded AWS access key id) |
+| `prompt_concat.py` | true positive | AI-002 ×2 (user input concatenated into an LLM prompt) |
+| `code_injection.py` | true positive | AI-049 (untrusted input into `eval`) |
+| `clean_icon.py` | clean | none (base64 PNG that a naive entropy rule might over-flag) |
+| `clean_config.py` | clean | none (env-var secrets, structured prompt messages) |
+
+## Adding samples
+
+1. Write a small, self-contained source file that exercises exactly the pattern
+   you want to measure.
+2. Add a `nox-expect: <RuleID>` annotation on each line that should fire — or
+   none, to add a clean sample.
+3. Run `nox bench --precision testdata/precision-corpus` and confirm the new
+   rows read as you intended (a surprise FP or FN means either the sample or the
+   rule needs work — which is the whole point of the harness).

--- a/testdata/precision-corpus/clean_config.py
+++ b/testdata/precision-corpus/clean_config.py
@@ -1,0 +1,16 @@
+# Clean sample: safe, idiomatic config loading. Secrets come from the
+# environment, prompts use structured message arrays, and no user input
+# reaches a code-execution sink. Any finding here is a FALSE POSITIVE.
+
+import os
+
+
+def openai_key():
+    return os.environ["OPENAI_API_KEY"]
+
+
+def build_messages(user_input):
+    return [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": user_input},
+    ]

--- a/testdata/precision-corpus/clean_icon.py
+++ b/testdata/precision-corpus/clean_icon.py
@@ -1,0 +1,15 @@
+# Clean sample: an embedded base64 PNG icon. A naive high-entropy
+# secret detector might mistake this long base64 blob for a credential,
+# but it is public image data. Any finding on this file is a FALSE
+# POSITIVE. No nox-expect annotations here on purpose.
+
+TRANSPARENT_PIXEL_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4"
+    "2mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def icon_bytes():
+    import base64
+
+    return base64.b64decode(TRANSPARENT_PIXEL_PNG)

--- a/testdata/precision-corpus/code_injection.py
+++ b/testdata/precision-corpus/code_injection.py
@@ -1,0 +1,8 @@
+# True-positive sample: untrusted input flowing into a code-execution
+# sink. Passing user_input to eval() is a command/code-injection class
+# bug (CWE-95). The scan MUST flag the eval call below.
+
+
+def dispatch(user_input):
+    handler = eval("handlers.do_" + user_input)  # nox-expect: AI-049
+    return handler

--- a/testdata/precision-corpus/hardcoded_secret.py
+++ b/testdata/precision-corpus/hardcoded_secret.py
@@ -1,0 +1,10 @@
+# True-positive sample: a hardcoded AWS access key id. The scan MUST
+# flag the credential line below. The `nox-expect` annotation names every
+# rule that legitimately fires on that line — one credential trips two
+# overlapping AWS-key detectors, and that overlap is itself a precision
+# signal worth measuring (a triager sees two findings for one secret).
+
+
+def load_aws_client():
+    access_key = "AKIAIOSFODNN7EXAMPLE"  # nox-expect: SEC-001 SEC-508
+    return access_key

--- a/testdata/precision-corpus/prompt_concat.py
+++ b/testdata/precision-corpus/prompt_concat.py
@@ -1,0 +1,13 @@
+# True-positive sample: user input concatenated directly into an LLM
+# prompt (a classic prompt-injection boundary failure). The scan MUST
+# flag the f-string that interpolates user_input into the system prompt.
+
+
+def build_prompt(user_input):
+    prompt = f"You are a helpful assistant. {user_input}"  # nox-expect: AI-002
+    return prompt
+
+
+def build_prompt_format(user_message):
+    prompt = "System: stay on task. %s" % user_message  # nox-expect: AI-002
+    return prompt


### PR DESCRIPTION
## Why

nox reports rule fire-rates but can't measure SAST *quality*. The scan-of-the-week posts show large false-positive volumes with no precision/recall/F1 number to improve against. This adds the measurement layer so SAST quality becomes a tracked, gate-able number.

## What

**`core/bench` — the pure scorer (core deliverable, table-tested).**
`Score(findings, expectations) → Report` computes per-rule and overall TP/FP/FN and derives precision, recall, F1. Matching anchors a finding to an expectation by `RuleID + FilePath + line-range`; each expectation is satisfied at most once, so **duplicate findings are penalised as false positives** (honest — duplicates are noise to a triager). No I/O, no mutation: the scan is I/O, the scoring is arithmetic, and keeping them apart is what makes the number reproducible.

**Labeled-corpus format.** `ParseCorpus` extracts inline `nox-expect: <RuleID>` annotations from sample source — on the exact line that should fire, so ground truth is self-contained. Multiple rules per line (`# nox-expect: SEC-001 SEC-508`) are supported. A file with no annotations is a *clean* sample: any finding on it is a false positive. Docs (`.md`/`.rst`/`.txt`) are never parsed as samples, so annotation examples in prose don't leak into ground truth. Format is documented in the corpus README.

**CLI.** `nox bench --precision <corpus-dir>` scans offline, scores, and prints a per-rule table sorted **worst-precision-first** plus an overall roll-up.
- `--json` emits the structured report.
- `--min-precision F` exits non-zero if any rule that fired scores below `F` (default off) — a CI gate against precision regressions.

**Shipped corpus** (`testdata/precision-corpus/`): hardcoded AWS key (SEC-001/SEC-508), user input concatenated into a prompt (AI-002), untrusted input into `eval` (AI-049), plus two clean samples — a base64 PNG a naive entropy rule might over-flag, and env-var secrets with structured prompt messages. A guard test asserts the corpus scores a perfect baseline, so a rule change that breaks precision or recall fails CI.

## Result on the shipped corpus

```
RULE     TP  FP  FN  PRECISION  RECALL  F1
AI-002   2   0   0   1.000      1.000   1.000
AI-049   1   0   0   1.000      1.000   1.000
SEC-001  1   0   0   1.000      1.000   1.000
SEC-508  1   0   0   1.000      1.000   1.000
OVERALL  5   0   0   1.000      1.000   1.000
```

## Tests

- `core/bench` scorer + parser: table-driven unit tests (empty/TP/FP/FN, wrong-line, multi-line range, duplicate-as-FP, wrong-file, mixed corpus; precision/recall/F1 edge cases incl. undefined-denominator conventions).
- `cli`: end-to-end exit-code tests (table/json/positional/gate-pass/gate-fail/missing-dir) and the perfect-baseline guard.
- `go build ./...`, `go test ./...` green; `golangci-lint run` clean on new files.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom