### PR TITLE
fix(sast): eliminate 2 residual precision-suite FPs at engine level (0.895 -> 1.00)

### DIFF
--- a/core/analyzers/secrets/decode.go
+++ b/core/analyzers/secrets/decode.go
@@ -105,7 +105,17 @@ func DecodeAndScan(content []byte, path string, engine *rules.Engine) []findings
 		if err != nil {
 			continue
 		}
+		// When the decoded bytes are themselves an image/markup/data blob (a
+		// base64 SVG, an embedded font, an inline PNG), the long alphanumeric
+		// runs inside them trip the entropy rules but are never credentials.
+		// Drop entropy-only findings in that case. A real secret hidden in
+		// base64 decodes to a bare credential — not to markup — so the provider
+		// pattern rules still fire and the secret is still caught.
+		blob := decodedIsBlob(seg.Decoded)
 		for j := range matches {
+			if blob && isEntropyRule(matches[j].RuleID) {
+				continue
+			}
 			// Copy metadata to avoid mutating the shared rule metadata map.
 			meta := make(map[string]string, len(matches[j].Metadata)+2)
 			for k, v := range matches[j].Metadata {
@@ -119,6 +129,55 @@ func DecodeAndScan(content []byte, path string, engine *rules.Engine) []findings
 	}
 
 	return results
+}
+
+// entropyRuleIDs are the entropy-based secret rules (Shannon-entropy matcher,
+// no provider pattern). They flag high-randomness strings that "look like"
+// secrets and are the class prone to firing on decoded image/markup blobs.
+var entropyRuleIDs = map[string]struct{}{
+	"SEC-161": {},
+	"SEC-162": {},
+	"SEC-163": {},
+}
+
+// isEntropyRule reports whether a rule ID is an entropy-only secret rule.
+func isEntropyRule(ruleID string) bool {
+	_, ok := entropyRuleIDs[ruleID]
+	return ok
+}
+
+// decodedIsBlob reports whether decoded content is itself a markup/image/binary
+// data blob rather than a plain credential. SVG/XML/HTML markup and common
+// image magic headers decode from data-URI payloads; a real hidden secret
+// decodes to a short credential string, not to markup, so this stays false for
+// genuine encoded secrets. Deterministic and content-only.
+func decodedIsBlob(decoded string) bool {
+	trimmed := strings.TrimSpace(decoded)
+	if trimmed == "" {
+		return false
+	}
+	// Markup blobs: SVG/XML/HTML documents embedded as data URIs.
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "<svg") ||
+		strings.HasPrefix(lower, "<?xml") ||
+		strings.HasPrefix(lower, "<!doctype") ||
+		strings.HasPrefix(lower, "<html") {
+		return true
+	}
+	// Image magic headers surviving the printable-ASCII filter (e.g. GIF).
+	for _, sig := range imageMagicPrefixes {
+		if strings.HasPrefix(decoded, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// imageMagicPrefixes are leading byte signatures of common image formats that
+// remain (mostly) printable after base64 decoding.
+var imageMagicPrefixes = []string{
+	"GIF87a", "GIF89a", // GIF
+	"%PDF-", // PDF documents embedded as data URIs
 }
 
 // truncateString truncates a string to maxLen characters with an ellipsis.

--- a/core/analyzers/secrets/decode_test.go
+++ b/core/analyzers/secrets/decode_test.go
@@ -73,6 +73,51 @@ func TestDecodeAndScan_Base64WrappedAWSKey(t *testing.T) {
 	}
 }
 
+func TestDecodeAndScan_SVGBlobSuppressesEntropy(t *testing.T) {
+	// A base64 data-URI SVG whose decoded body contains long alphanumeric runs
+	// that trip the entropy rules (SEC-161/162/163). The decoded content is
+	// markup/image data, not a credential, so entropy-only findings must be
+	// dropped. This mirrors the clean_svg_blob.ts precision-suite sample.
+	a := NewAnalyzer()
+
+	svg := `<svg xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10AKIAIOSFODNN7EXAMPLEabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"/></svg>`
+	encoded := base64.StdEncoding.EncodeToString([]byte(svg))
+	content := []byte(`const icon = "data:image/svg+xml;base64,` + encoded + `";`)
+
+	results := DecodeAndScan(content, "icon.ts", a.engine)
+
+	for _, f := range results {
+		if isEntropyRule(f.RuleID) {
+			t.Errorf("entropy-only finding %s should be suppressed for a decoded SVG/image blob", f.RuleID)
+		}
+	}
+}
+
+func TestDecodeAndScan_RealSecretInBase64StillFound(t *testing.T) {
+	// A genuine AWS key hidden in base64 must still be caught: the decoded
+	// content is a bare credential, not an image/markup blob.
+	a := NewAnalyzer()
+
+	secret := "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+	encoded := base64.StdEncoding.EncodeToString([]byte(secret))
+	content := []byte("blob = " + encoded)
+
+	results := DecodeAndScan(content, "config.py", a.engine)
+
+	if len(results) == 0 {
+		t.Fatal("expected a decoded-secret finding for a real credential hidden in base64")
+	}
+	found := false
+	for _, f := range results {
+		if f.Metadata["encoding"] == "base64" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("real secret in base64 should surface as an encoded finding")
+	}
+}
+
 func TestIsPrintable(t *testing.T) {
 	tests := []struct {
 		input []byte

--- a/core/analyzers/variants/data/signatures.json
+++ b/core/analyzers/variants/data/signatures.json
@@ -52,6 +52,7 @@
     "severity": "high",
     "confidence": "low",
     "exts": [".py"],
+    "vuln_class": "ssti",
     "pattern": "render_template_string\\s*\\([^)]*(\\+|%|\\.format\\(|f\")",
     "remediation": "render_template_string() built from concatenation/formatting lets attacker input reach the template compiler — the SSTI class (e.g. CVE-2019-10906). Render a static template and pass user data only as bound context variables.",
     "references": ["https://nvd.nist.gov/vuln/detail/CVE-2019-10906"]

--- a/core/analyzers/variants/variants.go
+++ b/core/analyzers/variants/variants.go
@@ -35,6 +35,10 @@ type signature struct {
 	Exclude     string   `json:"exclude"`
 	Remediation string   `json:"remediation"`
 	References  []string `json:"references"`
+	// VulnClass is the underlying vulnerability class (e.g. "ssti", "xss").
+	// Optional; when set it lets the pipeline dedup a signature against another
+	// analyzer's finding of the same class at the same location.
+	VulnClass string `json:"vuln_class,omitempty"`
 
 	re      *regexp.Regexp
 	exclude *regexp.Regexp
@@ -128,13 +132,17 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, content []byte
 			if s.exclude != nil && s.exclude.MatchString(line) {
 				continue
 			}
+			meta := map[string]string{"cve": s.CVE}
+			if s.VulnClass != "" {
+				meta["vuln_class"] = s.VulnClass
+			}
 			fs.Add(findings.Finding{
 				RuleID:     s.ID,
 				Severity:   findings.Severity(s.Severity),
 				Confidence: findings.Confidence(s.Confidence),
 				Location:   findings.Location{FilePath: path, StartLine: ln + 1, EndLine: ln + 1},
 				Message:    s.CVE + " variant: " + s.Title,
-				Metadata:   map[string]string{"cve": s.CVE},
+				Metadata:   meta,
 			})
 		}
 	}

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -218,6 +218,63 @@ func (fs *FindingSet) Deduplicate() {
 	fs.items = unique
 }
 
+// SuppressDuplicateVulnClass drops a finding from suppressRulePrefix when
+// another finding at the same file+line reports the same underlying vuln class
+// via its "vuln_class" metadata. It resolves cross-analyzer over-reporting:
+// when two SAST analyzers independently flag the same vulnerability at one
+// location (e.g. the taint engine's TAINT-003 SSTI sink and the variants
+// engine's VARIANT-005 SSTI CVE signature both firing on one
+// render_template_string call), the more specific signature is kept and the
+// generic taint duplicate is dropped, so the vulnerability is reported once.
+//
+// Suppression is class-scoped: a finding is only dropped when a *co-located,
+// same-class* finding from a different rule exists. It never touches a lone
+// finding and never crosses vuln classes, so it cannot hide a distinct
+// vulnerability (an XSS finding is only ever suppressed by another XSS finding
+// at the same span, which is itself reported). Deterministic and order-free.
+func (fs *FindingSet) SuppressDuplicateVulnClass(suppressRulePrefix string) {
+	// Index the vuln classes reported at each location by rules *other than* the
+	// suppressible ones, so a suppressible finding can be dropped only when an
+	// independent analyzer already covers the same class at the same span.
+	type locKey struct {
+		file string
+		line int
+	}
+	covered := make(map[locKey]map[string]struct{})
+	for i := range fs.items {
+		f := &fs.items[i]
+		if strings.HasPrefix(f.RuleID, suppressRulePrefix) {
+			continue
+		}
+		class := f.Metadata["vuln_class"]
+		if class == "" {
+			continue
+		}
+		k := locKey{f.Location.FilePath, f.Location.StartLine}
+		if covered[k] == nil {
+			covered[k] = make(map[string]struct{})
+		}
+		covered[k][class] = struct{}{}
+	}
+
+	kept := make([]Finding, 0, len(fs.items))
+	for i := range fs.items {
+		f := fs.items[i]
+		if strings.HasPrefix(f.RuleID, suppressRulePrefix) {
+			if class := f.Metadata["vuln_class"]; class != "" {
+				k := locKey{f.Location.FilePath, f.Location.StartLine}
+				if classes, ok := covered[k]; ok {
+					if _, dup := classes[class]; dup {
+						continue // another analyzer already reports this class here
+					}
+				}
+			}
+		}
+		kept = append(kept, f)
+	}
+	fs.items = kept
+}
+
 // SortDeterministic orders findings by RuleID, then FilePath, then StartLine.
 // This guarantees stable, reproducible output regardless of the order in which
 // analyzers emit their results.

--- a/core/findings/findings_test.go
+++ b/core/findings/findings_test.go
@@ -224,6 +224,78 @@ func TestFindingSet_Deduplicate(t *testing.T) {
 	}
 }
 
+func TestFindingSet_SuppressDuplicateVulnClass(t *testing.T) {
+	t.Parallel()
+
+	fs := NewFindingSet()
+	// A variants SSTI CVE signature and a taint SSTI sink both fire on the same
+	// render_template_string line — the same vulnerability reported twice.
+	fs.Add(Finding{
+		RuleID:   "VARIANT-005",
+		Location: Location{FilePath: "app.py", StartLine: 9},
+		Message:  "SSTI variant",
+		Metadata: map[string]string{"vuln_class": "ssti"},
+	})
+	fs.Add(Finding{
+		RuleID:   "TAINT-003",
+		Location: Location{FilePath: "app.py", StartLine: 9},
+		Message:  "taint SSTI",
+		Metadata: map[string]string{"vuln_class": "ssti"},
+	})
+
+	fs.SuppressDuplicateVulnClass("TAINT-")
+
+	got := fs.Findings()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding after cross-analyzer SSTI dedup, got %d", len(got))
+	}
+	if got[0].RuleID != "VARIANT-005" {
+		t.Fatalf("expected the specific VARIANT-005 signature kept, got %q", got[0].RuleID)
+	}
+}
+
+func TestFindingSet_SuppressDuplicateVulnClass_KeepsDistinctClass(t *testing.T) {
+	t.Parallel()
+
+	fs := NewFindingSet()
+	// A taint XSS finding co-located with a variants SSTI finding must be kept:
+	// different vuln classes are different vulnerabilities.
+	fs.Add(Finding{
+		RuleID:   "VARIANT-005",
+		Location: Location{FilePath: "app.py", StartLine: 9},
+		Metadata: map[string]string{"vuln_class": "ssti"},
+	})
+	fs.Add(Finding{
+		RuleID:   "TAINT-003",
+		Location: Location{FilePath: "app.py", StartLine: 9},
+		Metadata: map[string]string{"vuln_class": "xss"},
+	})
+
+	fs.SuppressDuplicateVulnClass("TAINT-")
+
+	if len(fs.Findings()) != 2 {
+		t.Fatalf("distinct vuln classes at one span must both survive, got %d", len(fs.Findings()))
+	}
+}
+
+func TestFindingSet_SuppressDuplicateVulnClass_KeepsLoneTaint(t *testing.T) {
+	t.Parallel()
+
+	fs := NewFindingSet()
+	// A taint SSTI finding with no other analyzer covering it must be kept.
+	fs.Add(Finding{
+		RuleID:   "TAINT-003",
+		Location: Location{FilePath: "app.py", StartLine: 9},
+		Metadata: map[string]string{"vuln_class": "ssti"},
+	})
+
+	fs.SuppressDuplicateVulnClass("TAINT-")
+
+	if len(fs.Findings()) != 1 {
+		t.Fatalf("a lone taint finding must survive, got %d", len(fs.Findings()))
+	}
+}
+
 func TestFindingSet_Deduplicate_KeepsFirst(t *testing.T) {
 	t.Parallel()
 

--- a/core/scan.go
+++ b/core/scan.go
@@ -642,6 +642,13 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		)
 	}
 
+	// Drop a taint finding when another analyzer already reports the same vuln
+	// class at the same location — e.g. the taint engine's TAINT-003 SSTI sink
+	// firing on a render_template_string call that a variants CVE signature
+	// (VARIANT-005) already covers. Keeps the more specific signature; reports
+	// the vulnerability once instead of twice.
+	allFindings.SuppressDuplicateVulnClass("TAINT-")
+
 	allFindings.Deduplicate()
 	allFindings.SortDeterministic()
 

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -30,21 +30,22 @@ nox bench --precision testdata/precision-suite --baseline testdata/precision-sui
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite` scores
-**precision 0.89 / recall 1.00 / F1 0.94** (17 TP, 2 FP, 0 FN) — up from the
-original honest baseline of precision 0.30 / F1 0.47 (39 FP). Recall stayed
-perfect while precision was raised by fixing the three false-positive classes
-the corpus indicted (items 1-3 below):
+**precision 1.00 / recall 1.00 / F1 1.00** (17 TP, 0 FP, 0 FN) — up from the
+original honest baseline of precision 0.30 / F1 0.47 (39 FP), and from the
+interim 0.89 / F1 0.94 once the last two residual FPs were fixed (items 5–6
+below). Recall stayed perfect throughout while precision was raised only by
+fixing the false-positive classes the corpus indicted:
 
-- **findings-per-issue: 1.12** (was 2.75) — across the annotated issues nox now
-  emits ~1.1 findings each; 1.00 is ideal. The two secret files that used to
+- **findings-per-issue: 1.06** (was 2.75) — across the annotated issues nox now
+  emits ~1.06 findings each; 1.00 is ideal. The two secret files that used to
   dominate collapsed to their canonical provider rule: `tp_secrets_cloud.py`
   from density **8.00 → 1.00** and `tp_secrets.py` from **5.33 → 1.33**. The
   secret analyzer now deduplicates overlapping rules by specificity and resolves
   the canonical provider owner per token (see `core/analyzers/secrets/dedup.go`).
-- **noise ratio: 0.11** (was 0.70) — 2 of the 19 findings nox produces are false
-  positives. The two remaining are outside the three fixed classes: a SEC-161
-  entropy hit on a base64 data-URI (`clean_svg_blob.ts`) and a TAINT-003
-  over-fire that accompanies the SSTI positive (`tp_ssti.py`).
+- **noise ratio: 0.00** (was 0.70) — 0 of the 17 findings nox produces are false
+  positives. The last two (a SEC-161 entropy hit on a base64 data-URI SVG in
+  `clean_svg_blob.ts`, and a TAINT-003 over-fire accompanying the SSTI positive
+  in `tp_ssti.py`) are now fixed at the engine level (items 5–6 below).
 
 Committed as `baseline.json`; `TestPrecisionSuiteBaseline` (in `cli/`) fails if
 any of precision/recall/F1 drops or FP / findings-per-issue rises, so the number
@@ -78,6 +79,24 @@ can only move the right way without a human refreshing the snapshot.
    recall to 1.0 — the measure→build→re-measure loop working end to end. (SSTI
    via `render_template_string(... + user)`
    is *already* caught by `VARIANT-005`, so it is annotated as a true positive.)
+5. **Entropy fired inside a decoded image/SVG blob — FIXED.** The secrets
+   decode-and-scan path (`core/analyzers/secrets/decode.go`) base64-decodes
+   embedded blobs and re-scans the decoded bytes. A data-URI SVG decodes to
+   markup whose long alphanumeric runs tripped the entropy rules
+   (`SEC-161/162/163`) on `clean_svg_blob.ts`. The decode path now suppresses
+   entropy-only findings when the decoded content is itself a markup/image/data
+   blob (SVG/XML/HTML markup or an image magic header), while a real credential
+   hidden in base64 — which decodes to a bare secret, not to markup — is still
+   caught by the provider pattern rules.
+6. **Taint SSTI double-reported the variants SSTI — FIXED.** The taint engine's
+   `TAINT-003` SSTI sink and the `VARIANT-005` CVE signature both fired on the
+   same `render_template_string(... + user)` call, reporting one vulnerability
+   twice. The pipeline now drops a taint finding when another analyzer already
+   reports the same `vuln_class` at the same location
+   (`FindingSet.SuppressDuplicateVulnClass`, wired in `core/scan.go`), keeping
+   the more specific CVE signature. It is class-scoped, so it never hides a
+   distinct vulnerability — an XSS taint finding is only ever suppressed by
+   another XSS finding at the same span.
 
 ## Sample inventory
 
@@ -89,7 +108,7 @@ True positives (annotated ground truth):
 | `tp_secrets_cloud.py` | Stripe / GCP keys | SEC-030 / SEC-007 | TP, deduped to canonical |
 | `tp_prompt.py` | prompt injection (f-string) | AI-002 | TP |
 | `tp_yaml.py` | unsafe `yaml.load` | SLOP-001 / VARIANT-002 | TP |
-| `tp_ssti.py` | SSTI via dynamic template | VARIANT-005 (+ SLOP-001) | TP |
+| `tp_ssti.py` | SSTI via dynamic template | VARIANT-005 (+ SLOP-001) | TP, taint SSTI duplicate deduped |
 | `tp_injection.py` | command / eval injection | TAINT-002 / TAINT-005 | FN (recall gap) |
 | `tp_pathtrav.py` | path traversal via `open()` | TAINT-004 | FN (recall gap) |
 | `tp_deser.py` | unsafe `pickle.loads` | TAINT-005 | FN (recall gap) |
@@ -105,7 +124,7 @@ Clean stressors (zero annotations — any finding is a false positive):
 | `clean_prose_comments.py` | sinks quoted in comments | clean |
 | `clean_safe_db.py` | parameterized / arg-vector / quoted | clean |
 | `clean_hashes.js` | lockfile hashes, git SHA | clean |
-| `clean_svg_blob.ts` | base64 data-URI SVG | 1 FP |
+| `clean_svg_blob.ts` | base64 data-URI SVG | clean |
 | `clean_minified_bundle.js` | minified bundle strings | clean |
 | `clean_json_blob.py` | base64/JSON blob constant | clean |
 | `clean_identifiers.py` | UUIDs, hex colors, git SHA | clean |

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -1,9 +1,9 @@
 {
-  "precision": 0.8947368421052632,
+  "precision": 1,
   "recall": 1,
-  "f1": 0.9444444444444444,
-  "fp": 2,
+  "f1": 1,
+  "fp": 0,
   "tp": 17,
   "fn": 0,
-  "findings_per_issue": 1.125
+  "findings_per_issue": 1.0625
 }


### PR DESCRIPTION
## Summary

The honest SAST precision suite scored **precision 0.895 / recall 1.00 / F1 0.944** (17 TP, 2 FP, 0 FN). This PR eliminates both residual false positives **at the engine level** (no file exclusion, no corpus curation), taking the suite to **precision 1.00 / recall 1.00 / F1 1.00** (17 TP, 0 FP, 0 FN), noise ratio 0.00.

## FP #1 — `clean_svg_blob.ts`: SEC-161 entropy inside a decoded SVG

**Root cause:** The secrets decode-and-scan path (`DecodeAndScan`) base64-decodes embedded blobs and re-scans the decoded bytes, but those decoded findings are added directly via `fs.Add` and bypass the lexctx data-blob filter the main scan applies. A base64 `data:image/svg+xml` blob decodes to SVG markup whose long alphanumeric runs trip the entropy rules (SEC-161/162/163).

**Fix:** `DecodeAndScan` now drops entropy-only findings when the decoded content is itself a markup/image/data blob (SVG/XML/HTML markup or an image magic header). A real secret hidden in base64 decodes to a bare credential — not markup — so provider pattern rules still catch it. Tested both ways: SVG-in-base64 suppressed; `AKIA...`-in-base64 still found.

## FP #2 — `tp_ssti.py`: TAINT-003 double-reports the SSTI

**Root cause:** `render_template_string` is a legitimate SSTI sink (TAINT-003, `vuln_class: ssti`) and is *also* matched by the `VARIANT-005` CVE signature. Both fire on the same line — one real vulnerability reported twice; the annotation designates VARIANT-005 as canonical, so TAINT-003 scores as a FP.

**Fix:** New `FindingSet.SuppressDuplicateVulnClass` (wired into `refineFindings`) drops a taint finding when another analyzer already reports the same `vuln_class` at the same file+line, keeping the more specific CVE signature. Variants signatures now carry an optional `vuln_class` (`ssti` on VARIANT-005) so the dedup is class-based, not rule-ID-hardcoded. It is class-scoped: an XSS taint finding is only ever suppressed by another XSS finding at the same span — it never hides a distinct vulnerability and never weakens XSS detection.

## Baseline + docs

- Ratcheted `testdata/precision-suite/baseline.json` to the 1.00 floor; `TestPrecisionSuiteBaseline` passes.
- Updated `testdata/precision-suite/README.md` headline numbers (now 1.00/1.00/1.00, noise 0.00, density 1.06) and marked items 5–6 resolved.

## Verification

- `go build ./...`, `go test ./...`, `go test -race ./core/taint/... ./core/analyzers/...` — all green.
- golangci-lint clean on changed packages (only pre-existing `hugeParam` on untouched code, filtered by CI `only-new-issues`).
- Self-scan gate: PR introduces **zero** new findings (identical finding set to `main`).

**Before → after: precision 0.895 → 1.00, recall 1.00 → 1.00, F1 0.944 → 1.00 (TP 17, FP 2 → 0, FN 0).**

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom