### PR TITLE
feat(agentflow): deterministic agentic-dataflow analyzer (ASI01/ASI02)

### DIFF
--- a/cli/ux.go
+++ b/cli/ux.go
@@ -31,6 +31,8 @@ func familyOf(ruleID string) string {
 		return "License"
 	case strings.HasPrefix(ruleID, "SLOP-"):
 		return "Slopsquatting"
+	case strings.HasPrefix(ruleID, "AGENTFLOW-"):
+		return "Agentic Dataflow"
 	case strings.HasPrefix(ruleID, "AGENT-"):
 		return "Agent Config"
 	case strings.HasPrefix(ruleID, "MCP-"):

--- a/core/analyzers/agentflow/agentflow.go
+++ b/core/analyzers/agentflow/agentflow.go
@@ -1,0 +1,495 @@
+// Package agentflow is Nox's deterministic "agentic dataflow" analyzer: it flags
+// the two prompt-injection-adjacent flows across an AI agent's data path that a
+// single-line rule cannot see, because both require following a value from where
+// it enters to where it is trusted.
+//
+//	AGENTFLOW-001 — untrusted input reaches an LLM prompt (goal hijack).
+//	  External or tool-derived data (an HTTP request, a retrieved/RAG document, a
+//	  tool/function result, a file, an environment variable) flows into a model
+//	  prompt (messages=, prompt=, .chat.completions.create, .messages.create,
+//	  .generate_content) without passing a sanitizer. The model can then be
+//	  steered by attacker-controlled input. Maps to OWASP ASI01 / LLM01.
+//	  (CWE-1427: improper neutralization of input used for LLM prompting.)
+//
+//	AGENTFLOW-002 — LLM output reaches a dangerous sink (excessive agency).
+//	  A model's *response* (the result of an LLM call, and any member of it such
+//	  as .choices[0].message.content or .text) flows into a shell/exec, SQL, eval,
+//	  filesystem, or HTTP sink. The model is trusted to drive a dangerous action;
+//	  a hijacked model then drives it with attacker intent. Maps to OWASP ASI02 /
+//	  LLM07. (CWE-77: the model's output is an untrusted command.)
+//
+// WHY a dedicated analyzer rather than a taint rule: both flows treat the LLM
+// boundary as a first-class node. AGENTFLOW-001 uses the existing untrusted
+// sources but a NEW sink class (the LLM prompt). AGENTFLOW-002 is the genuinely
+// new direction — the LLM CALL RESULT is itself the taint source, which the
+// classic taint catalog does not model (it only treats the prompt as a sink).
+// This analyzer reuses core/taint/engine's Unit extractor (statements with
+// assigns/calls/reads, code-only via core/lexctx) and runs its own forward,
+// straight-line, intraprocedural propagation over those Units.
+//
+// SCOPE AND LIMITS (honest, deterministic first version):
+//   - Python and JS/TS only (whatever core/lexctx lexes as code).
+//   - Intraprocedural and straight-line: source var → prompt arg, and LLM-call
+//     result var → sink arg, within one function body, following simple
+//     reassignment. No cross-function/cross-file flow, no control-flow graph, no
+//     loops/branches merging, no alias or field sensitivity. A taint laundered
+//     through an untracked dict/object is lost (may under-report); a taint that
+//     only exists on one branch is treated as always present (may over-report).
+//   - A recognized sanitizer/validator between source and prompt clears
+//     AGENTFLOW-001; there is no sanitizer notion for AGENTFLOW-002 because
+//     "trusting the model's output in a dangerous sink" has no safe-by-wrapping
+//     form the way input escaping does.
+package agentflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/rules"
+	"github.com/nox-hq/nox/core/taint"
+	"github.com/nox-hq/nox/core/taint/engine"
+)
+
+// Rule IDs emitted by this analyzer. Kept as constants so the analyzer, its
+// Rules() declaration, and tests never drift on the string.
+const (
+	ruleUntrustedToPrompt = "AGENTFLOW-001"
+	ruleOutputToSink      = "AGENTFLOW-002"
+)
+
+// Analyzer runs the agentic-dataflow analysis over source artifacts. It holds
+// the embedded taint catalog so it can reuse the catalog's untrusted-source and
+// dangerous-sink knowledge; the LLM-prompt call set and the LLM-output accessor
+// recognition are agentflow-specific and defined below.
+type Analyzer struct {
+	cat *taint.Catalog
+}
+
+// NewAnalyzer returns an agentflow analyzer backed by the embedded catalog.
+func NewAnalyzer() *Analyzer {
+	return &Analyzer{cat: taint.MustDefault()}
+}
+
+// Rules declares the two agentic-dataflow rules so rule listing, SARIF export,
+// and the skip_analyzer action all know the IDs this analyzer can emit. The
+// descriptions state the honest intraprocedural limit.
+func (a *Analyzer) Rules() *rules.RuleSet {
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID:          ruleUntrustedToPrompt,
+		Version:     "1.0",
+		Description: "Untrusted input reaches an LLM prompt without sanitization (agentic goal hijack, OWASP ASI01 / LLM01)",
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"ai", "agentic", "prompt-injection", "owasp-asi01", "owasp-llm01"},
+		Remediation: "A value derived from untrusted input (an HTTP request, a retrieved/RAG document, a tool/function result, a file, or an environment variable) flows into a model prompt in the same function without sanitization. An attacker who controls that input can steer the model (goal hijack). Keep untrusted content in the user role only, wrap it in explicit boundary markers, validate it against an allowlist, and never place it in the system role. Note: this is intraprocedural analysis — it reasons within one function body only.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/1427.html",
+			"https://genai.owasp.org/llmrisk/llm01-prompt-injection/",
+			"https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-1427", "owasp_asi": "ASI01"},
+	})
+	rs.Add(&rules.Rule{
+		ID:          ruleOutputToSink,
+		Version:     "1.0",
+		Description: "LLM output reaches a dangerous sink without validation (excessive agency, OWASP ASI02 / LLM07)",
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"ai", "agentic", "excessive-agency", "owasp-asi02", "owasp-llm07"},
+		Remediation: "The response from an LLM call flows into a dangerous operation (shell/exec, SQL, eval, filesystem, or outbound HTTP) in the same function. Treating model output as a trusted command is excessive agency: a prompt-injected model then drives that action with attacker intent. Do not pass model output to an interpreter, query, or command directly. Constrain the model to a fixed, validated action set (structured tool calls with schema validation and an allowlist), and add human confirmation for state-changing actions. Note: this is intraprocedural analysis — it reasons within one function body only.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/77.html",
+			"https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/",
+			"https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-77", "owasp_asi": "ASI02"},
+	})
+	return rs
+}
+
+// ScanArtifacts runs the agentic-dataflow analysis over every Source artifact.
+// It is deterministic: artifacts are processed in stable path order and each
+// file's flows are sorted, so the FindingSet is reproducible.
+func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
+	fs := findings.NewFindingSet()
+
+	ordered := make([]discovery.Artifact, len(artifacts))
+	copy(ordered, artifacts)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Path < ordered[j].Path })
+
+	for i := range ordered {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		art := ordered[i]
+		if art.Type != discovery.Source {
+			continue
+		}
+		lang := lexctx.LangFromPath(art.Path)
+		if lang == lexctx.LangUnknown {
+			continue // Python and JS/TS only
+		}
+		content, err := os.ReadFile(art.AbsPath)
+		if err != nil {
+			continue
+		}
+		a.scanFile(fs, art.Path, lang, content)
+	}
+	return fs, nil
+}
+
+// scanFile extracts Units (reusing the taint engine's extractor) and runs both
+// flow analyses over each Unit, deduplicating per (rule, line).
+func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, lang lexctx.Lang, content []byte) {
+	units := engine.ExtractUnits(path, lang, content)
+	seen := map[string]struct{}{}
+	add := func(f *findings.Finding) {
+		key := fmt.Sprintf("%s:%d", f.RuleID, f.Location.StartLine)
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
+		fs.Add(*f)
+	}
+	for i := range units {
+		flows := a.analyzeUnit(&units[i])
+		for j := range flows {
+			add(&flows[j])
+		}
+	}
+}
+
+// analyzeUnit runs one forward pass over a Unit's statements, tracking two taint
+// colors at once so a single walk finds both flows:
+//
+//	"untrusted" — a value derived from a catalog untrusted source. Reaching an
+//	  LLM-prompt call fires AGENTFLOW-001. Cleared by a catalog sanitizer.
+//	"llmout"    — a value derived from an LLM call's result. Reaching a dangerous
+//	  sink fires AGENTFLOW-002. Not cleared by input sanitizers (they do not make
+//	  model output safe to execute).
+//
+// The two colors are independent maps so a variable can carry either or both.
+// Straight-line, intraprocedural, following simple reassignment only.
+func (a *Analyzer) analyzeUnit(unit *taint.Unit) []findings.Finding {
+	lang := unit.Language
+	// untrusted[var] = origin source that tainted it.
+	untrusted := map[string]taint.Source{}
+	untrustedLine := map[string]int{}
+	// llmout[var] = line of the LLM call that produced it.
+	llmout := map[string]int{}
+
+	var out []findings.Finding
+
+	for i := range unit.Stmts {
+		st := &unit.Stmts[i]
+
+		// 1) AGENTFLOW-001: an untrusted variable reaching an LLM-prompt call.
+		for _, rawCall := range st.Calls {
+			if !isPromptCall(rawCall) {
+				continue
+			}
+			// If a sanitizer wraps the value at the call site, treat it as cleared.
+			inlineSafe := a.stmtHasSanitizer(lang, st)
+			for _, v := range promptArgVars(st, rawCall) {
+				src, ok := untrusted[v]
+				if !ok || inlineSafe {
+					continue
+				}
+				out = append(out, a.untrustedToPromptFinding(unit, st, rawCall, v, src, untrustedLine[v]))
+				break
+			}
+		}
+
+		// 2) AGENTFLOW-002: an LLM-output variable reaching a dangerous sink.
+		for _, rawCall := range st.Calls {
+			sink, ok := a.resolveDangerousSink(lang, rawCall)
+			if !ok {
+				continue
+			}
+			for _, v := range sinkArgVars(st, rawCall) {
+				line, ok := llmout[v]
+				if !ok {
+					continue
+				}
+				out = append(out, a.outputToSinkFinding(unit, st, rawCall, v, &sink, line))
+				break
+			}
+		}
+
+		// 3) Propagation into the assignee.
+		if st.Assigns == "" {
+			continue
+		}
+
+		// An LLM call assigned to a variable makes that variable LLM-output. This
+		// takes precedence: `r = client.chat.completions.create(...)` colors r.
+		if stmtCallsLLM(st) {
+			llmout[st.Assigns] = st.Line
+			// The prompt of that call may itself be untrusted, but the RESULT is
+			// not untrusted input — clear any inherited untrusted color on the LHS.
+			delete(untrusted, st.Assigns)
+			delete(untrustedLine, st.Assigns)
+			continue
+		}
+
+		// An untrusted source assigned to a variable colors it untrusted afresh.
+		if src, ok := a.resolveUntrustedSource(lang, st); ok {
+			untrusted[st.Assigns] = src
+			untrustedLine[st.Assigns] = st.Line
+			delete(llmout, st.Assigns)
+			continue
+		}
+
+		// Otherwise propagate whichever color(s) the RHS reads carry. A sanitizer
+		// call in this statement clears the untrusted color (input sanitizers do
+		// not clear the llmout color).
+		sanitized := a.stmtHasSanitizer(lang, st)
+		var carriedUntrusted *taint.Source
+		var carriedUntrustedLine int
+		carriedLLMLine := -1
+		for _, v := range st.Reads {
+			if src, ok := untrusted[v]; ok && carriedUntrusted == nil {
+				s := src
+				carriedUntrusted = &s
+				carriedUntrustedLine = untrustedLine[v]
+			}
+			if line, ok := llmout[v]; ok && carriedLLMLine == -1 {
+				carriedLLMLine = line
+			}
+		}
+
+		switch {
+		case sanitized || carriedUntrusted == nil:
+			delete(untrusted, st.Assigns)
+			delete(untrustedLine, st.Assigns)
+		default:
+			untrusted[st.Assigns] = *carriedUntrusted
+			untrustedLine[st.Assigns] = carriedUntrustedLine
+		}
+		if carriedLLMLine >= 0 {
+			llmout[st.Assigns] = carriedLLMLine
+		} else {
+			delete(llmout, st.Assigns)
+		}
+	}
+
+	sortFindings(out)
+	return out
+}
+
+// resolveUntrustedSource returns the untrusted source introduced by st, matching
+// its call chains and bare attribute chains against the catalog by dotted suffix.
+// It deliberately EXCLUDES the LLM-prompt sinks that the catalog also lists as
+// prompt_injection sinks (those are prompt destinations, not untrusted origins).
+func (a *Analyzer) resolveUntrustedSource(lang string, st *taint.Statement) (taint.Source, bool) {
+	for _, rawCall := range st.Calls {
+		for _, key := range suffixKeys(rawCall) {
+			if s, ok := a.cat.Source(lang, key); ok {
+				return s, true
+			}
+		}
+	}
+	for _, chain := range st.Chains {
+		for _, key := range suffixKeys(chain) {
+			if s, ok := a.cat.Source(lang, key); ok {
+				return s, true
+			}
+		}
+	}
+	return taint.Source{}, false
+}
+
+// resolveDangerousSink resolves a raw call to a catalog sink that is dangerous
+// for LLM output — every sink class EXCEPT prompt_injection (the LLM prompt is
+// not a "dangerous action driven by the model"; it is the model's own input).
+func (a *Analyzer) resolveDangerousSink(lang, rawCall string) (taint.Sink, bool) {
+	for _, key := range suffixKeys(rawCall) {
+		if s, ok := a.cat.IsSink(lang, key); ok {
+			if s.VulnClass == taint.VulnPromptInjection {
+				return taint.Sink{}, false
+			}
+			return s, true
+		}
+	}
+	return taint.Sink{}, false
+}
+
+// stmtHasSanitizer reports whether any call in st is a recognized catalog
+// sanitizer/validator (for any vuln class). It is the AGENTFLOW-001 clearing
+// signal: an untrusted value that passes through a validator before the prompt
+// is treated as no longer attacker-controlled.
+func (a *Analyzer) stmtHasSanitizer(lang string, st *taint.Statement) bool {
+	for _, rawCall := range st.Calls {
+		for _, key := range suffixKeys(rawCall) {
+			for _, class := range allVulnClasses {
+				if a.cat.IsSanitizer(lang, key, class) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// untrustedToPromptFinding builds the AGENTFLOW-001 finding at the prompt call.
+func (a *Analyzer) untrustedToPromptFinding(unit *taint.Unit, st *taint.Statement, call, srcVar string, src taint.Source, srcLine int) findings.Finding {
+	msg := fmt.Sprintf(
+		"Untrusted input (%s via %q) reaches LLM prompt call %q without sanitization — the model can be goal-hijacked (ASI01).",
+		src.Kind, srcVar, call,
+	)
+	return findings.Finding{
+		RuleID:     ruleUntrustedToPrompt,
+		Severity:   findings.SeverityHigh,
+		Confidence: findings.ConfidenceMedium,
+		Location:   findings.Location{FilePath: unit.FilePath, StartLine: st.Line, EndLine: st.Line},
+		Message:    msg,
+		Metadata: map[string]string{
+			"cwe":         "CWE-1427",
+			"owasp_asi":   "ASI01",
+			"flow":        "untrusted_input->llm_prompt",
+			"prompt_call": call,
+			"source_kind": string(src.Kind),
+			"source_call": src.Call,
+			"source_var":  srcVar,
+			"source_line": fmt.Sprintf("%d", srcLine),
+			"function":    unit.FuncName,
+		},
+	}
+}
+
+// outputToSinkFinding builds the AGENTFLOW-002 finding at the dangerous sink.
+func (a *Analyzer) outputToSinkFinding(unit *taint.Unit, st *taint.Statement, call, outVar string, sink *taint.Sink, llmLine int) findings.Finding {
+	msg := fmt.Sprintf(
+		"LLM output (via %q) reaches %s sink %q without validation — excessive agency lets a hijacked model drive a dangerous action (ASI02, %s).",
+		outVar, sink.VulnClass, call, sink.CWE,
+	)
+	return findings.Finding{
+		RuleID:     ruleOutputToSink,
+		Severity:   findings.SeverityHigh,
+		Confidence: findings.ConfidenceMedium,
+		Location:   findings.Location{FilePath: unit.FilePath, StartLine: st.Line, EndLine: st.Line},
+		Message:    msg,
+		Metadata: map[string]string{
+			"cwe":        "CWE-77",
+			"sink_cwe":   sink.CWE,
+			"owasp_asi":  "ASI02",
+			"flow":       "llm_output->dangerous_sink",
+			"sink":       sink.Call,
+			"vuln_class": string(sink.VulnClass),
+			"llm_var":    outVar,
+			"llm_line":   fmt.Sprintf("%d", llmLine),
+			"function":   unit.FuncName,
+		},
+	}
+}
+
+// promptArgVars returns the variables that reach an LLM-prompt call. Prompt
+// content can arrive positionally, as a keyword (messages=, prompt=,
+// contents=), or nested in a message list literal; the extractor's per-call
+// arg vars (which include the head of any dotted chain) capture all of these,
+// so we prefer them and fall back to the whole statement's reads.
+func promptArgVars(st *taint.Statement, rawCall string) []string {
+	return sinkArgVars(st, rawCall)
+}
+
+// sinkArgVars returns the variables passed as arguments to a specific call,
+// preferring the extractor's precise per-call arg vars and falling back to the
+// statement's whole Reads set when none were captured.
+func sinkArgVars(st *taint.Statement, rawCall string) []string {
+	if st.SinkArgs != nil {
+		if info, ok := st.SinkArgs[rawCall]; ok && len(info.TaintedArgVars) > 0 {
+			return info.TaintedArgVars
+		}
+		for _, key := range suffixKeys(rawCall) {
+			if info, ok := st.SinkArgs[key]; ok && len(info.TaintedArgVars) > 0 {
+				return info.TaintedArgVars
+			}
+		}
+	}
+	return st.Reads
+}
+
+// stmtCallsLLM reports whether st invokes an LLM call whose result is a model
+// response worth tracking as output taint.
+func stmtCallsLLM(st *taint.Statement) bool {
+	for _, rawCall := range st.Calls {
+		if isPromptCall(rawCall) {
+			return true
+		}
+	}
+	return false
+}
+
+// llmPromptCalls is the set of model-invocation call suffixes recognized as the
+// LLM boundary, shared by both flows: AGENTFLOW-001 treats them as the prompt
+// SINK, and AGENTFLOW-002 treats their RESULT as the output SOURCE. Matched by
+// dotted-suffix so framework/aliased prefixes resolve (openai.chat.completions.
+// create → chat.completions.create). Kept as an explicit set — not derived from
+// the taint catalog's prompt_injection sinks — so embedding calls (which do not
+// produce steerable text output) are excluded from the AGENTFLOW-002 source set.
+var llmPromptCalls = map[string]struct{}{
+	"chat.completions.create": {},
+	"completions.create":      {},
+	"ChatCompletion.create":   {},
+	"messages.create":         {},
+	"messages.stream":         {},
+	"generate_content":        {},
+	"generateContent":         {},
+	"litellm.completion":      {},
+	"invoke_model":            {},
+	"converse":                {},
+}
+
+// isPromptCall reports whether a raw call chain is an LLM model invocation.
+func isPromptCall(rawCall string) bool {
+	for _, key := range suffixKeys(rawCall) {
+		if _, ok := llmPromptCalls[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// suffixKeys returns the dotted suffixes of a call chain, longest first, so a
+// prefixed/aliased chain resolves to the catalog's canonical suffix. Mirrors the
+// engine's own suffix matching (kept local to avoid exporting engine internals).
+func suffixKeys(chain string) []string {
+	parts := strings.Split(chain, ".")
+	out := make([]string, 0, len(parts))
+	for i := range parts {
+		out = append(out, strings.Join(parts[i:], "."))
+	}
+	return out
+}
+
+// allVulnClasses is the fixed class set consulted when checking whether a call
+// is any sanitizer. Ordered deterministically.
+var allVulnClasses = []taint.VulnClass{
+	taint.VulnCommandInjection,
+	taint.VulnSQLInjection,
+	taint.VulnCodeInjection,
+	taint.VulnXSS,
+	taint.VulnSSTI,
+	taint.VulnPathTraversal,
+	taint.VulnSSRF,
+	taint.VulnUnsafeDeserialization,
+	taint.VulnPromptInjection,
+}
+
+// sortFindings orders findings deterministically by line, then rule ID, so
+// repeated runs over one Unit produce identical output.
+func sortFindings(fs []findings.Finding) {
+	sort.SliceStable(fs, func(i, j int) bool {
+		if fs[i].Location.StartLine != fs[j].Location.StartLine {
+			return fs[i].Location.StartLine < fs[j].Location.StartLine
+		}
+		return fs[i].RuleID < fs[j].RuleID
+	})
+}

--- a/core/analyzers/agentflow/agentflow_test.go
+++ b/core/analyzers/agentflow/agentflow_test.go
@@ -1,0 +1,304 @@
+package agentflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scan writes one source file and returns the rule IDs the analyzer emits, in
+// deterministic finding order. The filename's extension drives the language.
+func scan(t *testing.T, name, content string) []findings.Finding {
+	t.Helper()
+	root := t.TempDir()
+	abs := filepath.Join(root, name)
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	art := discovery.Artifact{Path: name, AbsPath: abs, Type: discovery.Source}
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(), []discovery.Artifact{art})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+// ruleIDs projects a finding slice to its rule IDs.
+func ruleIDs(fs []findings.Finding) []string {
+	out := make([]string, 0, len(fs))
+	for i := range fs {
+		out = append(out, fs[i].RuleID)
+	}
+	return out
+}
+
+// has reports whether ruleID appears among the findings.
+func has(fs []findings.Finding, ruleID string) bool {
+	for i := range fs {
+		if fs[i].RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAgentflow(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		src     string
+		want    string // rule expected to fire ("" = expect nothing)
+		notWant string // rule that must NOT fire
+	}{
+		// -------- AGENTFLOW-001: untrusted input -> LLM prompt --------
+		{
+			name: "python request arg into chat completion messages",
+			file: "app.py",
+			src: `def handler():
+    q = request.args.get("q")
+    openai.chat.completions.create(messages=[{"role": "user", "content": q}])
+`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			name: "python env var into anthropic messages create",
+			file: "agent.py",
+			src: `def run():
+    ctx = os.getenv("CTX")
+    client.messages.create(model="claude", messages=[{"role": "user", "content": ctx}])
+`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			name: "python fetched external content into gemini prompt (indirect injection)",
+			file: "rag.py",
+			src: `def ask():
+    doc = urllib.request.urlopen(url)
+    model.generate_content(doc)
+`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			name: "js req body into chat completion",
+			file: "route.ts",
+			src: `function handler(req) {
+  const q = req.body;
+  openai.chat.completions.create({ messages: [{ role: "user", content: q }] });
+}`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			name: "python untrusted propagated through reassignment",
+			file: "prop.py",
+			src: `def h():
+    raw = request.form.get("m")
+    prompt = raw
+    openai.chat.completions.create(messages=[{"role": "user", "content": prompt}])
+`,
+			want: ruleUntrustedToPrompt,
+		},
+
+		// -------- AGENTFLOW-002: LLM output -> dangerous sink --------
+		{
+			name: "python llm output into os.system",
+			file: "exec.py",
+			src: `def act():
+    r = client.chat.completions.create(model="gpt-4", messages=[{"role": "user", "content": "hi"}])
+    os.system(r.choices[0].message.content)
+`,
+			want: ruleOutputToSink,
+		},
+		{
+			name: "python llm output into cursor execute",
+			file: "sql.py",
+			src: `def act():
+    r = openai.chat.completions.create(messages=[])
+    cursor.execute(r.choices[0].message.content)
+`,
+			want: ruleOutputToSink,
+		},
+		{
+			name: "python llm output into eval",
+			file: "eval.py",
+			src: `def act():
+    out = model.generate_content("do math")
+    eval(out.text)
+`,
+			want: ruleOutputToSink,
+		},
+		{
+			name: "js llm output into child_process exec",
+			file: "shell.ts",
+			src: `async function act() {
+  const r = await openai.chat.completions.create({ messages: [] });
+  child_process.exec(r.choices[0].message.content);
+}`,
+			want: ruleOutputToSink,
+		},
+		{
+			name: "python llm output propagated then executed",
+			file: "prop2.py",
+			src: `def act():
+    r = client.chat.completions.create(messages=[])
+    cmd = r.choices[0].message.content
+    os.system(cmd)
+`,
+			want: ruleOutputToSink,
+		},
+
+		// -------- No-fire cases --------
+		{
+			name: "hardcoded constant prompt does not fire",
+			file: "const.py",
+			src: `def h():
+    prompt = "summarize the following report"
+    openai.chat.completions.create(messages=[{"role": "user", "content": prompt}])
+`,
+			want:    "",
+			notWant: ruleUntrustedToPrompt,
+		},
+		{
+			name: "llm output only printed does not fire 002",
+			file: "print.py",
+			src: `def h():
+    r = client.chat.completions.create(messages=[])
+    print(r.choices[0].message.content)
+`,
+			want:    "",
+			notWant: ruleOutputToSink,
+		},
+		{
+			name: "llm output only returned does not fire 002",
+			file: "ret.py",
+			src: `def h():
+    r = client.chat.completions.create(messages=[])
+    return r.choices[0].message.content
+`,
+			want:    "",
+			notWant: ruleOutputToSink,
+		},
+		{
+			name: "sanitized input before prompt does not fire 001",
+			file: "san.py",
+			src: `def h():
+    q = request.args.get("q")
+    safe = shlex.quote(q)
+    openai.chat.completions.create(messages=[{"role": "user", "content": safe}])
+`,
+			want:    "",
+			notWant: ruleUntrustedToPrompt,
+		},
+		{
+			name: "unrelated untrusted-to-classic-sink does not fire agentflow",
+			file: "classic.py",
+			src: `def h():
+    q = request.args.get("q")
+    os.system(q)
+`,
+			want:    "",
+			notWant: ruleUntrustedToPrompt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := scan(t, tt.file, tt.src)
+			if tt.want != "" && !has(fs, tt.want) {
+				t.Errorf("expected %s to fire, got %v", tt.want, ruleIDs(fs))
+			}
+			if tt.notWant != "" && has(fs, tt.notWant) {
+				t.Errorf("expected %s NOT to fire, got %v", tt.notWant, ruleIDs(fs))
+			}
+			if tt.want == "" && tt.notWant == "" && len(fs) != 0 {
+				t.Errorf("expected no findings, got %v", ruleIDs(fs))
+			}
+		})
+	}
+}
+
+// TestDeterminism verifies repeated scans of the same source yield byte-identical
+// finding order and content — the offline/deterministic guarantee.
+func TestDeterminism(t *testing.T) {
+	src := `def handler():
+    q = request.args.get("q")
+    r = openai.chat.completions.create(messages=[{"role": "user", "content": q}])
+    os.system(r.choices[0].message.content)
+`
+	first := ruleIDs(scan(t, "det.py", src))
+	for i := 0; i < 5; i++ {
+		got := ruleIDs(scan(t, "det.py", src))
+		if !reflect.DeepEqual(first, got) {
+			t.Fatalf("nondeterministic output: %v vs %v", first, got)
+		}
+	}
+	// This file exercises both flows; both rules must be present.
+	if !has(scan(t, "det.py", src), ruleUntrustedToPrompt) {
+		t.Errorf("expected %s in combined flow", ruleUntrustedToPrompt)
+	}
+	if !has(scan(t, "det.py", src), ruleOutputToSink) {
+		t.Errorf("expected %s in combined flow", ruleOutputToSink)
+	}
+}
+
+// TestRulesDeclared verifies Rules() declares exactly the two IDs the analyzer
+// emits, with the ASI tags the fleet convention expects.
+func TestRulesDeclared(t *testing.T) {
+	rs := NewAnalyzer().Rules()
+	byID := map[string]bool{}
+	for _, r := range rs.Rules() {
+		byID[r.ID] = true
+	}
+	for _, id := range []string{ruleUntrustedToPrompt, ruleOutputToSink} {
+		if !byID[id] {
+			t.Errorf("Rules() missing %s", id)
+		}
+	}
+	// Tag convention check: 001 -> asi01, 002 -> asi02.
+	for _, r := range rs.Rules() {
+		wantTag := ""
+		switch r.ID {
+		case ruleUntrustedToPrompt:
+			wantTag = "owasp-asi01"
+		case ruleOutputToSink:
+			wantTag = "owasp-asi02"
+		}
+		found := false
+		for _, tag := range r.Tags {
+			if tag == wantTag {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s missing tag %s (tags: %v)", r.ID, wantTag, r.Tags)
+		}
+	}
+}
+
+// TestMetadataCarriesTriage verifies findings carry the source/sink triage
+// metadata callers rely on for explanation.
+func TestMetadataCarriesTriage(t *testing.T) {
+	fs := scan(t, "meta.py", `def h():
+    q = request.args.get("q")
+    openai.chat.completions.create(messages=[{"role": "user", "content": q}])
+`)
+	var f *findings.Finding
+	for i := range fs {
+		if fs[i].RuleID == ruleUntrustedToPrompt {
+			f = &fs[i]
+		}
+	}
+	if f == nil {
+		t.Fatalf("no %s finding", ruleUntrustedToPrompt)
+	}
+	if f.Metadata["source_var"] != "q" {
+		t.Errorf("source_var = %q, want q", f.Metadata["source_var"])
+	}
+	if f.Metadata["owasp_asi"] != "ASI01" {
+		t.Errorf("owasp_asi = %q, want ASI01", f.Metadata["owasp_asi"])
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/nox-hq/nox/core/analyzers/agentflow"
 	"github.com/nox-hq/nox/core/analyzers/ai"
 	"github.com/nox-hq/nox/core/analyzers/data"
 	"github.com/nox-hq/nox/core/analyzers/deps"
@@ -200,6 +201,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	slopAnalyzer := slop.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
 	taintflowAnalyzer := taintflow.NewAnalyzer()
+	agentflowAnalyzer := agentflow.NewAnalyzer()
 	provenanceAnalyzer := provenance.NewAnalyzer()
 
 	// Per-analyzer result collectors.
@@ -295,6 +297,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			return nil
 		},
 		func(c context.Context) error {
+			fs, err := agentflowAnalyzer.ScanArtifacts(c, artifacts)
+			if err != nil {
+				return err
+			}
+			addFindings(fs)
+			return nil
+		},
+		func(c context.Context) error {
 			fs, err := provenanceAnalyzer.ScanArtifacts(c, artifacts)
 			if err != nil {
 				return err
@@ -356,6 +366,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		allRules.Add(r)
 	}
 	for _, r := range taintflowAnalyzer.Rules().Rules() {
+		allRules.Add(r)
+	}
+	for _, r := range agentflowAnalyzer.Rules().Rules() {
 		allRules.Add(r)
 	}
 	for _, r := range provenanceAnalyzer.Rules().Rules() {
@@ -1009,6 +1022,8 @@ func analyzerRulePatterns(analyzer string) []string {
 		return []string{"VARIANT-*"}
 	case "taintflow":
 		return []string{"TAINT-*"}
+	case "agentflow":
+		return []string{"AGENTFLOW-*"}
 	case "provenance":
 		return []string{"PROV-*"}
 	default:


### PR DESCRIPTION
## What

Adds `core/analyzers/agentflow`, Nox's differentiated **agentic dataflow** lane: a deterministic, offline, pure-Go analyzer that flags the two prompt-injection-adjacent flows across an AI agent's data path that a single-line rule cannot see, because both require following a value from where it enters to where it is trusted.

### The two flows

| Rule | Flow | OWASP | CWE |
|------|------|-------|-----|
| **AGENTFLOW-001** | Untrusted input → LLM prompt (goal hijack) | ASI01 / LLM01 | CWE-1427 |
| **AGENTFLOW-002** | LLM output → dangerous sink (excessive agency) | ASI02 / LLM07 | CWE-77 |

- **AGENTFLOW-001** — external/tool-derived data (HTTP request, fetched/RAG content, file, env) flows into a model prompt call (`chat.completions.create`, `messages.create`, `generate_content`, ...) without sanitization → the model can be steered by attacker input.
- **AGENTFLOW-002** — the genuinely new direction: a model's *response* (the result of an LLM call, and any member such as `.choices[0].message.content` or `.text`) flows into a shell/exec, SQL, eval, filesystem, or HTTP sink. The **LLM call result is the taint source**, which the classic taint catalog does not model.

## How (reuse, not reinvent)

- Reuses `core/taint/engine.ExtractUnits` (code-only extraction via `core/lexctx`) and the embedded `core/taint` catalog for untrusted **sources**, dangerous **sinks** (all classes except `prompt_injection`), and input **sanitizers**.
- Runs its own forward, straight-line, intraprocedural **two-color** propagation (`untrusted` / `llm-output`) over the Units in a single pass. Python + JS/TS.
- Wired into `core/scan.go` (init, task, rule merge, `analyzerRulePatterns` → `AGENTFLOW-*`) and `cli/ux.go` `familyOf` → **"Agentic Dataflow"**.

## What fires / doesn't

**Fires:** untrusted→prompt (request/env/file/fetched-URL); LLM output→`os.system`/`cursor.execute`/`eval`/`child_process.exec`; propagation through simple reassignment; JS/TS equivalents.

**Does not fire:** constant prompt; LLM output only `print`/`return`ed; sanitized input (`shlex.quote`) before prompt; classic untrusted→non-LLM sink (taintflow's job).

## Honest limits

Intraprocedural, straight-line, simple reassignment only. No cross-function/file flow, no CFG/alias/field sensitivity. Laundering through an untracked structure under-reports; a one-branch taint over-reports.

## Tests

Table-driven: both TP flows (Python + JS/TS), four no-fire cases, determinism, `Rules()` declaration with ASI tags, triage metadata. `go build ./... && go test ./core/... ./cli/...` green; `golangci-lint run core/analyzers/agentflow/...` clean. E2E scan reports `Agentic Dataflow:2`.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom