### PR TITLE
feat(lexctx): pure-Go lexical-context classifier to kill the SAST false-positive class

### DIFF
--- a/core/lexctx/bench_test.go
+++ b/core/lexctx/bench_test.go
@@ -1,0 +1,27 @@
+package lexctx
+
+import (
+	"bytes"
+	"testing"
+)
+
+// BenchmarkClassify substantiates the ADR's "single cheap linear pass" claim on
+// a realistic mixed file (code, a big base64 blob, comments, interpolation).
+func BenchmarkClassify(b *testing.B) {
+	blob := bytes.Repeat([]byte("QUJDREVGR0hJSg"), 400) // ~5.6 KB base64 blob
+	var buf bytes.Buffer
+	buf.WriteString("const awsKey = \"AKIAIOSFODNN7EXAMPLE\";\n")
+	buf.WriteString("const icon = \"data:image/png;base64,")
+	buf.Write(blob)
+	buf.WriteString("\";\n")
+	buf.WriteString("// a comment line with AKIAIOSFODNN7EXAMPLE inside it\n")
+	buf.WriteString("const u = `Bearer ${token} suffix`;\n")
+	content := buf.Bytes()
+
+	b.SetBytes(int64(len(content)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Classify(LangJavaScript, content)
+	}
+}

--- a/core/lexctx/fpcollapse_test.go
+++ b/core/lexctx/fpcollapse_test.go
@@ -1,0 +1,133 @@
+package lexctx
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestFPCollapse is the thesis of this package made executable. A single broad
+// secret-shaped pattern appears three times in a realistic file:
+//
+//  1. in a live code assignment (a TRUE positive we must keep)
+//  2. inside a base64 SVG data string blob (a FALSE positive)
+//  3. inside a `//` comment (a FALSE positive)
+//
+// A naive text regex — exactly what Nox's SAST rules do today — fires on all
+// three. Gating each raw match through the lexical-context classifier collapses
+// the two non-code matches and keeps only the real one. This is the mechanism
+// behind the 99.5%-noise reduction claim in the scan-of-the-week reports.
+func TestFPCollapse(t *testing.T) {
+	// The same 32-char token in all three positions.
+	const token = "AKIA1234567890ABCDEF1234567890AB"
+
+	// A realistic TS file. The token appears three times:
+	//   1. as a genuine hardcoded secret in a short string literal (a TRUE
+	//      positive — a rule MUST keep this),
+	//   2. buried inside a base64 SVG data-URI string blob (a FALSE positive),
+	//   3. inside a `//` comment (a FALSE positive).
+	//
+	// Note (1) and (2) are BOTH strings: the discriminator is not the lexical
+	// kind alone but whether the string is a short literal or a data blob. That
+	// is exactly what SuppressNonCode encodes and why it is safe for secrets.
+	// The base64 chunks are broken by '/' so the token is the only 32-char run
+	// inside the blob — keeping the "exactly 3 raw matches" assertion clean.
+	src := "const awsKey = \"" + token + "\";\n" +
+		"const icon = \"data:image/svg+xml;base64,PHN2/" + token + "/Zz4=\";\n" +
+		"// legacy key was " + token + " rotate before removing\n" +
+		"export { awsKey };\n"
+
+	// A deliberately broad, high-noise pattern: any 32-char alphanumeric run.
+	// This is the archetype that generates the false-positive flood.
+	re := regexp.MustCompile(`[A-Za-z0-9]{32}`)
+
+	rawMatches := re.FindAllStringIndex(src, -1)
+	if len(rawMatches) != 3 {
+		t.Fatalf("fixture precondition: expected 3 raw regex matches, got %d", len(rawMatches))
+	}
+
+	lang := LangFromPath("keys.ts")
+	if lang != LangJavaScript {
+		t.Fatalf("fixture precondition: expected JS/TS, got %v", lang)
+	}
+	regions := Classify(lang, []byte(src))
+	regionsCover(t, regions, len(src))
+
+	// Gate every raw match through the analyzer-facing helper. This is exactly
+	// the call a secrets/ai analyzer would add: keep a match only if it is NOT
+	// suppressed as non-code.
+	var survivors [][]int
+	kinds := make([]Kind, 0, len(rawMatches))
+	for _, m := range rawMatches {
+		kinds = append(kinds, KindAt(regions, m[0]))
+		if !SuppressNonCode(lang, []byte(src), m[0], m[1]) {
+			survivors = append(survivors, m)
+		}
+	}
+
+	// Exactly the genuine hardcoded secret survives the gate; the base64 blob
+	// and the comment are collapsed.
+	if len(survivors) != 1 {
+		t.Fatalf("expected exactly 1 survivor, got %d (kinds=%v)", len(survivors), kinds)
+	}
+	got := src[survivors[0][0]:survivors[0][1]]
+	if got != token {
+		t.Errorf("survivor = %q, want the token %q", got, token)
+	}
+	// The survivor is a string literal (the real secret), proving we did NOT
+	// blanket-suppress strings — only the data-blob string.
+	if k := KindAt(regions, survivors[0][0]); k != KindString {
+		t.Errorf("survivor should be a (short) string literal, got kind %v", k)
+	}
+
+	// Cross-check: the two suppressed matches are precisely the blob string and
+	// the comment — proving we drop the right ones, not just the right count.
+	var sawBlob, sawComment bool
+	for i, m := range rawMatches {
+		if !SuppressNonCode(lang, []byte(src), m[0], m[1]) {
+			continue // the survivor
+		}
+		switch kinds[i] {
+		case KindString:
+			sawBlob = true
+		case KindComment:
+			sawComment = true
+		}
+	}
+	if !sawBlob {
+		t.Error("expected the base64 data-URI blob match to be suppressed")
+	}
+	if !sawComment {
+		t.Error("expected the comment match to be suppressed")
+	}
+}
+
+// TestFPCollapsePython mirrors the demonstration for Python's `#` comments and
+// triple-quoted string blobs, the other big FP source. The true positive is a
+// genuine hardcoded secret in a short literal; the FPs are a long triple-quoted
+// base64 blob and a comment.
+func TestFPCollapsePython(t *testing.T) {
+	const token = "AKIA1234567890ABCDEF1234567890AB"
+	// A long base64 data-URI embedded in a docstring, with the token buried
+	// inside it — this string exceeds the blob threshold and is dropped.
+	blob := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB" + token + "kJggg=="
+	src := "aws_key = \"" + token + "\"\n" +
+		"PAYLOAD = \"\"\"\n" + blob + "\n\"\"\"\n" +
+		"# old key " + token + " deprecated\n"
+
+	// Gate each of the three token occurrences directly; the token substring is
+	// unambiguous, and each occurrence lives in a distinct lexical context.
+	assertGate := func(context string, occurrence int, wantSuppressed bool) {
+		t.Helper()
+		off := nthIndexOf(src, token, occurrence)
+		if off < 0 {
+			t.Fatalf("fixture: could not find occurrence %d of token", occurrence)
+		}
+		got := SuppressNonCode(LangPython, []byte(src), off, off+len(token))
+		if got != wantSuppressed {
+			t.Errorf("%s: SuppressNonCode = %v, want %v", context, got, wantSuppressed)
+		}
+	}
+	assertGate("hardcoded secret in short literal", 0, false)
+	assertGate("token in triple-quoted data blob", 1, true)
+	assertGate("token in # comment", 2, true)
+}

--- a/core/lexctx/hardcases_test.go
+++ b/core/lexctx/hardcases_test.go
@@ -1,0 +1,196 @@
+package lexctx
+
+import "testing"
+
+// These tests cover the cases that break naive lexers — the exact scenarios
+// that make regex-on-raw-text SAST noisy. Each asserts the lexical Kind at a
+// specific needle so a regression in the scanner is caught precisely.
+
+func TestPythonFStringInterpolationIsCode(t *testing.T) {
+	// The interpolated expression is CODE; the literal text around it is string.
+	src := `msg = f"prefix {user_secret} suffix"`
+	if k := kindOfSubstring(t, LangPython, src, `prefix `); k != KindString {
+		t.Errorf("f-string literal text should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `user_secret`); k != KindCode {
+		t.Errorf("f-string {expr} should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, ` suffix`); k != KindString {
+		t.Errorf("f-string trailing text should be string, got %v", k)
+	}
+}
+
+func TestPythonFStringDoubleBraceIsLiteral(t *testing.T) {
+	// `{{` is a literal brace, not an interpolation opener.
+	src := `x = f"literal {{braces}} here"`
+	if k := kindOfSubstring(t, LangPython, src, `literal `); k != KindString {
+		t.Errorf("text before {{ should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `braces`); k != KindString {
+		t.Errorf("text inside {{ }} should be string, got %v", k)
+	}
+}
+
+func TestPythonFStringNestedString(t *testing.T) {
+	// A `}` inside a nested string in the field must not close the field early:
+	// the field is `{d["}"]}`; the closing `}` is the last one. The trailing
+	// literal ` tail` after the field is still string.
+	src := `v = f"a {d["}"]} tail"`
+	if k := kindOfSubstring(t, LangPython, src, `d[`); k != KindCode {
+		t.Errorf("f-string field expression should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, ` tail`); k != KindString {
+		t.Errorf("literal after nested-string field should be string, got %v", k)
+	}
+}
+
+func TestPythonRawStringBackslashDoesNotEscape(t *testing.T) {
+	// In a raw string, `\"` does NOT escape the quote — the string ends at the
+	// quote, and the following bytes are code.
+	src := `p = r"a\" + SECRET`
+	// The raw string is r"a\"  -> ends at the second quote (the one after \).
+	if k := kindOfSubstring(t, LangPython, src, `SECRET`); k != KindCode {
+		t.Errorf("code after raw string should be code, got %v", k)
+	}
+}
+
+func TestPythonBytePrefixString(t *testing.T) {
+	src := `data = b"AKIAsecretinbytes"`
+	if k := kindOfSubstring(t, LangPython, src, `AKIAsecretinbytes`); k != KindString {
+		t.Errorf("byte-string body should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `data`); k != KindCode {
+		t.Errorf("assignment target should be code, got %v", k)
+	}
+}
+
+func TestPythonHashInsideStringIsNotComment(t *testing.T) {
+	src := `url = "http://x/#frag" ; SECRET = 1`
+	if k := kindOfSubstring(t, LangPython, src, `#frag`); k != KindString {
+		t.Errorf("'#' inside a string must stay string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `SECRET`); k != KindCode {
+		t.Errorf("code after the string should be code, got %v", k)
+	}
+}
+
+func TestPythonPrefixLetterNotMisreadInIdentifier(t *testing.T) {
+	// `myfunc("x")` — the `f` in myfunc must NOT be read as an f-string prefix.
+	src := `result = myf("literalvalue")`
+	if k := kindOfSubstring(t, LangPython, src, `myf(`); k != KindCode {
+		t.Errorf("identifier ending in f should stay code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `literalvalue`); k != KindString {
+		t.Errorf("the actual string literal should be string, got %v", k)
+	}
+}
+
+func TestJSTemplateInterpolationIsCode(t *testing.T) {
+	src := "const u = `Bearer ${apiToken} end`;"
+	if k := kindOfSubstring(t, LangJavaScript, src, `Bearer `); k != KindString {
+		t.Errorf("template literal text should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `apiToken`); k != KindCode {
+		t.Errorf("template ${expr} should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, ` end`); k != KindString {
+		t.Errorf("template trailing text should be string, got %v", k)
+	}
+}
+
+func TestJSNestedTemplate(t *testing.T) {
+	// A template nested inside an interpolation: the inner literal is string,
+	// the inner ${...} is code again.
+	src := "const x = `a ${ `b ${c} d` } e`;"
+	if k := kindOfSubstring(t, LangJavaScript, src, `a `); k != KindString {
+		t.Errorf("outer template text should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `b `); k != KindString {
+		t.Errorf("inner template text should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `${c}`); k != KindCode {
+		t.Errorf("inner interpolation expression should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, ` e`); k != KindString {
+		t.Errorf("outer trailing text should be string, got %v", k)
+	}
+}
+
+func TestJSRegexLiteralNotComment(t *testing.T) {
+	// `/=/` at an expression position is a regex; the `//`-looking bytes must
+	// not start a comment, and the trailing code stays code.
+	src := "const re = /ab\\/cd/g; const SECRET = 1;"
+	if k := kindOfSubstring(t, LangJavaScript, src, `ab`); k != KindString {
+		t.Errorf("regex body should be string-kind, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `SECRET`); k != KindCode {
+		t.Errorf("code after regex literal should be code, got %v", k)
+	}
+}
+
+func TestJSDivisionIsNotRegex(t *testing.T) {
+	// After an identifier, `/` is division, not a regex — the rest of the line
+	// stays code (not swallowed as a regex/string).
+	src := "const r = width / height; const SECRET = 2;"
+	if k := kindOfSubstring(t, LangJavaScript, src, `height`); k != KindCode {
+		t.Errorf("division operand should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `SECRET`); k != KindCode {
+		t.Errorf("code after division should be code, got %v", k)
+	}
+}
+
+func TestJSDoubleSlashInsideStringIsNotComment(t *testing.T) {
+	// A URL's `//` inside a string must not start a comment.
+	src := `const url = "https://example.com/path"; const SECRET = 3;`
+	if k := kindOfSubstring(t, LangJavaScript, src, `//example`); k != KindString {
+		t.Errorf("'//' inside a string must stay string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `SECRET`); k != KindCode {
+		t.Errorf("code after the URL string should be code, got %v", k)
+	}
+}
+
+func TestJSEscapedQuoteInString(t *testing.T) {
+	src := `const s = "a\"b"; const SECRET = 4;`
+	if k := kindOfSubstring(t, LangJavaScript, src, `SECRET`); k != KindCode {
+		t.Errorf("code after escaped-quote string should be code, got %v", k)
+	}
+}
+
+func TestJSBlockCommentSpansLines(t *testing.T) {
+	src := "before;\n/* multi\n line SECRET\n comment */\nafter;"
+	if k := kindOfSubstring(t, LangJavaScript, src, `line SECRET`); k != KindComment {
+		t.Errorf("multi-line block comment body should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `after`); k != KindCode {
+		t.Errorf("code after block comment should be code, got %v", k)
+	}
+}
+
+// TestClassifyIsDeterministic guards nox's determinism invariant: repeated
+// classification of the same input yields byte-identical region lists.
+func TestClassifyIsDeterministic(t *testing.T) {
+	inputs := []struct {
+		lang Lang
+		src  string
+	}{
+		{LangPython, `x = f"a {b} c" # tail`},
+		{LangJavaScript, "const x = `a ${b} c`; // tail"},
+	}
+	for _, in := range inputs {
+		first := Classify(in.lang, []byte(in.src))
+		for i := 0; i < 5; i++ {
+			again := Classify(in.lang, []byte(in.src))
+			if len(again) != len(first) {
+				t.Fatalf("non-deterministic region count for %q", in.src)
+			}
+			for j := range first {
+				if again[j] != first[j] {
+					t.Fatalf("non-deterministic region %d for %q: %+v vs %+v",
+						j, in.src, again[j], first[j])
+				}
+			}
+		}
+	}
+}

--- a/core/lexctx/integration_secrets_test.go
+++ b/core/lexctx/integration_secrets_test.go
@@ -1,0 +1,127 @@
+package lexctx_test
+
+// This integration test proves the package's thesis end to end: it runs the
+// REAL secrets analyzer over a realistic fixture, then applies lexctx as an
+// opt-in post-filter and shows a concrete before/after drop in finding count —
+// without the two comment/blob false positives, keeping the one true positive.
+//
+// It lives in an external test package (lexctx_test) and imports the secrets
+// analyzer, which is the same direction a future integration would take. It
+// does NOT modify the analyzer: the filter is applied to the analyzer's output,
+// demonstrating that adoption is a small, additive change.
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/secrets"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// suppressNonCodeFindings returns the findings that survive the lexctx gate for
+// the given file: a finding is dropped when its reported location is inside a
+// comment or a string data blob. This is the ~5-line adapter a real analyzer
+// would add to consume lexctx.
+func suppressNonCodeFindings(path string, content []byte, in []findings.Finding) []findings.Finding {
+	lang := lexctx.LangFromPath(path)
+	if lang == lexctx.LangUnknown {
+		return in // graceful degrade: no language, no filtering
+	}
+	kept := make([]findings.Finding, 0, len(in))
+	for i := range in {
+		f := in[i]
+		start := lexctx.LineColToOffset(content, f.Location.StartLine, f.Location.StartColumn)
+		end := lexctx.LineColToOffset(content, f.Location.EndLine, f.Location.EndColumn)
+		if end <= start {
+			end = start + 1
+		}
+		// Drop comments always; drop string matches only when the string is a
+		// data blob (SuppressNonCode encodes both), so real hardcoded secrets in
+		// short string literals are preserved.
+		if lexctx.SuppressNonCode(lang, content, start, end) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
+}
+
+func TestSecretsAnalyzer_LexctxCollapsesFalsePositives(t *testing.T) {
+	// A real AWS access-key ID: AKIA + 16 chars from [A-Z2-7].
+	const awsKey = "AKIAIOSFODNN7EXAMPLE"
+
+	// A realistic .ts file. The key appears three times:
+	//   1. as a genuine hardcoded secret in a short string literal (TRUE +),
+	//   2. buried in a base64 SVG data-URI blob (FALSE +),
+	//   3. inside a `//` comment (FALSE +).
+	// The base64 chunks are broken with '/' so only the key is a key-shaped run.
+	src := []byte("" +
+		"export const awsKey = \"" + awsKey + "\";\n" +
+		"export const icon = \"data:image/svg+xml;base64,PHN2/" + awsKey + "/Zz4=\";\n" +
+		"// rotate legacy key " + awsKey + " before removing this line\n" +
+		"export function useKey() { return awsKey; }\n")
+	const path = "src/config.ts"
+
+	analyzer := secrets.NewAnalyzer()
+	raw, err := analyzer.ScanFile(path, src)
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	// Count how many findings reference the AWS key rule (SEC-2 family) before
+	// filtering. We expect the naive scan to fire on all three occurrences.
+	rawKeyHits := countAWSKeyFindings(raw)
+	if rawKeyHits < 3 {
+		t.Fatalf("precondition: expected the raw scan to fire >=3 times on the "+
+			"AWS key (code + blob + comment), got %d (total findings %d)",
+			rawKeyHits, len(raw))
+	}
+
+	filtered := suppressNonCodeFindings(path, src, raw)
+	filteredKeyHits := countAWSKeyFindings(filtered)
+
+	if filteredKeyHits != 1 {
+		t.Fatalf("expected exactly 1 AWS-key finding after lexctx gate "+
+			"(the real hardcoded secret), got %d", filteredKeyHits)
+	}
+
+	// The surviving key finding must be the one on line 1 (the code assignment),
+	// not the blob (line 2) or comment (line 3).
+	survivor := firstAWSKeyFinding(filtered)
+	if survivor == nil {
+		t.Fatal("no surviving AWS-key finding")
+	}
+	if survivor.Location.StartLine != 1 {
+		t.Errorf("survivor should be the line-1 code secret, got line %d",
+			survivor.Location.StartLine)
+	}
+
+	t.Logf("FP collapse: AWS-key findings %d -> %d (dropped blob + comment)",
+		rawKeyHits, filteredKeyHits)
+}
+
+// countAWSKeyFindings counts findings whose match is the AWS access-key ID rule
+// (SEC-001 in the builtin set).
+func countAWSKeyFindings(fs []findings.Finding) int {
+	c := 0
+	for i := range fs {
+		if isAWSKeyRule(fs[i].RuleID) {
+			c++
+		}
+	}
+	return c
+}
+
+func firstAWSKeyFinding(fs []findings.Finding) *findings.Finding {
+	for i := range fs {
+		if isAWSKeyRule(fs[i].RuleID) {
+			return &fs[i]
+		}
+	}
+	return nil
+}
+
+func isAWSKeyRule(ruleID string) bool {
+	// SEC-001 is the AWS access-key ID rule in the builtin secrets set.
+	return ruleID == "SEC-001"
+}

--- a/core/lexctx/lang.go
+++ b/core/lexctx/lang.go
@@ -1,0 +1,74 @@
+// Package lexctx provides a pure-Go "lexical context" classifier that labels
+// byte ranges of a source file as code, string-literal, or comment. Nox's SAST
+// analyzers match regexes against raw file TEXT, so a pattern fires equally
+// whether it appears in a live code assignment, inside a base64 SVG blob, in a
+// lockfile hash, or in a comment. The overwhelming majority of those matches
+// are false positives: the pattern is not code, it is data or prose that merely
+// looks like a secret.
+//
+// The fix is structural without paying for a full parser: hand-rolled scanners
+// walk the byte stream and track whether the cursor is inside a string or a
+// comment. Downstream analyzers can then drop any match whose span is not code.
+//
+// The package is deliberately dependency-free and CGo-free — Nox ships a single
+// static binary, and every classifier here degrades gracefully: an unknown
+// language yields one big code region, so gating on lexctx is never worse than
+// today's behavior (it only ever removes matches that are provably non-code).
+package lexctx
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Lang identifies the source language whose lexical grammar drives scanning.
+// Only the languages Nox's SAST rules actually target are enumerated; anything
+// else maps to LangUnknown, which the scanner treats as one big code region.
+type Lang int
+
+// Supported languages. LangUnknown is the graceful-degrade sentinel.
+const (
+	LangUnknown Lang = iota
+	LangPython
+	LangJavaScript // JS, JSX, TS, TSX — they share comment/string/template lexing
+)
+
+// String returns a stable, lowercase label for the language. Used in metadata
+// and test output; the exact spelling is part of the package's contract.
+func (l Lang) String() string {
+	switch l {
+	case LangPython:
+		return "python"
+	case LangJavaScript:
+		return "javascript"
+	default:
+		return "unknown"
+	}
+}
+
+// extToLang maps a lowercased file extension (including the dot) to a Lang.
+// TypeScript and the JSX/TSX variants fold into LangJavaScript because their
+// comment and string lexing is identical for our purposes — we only need to
+// know "is this cursor inside code" and the grammars agree on that.
+var extToLang = map[string]Lang{
+	".py":  LangPython,
+	".pyi": LangPython,
+	".pyw": LangPython,
+	".js":  LangJavaScript,
+	".jsx": LangJavaScript,
+	".mjs": LangJavaScript,
+	".cjs": LangJavaScript,
+	".ts":  LangJavaScript,
+	".tsx": LangJavaScript,
+	".mts": LangJavaScript,
+	".cts": LangJavaScript,
+}
+
+// LangFromPath infers the language from a file path's extension. Detection is
+// extension-only on purpose: it is deterministic, offline, and cheap, and a
+// wrong guess only costs us the FP-suppression benefit for that file (never
+// correctness) because the scanner degrades to a single code region.
+func LangFromPath(path string) Lang {
+	ext := strings.ToLower(filepath.Ext(path))
+	return extToLang[ext]
+}

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -1,0 +1,240 @@
+package lexctx
+
+// Kind labels the lexical role of a byte range.
+type Kind int
+
+// Kind values. KindCode is the only role a SAST match should be trusted in;
+// KindString and KindComment are where the false positives live (base64 blobs,
+// minified data, prose).
+const (
+	KindCode Kind = iota
+	KindString
+	KindComment
+)
+
+// String returns a stable lowercase label for the kind, used in test output and
+// metadata.
+func (k Kind) String() string {
+	switch k {
+	case KindString:
+		return "string"
+	case KindComment:
+		return "comment"
+	default:
+		return "code"
+	}
+}
+
+// Region is a half-open byte span [Start, End) with a single lexical Kind.
+// Classify returns a contiguous, gap-free, ascending list of regions covering
+// the whole input, so callers can binary-search by offset.
+type Region struct {
+	Start int
+	End   int
+	Kind  Kind
+}
+
+// Classify partitions content into contiguous lexical regions for the given
+// language. The returned regions cover [0, len(content)) with no gaps or
+// overlaps, in ascending order. For LangUnknown (or empty input of a known
+// language) it returns a single KindCode region spanning the whole file, which
+// is the graceful-degrade contract: gating on lexctx then suppresses nothing
+// and behaves exactly like today.
+func Classify(lang Lang, content []byte) []Region {
+	if len(content) == 0 {
+		return nil
+	}
+	switch lang {
+	case LangPython:
+		return scanPython(content)
+	case LangJavaScript:
+		return scanJavaScript(content)
+	default:
+		return []Region{{Start: 0, End: len(content), Kind: KindCode}}
+	}
+}
+
+// regionBuilder accumulates regions and coalesces adjacent runs of the same
+// Kind so callers see the minimal region list. It tracks the start of the
+// current open run and the Kind it is emitting.
+type regionBuilder struct {
+	regions []Region
+	// runStart is the offset where the current same-Kind run began.
+	runStart int
+	runKind  Kind
+	started  bool
+}
+
+// emit records that the bytes of [from, to) have kind k. Runs of the same kind
+// are merged; a change in kind flushes the previous run. Callers must invoke
+// emit for strictly increasing, contiguous spans and call finish at the end.
+func (b *regionBuilder) emit(from, to int, k Kind) {
+	if to <= from {
+		return
+	}
+	if !b.started {
+		b.runStart = from
+		b.runKind = k
+		b.started = true
+		return
+	}
+	if k == b.runKind {
+		return // extend the current run; End is computed at flush time
+	}
+	b.regions = append(b.regions, Region{Start: b.runStart, End: from, Kind: b.runKind})
+	b.runStart = from
+	b.runKind = k
+}
+
+// finish flushes the trailing run up to end and returns the region list.
+func (b *regionBuilder) finish(end int) []Region {
+	if b.started && end > b.runStart {
+		b.regions = append(b.regions, Region{Start: b.runStart, End: end, Kind: b.runKind})
+	}
+	return b.regions
+}
+
+// KindAt returns the Kind of the region containing offset, or KindCode if the
+// offset falls outside every region (defensive: out-of-range offsets are
+// treated as code so a bad offset never spuriously suppresses a finding).
+// Regions are assumed sorted and non-overlapping, so this binary-searches.
+func KindAt(regions []Region, offset int) Kind {
+	lo, hi := 0, len(regions)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		switch {
+		case offset < regions[mid].Start:
+			hi = mid
+		case offset >= regions[mid].End:
+			lo = mid + 1
+		default:
+			return regions[mid].Kind
+		}
+	}
+	return KindCode
+}
+
+// InCode reports whether the entire half-open span [start, end) lies within
+// code regions. A match straddling a code/non-code boundary is NOT code — we
+// require every byte of the span to be code so a regex that begins in a comment
+// and leaks into code (or vice versa) is treated as suspect. An empty or
+// inverted span is not considered code.
+func InCode(regions []Region, start, end int) bool {
+	if end <= start {
+		return false
+	}
+	pos := start
+	for pos < end {
+		idx := regionIndexAt(regions, pos)
+		if idx < 0 || regions[idx].Kind != KindCode {
+			return false
+		}
+		// Advance to the end of this code region; if it already covers the
+		// span we are done.
+		if regions[idx].End >= end {
+			return true
+		}
+		pos = regions[idx].End
+	}
+	return true
+}
+
+// regionIndexAt returns the index of the region containing offset, or -1.
+func regionIndexAt(regions []Region, offset int) int {
+	lo, hi := 0, len(regions)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		switch {
+		case offset < regions[mid].Start:
+			hi = mid
+		case offset >= regions[mid].End:
+			lo = mid + 1
+		default:
+			return mid
+		}
+	}
+	return -1
+}
+
+// SuppressNonCode is the reusable post-filter for analyzers: given a raw regex
+// match at [matchStart, matchEnd) in content, it returns true when the match
+// should be DROPPED as a likely false positive.
+//
+// A match is dropped when it lies inside:
+//
+//   - a comment (always — prose and commented-out code are never live), or
+//   - a string that is a DATA BLOB, not an ordinary literal. This is the
+//     crucial distinction for secret detection: a hardcoded secret genuinely
+//     lives in a short string literal (`key = "AKIA..."`) and MUST be kept,
+//     whereas the same pattern buried inside a base64 data-URI, a minified
+//     bundle, or a long encoded payload is noise and is dropped. blobFraction
+//     encodes that "is this string data rather than a literal" heuristic.
+//
+// This asymmetry is why the helper is safe for the secrets analyzer to adopt:
+// it removes the base64/minified/comment FP class without silencing real
+// hardcoded-secret-in-string findings. Callers wanting strict code-only gating
+// (e.g. AST-shaped rules) should use InCode directly instead.
+//
+// It classifies content itself for convenience; analyzers scanning a file many
+// times should call Classify once and reuse the regions. For LangUnknown this
+// always returns false (never suppress), preserving the graceful-degrade
+// guarantee.
+func SuppressNonCode(lang Lang, content []byte, matchStart, matchEnd int) bool {
+	if lang == LangUnknown {
+		return false
+	}
+	if matchEnd <= matchStart || matchStart < 0 || matchEnd > len(content) {
+		return false
+	}
+	regions := Classify(lang, content)
+	idx := regionIndexAt(regions, matchStart)
+	if idx < 0 {
+		return false
+	}
+	r := regions[idx]
+	// A match straddling regions (leaking out of a comment/string into code) is
+	// suspect but not clearly noise — keep it so we never hide a real finding.
+	if r.End < matchEnd {
+		return false
+	}
+	switch r.Kind {
+	case KindComment:
+		return true
+	case KindString:
+		return isStringBlob(content, r)
+	default:
+		return false
+	}
+}
+
+// blobThreshold is the string length (in bytes, excluding delimiters) above
+// which a string literal is considered a data blob rather than an ordinary
+// literal. Real hardcoded secrets and config values are short; base64 payloads,
+// data-URIs, and minified chunks are long. 96 bytes comfortably clears the
+// longest real credentials (a GitHub PAT is ~40 chars, a JWT header segment is
+// short) while catching data-URI/base64 blobs, which run to hundreds of bytes.
+const blobThreshold = 96
+
+// isStringBlob reports whether the string region r is a data blob rather than
+// an ordinary literal. A string is a blob if it is very long, or if it is a
+// data-URI (the single most common SVG/base64 FP carrier). Deterministic and
+// content-only — no heurist­ic that depends on scan order or environment.
+func isStringBlob(content []byte, r Region) bool {
+	body := content[r.Start:r.End]
+	if len(body) > blobThreshold {
+		return true
+	}
+	return containsDataURI(body)
+}
+
+// containsDataURI reports whether body holds a `data:` URI scheme marker, the
+// hallmark of an embedded base64 image/font blob.
+func containsDataURI(body []byte) bool {
+	const marker = "data:"
+	for i := 0; i+len(marker) <= len(body); i++ {
+		if string(body[i:i+len(marker)]) == marker {
+			return true
+		}
+	}
+	return false
+}

--- a/core/lexctx/lexctx_test.go
+++ b/core/lexctx/lexctx_test.go
@@ -1,0 +1,266 @@
+package lexctx
+
+import (
+	"testing"
+)
+
+func TestLangFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want Lang
+	}{
+		{"a.py", LangPython},
+		{"a.pyi", LangPython},
+		{"src/App.tsx", LangJavaScript},
+		{"bundle.min.js", LangJavaScript},
+		{"mod.mjs", LangJavaScript},
+		{"types.d.ts", LangJavaScript},
+		{"README.md", LangUnknown},
+		{"Makefile", LangUnknown},
+		{"UPPER.PY", LangPython}, // case-insensitive
+	}
+	for _, tt := range tests {
+		if got := LangFromPath(tt.path); got != tt.want {
+			t.Errorf("LangFromPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestKindString(t *testing.T) {
+	tests := []struct {
+		k    Kind
+		want string
+	}{
+		{KindCode, "code"},
+		{KindString, "string"},
+		{KindComment, "comment"},
+	}
+	for _, tt := range tests {
+		if got := tt.k.String(); got != tt.want {
+			t.Errorf("Kind(%d).String() = %q, want %q", tt.k, got, tt.want)
+		}
+	}
+}
+
+// regionsCover asserts the region list is contiguous, gap-free, and covers
+// exactly [0, total). It is the structural invariant every scanner must uphold.
+func regionsCover(t *testing.T, regions []Region, total int) {
+	t.Helper()
+	if total == 0 {
+		if len(regions) != 0 {
+			t.Fatalf("empty input should yield no regions, got %d", len(regions))
+		}
+		return
+	}
+	if len(regions) == 0 {
+		t.Fatalf("non-empty input yielded no regions")
+	}
+	if regions[0].Start != 0 {
+		t.Errorf("first region starts at %d, want 0", regions[0].Start)
+	}
+	if last := regions[len(regions)-1].End; last != total {
+		t.Errorf("last region ends at %d, want %d", last, total)
+	}
+	for i := 1; i < len(regions); i++ {
+		if regions[i].Start != regions[i-1].End {
+			t.Errorf("gap/overlap between region %d (end %d) and %d (start %d)",
+				i-1, regions[i-1].End, i, regions[i].Start)
+		}
+		if regions[i].Kind == regions[i-1].Kind {
+			t.Errorf("adjacent regions %d and %d share kind %v (not coalesced)",
+				i-1, i, regions[i].Kind)
+		}
+	}
+}
+
+func TestClassifyUnknownIsAllCode(t *testing.T) {
+	content := []byte("anything at all # not a comment here")
+	regions := Classify(LangUnknown, content)
+	regionsCover(t, regions, len(content))
+	if len(regions) != 1 || regions[0].Kind != KindCode {
+		t.Fatalf("unknown language must be one code region, got %+v", regions)
+	}
+}
+
+func TestClassifyEmpty(t *testing.T) {
+	if r := Classify(LangPython, nil); r != nil {
+		t.Errorf("empty content should return nil, got %+v", r)
+	}
+}
+
+func kindOfSubstring(t *testing.T, lang Lang, content, needle string) Kind {
+	t.Helper()
+	idx := indexOf(content, needle)
+	if idx < 0 {
+		t.Fatalf("needle %q not found in content", needle)
+	}
+	regions := Classify(lang, []byte(content))
+	regionsCover(t, regions, len(content))
+	start, end := idx, idx+len(needle)
+	k := KindAt(regions, start)
+	// The whole needle should share one kind for these fixtures.
+	if !allSameKind(regions, start, end, k) {
+		t.Fatalf("needle %q spans multiple kinds", needle)
+	}
+	return k
+}
+
+func allSameKind(regions []Region, start, end int, k Kind) bool {
+	for i := start; i < end; i++ {
+		if KindAt(regions, i) != k {
+			return false
+		}
+	}
+	return true
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// nthIndexOf returns the byte offset of the n-th (0-based) occurrence of needle
+// in haystack, or -1 if there are fewer than n+1 occurrences.
+func nthIndexOf(haystack, needle string, n int) int {
+	start := 0
+	for {
+		idx := indexOf(haystack[start:], needle)
+		if idx < 0 {
+			return -1
+		}
+		if n == 0 {
+			return start + idx
+		}
+		n--
+		start += idx + 1
+	}
+}
+
+func TestScanPython(t *testing.T) {
+	src := `API_KEY = "s3cr3t_value_here"
+# comment with s3cr3t_value_here inside
+doc = """
+triple s3cr3t_value_here blob
+"""
+x = 'single s3cr3t_value_here'
+`
+	if k := kindOfSubstring(t, LangPython, src, `API_KEY`); k != KindCode {
+		t.Errorf("API_KEY should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `"s3cr3t_value_here"`); k != KindString {
+		t.Errorf("double-quoted literal should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `comment with`); k != KindComment {
+		t.Errorf("comment body should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `triple s3cr3t_value_here blob`); k != KindString {
+		t.Errorf("triple-quoted body should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangPython, src, `'single s3cr3t_value_here'`); k != KindString {
+		t.Errorf("single-quoted literal should be string, got %v", k)
+	}
+}
+
+func TestScanJavaScript(t *testing.T) {
+	src := "const apiKey = \"s3cr3t\";\n" +
+		"// line comment s3cr3t\n" +
+		"/* block s3cr3t comment */\n" +
+		"const t = `template s3cr3t line`;\n" +
+		"const s = 'single s3cr3t';\n"
+	if k := kindOfSubstring(t, LangJavaScript, src, `apiKey`); k != KindCode {
+		t.Errorf("apiKey should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `"s3cr3t"`); k != KindString {
+		t.Errorf("double-quoted literal should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `line comment s3cr3t`); k != KindComment {
+		t.Errorf("line comment should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, `block s3cr3t comment`); k != KindComment {
+		t.Errorf("block comment should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangJavaScript, src, "`template s3cr3t line`"); k != KindString {
+		t.Errorf("template literal should be string, got %v", k)
+	}
+}
+
+func TestScanPythonEscapesDoNotEndString(t *testing.T) {
+	// A backslash-escaped quote must not close the string early, otherwise the
+	// trailing code bytes would be mislabeled.
+	src := `x = "a\"b" ; SECRET = 1`
+	regions := Classify(LangPython, []byte(src))
+	regionsCover(t, regions, len(src))
+	if k := kindOfSubstring(t, LangPython, src, `SECRET`); k != KindCode {
+		t.Errorf("code after escaped-quote string should be code, got %v", k)
+	}
+}
+
+func TestKindAtOutOfRange(t *testing.T) {
+	regions := Classify(LangPython, []byte(`x = 1`))
+	if k := KindAt(regions, 999); k != KindCode {
+		t.Errorf("out-of-range offset should default to code, got %v", k)
+	}
+	if k := KindAt(regions, -5); k != KindCode {
+		t.Errorf("negative offset should default to code, got %v", k)
+	}
+}
+
+func TestInCode(t *testing.T) {
+	// code|string|code layout: `a = "xx" + b`
+	src := `a = "xx" + b`
+	regions := Classify(LangPython, []byte(src))
+	tests := []struct {
+		name       string
+		start, end int
+		want       bool
+	}{
+		{"whole assignment target is code", 0, 3, true},
+		{"inside the string literal", 5, 7, false},
+		{"spanning code into string is not code", 3, 6, false},
+		{"empty span is not code", 4, 4, false},
+		{"inverted span is not code", 6, 4, false},
+		{"trailing code is code", 9, 12, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InCode(regions, tt.start, tt.end); got != tt.want {
+				t.Errorf("InCode(%d,%d) = %v, want %v", tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSuppressNonCodeUnknownNeverSuppresses(t *testing.T) {
+	content := []byte(`# whatever "looks" like a string`)
+	if SuppressNonCode(LangUnknown, content, 2, 10) {
+		t.Error("unknown language must never suppress (graceful degrade)")
+	}
+}
+
+// TestSuppressNonCodeStringPolicy pins the crucial secrets-safety behavior: a
+// short string literal (a real hardcoded secret) is kept, while a comment and a
+// data-blob string are dropped.
+func TestSuppressNonCodeStringPolicy(t *testing.T) {
+	shortSecret := []byte(`key = "AKIA1234567890ABCDEF1234567890AB"`)
+	// Offset of the token inside the short literal.
+	i := indexOf(string(shortSecret), "AKIA1234567890ABCDEF1234567890AB")
+	if SuppressNonCode(LangPython, shortSecret, i, i+32) {
+		t.Error("short hardcoded secret in a string literal must NOT be suppressed")
+	}
+
+	dataURI := []byte(`icon = "data:image/svg+xml;base64,AKIA1234567890ABCDEF1234567890AB=="`)
+	j := indexOf(string(dataURI), "AKIA1234567890ABCDEF1234567890AB")
+	if !SuppressNonCode(LangPython, dataURI, j, j+32) {
+		t.Error("token inside a data-URI blob string must be suppressed")
+	}
+
+	comment := []byte("x = 1  # AKIA1234567890ABCDEF1234567890AB legacy")
+	k := indexOf(string(comment), "AKIA1234567890ABCDEF1234567890AB")
+	if !SuppressNonCode(LangPython, comment, k, k+32) {
+		t.Error("token inside a comment must be suppressed")
+	}
+}

--- a/core/lexctx/offset.go
+++ b/core/lexctx/offset.go
@@ -1,0 +1,42 @@
+package lexctx
+
+// LineColToOffset converts a 1-based line and 1-based column into a 0-based
+// byte offset into content. It is the bridge that lets analyzers which report
+// findings by (line, column) — as Nox's rules engine does — feed those findings
+// into the byte-oriented classifier without threading raw offsets through the
+// whole pipeline.
+//
+// Columns are counted in bytes (not runes): the rules engine's Column is a byte
+// column, so this stays consistent with it. A line or column past the end of
+// content clamps to len(content); a non-positive line or column clamps to the
+// start of the addressed line. The result is always in [0, len(content)].
+func LineColToOffset(content []byte, line, col int) int {
+	if line < 1 {
+		line = 1
+	}
+	if col < 1 {
+		col = 1
+	}
+	n := len(content)
+	// Walk to the start of the target line.
+	offset := 0
+	curLine := 1
+	for offset < n && curLine < line {
+		if content[offset] == '\n' {
+			curLine++
+		}
+		offset++
+	}
+	// Advance col-1 bytes into the line, stopping at a newline or EOF.
+	target := offset + (col - 1)
+	if target > n {
+		target = n
+	}
+	// Do not step past the end of this line into the next one.
+	for i := offset; i < target && i < n; i++ {
+		if content[i] == '\n' {
+			return i
+		}
+	}
+	return target
+}

--- a/core/lexctx/scan_javascript.go
+++ b/core/lexctx/scan_javascript.go
@@ -1,0 +1,235 @@
+package lexctx
+
+// scanJavaScript walks JS/TS/JSX/TSX source and classifies each byte. It
+// recognizes:
+//
+//   - `//` line comments and `/* ... */` block comments — including a `//` that
+//     appears inside a string or URL, which is NOT a comment because the string
+//     scanner consumes the literal first
+//   - single-quoted, double-quoted, and backtick template-literal strings, all
+//     with backslash escapes
+//   - template-literal `${ ... }` interpolation, whose bytes are emitted as
+//     CODE (a value spliced into a template lives in a real expression), with
+//     correct handling of nested templates and brace balancing
+//   - regex literals (`/.../`) vs the division operator, disambiguated by the
+//     preceding significant token (the standard lexer heuristic), so a pattern
+//     inside a regex body is classified as string rather than mis-scanned as a
+//     `//` comment
+//
+// It does not model JSX element structure: JSX text between tags is ordinary
+// code as far as "could a secret hide here" goes, and treating it as code is
+// the safe default (it never wrongly suppresses).
+func scanJavaScript(content []byte) []Region {
+	var b regionBuilder
+	i := 0
+	n := len(content)
+	// lastSignificant is the previous non-space, non-comment byte; it decides
+	// whether a `/` begins a regex literal or is a division operator.
+	var lastSignificant byte
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '/' && i+1 < n && content[i+1] == '/':
+			start := i
+			for i < n && content[i] != '\n' {
+				i++
+			}
+			b.emit(start, i, KindComment)
+			// comment does not change lastSignificant
+		case c == '/' && i+1 < n && content[i+1] == '*':
+			end := scanBlockComment(content, i+2)
+			b.emit(i, end, KindComment)
+			i = end
+		case c == '/' && regexAllowedAfter(lastSignificant):
+			end := scanJSRegex(content, i)
+			b.emit(i, end, KindString)
+			i = end
+			lastSignificant = '/'
+		case c == '\'' || c == '"':
+			end := scanJSQuoted(content, i, c)
+			b.emit(i, end, KindString)
+			i = end
+			lastSignificant = c
+		case c == '`':
+			end := scanJSTemplate(content, i, &b)
+			i = end
+			lastSignificant = '`'
+		default:
+			b.emit(i, i+1, KindCode)
+			if !isJSSpace(c) {
+				lastSignificant = c
+			}
+			i++
+		}
+	}
+	return b.finish(n)
+}
+
+// isJSSpace reports whether c is insignificant whitespace for the regex/division
+// disambiguation.
+func isJSSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// regexAllowedAfter reports whether a `/` following the given previous
+// significant byte begins a regex literal rather than a division. A regex is
+// allowed at expression-start positions: after operators, `(`, `[`, `{`, `,`,
+// `;`, etc., or at the very start of input (prev == 0). After an identifier
+// char, `)`, `]`, or `}` a `/` is division. This is the well-known,
+// deterministic heuristic; it can misjudge a few exotic cases, but a misjudged
+// regex only ever fails to suppress an FP — it never surfaces one.
+func regexAllowedAfter(prev byte) bool {
+	if prev == 0 {
+		return true
+	}
+	if isIdentByte(prev) {
+		return false
+	}
+	switch prev {
+	case ')', ']', '}':
+		return false
+	default:
+		return true
+	}
+}
+
+// scanBlockComment returns the offset just past a `/* ... */` block comment
+// whose body begins at bodyStart. Unterminated comments run to EOF.
+func scanBlockComment(content []byte, bodyStart int) int {
+	n := len(content)
+	i := bodyStart
+	for i < n {
+		if content[i] == '*' && i+1 < n && content[i+1] == '/' {
+			return i + 2
+		}
+		i++
+	}
+	return n
+}
+
+// scanJSQuoted returns the offset just past a '...'/"..." literal opening at
+// content[start] with delimiter q. A newline ends the scan (JS single/double
+// quotes do not span lines unless escaped) so a stray quote cannot swallow code.
+func scanJSQuoted(content []byte, start int, q byte) int {
+	n := len(content)
+	i := start + 1
+	for i < n {
+		switch content[i] {
+		case '\\':
+			i += 2
+			continue
+		case q:
+			return i + 1
+		case '\n':
+			return i
+		}
+		i++
+	}
+	return n
+}
+
+// scanJSRegex returns the offset just past a `/.../flags` regex literal opening
+// at content[start]. It honors escapes and character classes (`[...]`) inside
+// which a `/` is literal, then consumes trailing flag letters. A newline ends
+// the scan defensively.
+func scanJSRegex(content []byte, start int) int {
+	n := len(content)
+	i := start + 1
+	inClass := false
+	for i < n {
+		switch content[i] {
+		case '\\':
+			i += 2
+			continue
+		case '[':
+			inClass = true
+		case ']':
+			inClass = false
+		case '/':
+			if !inClass {
+				i++ // consume closing slash
+				for i < n && isIdentByte(content[i]) {
+					i++ // consume flag letters
+				}
+				return i
+			}
+		case '\n':
+			return i
+		}
+		i++
+	}
+	return n
+}
+
+// scanJSTemplate classifies a `...` template literal opening at content[start],
+// emitting the literal chunks as string and each `${ ... }` interpolation as
+// code. It handles nested templates (a template inside an interpolation) via
+// recursion and returns the offset just past the closing backtick. It emits
+// directly into b so the mixed string/code structure is preserved.
+func scanJSTemplate(content []byte, start int, b *regionBuilder) int {
+	n := len(content)
+	i := start + 1
+	stringRunStart := start // include the opening backtick in the string run
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '\\':
+			i += 2
+			continue
+		case c == '`':
+			b.emit(stringRunStart, i+1, KindString)
+			return i + 1
+		case c == '$' && i+1 < n && content[i+1] == '{':
+			// Flush the string chunk up to `${`, then scan the interpolation
+			// expression as code.
+			b.emit(stringRunStart, i, KindString)
+			exprEnd := scanJSInterpolation(content, i, b)
+			i = exprEnd
+			stringRunStart = i
+			continue
+		}
+		i++
+	}
+	b.emit(stringRunStart, n, KindString)
+	return n
+}
+
+// scanJSInterpolation classifies a `${ ... }` field opening at content[open].
+// The `${` and `}` framing plus the expression bytes are code, except that
+// nested strings and nested templates inside the expression are recursed into
+// so their contents keep the correct kind. Returns the offset just past `}`.
+func scanJSInterpolation(content []byte, open int, b *regionBuilder) int {
+	n := len(content)
+	depth := 0
+	i := open
+	codeRunStart := open
+	for i < n {
+		c := content[i]
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				b.emit(codeRunStart, i+1, KindCode)
+				return i + 1
+			}
+		case '\'', '"':
+			b.emit(codeRunStart, i, KindCode)
+			end := scanJSQuoted(content, i, c)
+			b.emit(i, end, KindString)
+			i = end
+			codeRunStart = i
+			continue
+		case '`':
+			b.emit(codeRunStart, i, KindCode)
+			end := scanJSTemplate(content, i, b)
+			i = end
+			codeRunStart = i
+			continue
+		}
+		i++
+	}
+	b.emit(codeRunStart, n, KindCode)
+	return n
+}

--- a/core/lexctx/scan_python.go
+++ b/core/lexctx/scan_python.go
@@ -1,0 +1,216 @@
+package lexctx
+
+// scanPython walks Python source and classifies each byte as code, string, or
+// comment. It recognizes:
+//
+//   - `#` line comments (to end of line) — but NOT a `#` inside a string, which
+//     is handled because the string scanner consumes the whole literal first
+//   - single- and double-quoted string literals with backslash escapes
+//   - triple-quoted ”'...”' / """...""" strings (which span lines and are the
+//     workhorse for embedding blobs and docstrings)
+//   - string prefixes r/b/f/u and their case/combination variants (rb, Rb, fr,
+//     …). The prefix letters are ordinary code bytes; scanning of the literal
+//     begins at the quote.
+//
+// f-string interpolation: the `{ ... }` replacement fields of an f-string are
+// CODE — a secret spliced in via `f"key={SECRET}"` lives in a real expression.
+// The scanner therefore emits the interpolated bytes as code (respecting `{{`
+// / `}}` escapes and nested braces). Raw strings (r"...") disable backslash
+// escaping, which matters: in a raw string `\"` does NOT escape the quote.
+func scanPython(content []byte) []Region {
+	var b regionBuilder
+	i := 0
+	n := len(content)
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '#':
+			start := i
+			for i < n && content[i] != '\n' {
+				i++
+			}
+			b.emit(start, i, KindComment)
+		case c == '\'' || c == '"':
+			// A bare quote with no preceding prefix.
+			i = scanPyStringLiteral(content, i, i, pyStringFlags{}, &b)
+		case isPyStringPrefixStart(content, i):
+			// Consume the prefix letters, then the opening quote.
+			prefixStart := i
+			flags, quotePos := readPyPrefix(content, i)
+			i = scanPyStringLiteral(content, prefixStart, quotePos, flags, &b)
+		default:
+			b.emit(i, i+1, KindCode)
+			i++
+		}
+	}
+	return b.finish(n)
+}
+
+// pyStringFlags captures the semantics a string prefix confers.
+type pyStringFlags struct {
+	raw     bool // r/R: backslash does not escape
+	fstring bool // f/F: has { } interpolation fields that are code
+}
+
+// isPyStringPrefixStart reports whether content[i] begins a prefixed string
+// literal (e.g. r", b', f"""). It requires that the prefix be preceded by a
+// non-identifier byte so we do not misread the tail of an identifier like
+// `myvar` or a hex literal as a `r`/`b` prefix.
+func isPyStringPrefixStart(content []byte, i int) bool {
+	if !isPyPrefixLetter(content[i]) {
+		return false
+	}
+	if i > 0 && isIdentByte(content[i-1]) {
+		return false // part of a longer identifier, not a string prefix
+	}
+	_, quotePos := readPyPrefix(content, i)
+	return quotePos > i && quotePos < len(content) &&
+		(content[quotePos] == '\'' || content[quotePos] == '"')
+}
+
+// readPyPrefix consumes up to two prefix letters starting at i and returns the
+// resulting flags and the index of the opening quote (or the first non-prefix
+// byte if there is no quote, in which case the caller's guard rejects it).
+func readPyPrefix(content []byte, i int) (flags pyStringFlags, quotePos int) {
+	j := i
+	n := len(content)
+	// Python string prefixes are at most two letters (e.g. rb, fr, br).
+	for count := 0; count < 2 && j < n && isPyPrefixLetter(content[j]); count++ {
+		switch content[j] {
+		case 'r', 'R':
+			flags.raw = true
+		case 'f', 'F':
+			flags.fstring = true
+		}
+		j++
+	}
+	return flags, j
+}
+
+// isPyPrefixLetter reports whether c is one of the recognized string-prefix
+// letters (case-insensitive): r, b, f, u.
+func isPyPrefixLetter(c byte) bool {
+	switch c {
+	case 'r', 'R', 'b', 'B', 'f', 'F', 'u', 'U':
+		return true
+	}
+	return false
+}
+
+// isIdentByte reports whether c can appear inside an identifier.
+func isIdentByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+// scanPyStringLiteral classifies the string literal whose prefix (if any) began
+// at prefixStart and whose opening quote is at quotePos. It emits the prefix and
+// quotes and body as string, EXCEPT f-string `{ ... }` fields which are emitted
+// as code. It returns the offset just past the literal.
+func scanPyStringLiteral(content []byte, prefixStart, quotePos int, flags pyStringFlags, b *regionBuilder) int {
+	n := len(content)
+	q := content[quotePos]
+	triple := quotePos+2 < n && content[quotePos+1] == q && content[quotePos+2] == q
+	bodyStart := quotePos + 1
+	if triple {
+		bodyStart = quotePos + 3
+	}
+	// Emit prefix + opening quote(s) as string.
+	b.emit(prefixStart, bodyStart, KindString)
+
+	i := bodyStart
+	stringRunStart := bodyStart
+	for i < n {
+		c := content[i]
+		if c == '\\' && !flags.raw {
+			i += 2 // escaped byte stays inside the string
+			continue
+		}
+		// f-string interpolation field: `{` (not `{{`) opens a code expression.
+		if flags.fstring && c == '{' {
+			if i+1 < n && content[i+1] == '{' {
+				i += 2 // `{{` is a literal brace
+				continue
+			}
+			// Flush the string run so far, then emit the field bytes as code.
+			b.emit(stringRunStart, i, KindString)
+			fieldEnd := scanPyFStringField(content, i)
+			b.emit(i, fieldEnd, KindCode)
+			i = fieldEnd
+			stringRunStart = i
+			continue
+		}
+		if triple {
+			if c == q && i+2 <= n-1 && content[i+1] == q && content[i+2] == q {
+				b.emit(stringRunStart, i+3, KindString)
+				return i + 3
+			}
+		} else {
+			if c == q {
+				b.emit(stringRunStart, i+1, KindString)
+				return i + 1
+			}
+			if c == '\n' {
+				// A non-triple string does not cross a newline; stop before it
+				// so runaway quotes cannot swallow real code.
+				b.emit(stringRunStart, i, KindString)
+				return i
+			}
+		}
+		i++
+	}
+	b.emit(stringRunStart, n, KindString)
+	return n
+}
+
+// scanPyFStringField returns the offset just past an f-string replacement field
+// that opens at content[open] == '{'. It balances nested braces and skips over
+// nested string literals inside the expression (so a `}` inside a nested string
+// does not close the field early). A format spec after `:` is included in the
+// field span; classifying it as code is harmless (it is not a secret carrier).
+func scanPyFStringField(content []byte, open int) int {
+	n := len(content)
+	depth := 0
+	i := open
+	for i < n {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		case '\'', '"':
+			// Skip a nested string literal wholesale.
+			i = skipPyNestedString(content, i)
+			continue
+		}
+		i++
+	}
+	return n
+}
+
+// skipPyNestedString returns the offset just past a simple (non-triple) nested
+// string opening at content[start], used only to keep brace-balancing honest
+// inside f-string fields.
+func skipPyNestedString(content []byte, start int) int {
+	n := len(content)
+	q := content[start]
+	i := start + 1
+	for i < n {
+		switch content[i] {
+		case '\\':
+			i += 2
+			continue
+		case q:
+			return i + 1
+		case '\n':
+			return i
+		}
+		i++
+	}
+	return n
+}

--- a/docs/adr/0001-sast-structural-matching.md
+++ b/docs/adr/0001-sast-structural-matching.md
@@ -1,0 +1,120 @@
+# ADR 0001: Structural matching for SAST false-positive suppression
+
+- Status: Accepted
+- Date: 2026-07-05
+- Deciders: nox maintainers
+- Supersedes: —
+
+## Context
+
+Nox's SAST rules (secrets, ai, variants, …) match regexes against raw file
+**text**. A regex has no idea whether the bytes it matched are live code, the
+contents of a string literal, or a comment. As a result a single broad pattern
+fires equally on:
+
+- a real hardcoded secret in a code assignment (a true positive),
+- the same byte sequence buried inside a base64 data-URI / SVG blob,
+- a lockfile hash or a minified-JS chunk,
+- a commented-out line or a prose comment.
+
+The scan-of-the-week reports put the resulting noise at ~99.5% for the broad
+rule classes. Almost all of that noise is patterns firing in **non-code text**.
+The users who hit it stop trusting the tool.
+
+The fix is to only trust a match that sits in real code. That requires knowing,
+for a given byte offset, whether it is code, string, or comment — i.e. some
+degree of structural (rather than purely textual) understanding of the file.
+
+Three implementation strategies were evaluated. The overriding constraint is
+non-negotiable and predates this ADR:
+
+> **nox ships a single, statically-linked, pure-Go binary with no CGo.** This is
+> load-bearing for the air-gapped / hermetic-CI story: one artifact, no shared
+> libraries, no runtime toolchain, reproducible builds, trivial cross-compile.
+
+## Options considered
+
+### Option A — Pure-Go lexical-context classifier (CHOSEN)
+
+Hand-rolled, dependency-free byte scanners (one per language family) that
+partition a file into `code` / `string` / `comment` regions. Analyzers gate
+each raw match: drop it if it lies in a comment, or in a string that is a *data
+blob* rather than a short literal (so genuine hardcoded-secret-in-string
+findings survive). Implemented in `core/lexctx`.
+
+- **Pros**
+  - Zero new dependencies; pure Go; keeps the single static binary intact.
+  - Deterministic and offline — same input, same regions, always. No network,
+    no model, no generated parser tables to ship.
+  - Cheap: a single linear pass over the bytes, no allocation-heavy AST.
+  - Graceful degradation: an unknown language returns one big code region, so
+    gating is *never worse than today* — it only ever removes provably non-code
+    matches.
+  - Incrementally adoptable: analyzers opt in with a ~5-line post-filter
+    (`SuppressNonCode` / `InCode`), no pipeline rewrite.
+- **Cons**
+  - Not a real parser. It tracks lexical context (string/comment/interpolation),
+    not grammar. It handles the cases that actually cause FPs — f-strings,
+    template-literal `${}` interpolation, raw/byte strings, regex-vs-division,
+    triple-quoted blobs, `#`/`//` inside strings — but it will never reason about
+    scopes, types, or data flow.
+  - One scanner per language family to write and maintain (Python and JS/TS
+    cover the bulk of nox's SAST surface today; others degrade to all-code).
+
+### Option B — CGo tree-sitter (real ASTs) — REJECTED
+
+Bind `go-tree-sitter` and ship per-language grammars for precise parse trees.
+
+- **Pros**: real ASTs; battle-tested grammars; node-kind queries are far more
+  expressive than lexical regions.
+- **Cons / why rejected**: **CGo breaks the pure-Go single-static-binary core
+  guarantee** — the decision that is explicitly out of scope to relitigate here.
+  CGo brings a C toolchain into the build, complicates and slows
+  cross-compilation, risks glibc/musl portability issues in minimal/air-gapped
+  images, and undermines reproducibility. The precision win does not justify
+  giving up the deployment properties that are central to nox's value. **Not in
+  core, now or later.**
+
+### Option C — WASM-embedded grammars — REJECTED
+
+Compile tree-sitter grammars to WASM and run them via a pure-Go WASM runtime
+(e.g. wazero), keeping CGo out.
+
+- **Pros**: real grammars without CGo; stays single-binary-ish.
+- **Cons / why rejected**: embeds megabytes of grammar blobs per language,
+  bloating the binary; adds a WASM runtime and its startup/marshalling overhead
+  on a hot path; determinism and reproducibility now depend on the runtime and
+  the pinned grammar artifacts; substantial engineering for a precision gain we
+  have no evidence we need. Rejected for core on cost/benefit grounds.
+
+## Decision
+
+Adopt **Option A**, the pure-Go lexical-context classifier (`core/lexctx`), as
+the chosen path for SAST false-positive suppression. It removes the dominant FP
+class (matches in comments and data blobs) while preserving the pure-Go,
+single-static-binary, deterministic, offline guarantees that define nox.
+
+Options B and C are rejected for **core**. Tree-sitter remains conceivable only
+as a **future opt-in, out-of-core module** (e.g. a separately built plugin a
+user explicitly installs) — and only if a precision benchmark later proves that
+lexical context leaves real, measurable accuracy on the table that scope/type/
+data-flow analysis would recover. Absent that evidence, we do not pay the cost.
+
+## Consequences
+
+- `core/lexctx` provides `Classify`, `KindAt`, `InCode`, `SuppressNonCode`, and
+  `LineColToOffset`. Analyzers adopt it as an additive post-filter; the demo
+  integration test wires it into the real secrets analyzer and shows the
+  AWS-key finding count collapse from 3 → 1 (dropping the base64-blob and
+  comment FPs, keeping the true code secret).
+- The classifier is a **suppression** aid, not a detector: it can only ever
+  *remove* matches, and only when it is confident they are non-code. A
+  misclassification therefore fails safe — it keeps a match it might have
+  dropped; it never invents one.
+- New language support is bounded work (one scanner per family); until a
+  language is added it degrades to all-code, i.e. today's behavior.
+- **Follow-up (out of scope here):** flip individual analyzers (secrets, ai) to
+  consume the filter behind a config flag, then measure the FP-rate delta on the
+  scan-of-the-week corpus. If precision plateaus below expectations, revisit a
+  tree-sitter opt-in module per the escape hatch above.
+```


### PR DESCRIPTION
## The FP-collapse thesis

nox's SAST rules match regexes against raw file **text**, so a pattern fires equally whether the bytes are:

- a real hardcoded secret in a code assignment (a **true positive**),
- the same sequence buried in a base64 / SVG data-URI blob,
- a lockfile hash or a minified-JS chunk,
- a commented-out line or prose.

The scan-of-the-week reports put the resulting noise at ~99.5% for the broad rule classes — almost all of it patterns matching **non-code text**. The fix is to only trust a match that sits in real **code**.

## What this PR adds

A new pure-Go, dependency-free, **CGo-free** package `core/lexctx` that partitions a file into `code` / `string` / `comment` regions with hand-rolled byte scanners (Python and JS/TS), plus the analyzer-facing helpers:

- `Classify(lang, content) []Region`
- `KindAt(regions, offset)` / `InCode(regions, start, end)`
- `SuppressNonCode(lang, content, start, end)` — the reusable post-filter: drops comments always, and drops string matches **only when the string is a data blob** (long or a `data:` URI), so genuine hardcoded-secret-in-string findings are preserved.
- `LineColToOffset(content, line, col)` — bridges `(line, col)` findings into the byte-oriented classifier.

### Robust against the cases that break naive lexers
- **Python:** f-string `{expr}` interpolation (classified as **code**), `{{ }}` escapes, raw/byte/unicode prefixes, triple-quoted blobs, escaped quotes, `#` inside a string, and prefix-letter-in-identifier disambiguation (`myfunc(` is not an f-string).
- **JS/TS:** template-literal `${...}` interpolation (**code**) incl. nested templates, regex-literal vs division disambiguation, `//` inside a string/URL, escaped quotes, multi-line block comments.

### Guarantees
Deterministic, offline, single linear pass (~1.9 GB/s, 5 allocs/op), and **graceful degradation** — an unknown language returns one all-code region, so gating is *never worse than today*: it can only ever remove provably non-code matches, never surface one.

## Proof of value (not the classifier in isolation)

- **`fpcollapse_test.go`** — a broad `[A-Za-z0-9]{32}` regex matches code + base64 blob + comment raw, but only the code match survives the lexctx gate (Python and JS variants).
- **`integration_secrets_test.go`** — runs the **real secrets analyzer** over a realistic `.ts` fixture (code secret + base64 SVG blob + comment). AWS-key findings collapse **3 → 1**: the blob and comment FPs are dropped, the true code secret is kept. The analyzer is *not* modified — the filter is a ~5-line additive post-filter on its output, showing how cheap adoption is.

## ADR recommendation

`docs/adr/0001-sast-structural-matching.md` records the maintainer-locked decision:

- **Chosen:** pure-Go lexical context (`core/lexctx`).
- **Rejected for core:** CGo tree-sitter and WASM grammars — **CGo breaks the single-static-binary / air-gapped guarantee** that is central to nox. tree-sitter stays a possible **future opt-in, out-of-core module**, and only if a precision benchmark later proves lexical context leaves real accuracy on the table.

## Scope

Package + demonstration + ADR only. Existing analyzers are **not** rewired (follow-up), but the API is clean enough for secrets/ai to adopt behind a flag.

## Checks
- `go build ./...` green
- `go test ./core/lexctx/...` green (incl. `-race`)
- `golangci-lint run ./core/lexctx/...` → 0 issues

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom