### PR TITLE
feat(lexctx): classify Go source; drop #195 self-scan workaround

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -17,13 +17,6 @@ scan:
     - "core/analyzers/secrets/rules.go"
     - "core/analyzers/iac/rules*.go"
     - "core/analyzers/ai/rules.go"
-    # Pattern-vocabulary files: provider-prefix owner table, placeholder/example
-    # token allowlist, and LLM prompt-context tokens. Like rules.go they must
-    # name the literal patterns they match against, so the self-scan flags them
-    # (Go is not yet lexctx-classified, so comments/constants aren't suppressed).
-    - "core/analyzers/secrets/dedup.go"
-    - "core/analyzers/secrets/placeholder.go"
-    - "core/analyzers/ai/prompt_context.go"
     - "registry/trust/signature.go"
     - "cli/plugin_cmd.go"
     # CI workflows and action scripts contain pinned commit SHAs, GITHUB_TOKEN refs, and Actions expressions (false positives)

--- a/core/analyzers/secrets/dedup.go
+++ b/core/analyzers/secrets/dedup.go
@@ -312,6 +312,77 @@ func ownersForValue(value string) map[string]struct{} {
 	return nil
 }
 
+// isBareProviderPrefix reports whether a finding matched only a provider prefix
+// (e.g. `glpat-`, `sk_live_`) with no credential body following it — the shape a
+// pattern-vocabulary file has when it names the prefixes its rules detect
+// (`{"glpat-", ...}`, `// prefix (ghp_, xoxb-, sk_live_, ...)`). A live token
+// always carries a 20+ char high-entropy body; a match that is the bare prefix,
+// immediately followed by a non-token-body byte, is a reference, not a secret.
+//
+// This runs AFTER dedupBySpecificity, so on a real token the precise owner rule
+// (which requires the body) has already claimed the span and the bare-prefix
+// alias is gone — a surviving bare-prefix match therefore never coincides with a
+// real credential.
+func isBareProviderPrefix(content []byte, f *findings.Finding) bool {
+	value := matchedValue(content, f)
+	v := strings.TrimLeft(value, `"'`)
+	if v == "" {
+		return false
+	}
+	prefix, ok := recognisedProviderPrefix(v)
+	if !ok {
+		return false
+	}
+	// The match must be ONLY the prefix (no body captured in the span).
+	if v != prefix {
+		return false
+	}
+	// Inspect the source bytes immediately after the match: if a token body of
+	// credential-length characters follows, this is a real (unquoted) token and
+	// must be kept. A boundary (quote, comma, brace, space, end of line) means
+	// the prefix stands alone as vocabulary.
+	end := lexctx.LineColToOffset(content, f.Location.EndLine, f.Location.EndColumn)
+	return !tokenBodyFollows(content, end)
+}
+
+// recognisedProviderPrefix returns the longest canonicalOwners prefix that v
+// starts with, or ("", false) if none matches.
+func recognisedProviderPrefix(v string) (string, bool) {
+	for i := range canonicalOwners {
+		if strings.HasPrefix(v, canonicalOwners[i].prefix) {
+			return canonicalOwners[i].prefix, true
+		}
+	}
+	return "", false
+}
+
+// barePrefixBodyThreshold is the run length of token-body characters that, if
+// present immediately after a provider prefix, marks a real credential rather
+// than a bare-prefix reference. Provider tokens carry 20+ body chars.
+const barePrefixBodyThreshold = 20
+
+// tokenBodyFollows reports whether content at offset begins a run of at least
+// barePrefixBodyThreshold token-body characters (alphanumerics plus `-`/`_`,
+// the alphabet real provider tokens draw from).
+func tokenBodyFollows(content []byte, offset int) bool {
+	run := 0
+	for i := offset; i < len(content) && run < barePrefixBodyThreshold; i++ {
+		if !isTokenBodyByte(content[i]) {
+			break
+		}
+		run++
+	}
+	return run >= barePrefixBodyThreshold
+}
+
+// isTokenBodyByte reports whether c can appear in a provider-token body.
+func isTokenBodyByte(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
 // specificityOf returns the specificity tier for a rule ID.
 func specificityOf(ruleID string, spec map[string]int) int {
 	if s, ok := spec[ruleID]; ok {

--- a/core/analyzers/secrets/lexctx_wiring_test.go
+++ b/core/analyzers/secrets/lexctx_wiring_test.go
@@ -53,3 +53,48 @@ func TestScanArtifacts_LexctxDropsEmbeddedBlob(t *testing.T) {
 		})
 	}
 }
+
+// TestScanArtifacts_BareProviderPrefixDropped locks the fix that lets nox's own
+// Go pattern-vocabulary files (core/analyzers/secrets/dedup.go) pass the self-
+// scan without an exclude: a bare provider prefix that names a rule's vocabulary
+// — `"glpat-"` in a string, `sk_live_` in a comment — is dropped, because a live
+// credential always carries a 20+ char high-entropy body. A FULL token in a Go
+// string is still reported (the regression guard: never silence a real secret).
+func TestScanArtifacts_BareProviderPrefixDropped(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		// The two shapes that tripped the #195 self-scan in dedup.go.
+		{"bare-prefix-in-go-string", "var owners = map[string]string{\n\t\"glpat-\": \"SEC-018\",\n}\n", 0},
+		{"bare-prefix-in-go-comment", "// prefix (ghp_, xoxb-, sk_live_, AKIA) resolution\nvar x = 1\n", 0},
+		// Regression guard: a real hardcoded secret in an ordinary Go string is
+		// STILL reported — a 20+ char body means it is not a bare prefix.
+		{"real-secret-in-go-string", "apiKey := \"glpat-ABCDEFGHIJKLMNOPQRST\"\n", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			abs := filepath.Join(dir, "dedup_like.go")
+			if err := os.WriteFile(abs, []byte(tc.src), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			art := discovery.Artifact{Path: "dedup_like.go", AbsPath: abs, Type: discovery.Source}
+			fs, err := NewAnalyzer().ScanArtifacts(context.Background(), []discovery.Artifact{art})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := 0
+			items := fs.Findings()
+			for i := range items {
+				if len(items[i].RuleID) >= 4 && items[i].RuleID[:4] == "SEC-" {
+					got++
+				}
+			}
+			if got != tc.want {
+				t.Errorf("%s: got %d SEC findings, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -163,6 +163,17 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			if inEmbeddedBlob(lang, content, &results[i]) {
 				continue
 			}
+			// Drop a bare provider-prefix match with no token body — the literal
+			// `"glpat-"` or the `sk_live_` inside a `// prefix (ghp_, sk_live_, …)`
+			// comment that a pattern-vocabulary file must name. A live credential
+			// always carries a 20+ char high-entropy body; a match that is only the
+			// prefix is a reference, never a leaked secret. This is deliberately
+			// narrower than dropping every comment/string match: a FULL token in a
+			// comment (a genuinely leaked credential) is still kept, because its
+			// matched value is more than the bare prefix.
+			if isBareProviderPrefix(content, &results[i]) {
+				continue
+			}
 			if isPlaceholderFinding(content, &results[i]) {
 				continue
 			}

--- a/core/lexctx/lang.go
+++ b/core/lexctx/lang.go
@@ -31,6 +31,7 @@ const (
 	LangUnknown Lang = iota
 	LangPython
 	LangJavaScript // JS, JSX, TS, TSX — they share comment/string/template lexing
+	LangGo         // Go — //, /*…*/, "…", `…` (raw), '…' (rune)
 )
 
 // String returns a stable, lowercase label for the language. Used in metadata
@@ -41,6 +42,8 @@ func (l Lang) String() string {
 		return "python"
 	case LangJavaScript:
 		return "javascript"
+	case LangGo:
+		return "go"
 	default:
 		return "unknown"
 	}
@@ -62,6 +65,7 @@ var extToLang = map[string]Lang{
 	".tsx": LangJavaScript,
 	".mts": LangJavaScript,
 	".cts": LangJavaScript,
+	".go":  LangGo,
 }
 
 // LangFromPath infers the language from a file path's extension. Detection is

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -49,6 +49,8 @@ func Classify(lang Lang, content []byte) []Region {
 		return scanPython(content)
 	case LangJavaScript:
 		return scanJavaScript(content)
+	case LangGo:
+		return scanGo(content)
 	default:
 		return []Region{{Start: 0, End: len(content), Kind: KindCode}}
 	}

--- a/core/lexctx/scan_go.go
+++ b/core/lexctx/scan_go.go
@@ -1,0 +1,120 @@
+package lexctx
+
+// scanGo walks Go source and classifies each byte as code, string, or comment.
+// It recognizes the four lexical constructs that carry secret/prompt false
+// positives in Go — a `//` in a URL string, a base64 blob in a raw string, a
+// provider prefix in a comment — and treats everything else as code:
+//
+//   - `//` line comments (to end of line) and `/* ... */` block comments. Go
+//     block comments do NOT nest, so the FIRST `*/` closes the comment even if
+//     an inner `/*` appeared (scanBlockComment, shared with the JS scanner,
+//     encodes exactly this).
+//   - interpreted string literals `"..."` with backslash escapes (`\"`, `\\`).
+//     A newline terminates an unclosed interpreted string (Go spec) so a stray
+//     quote cannot swallow the following code.
+//   - raw string literals “ `...` “ — no escapes are processed (a backslash is
+//     literal and does NOT escape the closing backtick) and they CAN span many
+//     lines, which matters because a base64/data-URI blob is often a raw string.
+//   - rune literals `'...'` with backslash escapes, closed at the matching `'`
+//     or defensively at a newline.
+//
+// It shares scanBlockComment with the JS scanner. Like the other scanners it
+// emits strictly increasing, contiguous spans into a regionBuilder so the
+// returned regions are gap-free and cover [0, len(content)).
+func scanGo(content []byte) []Region {
+	var b regionBuilder
+	i := 0
+	n := len(content)
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '/' && i+1 < n && content[i+1] == '/':
+			start := i
+			for i < n && content[i] != '\n' {
+				i++
+			}
+			b.emit(start, i, KindComment)
+		case c == '/' && i+1 < n && content[i+1] == '*':
+			end := scanBlockComment(content, i+2)
+			b.emit(i, end, KindComment)
+			i = end
+		case c == '"':
+			end := scanGoInterpreted(content, i)
+			b.emit(i, end, KindString)
+			i = end
+		case c == '`':
+			end := scanGoRawString(content, i)
+			b.emit(i, end, KindString)
+			i = end
+		case c == '\'':
+			end := scanGoRune(content, i)
+			b.emit(i, end, KindString)
+			i = end
+		default:
+			b.emit(i, i+1, KindCode)
+			i++
+		}
+	}
+	return b.finish(n)
+}
+
+// scanGoInterpreted returns the offset just past an interpreted string literal
+// `"..."` opening at content[start]. Backslash escapes are honored (`\"`, `\\`);
+// a newline ends the scan because an interpreted string may not span a line in
+// Go, so a runaway quote cannot swallow real code.
+func scanGoInterpreted(content []byte, start int) int {
+	n := len(content)
+	i := start + 1
+	for i < n {
+		switch content[i] {
+		case '\\':
+			i += 2
+			continue
+		case '"':
+			return i + 1
+		case '\n':
+			return i
+		}
+		i++
+	}
+	return n
+}
+
+// scanGoRawString returns the offset just past a raw string literal “ `...` “
+// opening at content[start]. Raw strings process NO escapes — a backslash is an
+// ordinary byte and does not escape the closing backtick — and they may span
+// multiple lines. An unterminated raw string runs to EOF.
+func scanGoRawString(content []byte, start int) int {
+	n := len(content)
+	i := start + 1
+	for i < n {
+		if content[i] == '`' {
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// scanGoRune returns the offset just past a rune literal `'...'` opening at
+// content[start]. Backslash escapes are honored (an escaped quote and an escaped
+// newline both stay inside the literal), the literal is closed at the matching
+// quote, and a real newline ends the scan defensively so a stray apostrophe
+// cannot swallow code.
+func scanGoRune(content []byte, start int) int {
+	n := len(content)
+	i := start + 1
+	for i < n {
+		switch content[i] {
+		case '\\':
+			i += 2
+			continue
+		case '\'':
+			return i + 1
+		case '\n':
+			return i
+		}
+		i++
+	}
+	return n
+}

--- a/core/lexctx/scan_go_test.go
+++ b/core/lexctx/scan_go_test.go
@@ -1,0 +1,215 @@
+package lexctx
+
+import "testing"
+
+// TestScanGo exercises the headline Go lexical roles the same way TestScanPython
+// / TestScanJavaScript do: one fixture, one needle per role. It pins the
+// code/string/comment classification that the secrets and AI analyzers rely on
+// when gating findings in Go source.
+func TestScanGo(t *testing.T) {
+	src := "apiKey := \"s3cr3t\"\n" +
+		"// line comment s3cr3t\n" +
+		"/* block s3cr3t comment */\n" +
+		"raw := `template s3cr3t line`\n" +
+		"r := 's'\n"
+	if k := kindOfSubstring(t, LangGo, src, `apiKey`); k != KindCode {
+		t.Errorf("apiKey should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `"s3cr3t"`); k != KindString {
+		t.Errorf("interpreted string literal should be string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `line comment s3cr3t`); k != KindComment {
+		t.Errorf("line comment should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `block s3cr3t comment`); k != KindComment {
+		t.Errorf("block comment should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, "`template s3cr3t line`"); k != KindString {
+		t.Errorf("raw string literal should be string, got %v", k)
+	}
+}
+
+func TestGoLangFromPath(t *testing.T) {
+	if got := LangFromPath("core/analyzers/secrets/dedup.go"); got != LangGo {
+		t.Errorf("LangFromPath(.go) = %v, want %v", got, LangGo)
+	}
+	if got := LangFromPath("UPPER.GO"); got != LangGo {
+		t.Errorf("LangFromPath is not case-insensitive for .go, got %v", got)
+	}
+}
+
+func TestGoLangString(t *testing.T) {
+	if got := LangGo.String(); got != "go" {
+		t.Errorf("LangGo.String() = %q, want %q", got, "go")
+	}
+}
+
+// TestGoLineComment: a `//` runs to end of line; the following line is code.
+func TestGoLineComment(t *testing.T) {
+	src := "x := 1 // comment SECRET here\ny := 2"
+	if k := kindOfSubstring(t, LangGo, src, `comment SECRET here`); k != KindComment {
+		t.Errorf("line-comment body should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `y := 2`); k != KindCode {
+		t.Errorf("code after a line comment should be code, got %v", k)
+	}
+}
+
+// TestGoBlockCommentSpansLines: `/* ... */` crosses newlines; Go block comments
+// do NOT nest, so the FIRST `*/` closes it and the rest is code.
+func TestGoBlockCommentSpansLines(t *testing.T) {
+	src := "before\n/* multi\n line SECRET\n comment */\nafter"
+	if k := kindOfSubstring(t, LangGo, src, `line SECRET`); k != KindComment {
+		t.Errorf("multi-line block comment body should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `after`); k != KindCode {
+		t.Errorf("code after a block comment should be code, got %v", k)
+	}
+}
+
+func TestGoBlockCommentSingleLine(t *testing.T) {
+	src := "a := 1 /* inline SECRET */ ; b := 2"
+	if k := kindOfSubstring(t, LangGo, src, `inline SECRET`); k != KindComment {
+		t.Errorf("single-line block comment should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `b := 2`); k != KindCode {
+		t.Errorf("code after inline block comment should be code, got %v", k)
+	}
+}
+
+// TestGoBlockCommentNotNested pins the non-nesting rule: the first `*/` ends the
+// comment even though an inner `/*` appeared, so the trailing `SECRET` is code.
+func TestGoBlockCommentNotNested(t *testing.T) {
+	src := "/* outer /* inner */ SECRET := 1"
+	if k := kindOfSubstring(t, LangGo, src, `inner`); k != KindComment {
+		t.Errorf("bytes before the first close should be comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("bytes after the first `*/` should be code (no nesting), got %v", k)
+	}
+}
+
+// TestGoInterpretedEscapedQuote: `\"` must not close the interpreted string, so
+// the trailing code stays code.
+func TestGoInterpretedEscapedQuote(t *testing.T) {
+	src := `s := "a\"b" ; SECRET := 1`
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("code after an escaped-quote string should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `a\"b`); k != KindString {
+		t.Errorf("escaped-quote string body should be string, got %v", k)
+	}
+}
+
+// TestGoInterpretedStringEndsAtNewline: an unterminated interpreted string is
+// closed by the newline (Go spec), so the next line's code is not swallowed.
+func TestGoInterpretedStringEndsAtNewline(t *testing.T) {
+	src := "s := \"unterminated\nSECRET := 1"
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("code after a newline-terminated string should be code, got %v", k)
+	}
+}
+
+// TestGoRawStringSpansLines: raw strings use backticks, span newlines, and do
+// NOT process escapes — a base64 blob is often a raw string. The `//` and `"`
+// inside must not be mis-scanned, and the trailing code stays code.
+func TestGoRawStringSpansLines(t *testing.T) {
+	src := "blob := `line1 // not a comment\nline2 \"not a string\" SECRET`\nafter := 1"
+	if k := kindOfSubstring(t, LangGo, src, `// not a comment`); k != KindString {
+		t.Errorf("`//` inside a raw string must stay string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `not a string`); k != KindString {
+		t.Errorf("`\"` inside a raw string must stay string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `after`); k != KindCode {
+		t.Errorf("code after a multi-line raw string should be code, got %v", k)
+	}
+}
+
+// TestGoRawStringNoEscape: a backslash in a raw string is literal and does NOT
+// escape the closing backtick — the string ends at the first backtick.
+func TestGoRawStringNoEscape(t *testing.T) {
+	src := "r := `a\\` + SECRET"
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("code after a raw string with a trailing backslash should be code, got %v", k)
+	}
+}
+
+// TestGoRuneLiteral: rune literals `'...'` carry escapes; a `'` inside an escape
+// must not be misread. Crucially, a `'` that is really an apostrophe-shaped
+// operator is not our concern here — Go has no such thing — but a rune with an
+// escaped quote must be handled.
+func TestGoRuneLiteral(t *testing.T) {
+	src := `c := '\'' ; SECRET := 1`
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("code after a rune literal should be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `'\''`); k != KindString {
+		t.Errorf("rune literal should be string-kind, got %v", k)
+	}
+}
+
+// TestGoDoubleSlashInsideStringIsNotComment: a URL's `//` inside an interpreted
+// string must not begin a comment.
+func TestGoDoubleSlashInsideStringIsNotComment(t *testing.T) {
+	src := `url := "https://example.com/path" ; SECRET := 1`
+	if k := kindOfSubstring(t, LangGo, src, `//example`); k != KindString {
+		t.Errorf("`//` inside a string must stay string, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangGo, src, `SECRET`); k != KindCode {
+		t.Errorf("code after the URL string should be code, got %v", k)
+	}
+}
+
+// TestGoStraddleIntoCodeIsNotSuppressed guards the boundary contract: a span
+// that begins in a string but leaks into code is not treated as a clean string
+// region (mirrors the InCode straddle rule the analyzers rely on).
+func TestGoStraddleNotDataBlob(t *testing.T) {
+	// code | string | code: `x := "yy" + b`
+	src := `x := "yy" + b`
+	regions := Classify(LangGo, []byte(src))
+	regionsCover(t, regions, len(src))
+	// The string literal "yy" starts at index 5.
+	strStart := indexOf(src, `"yy"`)
+	// A match that spans from inside the string into the following code is a
+	// straddle: InDataBlob must keep it (return false).
+	if InDataBlob(LangGo, []byte(src), strStart+1, strStart+6) {
+		t.Error("a span straddling string into code must not be reported as a data blob")
+	}
+}
+
+// TestGoDataBlobInRawStringSuppressed proves the payoff: a long base64/data-URI
+// payload inside a Go raw string is a blob (suppressed), while a short secret in
+// an ordinary interpreted string is NOT (kept). This is the whole point of the
+// classifier for Go.
+func TestGoDataBlobInRawStringSuppressed(t *testing.T) {
+	longBlob := "var icon = `data:image/svg+xml;base64," +
+		"AKIA1234567890ABCDEF1234567890ABAKIA1234567890ABCDEF1234567890AB==`"
+	j := indexOf(longBlob, "AKIA1234567890ABCDEF1234567890AB")
+	if !InDataBlob(LangGo, []byte(longBlob), j, j+32) {
+		t.Error("a token inside a long data-URI raw-string blob must be reported as a data blob")
+	}
+
+	shortSecret := []byte(`apiKey := "AKIA1234567890ABCDEF1234567890AB"`)
+	i := indexOf(string(shortSecret), "AKIA1234567890ABCDEF1234567890AB")
+	if InDataBlob(LangGo, shortSecret, i, i+32) {
+		t.Error("a short hardcoded secret in an ordinary Go string must NOT be a data blob")
+	}
+}
+
+// TestGoSuppressNonCodePolicy mirrors the Python policy test for Go: a comment
+// match and a data-blob-string match are dropped by SuppressNonCode, while a
+// short ordinary-string secret is kept.
+func TestGoSuppressNonCodePolicy(t *testing.T) {
+	comment := []byte("x := 1 // AKIA1234567890ABCDEF1234567890AB legacy")
+	k := indexOf(string(comment), "AKIA1234567890ABCDEF1234567890AB")
+	if !SuppressNonCode(LangGo, comment, k, k+32) {
+		t.Error("a token inside a Go comment must be suppressed by SuppressNonCode")
+	}
+
+	shortSecret := []byte(`key := "AKIA1234567890ABCDEF1234567890AB"`)
+	i := indexOf(string(shortSecret), "AKIA1234567890ABCDEF1234567890AB")
+	if SuppressNonCode(LangGo, shortSecret, i, i+32) {
+		t.Error("a short hardcoded secret in a Go string literal must NOT be suppressed")
+	}
+}


### PR DESCRIPTION
## Summary

Adds **Go** to the `core/lexctx` lexical classifier so code/string/comment/data-blob gating works on Go source, then **proves it by removing the `.nox.yaml` workaround #195 shipped** for nox's own Go pattern-vocabulary files.

Before this, `lexctx` classified only Python and JS/TS; Go fell through to `LangUnknown` (one big code region). Because Go was unclassified, nox's own PR gate flagged literal secret/prompt patterns in nox's Go analyzer source — the comments and prefix constants that a pattern-vocabulary file must name. #195 worked around that by excluding three files. This is the systemic fix.

## What changed

**1. lexctx-Go classifier** (`core/lexctx/`)
- `LangGo` constant; `.go` → `LangGo` in `LangFromPath`; `LangGo` registered in `Classify`.
- `scanGo` hand-rolls the four Go lexical constructs that carry FP noise:
  - `//` line comments and `/* */` block comments (Go block comments do **not** nest — first `*/` closes; reuses `scanBlockComment`)
  - interpreted `"..."` strings with backslash escapes; a newline terminates an unclosed one (Go spec)
  - **raw** `` `...` `` strings: no escapes, may span lines (a base64/data-URI blob is often a raw string)
  - `'...'` rune literals with escapes
- The `InDataBlob` / `SuppressNonCode` / `InCode` helpers are language-agnostic once regions exist, so they light up for Go automatically. The secrets analyzer (`inEmbeddedBlob` → `InDataBlob`) and AI analyzer (`suppressNonCode` → `SuppressNonCode`) activate for `.go` with no wiring change.
- Table-driven tests mirror the existing `scan_python` / `scan_javascript` suites: line/block (single + multi-line, non-nesting) comments, interpreted escaped-quote, newline-terminated string, raw string spanning lines, rune literal, `//` and `"` inside strings, straddle/boundary, and the data-blob-vs-short-secret policy.

**2. Secrets: drop bare provider-prefix matches** (`core/analyzers/secrets/`)
- Two prefix-only rules (SEC-436 `glpat-`, SEC-438 `sk_live_`) fire on the literal prefix wherever it appears, including the owner table `{"glpat-": ...}` and the `// prefix (ghp_, sk_live_, …)` comments in `dedup.go`. `InDataBlob` deliberately keeps ordinary strings and comments (so a genuinely leaked credential is never hidden), so lexctx-Go alone does not suppress these.
- Fix: a live credential always carries a 20+ char high-entropy body, so a match that is **only the bare prefix** (no token body follows) is a vocabulary reference, not a secret, and is dropped. Runs after `dedupBySpecificity`, so on a real token the precise owner rule (which requires the body) has already claimed the span — a surviving bare-prefix match never coincides with a real credential.
- **Regression guard preserved:** a FULL token in a Go string (`apiKey := "glpat-…20chars"`) is still reported, and the existing `leaked-in-comment` test (a full AWS key in a comment is kept) still passes.

**3. Remove the #195 workaround** (`.nox.yaml`)
- Dropped the three excludes (`secrets/dedup.go`, `secrets/placeholder.go`, `ai/prompt_context.go`) and their comment block. The pre-existing `rules.go` / `iac/rules*.go` / `ai/rules.go` excludes are left alone (they carry regex character-class patterns lexctx-Go does not suppress).

## Verification

- **Self-scan gate (the one that bit #195), excludes removed:**
  ```
  nox scan --changed-since origin/main --severity-threshold high .
  → 0 findings (exit 0)
  ```
- `go build ./...`, `go test ./...`, `go test -race ./core/lexctx/... ./core/analyzers/secrets/... ./core/analyzers/ai/...` — all green.
- `golangci-lint run` on changed packages — 0 issues (gofmt clean).
- `go test ./cli/ -run PrecisionSuiteBaseline` — unchanged (the precision suite is Python/JS/TS; Go support does not touch it).

## Constraints honored
Pure Go, no CGo, no new deps; deterministic content-only classification; matches surrounding lexctx style/naming.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom