### PR TITLE
feat(taint): same-file interprocedural taint via function summaries

### DIFF
--- a/core/analyzers/taintflow/taintflow.go
+++ b/core/analyzers/taintflow/taintflow.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
@@ -147,11 +148,14 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 // does not double-report.
 func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, lang lexctx.Lang, content []byte) {
 	units := engine.ExtractUnits(path, lang, content)
-	for i := range units {
-		flows := a.eng.Analyze(units[i])
-		for j := range flows {
-			fs.Add(a.toFinding(&flows[j]))
-		}
+	// AnalyzeFile runs the whole file at once so it can join a source in one
+	// function to a sink reached through a locally-defined helper (SAME-FILE
+	// interprocedural flow via function summaries), in addition to the
+	// intraprocedural flows Analyze finds. It de-duplicates a source→sink pair
+	// reachable both ways, so a purely intraprocedural bug is still reported once.
+	flows := a.eng.AnalyzeFile(units)
+	for j := range flows {
+		fs.Add(a.toFinding(&flows[j]))
 	}
 }
 
@@ -161,10 +165,36 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, lang lexctx.La
 // source line.
 func (a *Analyzer) toFinding(flow *taint.Flow) findings.Finding {
 	sink := flow.Sink
-	msg := fmt.Sprintf(
-		"Untrusted input (%s via %q) reaches %s sink %q without sanitization — %s.",
-		flow.Source.Kind, flow.SourceVar, sink.VulnClass, sink.Call, sink.CWE,
-	)
+	var msg string
+	if len(flow.Via) > 0 {
+		// Cross-function flow: name the intermediate helper(s) so triage can follow
+		// the path from the caller's source through the summarized helper(s) to the
+		// sink.
+		msg = fmt.Sprintf(
+			"Untrusted input (%s via %q) reaches %s sink %q through %s without sanitization — %s.",
+			flow.Source.Kind, flow.SourceVar, sink.VulnClass, sink.Call,
+			viaPath(flow.Via), sink.CWE,
+		)
+	} else {
+		msg = fmt.Sprintf(
+			"Untrusted input (%s via %q) reaches %s sink %q without sanitization — %s.",
+			flow.Source.Kind, flow.SourceVar, sink.VulnClass, sink.Call, sink.CWE,
+		)
+	}
+	meta := map[string]string{
+		"cwe":         sink.CWE,
+		"vuln_class":  string(sink.VulnClass),
+		"sink":        sink.Call,
+		"source_kind": string(flow.Source.Kind),
+		"source_call": flow.Source.Call,
+		"source_var":  flow.SourceVar,
+		"source_line": fmt.Sprintf("%d", flow.SourceLine),
+		"function":    flow.FuncName,
+	}
+	if len(flow.Via) > 0 {
+		meta["interprocedural"] = "true"
+		meta["via"] = strings.Join(flow.Via, " -> ")
+	}
 	return findings.Finding{
 		RuleID:     sink.RuleID,
 		Severity:   severityForClass(sink.VulnClass),
@@ -174,16 +204,17 @@ func (a *Analyzer) toFinding(flow *taint.Flow) findings.Finding {
 			StartLine: flow.SinkLine,
 			EndLine:   flow.SinkLine,
 		},
-		Message: msg,
-		Metadata: map[string]string{
-			"cwe":         sink.CWE,
-			"vuln_class":  string(sink.VulnClass),
-			"sink":        sink.Call,
-			"source_kind": string(flow.Source.Kind),
-			"source_call": flow.Source.Call,
-			"source_var":  flow.SourceVar,
-			"source_line": fmt.Sprintf("%d", flow.SourceLine),
-			"function":    flow.FuncName,
-		},
+		Message:  msg,
+		Metadata: meta,
 	}
+}
+
+// viaPath renders a cross-function path for a finding message, e.g.
+// `helper "wrap" -> "run"` for a two-hop chain.
+func viaPath(via []string) string {
+	quoted := make([]string, len(via))
+	for i, v := range via {
+		quoted[i] = fmt.Sprintf("%q", v)
+	}
+	return "helper " + strings.Join(quoted, " -> ")
 }

--- a/core/analyzers/taintflow/taintflow_test.go
+++ b/core/analyzers/taintflow/taintflow_test.go
@@ -140,6 +140,57 @@ func TestAnalyzerDeterministicAcrossFiles(t *testing.T) {
 	}
 }
 
+func TestAnalyzerInterproceduralCommandInjection(t *testing.T) {
+	// Cross-function: the sink lives in a helper, the tainted value is produced in
+	// the handler and handed to the helper. The finding must fire and its metadata
+	// must record the interprocedural path through the helper.
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "app.py", `def run(c):
+    os.system(c)
+
+def handler():
+    cmd = request.args.get("x")
+    run(cmd)
+`)
+	a := NewAnalyzer()
+	fs, err := a.ScanArtifacts(context.Background(), []discovery.Artifact{art})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	items := fs.Findings()
+	if len(items) != 1 || items[0].RuleID != "TAINT-002" {
+		t.Fatalf("want one TAINT-002 finding, got %+v", items)
+	}
+	f := items[0]
+	if f.Metadata["interprocedural"] != "true" {
+		t.Errorf("interprocedural metadata = %q, want true", f.Metadata["interprocedural"])
+	}
+	if f.Metadata["via"] != "run" {
+		t.Errorf("via metadata = %q, want run", f.Metadata["via"])
+	}
+	// The finding is located at the call site (line 6, `run(cmd)`) — the
+	// actionable line in the caller where untrusted data is handed to the helper.
+	// The message and `via` metadata name the helper whose body holds the sink.
+	if f.Location.StartLine != 6 {
+		t.Errorf("sink line = %d, want 6 (the run(cmd) call site)", f.Location.StartLine)
+	}
+}
+
+func TestAnalyzerInterproceduralSanitizedNoFinding(t *testing.T) {
+	// The helper sanitizes its argument before the sink: no finding.
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "app.py", `def run(c):
+    os.system(shlex.quote(c))
+
+def handler():
+    cmd = request.args.get("x")
+    run(cmd)
+`)
+	if ids := scan(t, art); len(ids) != 0 {
+		t.Fatalf("want no findings (sanitized in helper), got %v", ids)
+	}
+}
+
 func TestAnalyzerRules(t *testing.T) {
 	rs := NewAnalyzer().Rules()
 	want := map[string]bool{"TAINT-001": false, "TAINT-002": false, "TAINT-005": false}

--- a/core/taint/engine.go
+++ b/core/taint/engine.go
@@ -34,6 +34,11 @@ type Statement struct {
 	// only the StructuralEngine consults it. Absent (nil) means "unknown", which
 	// the StructuralEngine treats conservatively (the call is dangerous).
 	SinkArgs map[string]SinkArgInfo
+	// Returns are the variable names this statement returns (a `return x` or
+	// `return a, b`). Populated by the substrate so the interprocedural summary
+	// pass can decide whether a parameter flows to a function's return value.
+	// Empty for non-return statements. The intraprocedural engine ignores it.
+	Returns []string
 }
 
 // SinkArgInfo is the argument-shape evidence a substrate extracts at a specific
@@ -55,6 +60,12 @@ type SinkArgInfo struct {
 	// positional argument. For cursor.execute the SQL string is arg 0; a tainted
 	// value only in arg 1 (the params tuple) is the SAFE parameterized form.
 	FirstArgTainted bool
+	// PositionalVars lists, per positional argument slot (index 0 = first
+	// positional), the variable identifiers appearing in that slot. It lets the
+	// interprocedural summary pass map a caller's argument position to the
+	// callee's parameter of the same index. Keyword arguments are excluded (they
+	// have no fixed position). Best-effort; empty when unobserved.
+	PositionalVars [][]string
 }
 
 // Unit is a single intraprocedural scope (typically one function body) presented
@@ -65,6 +76,12 @@ type Unit struct {
 	FuncName string
 	Language string
 	Stmts    []Statement
+	// Params are the positional parameter names of this function, in declaration
+	// order, so the interprocedural summary pass can map a caller's argument
+	// position to the parameter the callee reasons over. Empty for the module
+	// unit and for functions with no parameters. The intraprocedural engine
+	// ignores it.
+	Params []string
 }
 
 // Flow is a reported source-to-sink taint path within a Unit. It is the engine's
@@ -80,6 +97,11 @@ type Flow struct {
 	FilePath   string
 	FuncName   string
 	Language   string
+	// Via names the intermediate, locally-defined functions a cross-function
+	// (interprocedural) flow passes through, from the caller toward the sink
+	// (e.g. ["wrap", "run"]). Empty for a purely intraprocedural flow. It lets a
+	// finding explain the summary-composed path. Deterministically ordered.
+	Via []string
 }
 
 // TaintEngine analyzes one intraprocedural Unit and returns the taint flows that
@@ -132,6 +154,8 @@ func NewHeuristicEngine(cat *Catalog) TaintEngine {
 }
 
 // Analyze implements TaintEngine with the documented same-scope heuristic.
+//
+//nolint:gocritic // Analyze(unit Unit) is the TaintEngine interface signature; the value parameter cannot be a pointer.
 func (e *heuristicEngine) Analyze(unit Unit) []Flow {
 	// tainted maps a tainted variable to the Source and line that introduced it.
 	type origin struct {
@@ -141,7 +165,8 @@ func (e *heuristicEngine) Analyze(unit Unit) []Flow {
 	tainted := make(map[string]origin)
 	var flows []Flow
 
-	for _, st := range unit.Stmts {
+	for i := range unit.Stmts {
+		st := unit.Stmts[i]
 		// A statement carrying a sanitizer call clears taint on its assignee.
 		// WHY conservative (any sanitizer clears): without the substrate we do
 		// not know which sink class the value will reach, so we treat any

--- a/core/taint/engine/args.go
+++ b/core/taint/engine/args.go
@@ -34,7 +34,15 @@ func argInfo(lang langKind, c callChain) sinkArgDraft {
 		// must capture (subprocess.run(["ls", cmd]) is safe; subprocess.run(cmd)
 		// is not).
 		firstIsVector := idx == 0 && strings.HasPrefix(trimmed, "[")
-		for _, id := range freeIdentifiers(lang, p) {
+		slotVars := freeIdentifiers(lang, p)
+		// Record the positional slot's variables so the interprocedural pass can
+		// map argument position → callee parameter. Keyword args occupy no fixed
+		// position and are excluded, so positionalVars[i] is the i-th POSITIONAL
+		// argument's variables.
+		if !isKeywordArg(p) {
+			info.positionalVars = append(info.positionalVars, append([]string(nil), slotVars...))
+		}
+		for _, id := range slotVars {
 			if _, dup := seen[id]; !dup {
 				seen[id] = struct{}{}
 				info.taintedArgVars = append(info.taintedArgVars, id)

--- a/core/taint/engine/extract.go
+++ b/core/taint/engine/extract.go
@@ -27,7 +27,11 @@ import (
 // stays an implementation detail of this package.
 type unitDraft struct {
 	funcName string
-	stmts    []stmtDraft
+	// params are the positional parameter names of the function, in declaration
+	// order. Empty for the module unit. Used by the interprocedural summary pass
+	// to map a caller argument position to the callee parameter it binds.
+	params []string
+	stmts  []stmtDraft
 }
 
 // stmtDraft is one recognized simple statement: either an assignment or a bare
@@ -45,6 +49,10 @@ type stmtDraft struct {
 	// calls.
 	chains   []string
 	sinkArgs map[string]sinkArgDraft
+	// returns are the variable names returned by a `return x` / `return a, b`
+	// statement. Empty for non-return statements. The interprocedural summary
+	// pass uses it to decide whether a parameter reaches the function's return.
+	returns []string
 }
 
 // sinkArgDraft is the internal form of taint.SinkArgInfo (see there for the
@@ -55,6 +63,10 @@ type sinkArgDraft struct {
 	argCount        int
 	shellTrue       bool
 	firstArgTainted bool
+	// positionalVars lists, per positional argument slot, the variable names in
+	// that slot (index 0 = first positional). Used by the interprocedural pass to
+	// bind a caller argument position to a callee parameter index.
+	positionalVars [][]string
 }
 
 // extractUnits parses content into unit drafts for the given language. It walks

--- a/core/taint/engine/extract_python.go
+++ b/core/taint/engine/extract_python.go
@@ -19,10 +19,14 @@ func extractPython(lines []logicalLine) []unitDraft {
 		if trimmed == "" {
 			continue
 		}
-		if name, ok := pyDefName(trimmed); ok {
-			u := &unitDraft{funcName: name}
+		if name, params, ok := pyDefHeader(trimmed); ok {
+			u := &unitDraft{funcName: name, params: params}
 			units = append(units, u)
 			cur = u
+			continue
+		}
+		if st, ok := pyReturnStatement(langPython, ll); ok {
+			cur.stmts = append(cur.stmts, st)
 			continue
 		}
 		if st, ok := recognizeStatement(langPython, ll); ok {
@@ -37,20 +41,125 @@ func extractPython(lines []logicalLine) []unitDraft {
 	return out
 }
 
-// pyDefName returns the function name if trimmed is a def header. `async def` is
-// handled too. Returns ("", false) for anything else.
-func pyDefName(trimmed string) (name string, ok bool) {
+// pyDefHeader returns the function name and its positional parameter names if
+// trimmed is a def header. `async def` is handled too. Parameters are the
+// bare identifier names in declaration order; `self`/`cls` are kept (their
+// position still matters for argument mapping) but *args/**kwargs, defaults, and
+// type annotations are stripped to the bare name. Returns ("", nil, false) for
+// anything else. The parameter list underpins interprocedural summaries — a
+// caller's Nth argument binds the callee's Nth parameter.
+func pyDefHeader(trimmed string) (name string, params []string, ok bool) {
 	rest := trimmed
 	if strings.HasPrefix(rest, "async ") {
 		rest = strings.TrimSpace(strings.TrimPrefix(rest, "async "))
 	}
 	if !strings.HasPrefix(rest, "def ") {
-		return "", false
+		return "", nil, false
 	}
 	rest = strings.TrimSpace(strings.TrimPrefix(rest, "def "))
 	paren := strings.IndexByte(rest, '(')
 	if paren <= 0 {
-		return "", false
+		return "", nil, false
 	}
-	return strings.TrimSpace(rest[:paren]), true
+	name = strings.TrimSpace(rest[:paren])
+	closeParen := matchParen(rest, paren)
+	if closeParen < 0 {
+		// Malformed / continued header: name only, no params (fail safe).
+		return name, nil, true
+	}
+	params = parsePythonParams(rest[paren+1 : closeParen])
+	return name, params, true
+}
+
+// parsePythonParams splits a Python parameter list into bare positional
+// parameter names in order. It strips default values (`x=1`), type annotations
+// (`x: int`), and the `*`/`**` variadic markers, and drops a bare `*` / `/`
+// separator. Best-effort and deterministic; an unparsable slot is skipped rather
+// than guessed (fail safe: a missed parameter only weakens a summary, never
+// fabricates a flow).
+func parsePythonParams(inner string) []string {
+	parts := splitTopLevelArgs(inner)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "*" || p == "/" {
+			continue
+		}
+		p = strings.TrimLeft(p, "*") // *args / **kwargs → args / kwargs
+		if i := strings.IndexAny(p, "=:"); i >= 0 {
+			p = strings.TrimSpace(p[:i])
+		}
+		if isSimpleIdent(p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// matchParen returns the index of the ')' matching the '(' at open, or -1 if
+// unbalanced within s. Literals in a def header are rare; this is a plain
+// bracket scan over the already code-only header text.
+func matchParen(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// pyReturnStatement recognizes a `return <expr>` line and produces a stmtDraft
+// whose `returns` lists the variable names in the returned expression, while
+// still capturing the calls and reads inside the expression (so a
+// `return os.system(x)` is both a sink read AND a return). A bare `return` (no
+// expression) or `return <constant>` yields a statement with empty returns.
+// Reports ok=false for any line that is not a return.
+func pyReturnStatement(lang langKind, ll logicalLine) (stmtDraft, bool) {
+	trimmed := strings.TrimSpace(ll.code)
+	if trimmed != "return" && !strings.HasPrefix(trimmed, "return ") {
+		return stmtDraft{}, false
+	}
+	// Build the expression logical line by blanking the leading `return` keyword
+	// in both views, preserving offsets so recognizeStatement's alignment holds.
+	kw := strings.Index(ll.code, "return")
+	exprCode := ll.code
+	exprRaw := ll.raw
+	if kw >= 0 && kw+len("return") <= len(exprCode) {
+		exprCode = blankRange(exprCode, kw, kw+len("return"))
+		if kw+len("return") <= len(exprRaw) {
+			exprRaw = blankRange(exprRaw, kw, kw+len("return"))
+		}
+	}
+	inner := logicalLine{line: ll.line, code: exprCode, raw: exprRaw}
+	st, ok := recognizeStatement(lang, inner)
+	if !ok {
+		// A bare `return` still needs a statement so the analyzer sees the line;
+		// it carries no reads and no returns.
+		return stmtDraft{line: ll.line, sinkArgs: map[string]sinkArgDraft{}}, true
+	}
+	// The returned variables are exactly the free identifiers of the expression
+	// (its Reads already collects them). A return never assigns.
+	st.assigns = ""
+	st.returns = append([]string(nil), st.reads...)
+	return st, true
+}
+
+// blankRange returns s with bytes [start,end) replaced by spaces, preserving
+// length and offsets so aligned code/raw views stay aligned.
+func blankRange(s string, start, end int) string {
+	if start < 0 || end > len(s) || start >= end {
+		return s
+	}
+	b := []byte(s)
+	for i := start; i < end; i++ {
+		b[i] = ' '
+	}
+	return string(b)
 }

--- a/core/taint/engine/extract_test.go
+++ b/core/taint/engine/extract_test.go
@@ -22,10 +22,10 @@ func findUnit(t *testing.T, units []unitDraft, name string) unitDraft {
 // stmtWithCall returns the first statement in u that invokes call.
 func stmtWithCall(t *testing.T, u unitDraft, call string) stmtDraft {
 	t.Helper()
-	for _, s := range u.stmts {
-		for _, c := range s.calls {
+	for i := range u.stmts {
+		for _, c := range u.stmts[i].calls {
 			if c == call {
-				return s
+				return u.stmts[i]
 			}
 		}
 	}

--- a/core/taint/engine/interproc.go
+++ b/core/taint/engine/interproc.go
@@ -1,0 +1,250 @@
+package engine
+
+import "github.com/nox-hq/nox/core/taint"
+
+// This file adds SAME-FILE interprocedural taint analysis on top of the
+// intraprocedural StructuralEngine, via FUNCTION SUMMARIES. It is the multiplier
+// that catches injection bugs split across helper functions defined in the same
+// file — the common "thin handler delegates to a helper that does the dangerous
+// thing" shape.
+//
+// HOW IT WORKS
+//
+//  1. Summarize each locally-defined function (funcSummary) by asking, for every
+//     parameter i: does parameter i reach a catalog SINK unsanitized inside the
+//     body (sinksArg), does it flow UNSANITIZED to the function's return
+//     (returnsTaintedIf), and for which classes is it SANITIZED before either
+//     (sanitizesClass). Summaries are computed by seeding each parameter as a
+//     synthetic source and running the same forward propagation the
+//     intraprocedural engine uses — so summary semantics never diverge from
+//     intraprocedural semantics.
+//
+//  2. Iterate summaries to a FIXPOINT over the file's call graph (bounded): a
+//     helper that returns its argument tainted lets a summary of a caller that
+//     wraps then sinks compose across two hops. Iteration is bounded by the
+//     function count (a monotone lattice: taint only ever spreads), so it always
+//     terminates — recursion and mutual recursion included.
+//
+//  3. Re-run propagation over each unit, this time RESOLVING calls to local
+//     functions against their summaries: a call helper(taintedVar) whose summary
+//     says sinksArg(0, cmdi) emits a cross-function Flow (naming helper in Via);
+//     x = wrap(taintedVar) whose summary says returnsTaintedIf(0) marks x
+//     tainted and analysis continues.
+//
+// HONEST LIMITS (documented, and exactly where the cross-file taint-analysis
+// plugin takes over):
+//   - SAME-FILE ONLY. A callee defined in another file is an unknown callee: we
+//     never invent a sink or propagate taint through it (fail safe — no false
+//     positive). Cross-FILE flow remains the taint-analysis plugin's job.
+//   - No alias or field/element sensitivity, no control-flow-graph/branch
+//     merging (inherited from the intraprocedural engine).
+//   - BEST-EFFORT callee resolution: a helper called by its bare local name is
+//     resolved; a helper reached through an attribute, a variable holding a
+//     function, or a decorator-rewrapped name is treated as unknown.
+//   - BOUNDED FIXPOINT: iteration is capped at the function count; a pathological
+//     graph simply stops early with the summaries computed so far (fail safe).
+//   - Argument→parameter binding is POSITIONAL only (keyword and *args calls do
+//     not bind a specific parameter and are conservatively ignored for
+//     summary application, never fabricated).
+
+// argSink records that a parameter reaches a specific catalog sink unsanitized.
+// It carries the full Sink so the emitted cross-function Flow keeps the sink's
+// RuleID/CWE/VulnClass, and the intermediate function chain that leads to it.
+type argSink struct {
+	sink taint.Sink
+	// via is the chain of local functions between the summarized function and the
+	// sink, nearest-caller first. Empty when the sink is directly in the body.
+	via []string
+}
+
+// funcSummary is the interprocedural summary of one locally-defined function.
+// All maps are keyed by positional parameter index. Absence means "no observed
+// effect for that parameter" (fail safe: we never assume an effect we did not
+// derive).
+type funcSummary struct {
+	name string
+	// sinksArg[i] lists the sinks parameter i reaches unsanitized.
+	sinksArg map[int][]argSink
+	// returnsTaintedIf[i] is true when parameter i flows unsanitized to a return.
+	returnsTaintedIf map[int]bool
+	// sanitizesClass[i] is the set of vuln classes parameter i is sanitized for
+	// before reaching any sink or return. Used to suppress a caller flow whose
+	// sink class the helper already neutralized.
+	sanitizesClass map[int]map[taint.VulnClass]bool
+	// returnVia[i] is the local-function chain a tainted return value of
+	// parameter i passed through (for Via provenance when the return is later
+	// sunk). Nearest-caller first.
+	returnVia map[int][]string
+}
+
+// newFuncSummary returns an empty summary for name.
+func newFuncSummary(name string) *funcSummary {
+	return &funcSummary{
+		name:             name,
+		sinksArg:         map[int][]argSink{},
+		returnsTaintedIf: map[int]bool{},
+		sanitizesClass:   map[int]map[taint.VulnClass]bool{},
+		returnVia:        map[int][]string{},
+	}
+}
+
+// maxFixpointIterations bounds summary refinement. The lattice is monotone
+// (taint only spreads), so convergence is guaranteed within one pass per
+// function-graph depth; capping at the function count (plus a small constant)
+// makes even a fully-connected or recursive graph terminate deterministically.
+const maxFixpointIterations = 64
+
+// AnalyzeFile runs SAME-FILE interprocedural taint analysis over all units of a
+// single file (as produced by ExtractUnits). It returns every un-sanitized
+// source→sink flow, whether intraprocedural (source and sink in one function) or
+// interprocedural (source in a caller, sink reached through a locally-defined
+// helper). Flows are deterministic and de-duplicated.
+//
+// Determinism: units are processed in their extraction order (source order),
+// summaries converge to a fixpoint independent of iteration count, and flows are
+// sorted by the shared sortFlows ordering before return.
+func (e *StructuralEngine) AnalyzeFile(units []taint.Unit) []taint.Flow {
+	if len(units) == 0 {
+		return nil
+	}
+	lang := units[0].Language
+
+	summaries := e.computeSummaries(lang, units)
+
+	var flows []taint.Flow
+	seen := map[flowKey]struct{}{}
+	for i := range units {
+		unitFlows := e.analyzeUnitInterproc(lang, &units[i], summaries)
+		for j := range unitFlows {
+			f := &unitFlows[j]
+			k := flowKey{f.SinkLine, f.SinkCall, f.SourceLine, f.SourceVar, f.Sink.RuleID}
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			flows = append(flows, *f)
+		}
+	}
+	sortFlows(flows)
+	return flows
+}
+
+// flowKey de-duplicates flows that the intraprocedural and interprocedural
+// passes could both surface (a source→sink pair reachable two ways is one bug).
+type flowKey struct {
+	sinkLine   int
+	sinkCall   string
+	sourceLine int
+	sourceVar  string
+	ruleID     string
+}
+
+// computeSummaries derives a funcSummary for each named function, iterating to a
+// bounded fixpoint so summaries that depend on other summaries (a helper that
+// returns tainted, then whose result is sunk) converge.
+func (e *StructuralEngine) computeSummaries(lang string, units []taint.Unit) map[string]*funcSummary {
+	summaries := map[string]*funcSummary{}
+	for i := range units {
+		if units[i].FuncName != "" {
+			summaries[units[i].FuncName] = newFuncSummary(units[i].FuncName)
+		}
+	}
+
+	for iter := 0; iter < maxFixpointIterations; iter++ {
+		changed := false
+		for i := range units {
+			u := &units[i]
+			if u.FuncName == "" {
+				continue
+			}
+			next := e.summarize(lang, u, summaries)
+			if !summaryEqual(summaries[u.FuncName], next) {
+				summaries[u.FuncName] = next
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return summaries
+}
+
+// summarize computes the summary of one function by seeding each parameter as a
+// distinct synthetic source and running the interprocedural-aware forward pass
+// (so a parameter that flows through ANOTHER local helper's summary is tracked).
+// It observes, per parameter, whether the tainted value reaches a sink, reaches a
+// return, and which classes it was sanitized for.
+func (e *StructuralEngine) summarize(lang string, u *taint.Unit, summaries map[string]*funcSummary) *funcSummary {
+	sum := newFuncSummary(u.FuncName)
+	for idx, param := range u.Params {
+		// Seed: parameter `param` is tainted by a synthetic "parameter" source.
+		seed := map[string]taintInfo{
+			param: {
+				src:     taint.Source{Call: u.FuncName + ":" + param, Kind: taint.SourceKind("parameter")},
+				srcLine: 0,
+				cleared: map[taint.VulnClass]bool{},
+				via:     nil,
+			},
+		}
+		res := e.forwardPass(lang, u, seed, summaries)
+
+		for fi := range res.flows {
+			f := &res.flows[fi]
+			if f.SourceVar != param {
+				continue
+			}
+			sum.sinksArg[idx] = append(sum.sinksArg[idx], argSink{sink: f.Sink, via: f.Via})
+		}
+		// Did the parameter's taint reach a return unsanitized?
+		for _, rv := range res.returned {
+			ti, ok := res.state[rv]
+			if !ok || ti.src.Call != u.FuncName+":"+param {
+				continue
+			}
+			sum.returnsTaintedIf[idx] = true
+			sum.returnVia[idx] = append([]string(nil), ti.via...)
+			// Classes the value was sanitized for on the way to the return.
+			if len(ti.cleared) > 0 {
+				cls := map[taint.VulnClass]bool{}
+				for c, v := range ti.cleared {
+					cls[c] = v
+				}
+				sum.sanitizesClass[idx] = cls
+			}
+		}
+	}
+	return sum
+}
+
+// summaryEqual reports whether two summaries are equivalent, so the fixpoint
+// loop can detect convergence. It compares the observable effect sets, not the
+// pointer identity.
+func summaryEqual(a, b *funcSummary) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if len(a.returnsTaintedIf) != len(b.returnsTaintedIf) {
+		return false
+	}
+	for k, v := range a.returnsTaintedIf {
+		if b.returnsTaintedIf[k] != v {
+			return false
+		}
+	}
+	if len(a.sinksArg) != len(b.sinksArg) {
+		return false
+	}
+	for k, av := range a.sinksArg {
+		bv := b.sinksArg[k]
+		if len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if av[i].sink.RuleID != bv[i].sink.RuleID || av[i].sink.Call != bv[i].sink.Call {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/core/taint/engine/interproc_test.go
+++ b/core/taint/engine/interproc_test.go
@@ -1,0 +1,268 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/taint"
+)
+
+// analyzeFile is the interprocedural end-to-end helper: source bytes → units →
+// cross-function flows, using the default embedded catalog. It exercises the
+// same-file function-summary propagation that the intraprocedural analyze helper
+// deliberately does not.
+func analyzeFile(t *testing.T, lang lexctx.Lang, src string) []taint.Flow {
+	t.Helper()
+	eng := NewStructuralEngine(nil)
+	units := ExtractUnits("t"+extFor(lang), lang, []byte(src))
+	return eng.AnalyzeFile(units)
+}
+
+// flowWithIntermediate reports whether some flow names fn in its Via path.
+func flowWithIntermediate(flows []taint.Flow, fn string) bool {
+	for i := range flows {
+		for _, v := range flows[i].Via {
+			if v == fn {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestInterprocSinksArgTruePositive(t *testing.T) {
+	// The canonical cross-function command injection: the sink lives in a helper,
+	// the tainted value is produced in the caller and handed to the helper.
+	src := `def run(c):
+    os.system(c)
+
+def handler():
+    cmd = request.args.get("x")
+    run(cmd)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if !hasRule(flows, "TAINT-002") {
+		t.Fatalf("cross-function command injection not detected: %+v", ruleIDs(flows))
+	}
+	if !flowWithIntermediate(flows, "run") {
+		t.Fatalf("flow does not name the intermediate helper 'run': %+v", flows)
+	}
+}
+
+func TestInterprocReturnsTaintedTruePositive(t *testing.T) {
+	// x = wrap(source()); sink(x) where wrap returns its argument unchanged.
+	src := `def wrap(v):
+    return v
+
+def handler():
+    x = wrap(request.args.get("x"))
+    os.system(x)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if !hasRule(flows, "TAINT-002") {
+		t.Fatalf("return-taint propagation across wrap() not detected: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocReturnsTaintedFromTaintedLocal(t *testing.T) {
+	// The source is assigned to a local first, then handed to wrap; the returned
+	// value must remain tainted.
+	src := `def wrap(v):
+    return v
+
+def handler():
+    raw = request.args.get("x")
+    x = wrap(raw)
+    os.system(x)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if !hasRule(flows, "TAINT-002") {
+		t.Fatalf("return-taint across wrap(local) not detected: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocTwoFunctionChain(t *testing.T) {
+	// A two-hop chain: handler → wrap (returns tainted) → run (sinks it). Requires
+	// iterating the summary fixpoint so run's summary and wrap's summary compose.
+	src := `def run(c):
+    os.system(c)
+
+def wrap(v):
+    return v
+
+def handler():
+    cmd = request.args.get("x")
+    y = wrap(cmd)
+    run(y)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if !hasRule(flows, "TAINT-002") {
+		t.Fatalf("two-function chain not detected: %+v", ruleIDs(flows))
+	}
+	if !flowWithIntermediate(flows, "run") {
+		t.Fatalf("two-function chain flow does not name 'run': %+v", flows)
+	}
+}
+
+func TestInterprocSanitizedInHelperNoFire(t *testing.T) {
+	// The helper sanitizes its argument before the sink: no finding, even though
+	// the caller passes tainted data.
+	src := `def run(c):
+    os.system(shlex.quote(c))
+
+def handler():
+    cmd = request.args.get("x")
+    run(cmd)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if hasRule(flows, "TAINT-002") {
+		t.Fatalf("sanitized-in-helper flow wrongly fired: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocNoSourceNoFire(t *testing.T) {
+	// The helper sinks its argument, but the caller passes a constant: no taint,
+	// no finding.
+	src := `def run(c):
+    os.system(c)
+
+def handler():
+    run("ls -la")
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if len(flows) != 0 {
+		t.Fatalf("no-source cross-function call fired: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocRecursionNoCrash(t *testing.T) {
+	// Direct and mutual recursion must terminate (bounded fixpoint) and never
+	// crash. We assert only that AnalyzeFile returns; correctness of the flow (if
+	// any) is secondary to fail-safe termination.
+	src := `def loop(x):
+    return loop(x)
+
+def ping(x):
+    return pong(x)
+
+def pong(x):
+    return ping(x)
+
+def handler():
+    cmd = request.args.get("x")
+    y = loop(cmd)
+    os.system(y)
+`
+	// Must not hang or panic.
+	_ = analyzeFile(t, lexctx.LangPython, src)
+}
+
+func TestInterprocUnknownCalleeNoFalsePositive(t *testing.T) {
+	// A call to a callee not defined in this file is not a local function; its
+	// summary is unknown, so we must NOT invent a sink or propagate taint through
+	// it (fail safe: no false positive).
+	src := `def handler():
+    cmd = request.args.get("x")
+    y = external_lib.process(cmd)
+    log(y)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if len(flows) != 0 {
+		t.Fatalf("unknown callee produced a false positive: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocDeterministic(t *testing.T) {
+	src := `def run(c):
+    os.system(c)
+
+def wrap(v):
+    return v
+
+def handler():
+    cmd = request.args.get("x")
+    y = wrap(cmd)
+    run(y)
+`
+	first := analyzeFile(t, lexctx.LangPython, src)
+	for i := 0; i < 8; i++ {
+		got := analyzeFile(t, lexctx.LangPython, src)
+		if len(got) != len(first) {
+			t.Fatalf("nondeterministic flow count at run %d: %d vs %d", i, len(got), len(first))
+		}
+		for j := range got {
+			if got[j].SinkLine != first[j].SinkLine || got[j].SinkCall != first[j].SinkCall {
+				t.Fatalf("nondeterministic output at run %d", i)
+			}
+		}
+	}
+}
+
+func TestInterprocDoesNotDoubleReportIntraprocedural(t *testing.T) {
+	// A purely intraprocedural flow (source and sink in the same function) must be
+	// reported exactly once by AnalyzeFile, not duplicated by the interprocedural
+	// pass.
+	src := `def handler():
+    cmd = request.args.get("x")
+    os.system(cmd)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	n := 0
+	for i := range flows {
+		if flows[i].Sink.RuleID == "TAINT-002" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("intraprocedural flow reported %d times, want 1: %+v", n, flows)
+	}
+}
+
+func TestInterprocLaunderReturnsConstant(t *testing.T) {
+	// wrap ignores its arg and returns a constant: the returned value is NOT
+	// tainted, so os.system must not fire. This proves a non-taint-returning local
+	// helper is a taint BARRIER — the raw argument read must not leak through it.
+	src := `def wrap(v):
+    return "safe-constant"
+
+def handler():
+    cmd = request.args.get("x")
+    x = wrap(cmd)
+    os.system(x)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if hasRule(flows, "TAINT-002") {
+		t.Fatalf("laundered (constant-return) value wrongly fired: %+v", ruleIDs(flows))
+	}
+}
+
+func TestInterprocKeywordArgNoBind(t *testing.T) {
+	// The tainted value is passed as a keyword argument; positional binding does
+	// not apply, so we neither fabricate a cross-function flow nor crash.
+	src := `def run(c):
+    os.system(c)
+
+def handler():
+    cmd = request.args.get("x")
+    run(c=cmd)
+`
+	_ = analyzeFile(t, lexctx.LangPython, src)
+}
+
+func TestInterprocParamSinksArgClassPrecise(t *testing.T) {
+	// A helper that sinks its arg into an XSS sink must not fire for a value that
+	// was command-sanitized but not XSS-sanitized, and vice-versa. Here we assert
+	// the summary carries the sink's vuln class through: the cross-function flow
+	// keeps the helper sink's rule ID.
+	src := `def render(name):
+    mark_safe(name)
+
+def handler():
+    n = request.args.get("n")
+    render(n)
+`
+	flows := analyzeFile(t, lexctx.LangPython, src)
+	if !hasRule(flows, "TAINT-003") { // TAINT-003 is XSS in the catalog
+		t.Fatalf("cross-function XSS flow not detected with correct rule ID: %+v", ruleIDs(flows))
+	}
+}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/nox-hq/nox/core/lexctx"
 	"github.com/nox-hq/nox/core/taint"
@@ -16,7 +17,12 @@ func ExtractUnits(filePath string, lang lexctx.Lang, content []byte) []taint.Uni
 	units := make([]taint.Unit, 0, len(drafts))
 	for i := range drafts {
 		d := drafts[i]
-		if len(d.stmts) == 0 {
+		// A named function with no statements is still kept: the interprocedural
+		// pass needs its (possibly empty) summary and parameter list so a call to
+		// it resolves as a known local callee rather than an unknown one. The
+		// module unit (funcName "") with no statements carries nothing, so it is
+		// dropped to avoid an empty analyzable scope.
+		if len(d.stmts) == 0 && d.funcName == "" {
 			continue
 		}
 		stmts := make([]taint.Statement, 0, len(d.stmts))
@@ -28,6 +34,7 @@ func ExtractUnits(filePath string, lang lexctx.Lang, content []byte) []taint.Uni
 			FuncName: d.funcName,
 			Language: lang.String(),
 			Stmts:    stmts,
+			Params:   append([]string(nil), d.params...),
 		})
 	}
 	return units
@@ -42,6 +49,7 @@ func toStatement(d *stmtDraft) taint.Statement {
 		Calls:   append([]string(nil), d.calls...),
 		Reads:   append([]string(nil), d.reads...),
 		Chains:  append([]string(nil), d.chains...),
+		Returns: append([]string(nil), d.returns...),
 	}
 	if len(d.sinkArgs) > 0 {
 		st.SinkArgs = make(map[string]taint.SinkArgInfo, len(d.sinkArgs))
@@ -51,10 +59,24 @@ func toStatement(d *stmtDraft) taint.Statement {
 				ArgCount:        a.argCount,
 				ShellTrue:       a.shellTrue,
 				FirstArgTainted: a.firstArgTainted,
+				PositionalVars:  copyPositional(a.positionalVars),
 			}
 		}
 	}
 	return st
+}
+
+// copyPositional deep-copies a per-slot positional-variable list so the
+// foundation's SinkArgInfo never aliases the extractor's internal slices.
+func copyPositional(src [][]string) [][]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([][]string, len(src))
+	for i := range src {
+		out[i] = append([]string(nil), src[i]...)
+	}
+	return out
 }
 
 // StructuralEngine is the real intraprocedural taint engine. It replaces the
@@ -100,21 +122,78 @@ func NewStructuralEngine(cat *taint.Catalog) *StructuralEngine {
 	return &StructuralEngine{cat: cat}
 }
 
-// Analyze implements taint.TaintEngine. See the StructuralEngine doc for the
-// exact propagation and sanitization semantics and their limits.
-func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
-	lang := unit.Language
+// taintInfo is a variable's taint state during a forward pass: the originating
+// source, the line it entered at, the set of vuln classes it has been SANITIZED
+// (cleared) for, and the chain of local functions its taint has flowed through
+// (via) for interprocedural provenance. A class in cleared means the variable is
+// safe for that class only.
+type taintInfo struct {
+	src     taint.Source
+	srcLine int
+	cleared map[taint.VulnClass]bool
+	// via is the nearest-caller-first chain of local helper functions whose
+	// summaries carried this taint (empty for a directly-assigned source). It
+	// feeds Flow.Via so a cross-function finding can name the path.
+	via []string
+}
 
-	// taintState maps a variable to its taint: the originating source and the set
-	// of vuln classes for which it has been SANITIZED (cleared). A class in
-	// cleared means the variable is safe for that class only.
-	type taintInfo struct {
-		src     taint.Source
-		srcLine int
-		cleared map[taint.VulnClass]bool
-	}
+// passResult is the output of a forward pass: the flows found, the final taint
+// state (for summary observation), and the variables returned by the unit.
+type passResult struct {
+	flows    []taint.Flow
+	state    map[string]taintInfo
+	returned []string
+}
+
+// Analyze implements taint.TaintEngine: intraprocedural, straight-line dataflow
+// over one Unit. It is unchanged in behavior — it runs the shared forward pass
+// with NO interprocedural summary resolution, so a call to another function is
+// just an ordinary call (its sink/source/sanitizer nature is judged by the
+// catalog only, never by a summary). See the StructuralEngine doc for semantics
+// and limits; cross-function flow is AnalyzeFile's job.
+//
+//nolint:gocritic // Analyze(unit taint.Unit) is the TaintEngine interface signature; the value parameter cannot be a pointer.
+func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
+	res := e.forwardPass(unit.Language, &unit, nil, nil)
+	sortFlows(res.flows)
+	return res.flows
+}
+
+// analyzeUnitInterproc runs the forward pass over one unit WITH interprocedural
+// summary resolution enabled, so calls to locally-defined functions apply their
+// summaries (sink-in-helper, return-taint). Flows are returned unsorted; the
+// caller dedups and sorts.
+func (e *StructuralEngine) analyzeUnitInterproc(lang string, unit *taint.Unit, summaries map[string]*funcSummary) []taint.Flow {
+	res := e.forwardPass(lang, unit, nil, summaries)
+	return res.flows
+}
+
+// forwardPass is the single, shared forward-propagation core used by BOTH the
+// intraprocedural Analyze and the interprocedural AnalyzeFile/summarize. Keeping
+// one implementation guarantees summary semantics never diverge from
+// intraprocedural semantics.
+//
+// Parameters:
+//   - seed: an optional initial taint state (used by summarize to mark a
+//     parameter tainted). nil starts clean.
+//   - summaries: when non-nil, calls to locally-defined functions apply their
+//     summaries — a summarized sink emits a cross-function Flow and a summarized
+//     tainted return propagates. When nil, no interprocedural resolution happens
+//     (pure intraprocedural behavior). Summary application reads precomputed
+//     summaries only (never re-enters a body), so recursion is handled by the
+//     bounded summary fixpoint in computeSummaries, not here.
+func (e *StructuralEngine) forwardPass(
+	lang string,
+	unit *taint.Unit,
+	seed map[string]taintInfo,
+	summaries map[string]*funcSummary,
+) passResult {
 	tainted := map[string]taintInfo{}
+	for k, v := range seed {
+		tainted[k] = cloneTaintInfo(v)
+	}
 	var flows []taint.Flow
+	var returned []string
 
 	for i := range unit.Stmts {
 		st := &unit.Stmts[i]
@@ -125,8 +204,9 @@ func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
 		// rather than in a prior assignment.
 		inlineCleared := e.inlineSanitized(lang, st)
 
-		// 1) Sink check: for each call that resolves to a sink, decide whether a
-		//    tainted, class-un-sanitized value reaches it in a dangerous position.
+		// 1) Catalog sink check: for each call that resolves to a catalog sink,
+		//    decide whether a tainted, class-un-sanitized value reaches it in a
+		//    dangerous position.
 		for _, rawCall := range st.Calls {
 			sink, ok := e.resolveSink(lang, rawCall)
 			if !ok {
@@ -135,7 +215,6 @@ func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
 			if !e.sinkArgIsDangerous(st, rawCall, &sink) {
 				continue // argument shape makes this call safe (parameterized, no shell)
 			}
-			// Which variables actually reach this sink call as arguments?
 			argVars := e.sinkArgVars(st, rawCall)
 			for _, v := range argVars {
 				ti, isTainted := tainted[v]
@@ -158,12 +237,26 @@ func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
 					FilePath:   unit.FilePath,
 					FuncName:   unit.FuncName,
 					Language:   unit.Language,
+					Via:        append([]string(nil), ti.via...),
 				})
 				break // one flow per sink call is enough
 			}
 		}
 
-		// 2) Propagation into the assignee.
+		// 2) Interprocedural sink check: a call to a locally-defined helper whose
+		//    summary says a tainted argument reaches a sink inside it emits a
+		//    cross-function flow. Only when summary resolution is enabled.
+		if summaries != nil {
+			flows = append(flows, e.interprocSinkFlows(lang, unit, st, tainted, summaries)...)
+		}
+
+		// 3) Record returned variables (for summary observation). A return never
+		//    assigns, so it is handled before the assignment logic.
+		if len(st.Returns) > 0 {
+			returned = append(returned, st.Returns...)
+		}
+
+		// 4) Propagation into the assignee.
 		if st.Assigns == "" {
 			continue
 		}
@@ -176,12 +269,35 @@ func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
 			continue
 		}
 
+		// Interprocedural return-taint: x = helper(taintedArg) where helper's
+		// summary returnsTaintedIf(i) marks x tainted, carrying the source of the
+		// tainted argument and the helper in the via chain. Checked before the
+		// generic read-propagation so a helper that LAUNDERS taint (returns clean)
+		// does not leak via a raw read of its tainted argument.
+		if summaries != nil {
+			if ti, ok := e.interprocReturnTaint(lang, st, tainted, summaries); ok {
+				tainted[st.Assigns] = ti
+				continue
+			}
+			// A lone local-helper call on the RHS (`x = helper(tainted)`) that did
+			// NOT return taint is a taint BARRIER: the helper consumed the tainted
+			// argument and returned a clean value, so x is clean — even though the
+			// raw argument read would otherwise propagate taint. This is what makes
+			// a launder-through-helper (return a constant) not over-report. Only a
+			// LONE call qualifies; a compound RHS (`x = helper(a) + tainted`) still
+			// falls through to conservative read-propagation.
+			if e.rhsIsLoneLocalCall(st, summaries) {
+				delete(tainted, st.Assigns)
+				continue
+			}
+		}
+
 		// Does the RHS read any tainted variable? If so, propagate — carrying the
-		// most-recently-introduced source and the intersection-safe cleared set.
+		// most-recently-introduced source and its cleared set.
 		var carried *taintInfo
-		for _, v := range st.Reads {
+		for _, v := range sortedReads(st.Reads) {
 			if ti, ok := tainted[v]; ok {
-				c := ti
+				c := cloneTaintInfo(ti)
 				carried = &c
 				break
 			}
@@ -202,11 +318,178 @@ func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
 				cleared[class] = true
 			}
 		}
-		tainted[st.Assigns] = taintInfo{src: carried.src, srcLine: carried.srcLine, cleared: cleared}
+		tainted[st.Assigns] = taintInfo{src: carried.src, srcLine: carried.srcLine, cleared: cleared, via: carried.via}
 	}
 
-	sortFlows(flows)
-	return flows
+	return passResult{flows: flows, state: tainted, returned: returned}
+}
+
+// interprocSinkFlows returns cross-function flows for a statement's calls to
+// locally-defined helpers whose summaries say a tainted argument reaches a sink
+// inside the helper. It maps each positional argument to the callee parameter of
+// the same index, and suppresses the flow when the helper sanitized that
+// parameter for the sink's class.
+func (e *StructuralEngine) interprocSinkFlows(lang string, unit *taint.Unit, st *taint.Statement, tainted map[string]taintInfo, summaries map[string]*funcSummary) []taint.Flow {
+	var out []taint.Flow
+	for _, rawCall := range sortedReads(st.Calls) {
+		sum := resolveLocalCallee(rawCall, summaries)
+		if sum == nil || len(sum.sinksArg) == 0 {
+			continue
+		}
+		info, ok := lookupSinkArg(st, rawCall)
+		if !ok {
+			continue
+		}
+		for argIdx, slotVars := range info.PositionalVars {
+			sinks, has := sum.sinksArg[argIdx]
+			if !has {
+				continue
+			}
+			for _, v := range slotVars {
+				ti, isTainted := tainted[v]
+				if !isTainted {
+					continue
+				}
+				for _, as := range sinks {
+					if ti.cleared[as.sink.VulnClass] {
+						continue // caller already sanitized for this class
+					}
+					if cls := sum.sanitizesClass[argIdx]; cls[as.sink.VulnClass] {
+						continue // helper sanitizes this parameter for this class
+					}
+					via := append(append([]string(nil), ti.via...), sum.name)
+					via = append(via, as.via...)
+					out = append(out, taint.Flow{
+						Source:     ti.src,
+						SourceLine: ti.srcLine,
+						SourceVar:  v,
+						Sink:       as.sink,
+						SinkLine:   st.Line,
+						SinkCall:   as.sink.Call,
+						FilePath:   unit.FilePath,
+						FuncName:   unit.FuncName,
+						Language:   unit.Language,
+						Via:        via,
+					})
+					break // one flow per (arg, helper) is enough
+				}
+			}
+		}
+	}
+	return out
+}
+
+// interprocReturnTaint checks whether st is `lhs = helper(args...)` for a local
+// helper whose summary returnsTaintedIf(i) with a tainted argument in position i.
+// It returns the taint state to assign to lhs (carrying the argument's source and
+// extending the via chain) and ok=true when so. A helper that sanitized the
+// parameter for all classes still returns tainted (the value is dangerous for the
+// remaining classes) — the cleared set is carried through.
+func (e *StructuralEngine) interprocReturnTaint(lang string, st *taint.Statement, tainted map[string]taintInfo, summaries map[string]*funcSummary) (taintInfo, bool) {
+	for _, rawCall := range sortedReads(st.Calls) {
+		sum := resolveLocalCallee(rawCall, summaries)
+		if sum == nil || len(sum.returnsTaintedIf) == 0 {
+			continue
+		}
+		info, ok := lookupSinkArg(st, rawCall)
+		if !ok {
+			continue
+		}
+		for argIdx, slotVars := range info.PositionalVars {
+			if !sum.returnsTaintedIf[argIdx] {
+				continue
+			}
+			for _, v := range slotVars {
+				ti, isTainted := tainted[v]
+				if !isTainted {
+					continue
+				}
+				cleared := map[taint.VulnClass]bool{}
+				for c, val := range ti.cleared {
+					cleared[c] = val
+				}
+				for c, val := range sum.sanitizesClass[argIdx] {
+					cleared[c] = val
+				}
+				via := append(append([]string(nil), ti.via...), sum.name)
+				via = append(via, sum.returnVia[argIdx]...)
+				return taintInfo{src: ti.src, srcLine: ti.srcLine, cleared: cleared, via: via}, true
+			}
+		}
+	}
+	return taintInfo{}, false
+}
+
+// rhsIsLoneLocalCall reports whether st's assignment RHS is exactly a single
+// call to a locally-defined helper, with no free variable read outside that
+// call's arguments — the `x = helper(args)` shape where the helper is
+// authoritative for x's taint. It is used to treat a non-taint-returning helper
+// as a barrier. A compound RHS (multiple calls, or a bare variable read
+// alongside the call) returns false so conservative read-propagation still runs.
+func (e *StructuralEngine) rhsIsLoneLocalCall(st *taint.Statement, summaries map[string]*funcSummary) bool {
+	if len(st.Calls) != 1 {
+		return false
+	}
+	sum := resolveLocalCallee(st.Calls[0], summaries)
+	if sum == nil {
+		return false
+	}
+	// Every variable the statement reads must be an argument of the sole call;
+	// any read outside the call means the RHS is compound and taint could enter
+	// by a path the helper's summary does not cover.
+	info, ok := lookupSinkArg(st, st.Calls[0])
+	if !ok {
+		return false
+	}
+	// Permitted reads: the call's argument variables plus the callee chain's own
+	// identifiers (the callee name leaks into Reads as the head of the chain,
+	// e.g. `wrap` in `x = wrap(cmd)`; it is not a data read).
+	permitted := map[string]struct{}{}
+	for _, v := range info.TaintedArgVars {
+		permitted[v] = struct{}{}
+	}
+	for _, seg := range strings.Split(st.Calls[0], ".") {
+		permitted[seg] = struct{}{}
+	}
+	for _, r := range st.Reads {
+		if _, ok := permitted[r]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveLocalCallee resolves a raw call chain to a locally-defined function's
+// summary by matching its dotted suffixes against the summary map. Best-effort:
+// a bare local name (run, wrap) resolves; a chain whose suffix is a local name
+// also resolves. An unknown callee returns nil — we never invent a summary,
+// which keeps unknown/cross-file calls fail-safe (no false positive).
+func resolveLocalCallee(rawCall string, summaries map[string]*funcSummary) *funcSummary {
+	for _, key := range suffixKeys(rawCall) {
+		if sum, ok := summaries[key]; ok {
+			return sum
+		}
+	}
+	return summaries[rawCall]
+}
+
+// cloneTaintInfo deep-copies a taintInfo so mutation of one variable's cleared
+// set or via chain never aliases another's.
+func cloneTaintInfo(ti taintInfo) taintInfo {
+	cleared := make(map[taint.VulnClass]bool, len(ti.cleared))
+	for k, v := range ti.cleared {
+		cleared[k] = v
+	}
+	return taintInfo{src: ti.src, srcLine: ti.srcLine, cleared: cleared, via: append([]string(nil), ti.via...)}
+}
+
+// sortedReads returns a deterministically ordered copy of a read/call slice so
+// the "first tainted read" chosen during propagation is stable across runs
+// regardless of map iteration or extractor ordering quirks.
+func sortedReads(reads []string) []string {
+	out := append([]string(nil), reads...)
+	sortStrings(out)
+	return out
 }
 
 // inlineSanitized returns, per variable, the vuln classes a sanitizer call in

--- a/docs/design/sast-taint.md
+++ b/docs/design/sast-taint.md
@@ -188,10 +188,57 @@ The substrate and real engine described above now exist:
   using `Sink.RuleID`/`Sink.CWE`, located at the sink, with source/sink/class
   metadata. It is registered in `core/scan.go` like any other analyzer.
 
-Honest limits (unchanged from the design intent): intraprocedural and
-straight-line only — no cross-function/cross-file flow (that remains the
-`nox-plugin-taint-analysis` territory), no control-flow-graph/branch merging,
-no alias or container-element/field sensitivity, best-effort call-name
-normalization, and JS/TS scoped to the module unit for now (Python gets
-per-function units). These are a measurable step up from the stub, not a full
-language-semantics engine.
+Honest limits (unchanged from the design intent): straight-line only — no
+control-flow-graph/branch merging, no alias or container-element/field
+sensitivity, best-effort call-name normalization, and JS/TS scoped to the module
+unit for now (Python gets per-function units). These are a measurable step up
+from the stub, not a full language-semantics engine.
+
+## Status update: same-file interprocedural flow via function summaries
+
+The engine now joins a source in one function to a sink reached through a
+locally-defined helper in the **same file**, via **function summaries** —
+`StructuralEngine.AnalyzeFile([]Unit)` (the per-file entry point the
+`taintflow` analyzer now calls instead of the per-`Unit` `Analyze`).
+
+How it works, in three steps:
+
+1. **Summarize each function.** For every parameter *i* of a locally-defined
+   function, a summary records: `sinksArg(i)` — parameter *i* reaches a catalog
+   sink unsanitized inside the body (carrying the sink's `VulnClass`/`RuleID`/
+   `CWE`); `returnsTaintedIf(i)` — parameter *i* flows unsanitized to a `return`;
+   and `sanitizesClass(i)` — the classes parameter *i* is sanitized for on the
+   way. Summaries are computed by seeding each parameter as a synthetic source
+   and running the **same forward pass** the intraprocedural engine uses, so
+   summary semantics never diverge from intraprocedural semantics.
+2. **Iterate to a bounded fixpoint** over the file's call graph, so a helper that
+   returns its argument tainted composes with a caller that then sinks the result
+   (a two-function chain). The lattice is monotone (taint only spreads), so
+   iteration converges; it is additionally capped at the function count, so
+   recursion and mutual recursion terminate deterministically.
+3. **Apply summaries at call sites.** A call `helper(taintedVar)` whose summary
+   `sinksArg(0)` fires emits a cross-function `Flow` (with the intermediate
+   helper named in `Flow.Via`); `x = wrap(taintedVar)` whose summary
+   `returnsTaintedIf(0)` fires marks `x` tainted and propagation continues.
+   Argument→parameter binding is **positional**. The finding is located at the
+   caller's call site and its message/metadata name the helper path
+   (`via: wrap -> run`).
+
+Honest limits of the interprocedural pass (this is exactly where the cross-file
+`nox-plugin-taint-analysis` takes over):
+
+- **Same-file only.** A callee defined in another file is an *unknown callee*: we
+  never invent a sink or propagate taint through it (fail safe — no false
+  positive). Cross-**file** flow stays the taint-analysis plugin's job.
+- **Best-effort callee resolution.** A helper called by its bare local name (or a
+  chain whose suffix is a local name) resolves; a helper reached through an
+  attribute, a variable holding a function, or a decorator-rewrapped name is
+  treated as unknown.
+- **Bounded fixpoint.** Iteration is capped at the function count; a pathological
+  graph simply stops early with the summaries computed so far (fail safe).
+- **Positional binding only.** Keyword and `*args` call arguments do not bind a
+  specific parameter and are conservatively ignored for summary application
+  (never fabricated).
+- Inherits all intraprocedural limits above (no CFG/branch merging, no alias or
+  field/element sensitivity), and JS/TS remains module-scoped so its
+  interprocedural benefit is limited to Python for now.


### PR DESCRIPTION
## What

Extends the structural taint engine from **intraprocedural-only** to **same-file interprocedural** flow using **function summaries** — catching injection bugs split across helper functions defined in the same file (the common "thin handler delegates to a helper that does the dangerous thing" shape).

## How

1. **Summarize each locally-defined function.** For every positional parameter *i*: `sinksArg(i)` (param reaches a catalog sink unsanitized, carrying `VulnClass`/`RuleID`/`CWE`), `returnsTaintedIf(i)` (param flows unsanitized to a `return`), `sanitizesClass(i)`. Summaries run the **same forward pass** the intraprocedural engine uses, so semantics never diverge.
2. **Bounded, monotone fixpoint** over the file call graph so a helper returning tainted composes with a caller that then sinks it. Capped at the function count → recursion/mutual recursion terminate deterministically.
3. **Apply summaries at call sites** in new `StructuralEngine.AnalyzeFile([]Unit)`. `helper(tainted)` that sinks → cross-function `Flow` (helper in `Flow.Via`); `x = wrap(tainted)` that returns tainted → `x` tainted. A non-taint-returning helper on a lone `x = helper(tainted)` RHS is a taint **barrier**.

`taintflow` now calls `AnalyzeFile` per file and surfaces the path (`interprocedural=true`, `via=wrap -> run`). **`scan.go` untouched.**

## Fires

- `def run(c): os.system(c)` + `cmd = request.args.get("x"); run(cmd)` → TAINT-002 via `run`
- `x = wrap(request.args.get("x")); os.system(x)` → fires
- Two-function chain `handler → wrap → run` → fires, names `run`
- Cross-function XSS → TAINT-003 (class-precise)

## Fail-safe (tested)

Sanitized-in-helper, no-source, unknown/cross-file callee, recursion (no crash/FP), launder barrier, keyword-arg no-bind, determinism, intraprocedural reported once.

## Honest limits (docs/design/sast-taint.md)

Same-file only (cross-file = taint-analysis plugin); best-effort callee resolution; bounded fixpoint; positional binding only; inherits no-CFG/no-alias limits; JS/TS module-scoped (Python-first).

## Validation

`go build ./...` + `go test ./...` green; `-race` clean; `golangci-lint run` 0 issues on changed files; `gofmt` clean.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom