### PR TITLE
feat(bench): harden precision harness — per-rule ratchet, anti-cheat + determinism guards, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,16 @@ jobs:
       - name: Build binary
         run: make build
 
+      - name: SAST precision gate
+        # The honest precision harness as a real check. Reuses the nox binary
+        # `make build` just produced, scans the labeled corpus offline (no
+        # network, deterministic), and fails the build on ANY regression vs the
+        # committed snapshot — overall OR per-rule (baseline.json now records a
+        # precision/recall floor per rule). --min-precision is a second, blunt
+        # floor: no rule that fired may score below it. This is what stops the
+        # precision number from silently rotting.
+        run: ./nox bench --precision testdata/precision-suite --baseline testdata/precision-suite/baseline.json --min-precision 0.90
+
       - name: Run nox self-scan
         # NOTE: Go's flag.Parse stops at the first positional argument,
         # so the path MUST come last. `nox scan . --vex foo` silently

--- a/core/bench/baseline.go
+++ b/core/bench/baseline.go
@@ -1,6 +1,9 @@
 package bench
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // A baseline turns the honest precision number into a ratchet. Measuring
 // precision once is worth little if it can silently rot; a committed snapshot
@@ -32,11 +35,31 @@ type Baseline struct {
 	// regression: it means the scanner started inflating real issues into more
 	// duplicate findings even if precision/recall held.
 	FindingsPerIssue float64 `json:"findings_per_issue"`
+	// Rules is the per-rule precision/recall floor. An overall-only ratchet lets
+	// one rule silently regress while another improves and hides it in the
+	// average; recording a floor per rule makes each rule defend its own number.
+	// It is omitempty and nil-tolerant: a baseline.json written before this field
+	// existed simply has no `rules` section, loads fine, and skips per-rule
+	// enforcement (backward compatible). Sorted by RuleID for a stable snapshot.
+	Rules []RuleBaseline `json:"rules,omitempty"`
 }
 
-// BaselineFromReport extracts the gated metrics from a full Report.
+// RuleBaseline is the floor for a single rule: its precision and recall may not
+// drop below these recorded values. Only rules that actually fired or had
+// expectations at snapshot time are recorded — a rule the corpus never exercises
+// has no meaningful floor and would only add noise to the ratchet.
+type RuleBaseline struct {
+	RuleID    string  `json:"rule_id"`
+	Precision float64 `json:"precision"`
+	Recall    float64 `json:"recall"`
+}
+
+// BaselineFromReport extracts the gated metrics from a full Report, including
+// the per-rule floors. Only rules that were exercised (TP+FP+FN > 0) get a
+// floor: an untouched rule scores a vacuous 1.0/1.0 (see RuleMetrics.Precision)
+// and recording that would gate on precision the corpus never actually measured.
 func BaselineFromReport(r *Report) Baseline {
-	return Baseline{
+	b := Baseline{
 		Precision:        r.Overall.Precision(),
 		Recall:           r.Overall.Recall(),
 		F1:               r.Overall.F1(),
@@ -45,6 +68,19 @@ func BaselineFromReport(r *Report) Baseline {
 		FN:               r.Overall.FN,
 		FindingsPerIssue: r.Density.FindingsPerIssue(),
 	}
+	for i := range r.Rules {
+		m := &r.Rules[i]
+		if m.TP+m.FP+m.FN == 0 {
+			continue
+		}
+		b.Rules = append(b.Rules, RuleBaseline{
+			RuleID:    m.RuleID,
+			Precision: m.Precision(),
+			Recall:    m.Recall(),
+		})
+	}
+	sort.Slice(b.Rules, func(i, j int) bool { return b.Rules[i].RuleID < b.Rules[j].RuleID })
+	return b
 }
 
 // BaselineTolerance is the slack the gate allows before calling a metric change
@@ -99,6 +135,45 @@ func CompareBaseline(base, current Baseline) []Regression {
 	}
 	if current.FindingsPerIssue > base.FindingsPerIssue+baselineEpsilon {
 		out = append(out, Regression{"findings_per_issue", base.FindingsPerIssue, current.FindingsPerIssue})
+	}
+	// Per-rule floors: any individual rule whose precision OR recall dropped
+	// below its recorded floor is a regression, even when the overall numbers
+	// hold (one rule improving can mask another regressing in the average). A
+	// base with no per-rule section (a pre-schema snapshot) skips this check
+	// entirely, keeping old baselines loadable and gated only on the overall.
+	out = append(out, compareRules(base.Rules, current.Rules)...)
+	return out
+}
+
+// compareRules flags every rule whose current precision or recall fell below its
+// baseline floor. Current per-rule numbers are looked up by RuleID; a floored
+// rule that no longer appears in current (it stopped firing and had no
+// expectation) is treated as a vacuous 1.0/1.0 — its absence is not itself a
+// regression, matching how BaselineFromReport declines to floor unexercised
+// rules. The Metric name is prefixed with the rule ID so the CLI diff points at
+// the exact rule that moved.
+func compareRules(base, current []RuleBaseline) []Regression {
+	if len(base) == 0 {
+		return nil
+	}
+	byRule := make(map[string]RuleBaseline, len(current))
+	for _, r := range current {
+		byRule[r.RuleID] = r
+	}
+	var out []Regression
+	for _, b := range base {
+		cur, ok := byRule[b.RuleID]
+		if !ok {
+			// Rule no longer exercised: precision/recall are the vacuous 1.0, so
+			// they cannot fall below any floor <= 1.0.
+			cur = RuleBaseline{RuleID: b.RuleID, Precision: 1.0, Recall: 1.0}
+		}
+		if cur.Precision < b.Precision-baselineEpsilon {
+			out = append(out, Regression{b.RuleID + " precision", b.Precision, cur.Precision})
+		}
+		if cur.Recall < b.Recall-baselineEpsilon {
+			out = append(out, Regression{b.RuleID + " recall", b.Recall, cur.Recall})
+		}
 	}
 	return out
 }

--- a/core/bench/baseline_test.go
+++ b/core/bench/baseline_test.go
@@ -1,6 +1,10 @@
 package bench
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
 
 func TestCompareBaseline(t *testing.T) {
 	t.Parallel()
@@ -62,6 +66,128 @@ func TestCompareBaseline(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCompareBaselinePerRule proves the per-rule ratchet catches a single rule
+// regressing even when the overall numbers are untouched — the exact blind spot
+// an overall-only floor has. It also proves the schema is backward compatible: a
+// baseline with no `rules` section skips per-rule enforcement.
+func TestCompareBaselinePerRule(t *testing.T) {
+	t.Parallel()
+
+	// Overall metrics are identical in every case; only the per-rule floors and
+	// current per-rule numbers differ, isolating the per-rule logic.
+	overall := Baseline{Precision: 0.90, Recall: 0.90, F1: 0.90, FP: 2, FindingsPerIssue: 1.0}
+	withRules := func(rules ...RuleBaseline) Baseline {
+		b := overall
+		b.Rules = rules
+		return b
+	}
+
+	tests := []struct {
+		name        string
+		base        Baseline
+		current     Baseline
+		wantMetrics []string
+	}{
+		{
+			name:        "flat per-rule floors are no regression",
+			base:        withRules(RuleBaseline{"SEC-001", 1.0, 1.0}, RuleBaseline{"AI-002", 0.5, 1.0}),
+			current:     withRules(RuleBaseline{"SEC-001", 1.0, 1.0}, RuleBaseline{"AI-002", 0.5, 1.0}),
+			wantMetrics: nil,
+		},
+		{
+			name:        "one rule's precision drop regresses even when overall holds",
+			base:        withRules(RuleBaseline{"SEC-001", 1.0, 1.0}, RuleBaseline{"AI-002", 1.0, 1.0}),
+			current:     withRules(RuleBaseline{"SEC-001", 0.5, 1.0}, RuleBaseline{"AI-002", 1.0, 1.0}),
+			wantMetrics: []string{"SEC-001 precision"},
+		},
+		{
+			name:        "one rule's recall drop regresses",
+			base:        withRules(RuleBaseline{"SEC-001", 1.0, 1.0}),
+			current:     withRules(RuleBaseline{"SEC-001", 1.0, 0.5}),
+			wantMetrics: []string{"SEC-001 recall"},
+		},
+		{
+			name:        "per-rule improvement never regresses",
+			base:        withRules(RuleBaseline{"SEC-001", 0.5, 0.5}),
+			current:     withRules(RuleBaseline{"SEC-001", 1.0, 1.0}),
+			wantMetrics: nil,
+		},
+		{
+			name:        "a floored rule that stopped firing is not a regression (vacuous 1.0)",
+			base:        withRules(RuleBaseline{"SEC-001", 1.0, 1.0}),
+			current:     overall, // no rules at all in the current run
+			wantMetrics: nil,
+		},
+		{
+			name:        "backward compatible: base without rules skips per-rule enforcement",
+			base:        overall, // pre-schema snapshot, no rules section
+			current:     withRules(RuleBaseline{"SEC-001", 0.0, 0.0}),
+			wantMetrics: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CompareBaseline(tt.base, tt.current)
+			names := make([]string, len(got))
+			for i := range got {
+				names[i] = got[i].Metric
+			}
+			if len(names) != len(tt.wantMetrics) {
+				t.Fatalf("regressions = %v, want %v", names, tt.wantMetrics)
+			}
+			for i := range tt.wantMetrics {
+				if names[i] != tt.wantMetrics[i] {
+					t.Errorf("regression[%d] = %s, want %s", i, names[i], tt.wantMetrics[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBaselineFromReportPerRule proves BaselineFromReport records a floor for
+// every exercised rule and omits rules the corpus never touched (which would
+// otherwise floor at a vacuous 1.0 and gate on unmeasured precision).
+func TestBaselineFromReportPerRule(t *testing.T) {
+	t.Parallel()
+
+	report := Score(
+		[]findings.Finding{
+			finding("SEC-001", "a.py", 1), // TP
+			finding("AI-002", "b.py", 2),  // FP (no expectation)
+		},
+		[]Expectation{
+			expect("SEC-001", "a.py", 1),
+			expect("SEC-510", "c.py", 3), // FN: never fired
+		},
+	)
+	b := BaselineFromReport(&report)
+
+	// All three rules were exercised (SEC-001 TP, AI-002 FP, SEC-510 FN), so all
+	// three get a floor. None is unexercised, so none is dropped.
+	got := map[string]RuleBaseline{}
+	for _, r := range b.Rules {
+		got[r.RuleID] = r
+	}
+	if len(got) != 3 {
+		t.Fatalf("recorded %d rule floors %v, want 3", len(got), b.Rules)
+	}
+	// Rules must be sorted by ID for a stable committed snapshot.
+	for i := 1; i < len(b.Rules); i++ {
+		if b.Rules[i-1].RuleID > b.Rules[i].RuleID {
+			t.Errorf("rule floors not sorted: %s before %s", b.Rules[i-1].RuleID, b.Rules[i].RuleID)
+		}
+	}
+	if p := got["AI-002"].Precision; p != 0.0 {
+		t.Errorf("AI-002 (pure FP) precision floor = %v, want 0.0", p)
+	}
+	if r := got["SEC-510"].Recall; r != 0.0 {
+		t.Errorf("SEC-510 (pure FN) recall floor = %v, want 0.0", r)
 	}
 }
 

--- a/core/bench/harness_guard_test.go
+++ b/core/bench/harness_guard_test.go
@@ -1,0 +1,208 @@
+package bench
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// These tests are the harness's guard against itself. A precision number is only
+// worth trusting if it can actually go down: a corpus curated (accidentally or
+// deliberately) to always report 1.00 measures nothing. The tests below prove
+// the scorer genuinely responds to a broken rule — that Score STRICTLY drops
+// below 1.0 and the ratchet FAILS when a false positive is injected or a true
+// positive is dropped. If a future change silently made Score unable to fall
+// below 1.0, these tests would catch it before the number lied in CI.
+
+// perfectCorpus is a tiny synthetic scenario that scores a clean 1.0/1.0/1.0:
+// two rules, each firing exactly on its one expected line, nothing else. It is
+// the honest baseline the anti-cheat tests then perturb.
+func perfectCorpus() ([]findings.Finding, []Expectation) {
+	fs := []findings.Finding{
+		finding("SEC-001", "a.py", 1),
+		finding("AI-002", "b.py", 2),
+	}
+	exp := []Expectation{
+		expect("SEC-001", "a.py", 1),
+		expect("AI-002", "b.py", 2),
+	}
+	return fs, exp
+}
+
+// TestCorpusCannotFakePerfectScore is the anti-cheat guardrail. It first
+// confirms the honest scenario scores a perfect 1.0, then perturbs it two ways —
+// an injected false positive and a dropped true positive — and asserts that in
+// each case Score STRICTLY drops below 1.0. A harness that kept reporting 1.0
+// after either perturbation would be measuring nothing, and this test fails
+// loudly if that ever happens.
+func TestCorpusCannotFakePerfectScore(t *testing.T) {
+	t.Parallel()
+
+	fs, exp := perfectCorpus()
+	clean := Score(fs, exp)
+	if p, r := clean.Overall.Precision(), clean.Overall.Recall(); p != 1.0 || r != 1.0 {
+		t.Fatalf("control corpus is not perfect: precision %v recall %v; the perturbation tests below are meaningless", p, r)
+	}
+
+	t.Run("injected false positive drops precision below 1.0", func(t *testing.T) {
+		t.Parallel()
+		// A synthetic finding on a clean line: no expectation matches it, so it is
+		// a false positive that MUST pull precision under 1.0.
+		poisoned := append(append([]findings.Finding(nil), fs...), finding("SEC-001", "clean.py", 99))
+		got := Score(poisoned, exp)
+		if got.Overall.Precision() >= 1.0 {
+			t.Fatalf("injected FP did not drop precision: got %v, want < 1.0 — the harness cannot detect a false positive", got.Overall.Precision())
+		}
+		if got.Overall.FP == 0 {
+			t.Errorf("injected FP not counted: overall FP = 0")
+		}
+	})
+
+	t.Run("dropped true positive drops recall below 1.0", func(t *testing.T) {
+		t.Parallel()
+		// Remove one real finding: its expectation is now unsatisfied, a false
+		// negative that MUST pull recall under 1.0.
+		short := []findings.Finding{fs[0]} // drop the AI-002 finding
+		got := Score(short, exp)
+		if got.Overall.Recall() >= 1.0 {
+			t.Fatalf("dropped TP did not drop recall: got %v, want < 1.0 — the harness cannot detect a missed finding", got.Overall.Recall())
+		}
+		if got.Overall.FN == 0 {
+			t.Errorf("dropped TP not counted as FN: overall FN = 0")
+		}
+	})
+}
+
+// TestHarnessCatchesRegression proves the whole ratchet chain fires: a baseline
+// snapshotted from the perfect corpus, compared against a perturbed run, MUST
+// report at least one regression. This is the end-to-end version of the anti-
+// cheat guarantee — not just that Score drops, but that CompareBaseline turns
+// that drop into a CI failure, at both the overall and per-rule level.
+func TestHarnessCatchesRegression(t *testing.T) {
+	t.Parallel()
+
+	fs, exp := perfectCorpus()
+	base := baselineOf(fs, exp)
+
+	tests := []struct {
+		name     string
+		findings []findings.Finding
+		// wantRule is a per-rule regression metric that must appear; empty means
+		// only "some regression must appear".
+		wantRule string
+	}{
+		{
+			name:     "injected false positive is caught",
+			findings: append(append([]findings.Finding(nil), fs...), finding("SEC-001", "clean.py", 99)),
+			wantRule: "SEC-001 precision",
+		},
+		{
+			name:     "dropped true positive is caught",
+			findings: []findings.Finding{fs[0]}, // AI-002 finding gone
+			wantRule: "AI-002 recall",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			current := baselineOf(tt.findings, exp)
+			regressions := CompareBaseline(base, current)
+			if len(regressions) == 0 {
+				t.Fatalf("ratchet did not fail on a broken corpus: no regressions reported")
+			}
+			if tt.wantRule != "" {
+				found := false
+				for _, r := range regressions {
+					if r.Metric == tt.wantRule {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("per-rule regression %q not among reported %v", tt.wantRule, regressions)
+				}
+			}
+		})
+	}
+}
+
+// TestScoreJSONDeterministic is the determinism guard. nox core guarantees
+// byte-identical output; the scorer builds its Report from Go maps (per-rule
+// counters, per-file density), whose iteration order is randomized, so the only
+// thing standing between us and nondeterministic JSON is the explicit sorting in
+// Score. This test scores the same inputs many times and asserts the marshalled
+// JSON is byte-for-byte identical every time, which would fail immediately if a
+// map ever leaked into the output ordering.
+func TestScoreJSONDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// A scenario deliberately rich in ties and shared families so any unsorted
+	// map iteration would surface as reordering: multiple rules per family,
+	// multiple files, clean and annotated files, duplicate FPs.
+	fs := []findings.Finding{
+		finding("SEC-508", "s.py", 1),
+		finding("SEC-001", "s.py", 1),
+		finding("SEC-003", "s.py", 1),
+		finding("AI-002", "p.py", 2),
+		finding("AI-002", "clean.py", 5), // FP
+		finding("TAINT-005", "t.py", 3),
+		finding("TAINT-004", "t.py", 3),
+		finding("SEC-001", "clean2.py", 9), // FP
+	}
+	exp := []Expectation{
+		expect("SEC-001", "s.py", 1),
+		expect("SEC-003", "s.py", 1),
+		expect("AI-002", "p.py", 2),
+		expect("TAINT-005", "t.py", 3),
+		expect("SEC-999", "missing.py", 7), // FN
+	}
+
+	var first []byte
+	const runs = 50
+	for i := 0; i < runs; i++ {
+		report := Score(fs, exp)
+		out, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("marshal report: %v", err)
+		}
+		if first == nil {
+			first = out
+			continue
+		}
+		if !bytes.Equal(first, out) {
+			t.Fatalf("Score JSON is nondeterministic across runs:\nrun 0:  %s\nrun %d: %s", first, i, out)
+		}
+	}
+
+	// Also assert the baseline snapshot derived from the report is deterministic:
+	// its per-rule floors are built from a map and sorted, so a missing sort would
+	// show up here too.
+	var firstBase []byte
+	for i := 0; i < runs; i++ {
+		report := Score(fs, exp)
+		b := BaselineFromReport(&report)
+		out, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("marshal baseline: %v", err)
+		}
+		if firstBase == nil {
+			firstBase = out
+			continue
+		}
+		if !bytes.Equal(firstBase, out) {
+			t.Fatalf("Baseline JSON is nondeterministic across runs:\nrun 0:  %s\nrun %d: %s", firstBase, i, out)
+		}
+	}
+}
+
+// baselineOf scores the inputs and derives the baseline snapshot in one step,
+// so the ratchet tests can go straight from (findings, expectations) to the
+// gated Baseline without an intermediate Report variable.
+func baselineOf(fs []findings.Finding, exp []Expectation) Baseline {
+	report := Score(fs, exp)
+	return BaselineFromReport(&report)
+}

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -49,7 +49,12 @@ fixing the false-positive classes the corpus indicted:
 
 Committed as `baseline.json`; `TestPrecisionSuiteBaseline` (in `cli/`) fails if
 any of precision/recall/F1 drops or FP / findings-per-issue rises, so the number
-can only move the right way without a human refreshing the snapshot.
+can only move the right way without a human refreshing the snapshot. The snapshot
+also records a **per-rule** precision/recall floor (the `rules` array): the
+ratchet fails if any individual rule regresses below its floor, so one rule
+rotting can no longer hide behind another improving in the overall average. The
+`rules` section is optional — a snapshot without it still loads and gates on the
+overall numbers only.
 
 ### The precise to-do list the corpus indicts
 

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -5,5 +5,77 @@
   "fp": 0,
   "tp": 17,
   "fn": 0,
-  "findings_per_issue": 1.0625
+  "findings_per_issue": 1.0625,
+  "rules": [
+    {
+      "rule_id": "AI-002",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-001",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-003",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-007",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-023",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-030",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SEC-508",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "SLOP-001",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "TAINT-002",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "TAINT-004",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "TAINT-005",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "TAINT-006",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "VARIANT-002",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "VARIANT-005",
+      "precision": 1,
+      "recall": 1
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Hardens the SAST precision harness so its `1.00` number defends itself and can't be trivially gamed. Four changes, all TDD:

### 1. Per-rule / per-family ratchet floors
`Baseline` gains a per-rule precision/recall floor (`Baseline.Rules []RuleBaseline`). `CompareBaseline` now fails if **any single rule** drops below its recorded floor — closing the blind spot where one rule silently regressing is masked by another improving in the overall average.

**Backward compatible:** a `baseline.json` written before this field existed has no `rules` section, loads fine, and skips per-rule enforcement (`compareRules` no-ops on an empty base). Only *exercised* rules (TP+FP+FN > 0) get a floor — an untouched rule scores a vacuous 1.0 and would gate on precision the corpus never measured. Floors are sorted by rule ID for a stable snapshot. `testdata/precision-suite/baseline.json` regenerated with the per-rule section (14 rules, all 1.0/1.0).

### 2. Anti-cheat / self-test meta-test
`TestCorpusCannotFakePerfectScore` and `TestHarnessCatchesRegression` (in `core/bench`, pure unit tests): start from a synthetic perfect-1.0 scenario, then inject a false positive or drop a true positive and assert `Score()` **strictly drops** below 1.0 **and** `CompareBaseline` reports a regression (at both overall and per-rule level). This is the guardrail that would catch a future corpus curated to always pass.

### 3. Determinism guard
`TestScoreJSONDeterministic`: `Score()`→JSON is byte-identical across 50 runs, and the derived `Baseline` JSON too. The scorer builds its report from Go maps (whose iteration order is randomized), so this fails immediately if a map ever leaks into output ordering. No nondeterminism was found — the existing explicit sorts hold. Also verified at the CLI level: `nox bench --precision --json` is byte-identical across consecutive runs.

### 4. CI-wired precision gate
New **SAST precision gate** step in the `Build & Scan` job, right after `make build`, reusing that binary:
```
./nox bench --precision testdata/precision-suite --baseline testdata/precision-suite/baseline.json --min-precision 0.90
```
Offline, deterministic, fails the build on any regression (overall or per-rule) or any fired rule below 0.90.

## Verification
- `go build ./...`, `go test ./...`, `go test -race ./core/bench/... ./cli/...` all green.
- `golangci-lint run` (v2.12.2): new test file clean; no new issues on changed lines.
- Suite still scores **precision 1.00 / recall 1.00 / F1 1.00** (0 FP of 17 findings) with per-rule enforcement active.
- Self-scan gate: every changed file scans clean at `--severity-threshold high`.

## Notes
- Per the sibling PHASE-2 effort owning Go corpus growth, the **only** change under `testdata/precision-suite/` is `baseline.json` — no sample files added or modified.
- `Improved()` intentionally left overall-only (it merely nudges a snapshot refresh; the ratchet failure is what enforces per-rule floors).

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom