### PR TITLE
feat(llm-triage): ground LLM triage to deterministic findings + residual routing

### DIFF
--- a/plugins/nox-plugin-llm-triage/README.md
+++ b/plugins/nox-plugin-llm-triage/README.md
@@ -10,6 +10,43 @@ a configured chat endpoint, and attaches a triage verdict —
 original finding. It never changes or gates the scan result; enrichments
 annotate, they don't decide.
 
+The model is a **second opinion, not a scanner**: nox finds and grounds every
+candidate deterministically, and the LLM only confirms/explains the residual.
+
+## Grounding guarantee — the LLM can never invent a finding
+
+Every finding is located deterministically (rule ID, file, line, fingerprint)
+before any LLM is involved. The plugin asks the model to judge **only that one
+finding at that one location** and enforces it structurally:
+
+- `buildPrompt` hands the model the exact, immutable rule ID, `file:line`, and
+  code snippet, and explicitly instructs it: *do not report new findings, do not
+  propose a different location.*
+- `parseVerdict` extracts a **verdict + rationale only** — it never reads a file
+  path or line number from the reply.
+- The resulting enrichment is anchored to the **original finding's fingerprint**
+  (copied from the input finding, never from model output).
+
+So a model that hallucinates a different file/line — or claims a second issue —
+in its prose is inert: the text can only ever land in the free-form rationale,
+never as a new or moved finding. The only observable effect of triage is an
+enrichment on a pre-existing, deterministically located finding.
+
+## Deterministic-first routing — spend tokens only on the residual
+
+Before any LLM call, findings are **de-duplicated** (by fingerprint, or rule +
+`file:line` when a fingerprint is absent) so the model is never asked the same
+question twice. Then routing gates decide what actually needs a second opinion:
+
+- `skip_high_confidence` (default **true**) — don't re-judge `CONFIDENCE_HIGH`
+  findings; they're already trustworthy deterministic hits. Low/medium/unset
+  confidence is the "residual" the LLM focuses on.
+- `only_rules` — restrict triage to matching rule families (glob or `PREFIX-*`),
+  e.g. point the LLM at just the noisy entropy secret rules.
+- `skip_rules` — exclude matching rule families (applied after `only_rules`, so
+  an exclusion always wins).
+- `min_severity` — skip findings below a severity threshold.
+
 ## Why it's a plugin, not a core feature
 
 The core's value is that the same inputs always produce the same outputs with no
@@ -33,7 +70,10 @@ snippets to the configured model, so it requires explicit confirmation:
   "authorize": true,          // required — confirms you accept sending code out
   "workspace_root": ".",
   "min_severity": "medium",   // optional: skip below this severity
-  "max_findings": 50           // optional: cap the number judged
+  "max_findings": 50,          // optional: cap the number judged
+  "skip_high_confidence": true, // optional (default true): only judge residual
+  "only_rules": ["SECRET-*"],  // optional: restrict to these rule families
+  "skip_rules": ["LICENSE-*"]  // optional: exclude these rule families
 }
 ```
 

--- a/plugins/nox-plugin-llm-triage/main.go
+++ b/plugins/nox-plugin-llm-triage/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"github.com/nox-hq/nox/sdk"
@@ -78,8 +79,11 @@ func handleTriage(ctx context.Context, req sdk.ToolRequest) (*pluginv1.InvokeToo
 	read := fileSnippetReader(workspaceRoot, 6)
 
 	verdicts, err := triageFindings(ctx, client, read, req.Findings(), TriageOptions{
-		MaxFindings: maxFindings,
-		MinSeverity: minSeverityFromInput(req.InputString("min_severity")),
+		MaxFindings:        maxFindings,
+		MinSeverity:        minSeverityFromInput(req.InputString("min_severity")),
+		SkipHighConfidence: boolInput(req.Input, "skip_high_confidence", true),
+		OnlyRules:          listInput(req.Input, "only_rules"),
+		SkipRules:          listInput(req.Input, "skip_rules"),
 	})
 	if err != nil {
 		return resp.Build(), err
@@ -116,6 +120,44 @@ func triageBody(v *Verdict) string {
 		return "LLM verdict: **" + string(v.Disposition) + "**"
 	}
 	return "LLM verdict: **" + string(v.Disposition) + "** — " + v.Rationale
+}
+
+// boolInput reads a boolean tool parameter, returning def when the key is
+// absent so a defaulted-on gate (like skip_high_confidence) stays on unless the
+// operator explicitly sets it false.
+func boolInput(input map[string]any, key string, def bool) bool {
+	if v, ok := input[key].(bool); ok {
+		return v
+	}
+	return def
+}
+
+// listInput reads a rule-pattern list parameter. It accepts either a JSON array
+// of strings or a single comma-separated string (both are common in tool
+// configs), returning nil when absent or empty so an unset filter is a no-op.
+func listInput(input map[string]any, key string) []string {
+	raw, ok := input[key]
+	if !ok {
+		return nil
+	}
+	var out []string
+	switch v := raw.(type) {
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				if s = strings.TrimSpace(s); s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+	case string:
+		for _, part := range strings.Split(v, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
 }
 
 func minSeverityFromInput(s string) Severity {

--- a/plugins/nox-plugin-llm-triage/triage.go
+++ b/plugins/nox-plugin-llm-triage/triage.go
@@ -11,6 +11,25 @@ import (
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 )
 
+// Grounding contract.
+//
+// The strategic design is "deterministic-first, LLM-second": nox's core finds
+// and GROUNDS every candidate deterministically (rule ID, file, line,
+// fingerprint). This plugin only asks the LLM to CONFIRM/EXPLAIN a candidate
+// that already exists — never to discover new ones.
+//
+// Two properties enforce that the LLM can never invent a finding location:
+//
+//  1. The prompt (buildPrompt) hands the model the exact, immutable rule ID,
+//     file:line, and code snippet and instructs it to judge ONLY that finding.
+//  2. parseVerdict extracts a disposition + rationale ONLY. It never reads a
+//     file path or line from the model's reply. The resulting Verdict carries
+//     the ORIGINAL finding's fingerprint (copied from the input finding, not
+//     from the model), and emitVerdicts anchors the enrichment to that
+//     fingerprint. A model that "hallucinates" a different file/line in its
+//     prose therefore cannot create, move, or emit any finding — the only
+//     observable effect of triage is an enrichment on the pre-existing finding.
+
 // Disposition is the LLM's verdict on whether a finding is a true positive.
 type Disposition string
 
@@ -38,10 +57,29 @@ type Verdict struct {
 	Rationale   string
 }
 
-// TriageOptions bounds and configures a triage run.
+// TriageOptions bounds and configures a triage run. The routing gates
+// (MinSeverity, SkipHighConfidence, OnlyRules, SkipRules) exist so an operator
+// can spend LLM tokens only on the residual that actually needs a second
+// opinion — deterministic-high-confidence findings are already trustworthy.
 type TriageOptions struct {
 	MaxFindings int      // 0 = unlimited
 	MinSeverity Severity // findings below this are skipped
+
+	// SkipHighConfidence, when true, routes only low/medium-confidence
+	// "residual" to the LLM. ConfidenceHigh findings are already trustworthy
+	// deterministic hits, so re-judging them wastes tokens without adding
+	// signal. Findings with unspecified confidence are treated as residual
+	// (judged) so an unset field never silently drops coverage.
+	SkipHighConfidence bool
+
+	// OnlyRules, if non-empty, restricts triage to findings whose rule ID
+	// matches one of these patterns (glob or prefix — see ruleMatches). Use it
+	// to point the LLM at exactly the noisy families (e.g. "SECRET-*").
+	OnlyRules []string
+
+	// SkipRules excludes findings whose rule ID matches one of these patterns.
+	// SkipRules is applied after OnlyRules, so an exclusion always wins.
+	SkipRules []string
 }
 
 // Severity ordering for the min-severity gate.
@@ -70,18 +108,105 @@ func severityRank(s pluginv1.Severity) Severity {
 	}
 }
 
+// isHighConfidence reports whether a finding is a deterministic high-confidence
+// hit. Only CONFIDENCE_HIGH qualifies; unspecified/medium/low are residual.
+func isHighConfidence(c pluginv1.Confidence) bool {
+	return c == pluginv1.Confidence_CONFIDENCE_HIGH
+}
+
+// ruleMatches reports whether ruleID matches pattern. A pattern ending in "*"
+// is a prefix match ("SECRET-*" matches "SECRET-ENTROPY"); otherwise it is an
+// exact, case-sensitive rule ID. filepath.Match handles richer glob syntax
+// ("SEC-00?"); a malformed pattern degrades to a literal compare rather than
+// erroring, so a bad filter never aborts the run.
+func ruleMatches(ruleID, pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	if strings.HasSuffix(pattern, "*") {
+		if strings.HasPrefix(ruleID, strings.TrimSuffix(pattern, "*")) {
+			return true
+		}
+	}
+	if ok, err := filepath.Match(pattern, ruleID); err == nil && ok {
+		return true
+	}
+	return ruleID == pattern
+}
+
+// matchesAny reports whether ruleID matches any pattern in patterns.
+func matchesAny(ruleID string, patterns []string) bool {
+	for _, p := range patterns {
+		if ruleMatches(ruleID, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldTriage applies the routing gates to a single finding and reports
+// whether it should be sent to the LLM. It is the single source of truth for
+// "does this finding need a second opinion", kept pure so it is table-testable.
+func shouldTriage(f *pluginv1.Finding, opts TriageOptions) bool {
+	if severityRank(f.GetSeverity()) < opts.MinSeverity {
+		return false
+	}
+	if opts.SkipHighConfidence && isHighConfidence(f.GetConfidence()) {
+		return false
+	}
+	ruleID := f.GetRuleId()
+	if len(opts.OnlyRules) > 0 && !matchesAny(ruleID, opts.OnlyRules) {
+		return false
+	}
+	if matchesAny(ruleID, opts.SkipRules) {
+		return false
+	}
+	return true
+}
+
+// dedupeFindings collapses findings that ask the LLM the same question twice.
+// Two findings are duplicates when they share a fingerprint, or (lacking a
+// fingerprint) the same rule ID + file:line. Deterministically pre-collapsing
+// them before any LLM call saves tokens and makes the run more reproducible —
+// the LLM sees each distinct candidate exactly once, in first-seen order. The
+// input slice is not mutated.
+func dedupeFindings(findings []*pluginv1.Finding) []*pluginv1.Finding {
+	seen := make(map[string]struct{}, len(findings))
+	out := make([]*pluginv1.Finding, 0, len(findings))
+	for _, f := range findings {
+		key := f.GetFingerprint()
+		if key == "" {
+			loc := f.GetLocation()
+			key = fmt.Sprintf("%s\x00%s\x00%d", f.GetRuleId(), loc.GetFilePath(), loc.GetStartLine())
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, f)
+	}
+	return out
+}
+
 // triageFindings asks the LLM to judge each finding as a true or false positive,
 // returning one verdict per judged finding. It is pure with respect to I/O: the
 // LLM client and snippet reader are injected, so the same logic runs in tests
 // with a deterministic mock. It never mutates the findings.
 func triageFindings(ctx context.Context, client LLMClient, read SnippetReader, findings []*pluginv1.Finding, opts TriageOptions) ([]Verdict, error) {
+	// Deterministic pre-dedup: collapse duplicate candidates before spending a
+	// single token, so the LLM is never asked the same question twice.
+	findings = dedupeFindings(findings)
+
 	var verdicts []Verdict
 	judged := 0
 	for _, f := range findings {
 		if opts.MaxFindings > 0 && judged >= opts.MaxFindings {
 			break
 		}
-		if severityRank(f.GetSeverity()) < opts.MinSeverity {
+		// Residual-only + confidence-gated routing: skip findings that don't
+		// need an LLM (below min severity, already high-confidence, or filtered
+		// out by rule).
+		if !shouldTriage(f, opts) {
 			continue
 		}
 		if err := ctx.Err(); err != nil {
@@ -122,11 +247,20 @@ func triageFindings(ctx context.Context, client LLMClient, read SnippetReader, f
 	return verdicts, nil
 }
 
-// buildPrompt renders a deterministic triage prompt for one finding. It asks for
-// a strict, machine-parseable first line so parseVerdict is unambiguous.
+// buildPrompt renders a deterministic triage prompt for one finding. It states
+// the grounding contract explicitly — the model judges ONLY the given finding
+// at its given location and must not report any new finding or location — and
+// asks for a strict, machine-parseable first line so parseVerdict is
+// unambiguous. The rule ID, file:line, and snippet are passed as immutable
+// context; nothing in the reply is ever used to derive a finding location.
 func buildPrompt(f *pluginv1.Finding, snippet string) string {
 	var b strings.Builder
-	b.WriteString("You are a security triage assistant. Decide whether the following static-analysis finding is a TRUE POSITIVE (a real, exploitable issue) or a FALSE POSITIVE (safe in context).\n\n")
+	b.WriteString("You are a security triage assistant. You are given ONE static-analysis finding, already located by a deterministic scanner. Your ONLY job is to judge whether THIS specific finding, at THIS exact location, is a TRUE POSITIVE (a real, exploitable issue) or a FALSE POSITIVE (safe in context).\n\n")
+	b.WriteString("Rules you must follow:\n")
+	b.WriteString("- Judge only the finding below. Do NOT report new findings, new issues, or any other file or line.\n")
+	b.WriteString("- Do NOT propose a different location; the location is fixed and authoritative.\n")
+	b.WriteString("- If the given snippet is insufficient to decide, answer UNCERTAIN.\n\n")
+	b.WriteString("Finding under review (immutable):\n")
 	b.WriteString("Rule: " + f.GetRuleId() + "\n")
 	b.WriteString("Severity: " + f.GetSeverity().String() + "\n")
 	b.WriteString("Message: " + f.GetMessage() + "\n")
@@ -134,17 +268,21 @@ func buildPrompt(f *pluginv1.Finding, snippet string) string {
 		fmt.Fprintf(&b, "Location: %s:%d\n", loc.GetFilePath(), loc.GetStartLine())
 	}
 	if snippet != "" {
-		b.WriteString("\nCode context:\n```\n")
+		b.WriteString("\nCode context (the given location):\n```\n")
 		b.WriteString(snippet)
 		b.WriteString("\n```\n")
 	}
-	b.WriteString("\nAnswer with exactly one of TRUE_POSITIVE, FALSE_POSITIVE, or UNCERTAIN on the first line, then one sentence of justification on the second line.")
+	b.WriteString("\nAnswer with exactly one of TRUE_POSITIVE, FALSE_POSITIVE, or UNCERTAIN on the first line, then one sentence of justification about THIS finding on the second line.")
 	return b.String()
 }
 
-// parseVerdict extracts the disposition and rationale from the model's reply.
-// It is lenient about surrounding formatting but keys off the first recognized
-// token so an unexpected reply falls back to UNCERTAIN rather than mislabeling.
+// parseVerdict extracts the disposition and rationale from the model's reply,
+// and NOTHING ELSE. It deliberately never reads a file path or line number from
+// the reply: the finding's location is fixed by the deterministic scanner, so a
+// hallucinated location in the model's prose is inert — it can only ever land in
+// the free-text rationale, never in a finding. It is lenient about surrounding
+// formatting but keys off the first recognized token so an unexpected reply
+// falls back to UNCERTAIN rather than mislabeling.
 func parseVerdict(out string) (disposition Disposition, rationale string) {
 	upper := strings.ToUpper(out)
 	disposition = DispUncertain

--- a/plugins/nox-plugin-llm-triage/triage_test.go
+++ b/plugins/nox-plugin-llm-triage/triage_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -28,6 +29,13 @@ func finding(rule string, sev pluginv1.Severity, fp, file string, line int, msg 
 		Message:     msg,
 		Location:    &pluginv1.Location{FilePath: file, StartLine: int32(line)},
 	}
+}
+
+// findingC is finding with an explicit confidence, for routing tests.
+func findingC(rule string, sev pluginv1.Severity, conf pluginv1.Confidence, fp string) *pluginv1.Finding {
+	f := finding(rule, sev, fp, "a.py", 1, "msg")
+	f.Confidence = conf
+	return f
 }
 
 func TestParseVerdict(t *testing.T) {
@@ -94,7 +102,10 @@ func TestTriageMaxFindings(t *testing.T) {
 	client := &mockClient{reply: "TRUE_POSITIVE\nx"}
 	var findings []*pluginv1.Finding
 	for i := 0; i < 5; i++ {
-		findings = append(findings, finding("SEC-001", pluginv1.Severity_SEVERITY_HIGH, "fp", "a.py", i+1, "x"))
+		// Distinct fingerprints so the pre-dedup step keeps all five; the cap,
+		// not dedup, is what limits the run here.
+		fp := fmt.Sprintf("fp-%d", i)
+		findings = append(findings, finding("SEC-001", pluginv1.Severity_SEVERITY_HIGH, fp, "a.py", i+1, "x"))
 	}
 	got, _ := triageFindings(context.Background(), client, nil, findings, TriageOptions{MaxFindings: 2})
 	if len(got) != 2 {
@@ -121,5 +132,165 @@ func TestBuildPromptIncludesSnippet(t *testing.T) {
 		if !strings.Contains(p, want) {
 			t.Errorf("prompt missing %q:\n%s", want, p)
 		}
+	}
+}
+
+// TestBuildPromptStatesGroundingContract proves the prompt explicitly forbids
+// the model from reporting new findings or locations.
+func TestBuildPromptStatesGroundingContract(t *testing.T) {
+	f := finding("SEC-001", pluginv1.Severity_SEVERITY_HIGH, "fp", "a.py", 3, "hardcoded secret")
+	p := buildPrompt(f, "api_key = \"AKIA...\"")
+	for _, want := range []string{"Do NOT report new findings", "Do NOT propose a different location"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing grounding instruction %q:\n%s", want, p)
+		}
+	}
+}
+
+// TestHallucinatedLocationCannotCreateFinding is the core grounding guarantee:
+// a mock LLM that invents a completely different file and line in its reply
+// still only produces a verdict anchored to the ORIGINAL finding's fingerprint
+// and location. No new finding location is ever emitted from model output.
+func TestHallucinatedLocationCannotCreateFinding(t *testing.T) {
+	// The model "hallucinates" a verdict about a different file/line than the
+	// one it was asked about, and even claims a second issue.
+	client := &mockClient{reply: "TRUE_POSITIVE\nActually the real bug is in /etc/shadow:999 and also secrets.env:1 leaks a key."}
+	orig := finding("SECRET-ENTROPY", pluginv1.Severity_SEVERITY_HIGH, "fp-orig", "src/app.py", 42, "high-entropy string")
+
+	got, err := triageFindings(context.Background(), client, nil, []*pluginv1.Finding{orig}, TriageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exactly one verdict, for the one input finding — the hallucinated extra
+	// location did not spawn a second verdict.
+	if len(got) != 1 {
+		t.Fatalf("hallucinated locations must not create findings: want 1 verdict, got %d: %+v", len(got), got)
+	}
+	v := got[0]
+	// The verdict is anchored to the original fingerprint and rule, taken from
+	// the input finding, never from the model reply.
+	if v.Fingerprint != "fp-orig" {
+		t.Errorf("verdict fingerprint = %q, want the original %q", v.Fingerprint, "fp-orig")
+	}
+	if v.RuleID != "SECRET-ENTROPY" {
+		t.Errorf("verdict rule = %q, want the original %q", v.RuleID, "SECRET-ENTROPY")
+	}
+	// The hallucinated paths can only ever surface as inert free-text rationale;
+	// they must never appear as a fingerprint or become a new finding key.
+	if v.Fingerprint == "/etc/shadow:999" || v.Fingerprint == "secrets.env:1" {
+		t.Errorf("hallucinated location leaked into fingerprint: %q", v.Fingerprint)
+	}
+}
+
+func TestShouldTriageRouting(t *testing.T) {
+	const (
+		hi  = pluginv1.Severity_SEVERITY_HIGH
+		med = pluginv1.Severity_SEVERITY_MEDIUM
+		low = pluginv1.Severity_SEVERITY_LOW
+	)
+	const (
+		cHigh = pluginv1.Confidence_CONFIDENCE_HIGH
+		cMed  = pluginv1.Confidence_CONFIDENCE_MEDIUM
+		cLow  = pluginv1.Confidence_CONFIDENCE_LOW
+		cUnk  = pluginv1.Confidence_CONFIDENCE_UNSPECIFIED
+	)
+	cases := []struct {
+		name string
+		f    *pluginv1.Finding
+		opts TriageOptions
+		want bool
+	}{
+		{"below min severity is skipped", findingC("SEC-1", low, cLow, "a"), TriageOptions{MinSeverity: SevHigh}, false},
+		{"high confidence skipped when gated", findingC("SEC-1", hi, cHigh, "a"), TriageOptions{SkipHighConfidence: true}, false},
+		{"medium confidence is residual", findingC("SEC-1", hi, cMed, "a"), TriageOptions{SkipHighConfidence: true}, true},
+		{"low confidence is residual", findingC("SEC-1", hi, cLow, "a"), TriageOptions{SkipHighConfidence: true}, true},
+		{"unspecified confidence is residual", findingC("SEC-1", hi, cUnk, "a"), TriageOptions{SkipHighConfidence: true}, true},
+		{"high confidence judged when gate off", findingC("SEC-1", hi, cHigh, "a"), TriageOptions{}, true},
+		{"only_rules prefix match kept", findingC("SECRET-ENTROPY", hi, cLow, "a"), TriageOptions{OnlyRules: []string{"SECRET-*"}}, true},
+		{"only_rules non-match dropped", findingC("SEC-1", hi, cLow, "a"), TriageOptions{OnlyRules: []string{"SECRET-*"}}, false},
+		{"skip_rules exact match dropped", findingC("SEC-1", hi, cLow, "a"), TriageOptions{SkipRules: []string{"SEC-1"}}, false},
+		{"skip_rules wins over only_rules", findingC("SECRET-X", hi, cLow, "a"), TriageOptions{OnlyRules: []string{"SECRET-*"}, SkipRules: []string{"SECRET-X"}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldTriage(c.f, c.opts); got != c.want {
+				t.Errorf("shouldTriage = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestTriageRoutingSendsOnlySubset proves that, end-to-end, only the intended
+// subset ever reaches the (mock) client — the LLM never sees a filtered-out
+// finding.
+func TestTriageRoutingSendsOnlySubset(t *testing.T) {
+	client := &mockClient{reply: "UNCERTAIN\nx"}
+	findings := []*pluginv1.Finding{
+		findingC("SECRET-ENTROPY", pluginv1.Severity_SEVERITY_HIGH, pluginv1.Confidence_CONFIDENCE_LOW, "fp-secret"),
+		findingC("SECRET-KNOWN", pluginv1.Severity_SEVERITY_HIGH, pluginv1.Confidence_CONFIDENCE_HIGH, "fp-known"),
+		findingC("SQLI-001", pluginv1.Severity_SEVERITY_HIGH, pluginv1.Confidence_CONFIDENCE_LOW, "fp-sqli"),
+	}
+	got, err := triageFindings(context.Background(), client, nil, findings, TriageOptions{
+		SkipHighConfidence: true,
+		OnlyRules:          []string{"SECRET-*"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the low-confidence SECRET-* finding qualifies: SECRET-KNOWN is
+	// high-confidence (gated out), SQLI-001 is not a SECRET rule.
+	if len(got) != 1 || got[0].Fingerprint != "fp-secret" {
+		t.Fatalf("routing should judge only fp-secret, got %+v", got)
+	}
+	if len(client.seen) != 1 {
+		t.Fatalf("LLM should be called exactly once, got %d calls", len(client.seen))
+	}
+	if !strings.Contains(client.seen[0], "SECRET-ENTROPY") {
+		t.Errorf("the one LLM call should be about SECRET-ENTROPY, got:\n%s", client.seen[0])
+	}
+}
+
+func TestDedupeFindings(t *testing.T) {
+	t.Run("dedupes by fingerprint", func(t *testing.T) {
+		in := []*pluginv1.Finding{
+			finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "same", "a.py", 1, "x"),
+			finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "same", "a.py", 1, "x"),
+			finding("SEC-2", pluginv1.Severity_SEVERITY_HIGH, "other", "b.py", 2, "y"),
+		}
+		got := dedupeFindings(in)
+		if len(got) != 2 {
+			t.Fatalf("want 2 unique findings, got %d", len(got))
+		}
+		if got[0].GetFingerprint() != "same" || got[1].GetFingerprint() != "other" {
+			t.Errorf("dedup must preserve first-seen order, got %q,%q", got[0].GetFingerprint(), got[1].GetFingerprint())
+		}
+	})
+	t.Run("dedupes by rule+location when fingerprint absent", func(t *testing.T) {
+		in := []*pluginv1.Finding{
+			finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "", "a.py", 1, "x"),
+			finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "", "a.py", 1, "x"),
+			finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "", "a.py", 2, "x"),
+		}
+		got := dedupeFindings(in)
+		if len(got) != 2 {
+			t.Fatalf("want 2 (same loc collapsed, different line kept), got %d", len(got))
+		}
+	})
+}
+
+// TestTriageDedupsBeforeLLM proves the LLM is not asked the same question twice.
+func TestTriageDedupsBeforeLLM(t *testing.T) {
+	client := &mockClient{reply: "TRUE_POSITIVE\nx"}
+	dup := finding("SEC-1", pluginv1.Severity_SEVERITY_HIGH, "same", "a.py", 1, "x")
+	findings := []*pluginv1.Finding{dup, dup, dup}
+	got, err := triageFindings(context.Background(), client, nil, findings, TriageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 verdict after dedup, got %d", len(got))
+	}
+	if len(client.seen) != 1 {
+		t.Fatalf("LLM must be called once for duplicates, got %d calls", len(client.seen))
 	}
 }


### PR DESCRIPTION
## What & why

Makes the opt-in `nox-plugin-llm-triage` **deterministic-first, LLM-second, and ungrounded-hallucination-proof**. nox finds and grounds every candidate deterministically; the LLM now only confirms/explains the residual, anchored to the real finding so it can never invent a location.

Scope is entirely within `plugins/nox-plugin-llm-triage/` (its own module). Core stays deterministic — this only changes what the plugin sends and how it's framed. The `authorize` egress gate is unchanged.

## 1. Grounding contract — a hallucinated location can't create a finding

- `buildPrompt` passes the **immutable** rule ID, `file:line`, and snippet, and explicitly instructs the model: judge only this finding, do **not** report new findings, do **not** propose a different location.
- `parseVerdict` extracts a **verdict + rationale only** — it never reads a path or line from the reply.
- Verdicts carry the **original finding's fingerprint** (copied from the input, never from model output); `emitVerdicts` anchors the enrichment to that fingerprint.

So a model that hallucinates a different `file:line` (or claims a second issue) is inert: the text can only land in the free-form rationale, never as a new/moved finding. Proven by `TestHallucinatedLocationCannotCreateFinding`.

## 2. Residual-only + confidence-gated routing

- `skip_high_confidence` (default **true**) — don't re-judge `CONFIDENCE_HIGH` deterministic hits; low/medium/unset confidence is the residual the LLM focuses on.
- `only_rules` / `skip_rules` — glob or `PREFIX-*` filters to point the LLM at exactly the noisy families (e.g. entropy secret rules); `skip_rules` wins over `only_rules`.
- `min_severity` gate retained.

Centralized in `shouldTriage` and table-tested (`TestShouldTriageRouting`, `TestTriageRoutingSendsOnlySubset`).

## 3. Deterministic pre-dedup before the LLM

`dedupeFindings` collapses duplicate candidates (by fingerprint, or rule + `file:line`) before any LLM call, so the model is never asked the same question twice — saves tokens, more reproducible. Tested by `TestDedupeFindings` / `TestTriageDedupsBeforeLLM`.

## Verification

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean in the plugin module. All new logic uses the existing mock `LLMClient` — no network in tests.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom