### PR TITLE
feat(taint): Go taint model — AST-precise dataflow closes the six Go FNs

### DIFF
--- a/core/analyzers/taintflow/taintflow_go_test.go
+++ b/core/analyzers/taintflow/taintflow_go_test.go
@@ -1,0 +1,64 @@
+package taintflow
+
+import "testing"
+
+// TestAnalyzerGoTruePositive proves the analyzer runs the taint engine on a .go
+// artifact end-to-end (discovery → lexctx LangGo → extractGo → engine → finding),
+// with no code path change beyond the catalog + extractor: a request query
+// parameter concatenated into db.Query fires TAINT-001.
+func TestAnalyzerGoTruePositive(t *testing.T) {
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "store.go", `package store
+
+func lookup(db *DB, r *Req) {
+	id := r.URL.Query().Get("id")
+	_ = db.Query("SELECT * FROM t WHERE id = '" + id + "'")
+}
+`)
+	ids := scan(t, art)
+	if len(ids) != 1 || ids[0] != "TAINT-001" {
+		t.Fatalf("want [TAINT-001], got %v", ids)
+	}
+}
+
+// TestAnalyzerGoCleanNoFinding proves the parameterized-query guardrail: a
+// placeholder ($1) query with the value passed as a distinct argument fires
+// nothing.
+func TestAnalyzerGoCleanNoFinding(t *testing.T) {
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "safe.go", `package store
+
+func lookup(db *DB, id string) {
+	_ = db.Query("SELECT name FROM users WHERE id = $1", id)
+}
+`)
+	ids := scan(t, art)
+	if len(ids) != 0 {
+		t.Fatalf("want no findings, got %v", ids)
+	}
+}
+
+// TestAnalyzerGoDeserialization proves the inline-source hoist wiring: r.Body used
+// directly as a sink argument fires TAINT-005.
+func TestAnalyzerGoDeserialization(t *testing.T) {
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "session.go", `package session
+
+func restore(r *Req) {
+	var env E
+	if err := gob.NewDecoder(r.Body).Decode(&env); err != nil {
+		_ = err
+	}
+}
+`)
+	ids := scan(t, art)
+	found := false
+	for _, id := range ids {
+		if id == "TAINT-005" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want TAINT-005, got %v", ids)
+	}
+}

--- a/core/taint/catalog_go_test.go
+++ b/core/taint/catalog_go_test.go
@@ -1,0 +1,79 @@
+package taint
+
+import "testing"
+
+// TestGoCatalogSinks asserts the Go language block carries the sinks the precision
+// corpus annotations require, with the exact rule_id/cwe/vuln_class the six tp_*.go
+// samples expect.
+func TestGoCatalogSinks(t *testing.T) {
+	cat := MustDefault()
+	tests := []struct {
+		name      string
+		call      string
+		wantClass VulnClass
+		wantCWE   string
+		wantRule  string
+	}{
+		{"exec.Command cmdi", "exec.Command", VulnCommandInjection, "CWE-78", "TAINT-002"},
+		{"db.Query sqli", "db.Query", VulnSQLInjection, "CWE-89", "TAINT-001"},
+		{"db.Exec sqli", "db.Exec", VulnSQLInjection, "CWE-89", "TAINT-001"},
+		{"os.ReadFile path", "os.ReadFile", VulnPathTraversal, "CWE-22", "TAINT-004"},
+		{"os.Open path", "os.Open", VulnPathTraversal, "CWE-22", "TAINT-004"},
+		{"http.Get ssrf", "http.Get", VulnSSRF, "CWE-918", "TAINT-006"},
+		{"gob.NewDecoder deser", "gob.NewDecoder", VulnUnsafeDeserialization, "CWE-502", "TAINT-005"},
+		{"yaml.Unmarshal deser", "yaml.Unmarshal", VulnUnsafeDeserialization, "CWE-502", "TAINT-005"},
+		{"template.New.Parse ssti", "template.New.Parse", VulnSSTI, "CWE-1336", "TAINT-003"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink, ok := cat.IsSink("go", tt.call)
+			if !ok {
+				t.Fatalf("IsSink(go, %q) = false, want true", tt.call)
+			}
+			if sink.VulnClass != tt.wantClass {
+				t.Errorf("VulnClass = %q, want %q", sink.VulnClass, tt.wantClass)
+			}
+			if sink.CWE != tt.wantCWE {
+				t.Errorf("CWE = %q, want %q", sink.CWE, tt.wantCWE)
+			}
+			if sink.RuleID != tt.wantRule {
+				t.Errorf("RuleID = %q, want %q", sink.RuleID, tt.wantRule)
+			}
+		})
+	}
+}
+
+// TestGoCatalogSources asserts the untrusted-input sources are present and that
+// os.Getenv is deliberately NOT a source (it would create FPs on the clean
+// placeholder sample).
+func TestGoCatalogSources(t *testing.T) {
+	cat := MustDefault()
+	for _, call := range []string{"URL.Query.Get", "r.FormValue", "r.Header.Get", "r.Body", "os.Args"} {
+		if !cat.IsSource("go", call) {
+			t.Errorf("IsSource(go, %q) = false, want true", call)
+		}
+	}
+	if cat.IsSource("go", "os.Getenv") {
+		t.Errorf("os.Getenv must NOT be a Go source (protects clean_placeholders.go precision)")
+	}
+}
+
+// TestGoCatalogSanitizers asserts the neutralizers and their classes.
+func TestGoCatalogSanitizers(t *testing.T) {
+	cat := MustDefault()
+	tests := []struct {
+		call  string
+		class VulnClass
+	}{
+		{"filepath.Clean", VulnPathTraversal},
+		{"filepath.Base", VulnPathTraversal},
+		{"url.QueryEscape", VulnSSRF},
+		{"strconv.Atoi", VulnCommandInjection},
+		{"strconv.Atoi", VulnSQLInjection},
+	}
+	for _, tt := range tests {
+		if !cat.IsSanitizer("go", tt.call, tt.class) {
+			t.Errorf("IsSanitizer(go, %q, %q) = false, want true", tt.call, tt.class)
+		}
+	}
+}

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -182,6 +182,54 @@
         {"call": "url.parse", "neutralizes": ["ssrf"], "note": "parse step for host allowlisting"},
         {"call": "new URL", "neutralizes": ["ssrf"], "note": "parse step; pair with a host allowlist decision"}
       ]
+    },
+    "go": {
+      "comment": "Go source/sink/sanitizer model. Sinks come in two shapes: package-qualified (exec.Command, os.ReadFile, http.Get, gob.NewDecoder, template.Parse) matched on the full dotted chain, and methods on a value whose receiver name varies (.Query/.Exec/.Decode) matched on the method suffix via the engine's suffixKeys fallback. See docs/design/go-taint.md for the precision trade of method-suffix matching and the AST-only (no go/types) scope.",
+      "sources": [
+        {"call": "URL.Query.Get", "kind": "http_query"},
+        {"call": "r.URL.Query", "kind": "http_query"},
+        {"call": "r.URL.RawQuery", "kind": "http_query"},
+        {"call": "r.FormValue", "kind": "http_body"},
+        {"call": "r.PostFormValue", "kind": "http_body"},
+        {"call": "r.PostForm.Get", "kind": "http_body"},
+        {"call": "r.Form.Get", "kind": "http_body"},
+        {"call": "r.Header.Get", "kind": "http_header"},
+        {"call": "r.Body", "kind": "http_body"},
+        {"call": "request.Body", "kind": "http_body"},
+        {"call": "req.Body", "kind": "http_body"},
+        {"call": "os.Args", "kind": "argv"}
+      ],
+      "sinks": [
+        {"call": "exec.Command", "vuln_class": "command_injection", "cwe": "CWE-78", "rule_id": "TAINT-002", "note": "dangerous when a tainted value is interpolated into a string command, e.g. sh -c"},
+        {"call": "exec.CommandContext", "vuln_class": "command_injection", "cwe": "CWE-78", "rule_id": "TAINT-002"},
+        {"call": "db.Query", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001", "note": "safe when the tainted value is passed as a placeholder arg ($1/?) rather than concatenated into the query string"},
+        {"call": "db.QueryContext", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001"},
+        {"call": "db.QueryRow", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001"},
+        {"call": "db.QueryRowContext", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001"},
+        {"call": "db.Exec", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001"},
+        {"call": "db.ExecContext", "vuln_class": "sql_injection", "cwe": "CWE-89", "rule_id": "TAINT-001"},
+        {"call": "os.Open", "vuln_class": "path_traversal", "cwe": "CWE-22", "rule_id": "TAINT-004"},
+        {"call": "os.OpenFile", "vuln_class": "path_traversal", "cwe": "CWE-22", "rule_id": "TAINT-004"},
+        {"call": "os.ReadFile", "vuln_class": "path_traversal", "cwe": "CWE-22", "rule_id": "TAINT-004"},
+        {"call": "ioutil.ReadFile", "vuln_class": "path_traversal", "cwe": "CWE-22", "rule_id": "TAINT-004"},
+        {"call": "http.Get", "vuln_class": "ssrf", "cwe": "CWE-918", "rule_id": "TAINT-006"},
+        {"call": "http.Post", "vuln_class": "ssrf", "cwe": "CWE-918", "rule_id": "TAINT-006"},
+        {"call": "http.Head", "vuln_class": "ssrf", "cwe": "CWE-918", "rule_id": "TAINT-006"},
+        {"call": "http.NewRequest", "vuln_class": "ssrf", "cwe": "CWE-918", "rule_id": "TAINT-006"},
+        {"call": "gob.NewDecoder", "vuln_class": "unsafe_deserialization", "cwe": "CWE-502", "rule_id": "TAINT-005", "note": "gob-decoding untrusted bytes (e.g. r.Body) is an RCE/DoS vector"},
+        {"call": "yaml.Unmarshal", "vuln_class": "unsafe_deserialization", "cwe": "CWE-502", "rule_id": "TAINT-005"},
+        {"call": "template.New.Parse", "vuln_class": "ssti", "cwe": "CWE-1336", "rule_id": "TAINT-003", "note": "parsing a tainted string as a text/template enables server-side template injection"},
+        {"call": "template.Parse", "vuln_class": "ssti", "cwe": "CWE-1336", "rule_id": "TAINT-003"},
+        {"call": "template.Must", "vuln_class": "ssti", "cwe": "CWE-1336", "rule_id": "TAINT-003"}
+      ],
+      "sanitizers": [
+        {"call": "filepath.Clean", "neutralizes": ["path_traversal"], "note": "canonicalizes; must be paired with a prefix/allow-base check"},
+        {"call": "filepath.Base", "neutralizes": ["path_traversal"]},
+        {"call": "url.QueryEscape", "neutralizes": ["ssrf", "xss"]},
+        {"call": "url.PathEscape", "neutralizes": ["ssrf", "xss"]},
+        {"call": "strconv.Atoi", "neutralizes": ["command_injection", "sql_injection", "path_traversal", "code_injection"], "note": "numeric coercion removes injection metacharacters"},
+        {"call": "strconv.ParseInt", "neutralizes": ["command_injection", "sql_injection", "path_traversal", "code_injection"]}
+      ]
     }
   }
 }

--- a/core/taint/engine/extract.go
+++ b/core/taint/engine/extract.go
@@ -84,6 +84,11 @@ func extractUnits(lang lexctx.Lang, content []byte) []unitDraft {
 		// continuations should merge physical lines, and each logical line is
 		// then split on top-level semicolons into separate statements.
 		return extractJavaScript(splitSemicolons(logicalLines(content, regions, true)))
+	case lexctx.LangGo:
+		// Go gets an AST-precise extractor (go/parser) rather than the lexctx line
+		// recognizer: nox is itself Go, so the pure-Go stdlib parser is free,
+		// precise, and deterministic. See extract_go.go / docs/design/go-taint.md.
+		return extractGo(content)
 	default:
 		return nil
 	}

--- a/core/taint/engine/extract_go.go
+++ b/core/taint/engine/extract_go.go
@@ -1,0 +1,625 @@
+package engine
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// extractGo turns Go source into unit drafts using the standard-library AST
+// parser (go/parser + go/ast + go/token). Unlike the Python/JS line recognizers
+// — which the project keeps deliberately parser-free to avoid CGo/heavy grammars
+// in a non-Go language — Go gets a REAL AST for free: nox is itself Go, so the
+// pure-Go stdlib parser adds no dependency, is precise, and stays deterministic.
+// See docs/design/go-taint.md for the rationale and the AST-only (no go/types)
+// scope.
+//
+// Each *ast.FuncDecl becomes one unitDraft (receiver + parameters as params, in
+// order); package-level var declarations fold into a synthetic module unit. On a
+// parse error the partial AST the parser recovers is still walked — a
+// non-compiling snippet degrades gracefully and never panics or crashes the scan.
+func extractGo(content []byte) []unitDraft {
+	fset := token.NewFileSet()
+	// SkipObjectResolution: we never need go/ast's identifier-object linking, and
+	// skipping it is faster and more tolerant. ParseComments is off — comments are
+	// not code and carry no flow. On error we still use the (partial) file.
+	file, _ := parser.ParseFile(fset, "src.go", content, parser.SkipObjectResolution)
+	if file == nil {
+		return nil
+	}
+
+	ex := &goExtractor{fset: fset}
+	module := &unitDraft{funcName: ""}
+	units := []*unitDraft{module}
+
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			u := &unitDraft{funcName: d.Name.Name, params: ex.funcParams(d)}
+			if d.Body != nil {
+				ex.walkBlock(u, d.Body.List)
+			}
+			units = append(units, u)
+		case *ast.GenDecl:
+			// Package-level var declarations with call/source initializers fold into
+			// the module unit so a top-level tainted assignment is still tracked.
+			ex.walkGenDecl(module, d)
+		}
+	}
+
+	out := make([]unitDraft, 0, len(units))
+	for _, u := range units {
+		out = append(out, *u)
+	}
+	return out
+}
+
+// goExtractor holds the fileset so every emitted statement carries the accurate
+// 1-based line number of its source position.
+type goExtractor struct {
+	fset      *token.FileSet
+	tmpserial int
+}
+
+// line returns the 1-based source line of a position.
+func (ex *goExtractor) line(pos token.Pos) int {
+	return ex.fset.Position(pos).Line
+}
+
+// funcParams returns the receiver (if any) followed by the positional parameter
+// names in declaration order — the ordering the interprocedural summary pass maps
+// caller-argument position onto. A blank (`_`) or unnamed slot is kept as "" so
+// positions do not shift.
+func (ex *goExtractor) funcParams(d *ast.FuncDecl) []string {
+	var params []string
+	if d.Recv != nil {
+		for _, f := range d.Recv.List {
+			params = append(params, fieldNames(f)...)
+		}
+	}
+	if d.Type != nil && d.Type.Params != nil {
+		for _, f := range d.Type.Params.List {
+			params = append(params, fieldNames(f)...)
+		}
+	}
+	return params
+}
+
+// fieldNames returns the identifier names of a field (one field may declare
+// several names, e.g. `a, b int`). An unnamed field yields a single "" slot so
+// positional indexing stays aligned.
+func fieldNames(f *ast.Field) []string {
+	if len(f.Names) == 0 {
+		return []string{""}
+	}
+	out := make([]string, 0, len(f.Names))
+	for _, n := range f.Names {
+		out = append(out, n.Name)
+	}
+	return out
+}
+
+// walkBlock walks a statement list in source order, emitting a stmtDraft per
+// analyzable statement. It descends into the init clauses of if/for/switch (so
+// `if err := dec.Decode(&v); err != nil` is analyzed) and into nested blocks,
+// keeping everything in the same unit (straight-line, no CFG — the engine's
+// documented limit).
+func (ex *goExtractor) walkBlock(u *unitDraft, stmts []ast.Stmt) {
+	for _, s := range stmts {
+		ex.walkStmt(u, s)
+	}
+}
+
+// walkStmt handles a single statement.
+func (ex *goExtractor) walkStmt(u *unitDraft, s ast.Stmt) {
+	switch st := s.(type) {
+	case *ast.AssignStmt:
+		ex.emitAssign(u, st)
+	case *ast.ExprStmt:
+		if call, ok := st.X.(*ast.CallExpr); ok {
+			ex.emitCallStmt(u, call, ex.line(st.Pos()))
+		}
+	case *ast.ReturnStmt:
+		ex.emitReturn(u, st)
+	case *ast.IfStmt:
+		if st.Init != nil {
+			ex.walkStmt(u, st.Init)
+		}
+		if st.Body != nil {
+			ex.walkBlock(u, st.Body.List)
+		}
+		if st.Else != nil {
+			ex.walkStmt(u, st.Else)
+		}
+	case *ast.ForStmt:
+		if st.Init != nil {
+			ex.walkStmt(u, st.Init)
+		}
+		if st.Body != nil {
+			ex.walkBlock(u, st.Body.List)
+		}
+	case *ast.RangeStmt:
+		if st.Body != nil {
+			ex.walkBlock(u, st.Body.List)
+		}
+	case *ast.SwitchStmt:
+		if st.Init != nil {
+			ex.walkStmt(u, st.Init)
+		}
+		if st.Body != nil {
+			ex.walkBlock(u, st.Body.List)
+		}
+	case *ast.CaseClause:
+		ex.walkBlock(u, st.Body)
+	case *ast.BlockStmt:
+		ex.walkBlock(u, st.List)
+	}
+}
+
+// walkGenDecl folds package-level `var x = expr` initializers into the module
+// unit as assignment statements.
+func (ex *goExtractor) walkGenDecl(module *unitDraft, d *ast.GenDecl) {
+	if d.Tok != token.VAR {
+		return
+	}
+	for _, spec := range d.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok || len(vs.Values) == 0 {
+			continue
+		}
+		lhs := make([]ast.Expr, len(vs.Names))
+		for i, n := range vs.Names {
+			lhs[i] = n
+		}
+		ex.emitAssignExprs(module, lhs, vs.Values, ex.line(vs.Pos()))
+	}
+}
+
+// emitAssign turns an *ast.AssignStmt (both `:=` and `=`) into a stmtDraft.
+func (ex *goExtractor) emitAssign(u *unitDraft, st *ast.AssignStmt) {
+	ex.emitAssignExprs(u, st.Lhs, st.Rhs, ex.line(st.Pos()))
+}
+
+// emitAssignExprs is the shared assignment builder. It first hoists any pure
+// selector-chain argument used inside the RHS into a synthetic assignment (so an
+// inline source like r.Body becomes a tracked variable — see hoistInlineSources),
+// then emits the assignment itself: LHS primary name → assigns, RHS calls/reads/
+// chains/sinkArgs collected from the (possibly rewritten) expressions.
+func (ex *goExtractor) emitAssignExprs(u *unitDraft, lhs, rhs []ast.Expr, line int) {
+	ex.hoistInlineSources(u, rhs, line)
+
+	var st stmtDraft
+	st.line = line
+	st.sinkArgs = map[string]sinkArgDraft{}
+	st.assigns = ex.primaryLHS(lhs)
+
+	ex.collectExprs(&st, rhs)
+	finalizeStmt(&st)
+	if stmtIsEmpty(&st) {
+		return
+	}
+	u.stmts = append(u.stmts, st)
+}
+
+// emitCallStmt emits a bare call statement (no assignment), hoisting inline
+// sources first so `dec.Decode(r.Body)` style inline sources are tracked.
+func (ex *goExtractor) emitCallStmt(u *unitDraft, call *ast.CallExpr, line int) {
+	ex.hoistInlineSources(u, []ast.Expr{call}, line)
+
+	var st stmtDraft
+	st.line = line
+	st.sinkArgs = map[string]sinkArgDraft{}
+	ex.collectExprs(&st, []ast.Expr{call})
+	finalizeStmt(&st)
+	if stmtIsEmpty(&st) {
+		return
+	}
+	u.stmts = append(u.stmts, st)
+}
+
+// emitReturn turns a `return e1, e2, ...` into a stmtDraft whose returns are the
+// free variables of the returned expressions, while still collecting the calls
+// and reads inside them (so `return db.Query(... + id)` is both a sink read and a
+// return). A bare `return` yields nothing.
+func (ex *goExtractor) emitReturn(u *unitDraft, st *ast.ReturnStmt) {
+	if len(st.Results) == 0 {
+		return
+	}
+	line := ex.line(st.Pos())
+	ex.hoistInlineSources(u, st.Results, line)
+
+	var out stmtDraft
+	out.line = line
+	out.sinkArgs = map[string]sinkArgDraft{}
+	ex.collectExprs(&out, st.Results)
+	finalizeStmt(&out)
+	// The returned variables are exactly the free identifiers of the expressions.
+	out.returns = append([]string(nil), out.reads...)
+	if stmtIsEmpty(&out) {
+		return
+	}
+	u.stmts = append(u.stmts, out)
+}
+
+// primaryLHS picks the single tracked assignee from an assignment's LHS. The
+// engine's assigns field is one variable; for a multi-value assign
+// (`out, _ := f()`, `tmp, err := f()`) we pick the first non-blank, non-error
+// identifier so the meaningful value — not the error — is tracked.
+func (ex *goExtractor) primaryLHS(lhs []ast.Expr) string {
+	names := make([]string, 0, len(lhs))
+	for _, e := range lhs {
+		if id, ok := e.(*ast.Ident); ok {
+			names = append(names, id.Name)
+		} else {
+			names = append(names, "")
+		}
+	}
+	for _, n := range names {
+		if n != "" && n != "_" && n != "err" {
+			return n
+		}
+	}
+	for _, n := range names {
+		if n != "" && n != "_" {
+			return n
+		}
+	}
+	return ""
+}
+
+// hoistInlineSources scans the given expressions for pure selector chains used as
+// CALL ARGUMENTS (idents and dots only, e.g. r.Body — never a call, operator, or
+// literal) and hoists each into a synthetic assignment `__noxsrcN = r.Body`
+// emitted before the current statement, rewriting the argument in place to read
+// the temp. This lets the engine — which only taints a VARIABLE on assignment
+// from a source — handle an inline source used directly at a sink
+// (gob.NewDecoder(r.Body).Decode(...)). It is catalog-independent and
+// semantics-preserving: a pure selector has no side effects, so a non-source
+// chain hoisted to a temp is simply never tainted and has no effect.
+func (ex *goExtractor) hoistInlineSources(u *unitDraft, exprs []ast.Expr, line int) {
+	for _, e := range exprs {
+		ex.hoistWithinCalls(u, e, line)
+	}
+}
+
+// hoistWithinCalls descends an expression; at every call it replaces a pure
+// selector-chain argument with a synthetic temp identifier and emits the
+// corresponding assignment.
+func (ex *goExtractor) hoistWithinCalls(u *unitDraft, e ast.Expr, line int) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		// Descend common wrapping expressions that can contain calls.
+		switch x := e.(type) {
+		case *ast.SelectorExpr:
+			ex.hoistWithinCalls(u, x.X, line)
+		case *ast.ParenExpr:
+			ex.hoistWithinCalls(u, x.X, line)
+		case *ast.BinaryExpr:
+			ex.hoistWithinCalls(u, x.X, line)
+			ex.hoistWithinCalls(u, x.Y, line)
+		case *ast.UnaryExpr:
+			ex.hoistWithinCalls(u, x.X, line)
+		}
+		return
+	}
+	// Descend the callee's receiver first (method chains) and any nested calls in
+	// arguments, so hoisting reaches every nesting level.
+	ex.hoistWithinCalls(u, call.Fun, line)
+	for i, arg := range call.Args {
+		if pureSelectorChain(arg) != "" {
+			chain := pureSelectorChain(arg)
+			tmp := ex.newTemp()
+			ex.emitSyntheticSource(u, tmp, arg, chain, line)
+			call.Args[i] = &ast.Ident{NamePos: arg.Pos(), Name: tmp}
+			continue
+		}
+		ex.hoistWithinCalls(u, arg, line)
+	}
+}
+
+// emitSyntheticSource appends a synthetic assignment `tmp = <chain>` carrying the
+// selector chain so the engine's source resolution (which consults st.chains) can
+// taint tmp when the chain is a catalog source.
+func (ex *goExtractor) emitSyntheticSource(u *unitDraft, tmp string, arg ast.Expr, chain string, line int) {
+	st := stmtDraft{
+		line:     line,
+		assigns:  tmp,
+		sinkArgs: map[string]sinkArgDraft{},
+		chains:   []string{chain},
+	}
+	// Record the chain's head identifier as a read so read-propagation still holds
+	// if the head itself is (transitively) tainted.
+	if head := chainHead(chain); head != "" {
+		st.reads = []string{head}
+	}
+	u.stmts = append(u.stmts, st)
+	_ = arg
+}
+
+// newTemp returns a fresh, deterministic synthetic variable name. The counter is
+// per-file (per extractGo call), so names are stable for identical input.
+func (ex *goExtractor) newTemp() string {
+	name := "__noxsrc" + strconv.Itoa(ex.tmpserial)
+	ex.tmpserial++
+	return name
+}
+
+// collectExprs walks a set of RHS/return/argument expressions and records every
+// call (with its argument-shape evidence), every free variable read, and every
+// dotted selector chain into st.
+func (ex *goExtractor) collectExprs(st *stmtDraft, exprs []ast.Expr) {
+	for _, e := range exprs {
+		ex.collectExpr(st, e)
+	}
+}
+
+// collectExpr recursively records the taint-relevant shapes of one expression.
+func (ex *goExtractor) collectExpr(st *stmtDraft, e ast.Expr) {
+	switch x := e.(type) {
+	case nil:
+		return
+	case *ast.CallExpr:
+		callee := renderCallChain(x.Fun)
+		if callee != "" {
+			st.calls = appendUnique(st.calls, callee)
+			st.sinkArgs[callee] = ex.callArgInfo(x)
+		}
+		// Reads/chains from the callee receiver (e.g. db in db.Query, the package
+		// path in template.New.Parse) and from every argument.
+		ex.collectExpr(st, x.Fun)
+		for _, a := range x.Args {
+			ex.collectExpr(st, a)
+		}
+	case *ast.SelectorExpr:
+		if chain := selectorChain(x); chain != "" && strings.Contains(chain, ".") {
+			st.chains = appendUnique(st.chains, chain)
+		}
+		// The head identifier of the chain is a read (e.g. db in db.Query).
+		if head := selectorHead(x); head != "" {
+			st.reads = appendUnique(st.reads, head)
+		}
+		// Recurse into the selector's base so a call in the receiver spine
+		// (exec.Command(...).Output, gob.NewDecoder(r.Body).Decode) is itself
+		// collected as a call with its own argument evidence.
+		ex.collectExpr(st, x.X)
+	case *ast.Ident:
+		if x.Name != "" && x.Name != "_" && !isGoKeyword(x.Name) {
+			st.reads = appendUnique(st.reads, x.Name)
+		}
+	case *ast.BinaryExpr:
+		ex.collectExpr(st, x.X)
+		ex.collectExpr(st, x.Y)
+	case *ast.ParenExpr:
+		ex.collectExpr(st, x.X)
+	case *ast.UnaryExpr:
+		ex.collectExpr(st, x.X)
+	case *ast.StarExpr:
+		ex.collectExpr(st, x.X)
+	case *ast.IndexExpr:
+		ex.collectExpr(st, x.X)
+		ex.collectExpr(st, x.Index)
+	case *ast.CompositeLit:
+		for _, elt := range x.Elts {
+			ex.collectExpr(st, elt)
+		}
+	case *ast.KeyValueExpr:
+		ex.collectExpr(st, x.Value)
+	}
+}
+
+// callArgInfo derives the argument-shape evidence for one call: positional count,
+// per-slot variable names, and whether a tainted variable lands in the first
+// positional argument (the dangerous, non-parameterized position for db.Query /
+// exec string commands). Go has no shell=True keyword, so shellTrue stays false;
+// an arg-vector exec is modeled by the first argument being a string literal
+// (firstArgTainted false) with the tainted value in a later, distinct argument.
+func (ex *goExtractor) callArgInfo(call *ast.CallExpr) sinkArgDraft {
+	var info sinkArgDraft
+	seen := map[string]struct{}{}
+	for idx, arg := range call.Args {
+		info.argCount++
+		firstIsLiteralOrVector := idx == 0 && (isStringLiteral(arg) || isCompositeVector(arg))
+		vars := ex.exprVars(arg)
+		info.positionalVars = append(info.positionalVars, append([]string(nil), vars...))
+		for _, v := range vars {
+			if _, dup := seen[v]; !dup {
+				seen[v] = struct{}{}
+				info.taintedArgVars = append(info.taintedArgVars, v)
+			}
+			if idx == 0 && !firstIsLiteralOrVector {
+				info.firstArgTainted = true
+			}
+		}
+	}
+	sort.Strings(info.taintedArgVars)
+	return info
+}
+
+// exprVars returns the free variable identifiers read in an expression argument,
+// deduplicated and in first-seen order. It descends binary expressions (string
+// concatenation), unary/star/paren wrappers, index and selector heads, so a
+// tainted var interpolated anywhere in the argument is captured.
+func (ex *goExtractor) exprVars(e ast.Expr) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	var walk func(ast.Expr)
+	walk = func(e ast.Expr) {
+		switch x := e.(type) {
+		case *ast.Ident:
+			if x.Name == "" || x.Name == "_" || isGoKeyword(x.Name) {
+				return
+			}
+			if _, dup := seen[x.Name]; !dup {
+				seen[x.Name] = struct{}{}
+				out = append(out, x.Name)
+			}
+		case *ast.BinaryExpr:
+			walk(x.X)
+			walk(x.Y)
+		case *ast.ParenExpr:
+			walk(x.X)
+		case *ast.UnaryExpr:
+			walk(x.X)
+		case *ast.StarExpr:
+			walk(x.X)
+		case *ast.IndexExpr:
+			walk(x.X)
+			walk(x.Index)
+		case *ast.SelectorExpr:
+			// The receiver head of a selector is a read (r in r.Body); the field name
+			// is not a free variable.
+			if head := selectorHead(x); head != "" {
+				if _, dup := seen[head]; !dup {
+					seen[head] = struct{}{}
+					out = append(out, head)
+				}
+			}
+		case *ast.CallExpr:
+			for _, a := range x.Args {
+				walk(a)
+			}
+		}
+	}
+	walk(e)
+	return out
+}
+
+// finalizeStmt sorts the reads for determinism, matching the recognizer engines'
+// contract (sortedReads picks the first tainted read stably).
+func finalizeStmt(st *stmtDraft) {
+	sort.Strings(st.reads)
+}
+
+// stmtIsEmpty reports whether a statement carries nothing the engine can use.
+func stmtIsEmpty(st *stmtDraft) bool {
+	return st.assigns == "" && len(st.calls) == 0 && len(st.reads) == 0 &&
+		len(st.chains) == 0 && len(st.returns) == 0
+}
+
+// renderCallChain renders a call's Fun expression into the dotted callee chain the
+// catalog matches against, dropping call parentheses at every level:
+// `template.New("g").Parse` → "template.New.Parse", `exec.Command` → "exec.Command",
+// `db.Query` → "db.Query". Returns "" for a shape with no identifier spine.
+func renderCallChain(fun ast.Expr) string {
+	switch x := fun.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		base := renderCallChain(x.X)
+		if base == "" {
+			return x.Sel.Name
+		}
+		return base + "." + x.Sel.Name
+	case *ast.CallExpr:
+		// Method on a call result: render the inner callee, then append the method
+		// via the enclosing SelectorExpr (handled by the SelectorExpr case above).
+		return renderCallChain(x.Fun)
+	case *ast.ParenExpr:
+		return renderCallChain(x.X)
+	case *ast.IndexExpr:
+		return renderCallChain(x.X)
+	case *ast.StarExpr:
+		return renderCallChain(x.X)
+	default:
+		return ""
+	}
+}
+
+// selectorChain renders a (non-call) selector expression into its dotted chain,
+// dropping any call parentheses in the spine: `r.URL.Query().Get` selector parts
+// render to "r.URL.Query.Get". Returns "" when there is no identifier spine.
+func selectorChain(sel *ast.SelectorExpr) string {
+	base := renderCallChain(sel.X)
+	if base == "" {
+		return sel.Sel.Name
+	}
+	return base + "." + sel.Sel.Name
+}
+
+// selectorHead returns the leftmost identifier of a selector chain (the receiver),
+// e.g. "r" in r.URL.Query, or "" if the spine does not start with an identifier.
+func selectorHead(sel *ast.SelectorExpr) string {
+	return chainHead(selectorChain(sel))
+}
+
+// pureSelectorChain returns the dotted chain of an expression IFF it is a pure
+// selector chain — identifiers and dots only, at least two segments, no call, no
+// literal, no operator (e.g. "r.Body", "r.URL"). Returns "" otherwise. This is the
+// exact shape that is safe to hoist into a synthetic source assignment.
+func pureSelectorChain(e ast.Expr) string {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	if !isPureSelector(sel) {
+		return ""
+	}
+	chain := selectorChain(sel)
+	if !strings.Contains(chain, ".") {
+		return ""
+	}
+	return chain
+}
+
+// isPureSelector reports whether a selector expression is composed only of
+// identifiers and nested selectors (no call, index, or other expression in its
+// spine).
+func isPureSelector(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		return isPureSelector(x.X)
+	default:
+		return false
+	}
+}
+
+// chainHead returns the first dot-separated segment of a dotted chain.
+func chainHead(chain string) string {
+	if i := strings.IndexByte(chain, '.'); i >= 0 {
+		return chain[:i]
+	}
+	return chain
+}
+
+// isStringLiteral reports whether an expression is a string basic literal — a
+// fixed command/query prefix, not a tainted value.
+func isStringLiteral(e ast.Expr) bool {
+	lit, ok := e.(*ast.BasicLit)
+	return ok && lit.Kind == token.STRING
+}
+
+// isCompositeVector reports whether an expression is a composite literal such as
+// a slice `[]string{...}` — an argument VECTOR, not a command string. exec.Command
+// with a first-arg vector is the safe arg-vector form.
+func isCompositeVector(e ast.Expr) bool {
+	_, ok := e.(*ast.CompositeLit)
+	return ok
+}
+
+// appendUnique appends s to out if not already present, preserving order.
+func appendUnique(out []string, s string) []string {
+	for _, v := range out {
+		if v == s {
+			return out
+		}
+	}
+	return append(out, s)
+}
+
+// isGoKeyword reports whether s is a Go keyword or predeclared literal that must
+// never be treated as a variable read.
+func isGoKeyword(s string) bool {
+	switch s {
+	case "break", "case", "chan", "const", "continue", "default", "defer",
+		"else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+		"interface", "map", "package", "range", "return", "select", "struct",
+		"switch", "type", "var", "nil", "true", "false", "iota":
+		return true
+	}
+	return false
+}

--- a/core/taint/engine/extract_go_test.go
+++ b/core/taint/engine/extract_go_test.go
@@ -1,0 +1,201 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// TestExtractGoAssignmentAndCall covers the core shape: a short-var-decl
+// assignment from a source call chain, then a bare sink call reading the tainted
+// variable. It asserts the LHS name, the rendered call chains, and the reads.
+func TestExtractGoAssignmentAndCall(t *testing.T) {
+	src := []byte(`package h
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("report")
+	exec.Command("sh", "-c", "gen "+name).Output()
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "handle")
+
+	// Parameters preserved in order (receiver-less function: w, r).
+	if len(u.params) != 2 || u.params[0] != "w" || u.params[1] != "r" {
+		t.Errorf("params = %v, want [w r]", u.params)
+	}
+
+	assign := stmtWithCall(t, u, "r.URL.Query.Get")
+	if assign.assigns != "name" {
+		t.Errorf("assign LHS = %q, want name", assign.assigns)
+	}
+
+	sink := stmtWithCall(t, u, "exec.Command")
+	if !containsStr(sink.reads, "name") {
+		t.Errorf("sink reads = %v, want to include name", sink.reads)
+	}
+}
+
+// TestExtractGoReturnCall covers a `return db.Query(... + id)` statement: the
+// return must carry the sink call and read the tainted variable.
+func TestExtractGoReturnCall(t *testing.T) {
+	src := []byte(`package s
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+func lookup(db *sql.DB, r *http.Request) (*sql.Rows, error) {
+	id := r.URL.Query().Get("id")
+	return db.Query("SELECT * FROM t WHERE id = '" + id + "'")
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "lookup")
+
+	sink := stmtWithCall(t, u, "db.Query")
+	if !containsStr(sink.reads, "id") {
+		t.Errorf("db.Query reads = %v, want to include id", sink.reads)
+	}
+	// The tainted value is in the FIRST positional argument (concatenated into the
+	// query string) — the dangerous, non-parameterized form.
+	info, ok := sink.sinkArgs["db.Query"]
+	if !ok {
+		t.Fatalf("no sinkArg for db.Query: %+v", sink.sinkArgs)
+	}
+	if !info.firstArgTainted {
+		t.Errorf("db.Query firstArgTainted = false, want true (concatenated query)")
+	}
+}
+
+// TestExtractGoParameterizedQuerySafe covers the clean form: `db.Query(sql, id)`
+// where id is a distinct placeholder argument, not concatenated. The tainted
+// value must NOT be in the first argument, and there must be >=2 positional args.
+func TestExtractGoParameterizedQuerySafe(t *testing.T) {
+	src := []byte(`package s
+
+import "database/sql"
+
+func lookup(db *sql.DB, id string) (*sql.Rows, error) {
+	return db.Query("SELECT name FROM users WHERE id = $1", id)
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "lookup")
+	sink := stmtWithCall(t, u, "db.Query")
+	info := sink.sinkArgs["db.Query"]
+	if info.argCount < 2 {
+		t.Errorf("db.Query argCount = %d, want >=2", info.argCount)
+	}
+	if info.firstArgTainted {
+		t.Errorf("db.Query firstArgTainted = true, want false (placeholder query)")
+	}
+}
+
+// TestExtractGoMethodChainRendering covers `template.New("g").Parse(src)`: the
+// method-on-call-result chain must render to the full dotted callee
+// template.New.Parse with the tainted argument recorded.
+func TestExtractGoMethodChainRendering(t *testing.T) {
+	src := []byte(`package r
+
+import (
+	"net/http"
+	"text/template"
+)
+
+func greet(w http.ResponseWriter, r *http.Request) {
+	src := r.URL.Query().Get("tmpl")
+	tmpl, err := template.New("greeting").Parse(src)
+	_ = tmpl
+	_ = err
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "greet")
+	sink := stmtWithCall(t, u, "template.New.Parse")
+	if !containsStr(sink.reads, "src") {
+		t.Errorf("template.New.Parse reads = %v, want to include src", sink.reads)
+	}
+}
+
+// TestExtractGoInlineSourceHoist covers the deserialization shape:
+// `gob.NewDecoder(r.Body).Decode(&env)` in an if-init. The source r.Body is used
+// inline as a sink argument; the extractor must hoist it into a synthetic
+// assignment so the engine can taint it. After hoisting, some statement assigns a
+// synthetic temp from the r.Body chain, and gob.NewDecoder reads that temp.
+func TestExtractGoInlineSourceHoist(t *testing.T) {
+	src := []byte(`package s
+
+import (
+	"encoding/gob"
+	"net/http"
+)
+
+func restore(r *http.Request) error {
+	var env struct{ User string }
+	if err := gob.NewDecoder(r.Body).Decode(&env); err != nil {
+		return err
+	}
+	return nil
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "restore")
+
+	// A synthetic assignment whose RHS chain is r.Body must exist.
+	var tmp string
+	for i := range u.stmts {
+		for _, ch := range u.stmts[i].chains {
+			if ch == "r.Body" && u.stmts[i].assigns != "" {
+				tmp = u.stmts[i].assigns
+			}
+		}
+	}
+	if tmp == "" {
+		t.Fatalf("no synthetic assignment carrying r.Body chain; stmts=%+v", u.stmts)
+	}
+
+	// The gob.NewDecoder sink must read that synthetic temp.
+	sink := stmtWithCall(t, u, "gob.NewDecoder")
+	if !containsStr(sink.reads, tmp) {
+		t.Errorf("gob.NewDecoder reads = %v, want to include hoisted temp %q", sink.reads, tmp)
+	}
+}
+
+// TestExtractGoParseErrorGraceful covers graceful degradation: a non-compiling
+// snippet must not panic and must not crash the extractor. It may return whatever
+// partial units the parser recovered, or none.
+func TestExtractGoParseErrorGraceful(t *testing.T) {
+	src := []byte(`package broken
+
+func oops( {
+	x :=
+`)
+	// Must not panic.
+	units := extractUnits(lexctx.LangGo, src)
+	_ = units
+}
+
+// TestExtractGoReceiverMethodParams covers a method with a receiver: the receiver
+// name is the first parameter (position matters for interproc summaries).
+func TestExtractGoReceiverMethodParams(t *testing.T) {
+	src := []byte(`package s
+
+type Server struct{}
+
+func (s *Server) handle(input string) {
+	_ = input
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "handle")
+	if len(u.params) != 2 || u.params[0] != "s" || u.params[1] != "input" {
+		t.Errorf("params = %v, want [s input] (receiver first)", u.params)
+	}
+}

--- a/core/taint/engine/structural_go_test.go
+++ b/core/taint/engine/structural_go_test.go
@@ -1,0 +1,167 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// analyzeGoFile runs the full same-file pipeline (extraction + interprocedural
+// AnalyzeFile) over Go source, mirroring how taintflow drives the engine.
+func analyzeGoFile(t *testing.T, src string) []string {
+	t.Helper()
+	eng := NewStructuralEngine(nil)
+	units := ExtractUnits("t.go", lexctx.LangGo, []byte(src))
+	flows := eng.AnalyzeFile(units)
+	return ruleIDs(flows)
+}
+
+func TestStructuralGoTruePositives(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		wantID string
+	}{
+		{
+			name: "command injection via exec.Command",
+			src: `package h
+func handle(r *Req) {
+	name := r.URL.Query().Get("report")
+	exec.Command("sh", "-c", "gen "+name).Output()
+}`,
+			wantID: "TAINT-002",
+		},
+		{
+			name: "sql injection via db.Query concat",
+			src: `package s
+func lookup(db *DB, r *Req) {
+	id := r.URL.Query().Get("id")
+	_ = db.Query("SELECT * FROM t WHERE id = '" + id + "'")
+}`,
+			wantID: "TAINT-001",
+		},
+		{
+			name: "path traversal via os.ReadFile",
+			src: `package f
+func serve(r *Req) {
+	name := r.URL.Query().Get("file")
+	_, _ = os.ReadFile(filepath.Join("/srv", name))
+}`,
+			wantID: "TAINT-004",
+		},
+		{
+			name: "ssrf via http.Get",
+			src: `package p
+func fetch(r *Req) {
+	target := r.URL.Query().Get("url")
+	_, _ = http.Get(target)
+}`,
+			wantID: "TAINT-006",
+		},
+		{
+			name: "unsafe deserialization via gob",
+			src: `package s
+func restore(r *Req) {
+	var env E
+	if err := gob.NewDecoder(r.Body).Decode(&env); err != nil {
+		_ = err
+	}
+}`,
+			wantID: "TAINT-005",
+		},
+		{
+			name: "ssti via text/template Parse",
+			src: `package r
+func greet(r *Req) {
+	src := r.URL.Query().Get("tmpl")
+	_, _ = template.New("greeting").Parse(src)
+}`,
+			wantID: "TAINT-003",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := analyzeGoFile(t, tt.src)
+			found := false
+			for _, id := range ids {
+				if id == tt.wantID {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("got rule IDs %v, want to include %s", ids, tt.wantID)
+			}
+		})
+	}
+}
+
+// TestStructuralGoCleanStaysClean asserts the precision guardrails fire nothing:
+// parameterized queries, arg-vector exec, and sanitized paths.
+func TestStructuralGoCleanStaysClean(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "parameterized query is safe",
+			src: `package s
+func lookup(db *DB, id string) {
+	_ = db.Query("SELECT name FROM users WHERE id = $1", id)
+}`,
+		},
+		{
+			name: "arg-vector exec is safe",
+			src: `package s
+func listDir(dir string) {
+	_, _ = exec.Command("ls", "-la", "--", dir).Output()
+}`,
+		},
+		{
+			name: "filepath.Clean sanitizes path traversal",
+			src: `package f
+func serve(r *Req) {
+	name := r.URL.Query().Get("file")
+	clean := filepath.Base(name)
+	_, _ = os.ReadFile(filepath.Join("/srv", clean))
+}`,
+		},
+		{
+			name: "no source means no flow",
+			src: `package s
+func run(dir string) {
+	_, _ = exec.Command("sh", "-c", "gen "+dir).Output()
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := analyzeGoFile(t, tt.src)
+			if len(ids) != 0 {
+				t.Errorf("want zero findings, got %v", ids)
+			}
+		})
+	}
+}
+
+// TestStructuralGoInterprocSameFile covers a source in a handler flowing through a
+// locally-defined helper to a sink (the same-file interprocedural summary path).
+func TestStructuralGoInterprocSameFile(t *testing.T) {
+	src := `package h
+func run(cmd string) {
+	exec.Command("sh", "-c", cmd).Output()
+}
+func handle(r *Req) {
+	name := r.URL.Query().Get("x")
+	run(name)
+}`
+	ids := analyzeGoFile(t, src)
+	found := false
+	for _, id := range ids {
+		if id == "TAINT-002" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("interproc: got %v, want TAINT-002 (source flows through run helper)", ids)
+	}
+}

--- a/docs/design/go-taint.md
+++ b/docs/design/go-taint.md
@@ -1,0 +1,124 @@
+# Go taint model — AST-precise extraction
+
+Status: implemented. Companion to [`sast-taint.md`](./sast-taint.md), which
+describes the language-agnostic engine (catalog + `StructuralEngine` +
+same-file interprocedural summaries). This document explains the ONE thing Go
+does differently from Python and JavaScript: how source is turned into the
+engine's IR.
+
+## Why Go uses `go/ast` while Python/JS use the line recognizer
+
+The Python and JavaScript extractors (`extract_python.go`, `extract_javascript.go`)
+deliberately avoid a real parser. Nox ships a single static, CGo-free binary and
+refuses to take on a tree-sitter grammar (CGo) or a large pure-Go grammar port
+for those languages; instead they lean on `core/lexctx` to see only real code and
+recognize the two statement shapes (`lhs = expr`, `callee(args)`) that carry the
+overwhelming majority of injection bugs. That is a pragmatic precision/cost trade.
+
+Go is different, and the difference is free:
+
+- **Nox is itself a Go program.** `go/parser`, `go/ast`, and `go/token` are in the
+  standard library the binary already links. There is no new dependency, no CGo,
+  and no module-graph cost — the constraint that rules out tree-sitter for the
+  other languages simply does not apply.
+- **A real AST is strictly more precise** than a line recognizer: selector chains,
+  nested calls, receivers, `if`/`for` init statements, and multi-return assignments
+  are parsed exactly rather than approximated by bracket-depth heuristics. Line and
+  column come from `token.FileSet`, so findings anchor on the real sink line.
+- **It stays deterministic and offline.** Parsing is a pure function of the bytes;
+  the walk is in source order; no map iteration escapes into output.
+
+So the rule is: **use the best tool that is already free.** For Go that is the
+stdlib AST. For Python/JS it remains the lexctx line recognizer, because a real
+grammar there would violate the no-CGo / no-heavy-dependency constraint. Tree-sitter
+remains refused for the non-Go languages.
+
+## What the extractor produces
+
+`extractGo` walks each `*ast.FuncDecl` and emits one `unitDraft` per function
+(receiver + parameters become `params`, in order, for the interprocedural summary
+pass). Package-level `var` declarations and `init` bodies fold into a synthetic
+module unit. For each statement it emits the same internal IR the other extractors
+do (`stmtDraft{assigns, calls, reads, chains, sinkArgs, returns}`), so the shared
+`StructuralEngine` and the same-file interprocedural fixpoint run **unchanged**.
+
+Statement shapes handled: `*ast.AssignStmt` (`:=` and `=`, including multi-value
+`a, err := f()`), bare `*ast.ExprStmt` calls, `*ast.ReturnStmt`, and the init
+clause of `*ast.IfStmt`/`*ast.ForStmt`/`*ast.SwitchStmt` (so
+`if err := decoder.Decode(&v); err != nil` is analyzed).
+
+### Call-chain rendering
+
+Selector and call expressions are rendered into the same **dotted chain** string
+the catalog and `recognize.go` match against, dropping call parentheses:
+`r.URL.Query().Get(id)` renders to `r.URL.Query.Get`, and the engine's
+`suffixKeys` fallback matches the catalog's canonical `URL.Query.Get`. Nested
+calls (a call in an argument, a call as a method receiver) are all emitted, so
+`exec.Command("sh","-c","x "+name).Output()` yields both `exec.Command` and
+`.Output`, and the tainted argument evidence is recorded against `exec.Command`.
+
+### Package-qualified vs method-suffix sinks (the precision trade)
+
+Go sinks come in two shapes and the catalog holds both:
+
+- **Package-qualified** — `exec.Command`, `os.ReadFile`, `http.Get`,
+  `gob.NewDecoder`, `template.Parse`. Here the selector's `X` is an imported
+  package, so the full chain is a precise, low-ambiguity key. These are matched on
+  the full dotted form.
+- **Method-on-a-value** — `db.Query`, `conn.Query`, `tx.Exec`, `.Decode`. The
+  receiver *name* varies (`db`, `conn`, `tx`), so the catalog keys the **method
+  suffix** (`.Query`, `.Exec`, `.QueryContext`, `.Decode`) and the engine's
+  `suffixKeys` matches any receiver. This is deliberately less specific: a
+  same-named method on an unrelated type can match (e.g. some non-SQL `.Query`).
+  The cost is bounded because (a) a flow only fires when a *tainted* value reaches
+  the call, and (b) SQL sinks apply the parameterized-query argument gate
+  (tainted value only in a non-first positional arg ⇒ safe), which suppresses the
+  common safe form. We accept a small potential over-match on method-suffix sinks
+  in exchange for covering the receiver-name-varies idiom that dominates real Go
+  database and decoder code. Package-qualified sinks carry no such ambiguity.
+
+### The inline-source hoist (deserialization)
+
+The shared engine taints a **variable** on assignment from a source; it has no
+path for a source used inline as a sink argument in the same statement. Go's
+`gob.NewDecoder(r.Body).Decode(&env)` is exactly that shape: the source `r.Body`
+is an argument to the sink call, never assigned. To keep the engine unchanged, the
+Go extractor **hoists a pure selector chain used as a call argument** (idents and
+dots only — `r.Body`, `r.URL`; never a call, operator, or literal) into a
+synthetic assignment `__noxsrcN = r.Body` immediately before the statement, and
+rewrites the argument to read the temp. The engine then taints `__noxsrcN` iff the
+chain is a catalog source, and the taint flows into the sink on the next line. The
+hoist is catalog-independent and semantics-preserving (a pure selector has no side
+effects), so it is inert on non-source chains and adds no false positives — the
+clean stressors, which contain no request-attribute chains, are untouched.
+
+## Scope and honest limits (AST-only, no `go/types`)
+
+The extractor is **AST-only**: it never loads packages or runs `go/types`. Type
+resolution needs a full build context (all imports resolvable, build tags, GOOS),
+which is heavy, network/filesystem-sensitive, and non-deterministic across
+environments — the opposite of what a fast, offline scanner wants. The
+consequences, inherited on top of the engine's existing intraprocedural /
+same-file limits:
+
+- **No type-based sink disambiguation.** `.Query`/`.Exec`/`.Decode` match by
+  method name, not by proving the receiver is a `*sql.DB` or `*gob.Decoder` (see
+  the method-suffix trade above).
+- **Import aliases are resolved lexically, not semantically.** `exec.Command`
+  matches whether or not `os/exec` was aliased, because matching is on the dotted
+  chain suffix; a package imported under a *different* local name than its suffix
+  (rare) would be missed.
+- **Inherited from the engine:** intraprocedural + same-file interprocedural only,
+  straight-line (no CFG/branch merging), no alias or field/element sensitivity.
+
+### Vuln classes covered / not covered
+
+Covered (fire on the precision corpus): command injection (`exec.Command`),
+SQL injection (`.Query`/`.Exec` concatenation), path traversal
+(`os.ReadFile`/`os.Open`), SSRF (`http.Get`/`http.Post`), unsafe deserialization
+(`gob.NewDecoder`, `yaml.Unmarshal`), SSTI (`text/template` `.Parse`).
+
+Not yet covered (honest): XSS via `html/template` misuse beyond auto-escaping,
+taint through struct fields / maps / slices (no field sensitivity), taint laundered
+through `fmt.Sprintf` into a struct then sunk, cross-file flow (the taint-analysis
+plugin's territory), and reflection-based sinks.

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -8,10 +8,13 @@ that always scores 1.0 measures nothing.
 
 The corpus spans **Python, JS/TS, and Go** (`clean_*.{py,js,ts,go}` /
 `tp_*.{py,go}`). Go samples were added once `lexctx` began classifying Go
-(#197): nox is now measured in its own language for the first time. Doing so
-honestly *lowered* recall — the Go taint classes are genuine false negatives
-today (nox's taint catalog only models python/javascript) — which is exactly
-the corpus doing its job. See "Go coverage gaps" below.
+(#197): nox is now measured in its own language for the first time. Adding them
+first *lowered* recall (the six Go taint classes were genuine false negatives
+until a Go taint model existed); the Go taint model has since landed
+(`core/taint/data/catalog.json` `go` block + `core/taint/engine/extract_go.go`,
+AST-precise via `go/ast`), flipping all six from FN to TP and taking recall back
+to 1.00 — the measure → build → re-measure loop, extended to Go. See "Go
+coverage: what's caught, what's still open" below.
 
 Run it:
 
@@ -38,28 +41,31 @@ nox bench --precision testdata/precision-suite --baseline testdata/precision-sui
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite` scores
-**precision 1.00 / recall 0.79 / F1 0.88** (23 TP, 0 FP, 6 FN). Precision is
-still perfect — every finding nox emits is a true positive — but recall dropped
-from the Python/JS-only 1.00 the moment realistic **Go** samples were added:
-nox's taint engine has no Go language model yet, so the six Go injection /
-traversal / SSRF / deserialization / SSTI positives are honest false negatives
-(see "Go coverage gaps" below). This is the corpus working as designed — adding
-a language nox can't fully see makes the number tell the truth rather than
-flatter it.
+**precision 1.00 / recall 1.00 / F1 1.00** (29 TP, 0 FP, 0 FN). Precision is
+perfect — every finding nox emits is a true positive — and recall is back to
+1.00: the six Go injection / traversal / SSRF / deserialization / SSTI positives
+now fire as `TAINT-001..006` thanks to the Go taint model (see "Go coverage"
+below). The earlier honest dip to recall 0.79 the moment realistic **Go** samples
+were added was the corpus working as designed — it named six real false negatives,
+and closing them (building the engine, not curating the corpus) is what moved the
+number back.
 
-For reference, the earlier Python/JS-only journey: precision rose from an
-original honest baseline of 0.30 / F1 0.47 (39 FP), through an interim
-0.89 / F1 0.94, to 1.00 / F1 1.00 — raised only by fixing the false-positive
-classes the corpus indicted (items 1–6 below), never by curating it.
+For reference, the earlier journey: precision rose from an original honest
+baseline of 0.30 / F1 0.47 (39 FP), through an interim 0.89 / F1 0.94, to
+1.00 / F1 1.00 on Python/JS — raised only by fixing the false-positive classes
+the corpus indicted (items 1–6 below), never by curating it. Recall then dipped
+to 0.79 when Go samples landed (six honest FNs) and returned to 1.00 once the Go
+taint model closed them.
 
-- **findings-per-issue: 0.85** — across the annotated issues nox emits ~0.85
-  findings each (below 1.00 because the six Go FNs contribute an annotated issue
-  with zero findings). On the Python secret files that once dominated, density
+- **findings-per-issue: 1.07** — across the annotated issues nox emits ~1.07
+  findings each (the Go secret files fire the language-agnostic secret regexes
+  slightly above 1.00; the taint classes are all exactly 1.00). On the Python
+  secret files that once dominated, density
   collapsed to canonical: `tp_secrets_cloud.py` from **8.00 → 1.00** and
   `tp_secrets.py` from **5.33 → 1.33**, via specificity dedup + per-token owner
   resolution (`core/analyzers/secrets/dedup.go`). The Go secret files
-  (`tp_secrets.go`, `tp_secrets_cloud.go`) each score density 1.00 — the
-  language-agnostic secret regexes resolve cleanly on Go too.
+  (`tp_secrets.go` at 1.33, `tp_secrets_cloud.go` at 1.00) score near-canonical —
+  the language-agnostic secret regexes resolve cleanly on Go too.
 - **noise ratio: 0.00** — 0 of the findings nox produces are false positives.
   The Go clean-stressors added here (a base64 data-URI in a Go raw string, an
   SRI integrity hash, a generated-code banner, placeholder creds) are all clean.
@@ -98,14 +104,18 @@ overall numbers only.
    `core/analyzers/ai/prompt_context.go`), so the parameterised SQL in
    `clean_safe_db.py` no longer trips it while the real `tp_prompt.py` positive
    still fires.
-4. **Injection recall gaps — CLOSED.** The intraprocedural taint engine has
-   landed, so command injection (`os.system("echo " + cmd)`), eval, path
-   traversal (`open(user_path)`), unsafe deserialization (`pickle.loads(user)`),
-   and SSRF (`requests.get(user_url)`) now fire as `TAINT-002/005/...`. Those
-   annotations flipped from false negatives to true positives, taking suite
-   recall to 1.0 — the measure→build→re-measure loop working end to end. (SSTI
-   via `render_template_string(... + user)`
-   is *already* caught by `VARIANT-005`, so it is annotated as a true positive.)
+4. **Injection recall gaps — CLOSED (Python/JS *and* Go).** The intraprocedural
+   taint engine has landed, so command injection (`os.system("echo " + cmd)`),
+   eval, path traversal (`open(user_path)`), unsafe deserialization
+   (`pickle.loads(user)`), and SSRF (`requests.get(user_url)`) fire as
+   `TAINT-002/005/...`. The **Go** taint model then closed the six Go FNs the
+   same way: an AST-precise extractor (`core/taint/engine/extract_go.go`, built on
+   `go/ast` because nox is itself Go) plus a `go` catalog block flip
+   `tp_cmdinjection.go`/`tp_sqlinjection.go`/`tp_pathtraversal.go`/`tp_ssrf.go`/
+   `tp_deserialization.go`/`tp_ssti.go` from FN to TP, taking suite recall back to
+   1.0 — the measure→build→re-measure loop working end to end. (Python SSTI via
+   `render_template_string(... + user)` is *already* caught by `VARIANT-005`, so it
+   is annotated as a true positive; Go SSTI fires the taint engine's `TAINT-003`.)
 5. **Entropy fired inside a decoded image/SVG blob — FIXED.** The secrets
    decode-and-scan path (`core/analyzers/secrets/decode.go`) base64-decodes
    embedded blobs and re-scans the decoded bytes. A data-URI SVG decodes to
@@ -148,12 +158,12 @@ language for the first time):
 | --- | --- | --- | --- |
 | `tp_secrets.go` | AWS / GitHub / Slack tokens in Go literals | SEC-001/003/023/508 | TP, deduped to canonical |
 | `tp_secrets_cloud.go` | Stripe / GCP keys in Go consts | SEC-030 / SEC-007 | TP, deduped to canonical |
-| `tp_cmdinjection.go` | `exec.Command("sh","-c",…)` | TAINT-002 | **FN** (no Go taint model) |
-| `tp_sqlinjection.go` | `db.Query("… '" + input)` | TAINT-001 | **FN** (no Go taint model) |
-| `tp_pathtraversal.go` | `os.ReadFile(filepath.Join(base, input))` | TAINT-004 | **FN** (no Go taint model) |
-| `tp_ssrf.go` | `http.Get(userURL)` | TAINT-006 | **FN** (no Go taint model) |
-| `tp_deserialization.go` | `gob.NewDecoder(r.Body).Decode` | TAINT-005 | **FN** (no Go taint model) |
-| `tp_ssti.go` | `text/template` parse of user input | TAINT-003 | **FN** (no Go taint model) |
+| `tp_cmdinjection.go` | `exec.Command("sh","-c",…)` | TAINT-002 | TP (Go taint model) |
+| `tp_sqlinjection.go` | `db.Query("… '" + input)` | TAINT-001 | TP (Go taint model) |
+| `tp_pathtraversal.go` | `os.ReadFile(filepath.Join(base, input))` | TAINT-004 | TP (Go taint model) |
+| `tp_ssrf.go` | `http.Get(userURL)` | TAINT-006 | TP (Go taint model) |
+| `tp_deserialization.go` | `gob.NewDecoder(r.Body).Decode` | TAINT-005 | TP (Go taint model) |
+| `tp_ssti.go` | `text/template` parse of user input | TAINT-003 | TP (Go taint model) |
 
 Clean stressors (zero annotations — any finding is a false positive):
 
@@ -180,17 +190,19 @@ rules the corpus indicts, not to curate the corpus to pass. When a rule fix
 legitimately improves the score, `TestPrecisionSuiteBaseline` tells you to
 refresh `baseline.json`.
 
-## Go coverage gaps — the next indictment
+## Go coverage: what's caught, what's still open
 
-Adding realistic Go samples is the whole point of measuring nox in its own
-language: it surfaced **six honest false negatives**. nox's taint catalog
-(`core/taint/data/catalog.json`) models sources/sinks for **python and
-javascript only** — there is no `go` language entry — so every Go dataflow
-vulnerability is currently missed. The secret regexes are language-agnostic and
-already fire on Go, so Go secrets are true positives; only the taint-dependent
-classes are gaps. What a correct scanner should catch that nox misses today:
+Adding realistic Go samples surfaced **six honest false negatives**, and the Go
+taint model has since closed all six. nox's taint catalog
+(`core/taint/data/catalog.json`) now carries a `go` language block, and
+`core/taint/engine/extract_go.go` does AST-precise extraction (built on `go/ast`,
+not the line recognizer Python/JS use — nox is itself Go, so the pure-Go stdlib
+parser is free, precise, and deterministic; see `docs/design/go-taint.md`). All
+six Go dataflow vulnerabilities now fire; the secret regexes were already
+language-agnostic, so Go secrets were true positives throughout. What nox catches
+in Go today:
 
-| Vuln class | Go sink (sample) | Should fire | CWE |
+| Vuln class | Go sink (sample) | Fires | CWE |
 | --- | --- | --- | --- |
 | Command injection | `exec.Command("sh","-c", userInput)` | TAINT-002 | CWE-78 |
 | SQL injection | `db.Query("… WHERE x='" + userInput + "'")` | TAINT-001 | CWE-89 |
@@ -199,9 +211,12 @@ classes are gaps. What a correct scanner should catch that nox misses today:
 | Unsafe deserialization | `gob.NewDecoder(r.Body).Decode(&v)` | TAINT-005 | CWE-502 |
 | SSTI | `text/template … Parse(userInput)` | TAINT-003 | CWE-1336 |
 
-Closing these is a separate, larger effort — it needs a Go source/sink/sanitizer
-model in the taint catalog plus Go-aware dataflow (the mirror of the Python
-taint work that flipped `tp_injection.py` & friends from FN to TP). This corpus
-already carries the annotated ground truth, so the day a Go taint model lands,
-these six flip to true positives and recall climbs back toward 1.00 — the
-measure → build → re-measure loop, now extended to Go.
+Still open (honest, the next indictment when a sample lands): XSS via `html/template`
+misuse beyond auto-escaping, taint laundered through struct fields / maps / slices
+(no field sensitivity), and reflection-based sinks — the same class of limits the
+Python/JS engine has. The extraction is AST-precise but stays **AST-only** (no
+`go/types`): method sinks like `.Query`/`.Exec`/`.Decode` are matched by method
+name, not by proving the receiver's type. Cross-file Go flow remains the
+taint-analysis plugin's territory. This corpus carries the annotated ground truth,
+so the day a new Go gap gets a sample, the number will tell the truth again — the
+measure → build → re-measure loop, now running on Go.

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.7931034482758621,
-  "f1": 0.8846153846153846,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 23,
-  "fn": 6,
-  "findings_per_issue": 0.8518518518518519,
+  "tp": 29,
+  "fn": 0,
+  "findings_per_issue": 1.0740740740740742,
   "rules": [
     {
       "rule_id": "AI-002",
@@ -50,32 +50,32 @@
     {
       "rule_id": "TAINT-001",
       "precision": 1,
-      "recall": 0
+      "recall": 1
     },
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",
       "precision": 1,
-      "recall": 0
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-005",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     },
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "VARIANT-002",


### PR DESCRIPTION
## Go taint model — real dataflow on Go, closing the six honest FNs

Builds a Go taint model so nox performs intraprocedural (+ same-file
interprocedural) dataflow on Go, closing the six false negatives the precision
corpus documented in #199. This is the mirror of the existing Python/JS taint
work.

### Measured result (the corpus is the acceptance test)

`nox bench --precision testdata/precision-suite`:

| | before (#199) | after |
| --- | --- | --- |
| precision | 1.00 | **1.00** |
| recall | 0.79 | **1.00** |
| F1 | 0.88 | **1.00** |
| TP / FP / FN | 23 / 0 / 6 | **29 / 0 / 0** |

All six `tp_*.go` flip FN→TP with density 1.00, and the `clean_*.go`
stressors stay finding-free (0 FP). The CI **SAST precision gate**
(`--min-precision 0.90`) passes, and `go test ./cli/ -run PrecisionSuiteBaseline`
passes against the refreshed per-rule baseline.

The six now firing: `tp_cmdinjection.go` → **TAINT-002**, `tp_sqlinjection.go`
→ **TAINT-001**, `tp_pathtraversal.go` → **TAINT-004**, `tp_ssrf.go` →
**TAINT-006**, `tp_deserialization.go` → **TAINT-005**, `tp_ssti.go` →
**TAINT-003**.

**No corpus curation:** the `tp_*.go`/`clean_*.go` samples were not edited to
move numbers — the engine was.

### How it works

- **`extract_go.go` — AST-precise via the Go stdlib.** Unlike Python/JS (which
  deliberately use the lexctx line recognizer to avoid CGo/heavy grammars), Go
  gets a real AST from `go/parser` + `go/ast` + `go/token` — pure stdlib, no
  CGo, no new dependency, deterministic. It walks each `*ast.FuncDecl` into the
  same internal IR the other extractors emit, so the **`StructuralEngine` and
  same-file interproc fixpoint are reused unchanged**. Graceful degrade on
  parse error (partial AST or nil, never a panic). Rationale and limits in
  `docs/design/go-taint.md`.
- **Call-chain rendering.** Selector/call expressions render to the dotted
  callee form `recognize.go` matches, dropping call parens:
  `r.URL.Query().Get` → `r.URL.Query.Get`, `template.New("g").Parse` →
  `template.New.Parse`. Nested calls in receivers and arguments are all emitted.
- **Package-qualified vs method-suffix sinks.** Package sinks (`exec.Command`,
  `os.ReadFile`, `http.Get`, `gob.NewDecoder`) match on the full chain;
  receiver-name-varies methods (`db.Query`, `.Exec`, `.Decode`) match on the
  method suffix via the engine's `suffixKeys` fallback. The precision trade of
  method-suffix matching is documented, and bounded by the taint requirement
  plus the parameterized-query argument gate.
- **Inline-source hoist.** The shared engine taints a variable on assignment; it
  has no path for a source used inline at a sink. `gob.NewDecoder(r.Body).Decode`
  is exactly that shape, so the extractor hoists a pure selector-chain argument
  (`r.Body`) into a synthetic assignment before the statement. Catalog-independent
  and semantics-preserving, so it is inert on non-source chains (zero new FPs).

### Catalog `go` block

- **Sinks:** `exec.Command`/`CommandContext` (TAINT-002/CWE-78);
  `db.Query`/`QueryRow`/`Exec`/`*Context` (TAINT-001/CWE-89);
  `os.Open`/`OpenFile`/`ReadFile`, `ioutil.ReadFile` (TAINT-004/CWE-22);
  `http.Get`/`Post`/`Head`/`NewRequest` (TAINT-006/CWE-918); `gob.NewDecoder`,
  `yaml.Unmarshal` (TAINT-005/CWE-502); `template.New.Parse`/`Parse`/`Must`
  (TAINT-003/CWE-1336).
- **Sources:** `r.URL.Query().Get`, `r.FormValue`/`PostFormValue`,
  `r.Header.Get`, `r.Body`, `os.Args`. `os.Getenv` is deliberately **not** a
  source (would FP on `clean_placeholders.go`).
- **Sanitizers:** `filepath.Clean`/`Base` (path_traversal),
  `url.QueryEscape`/`PathEscape` (ssrf), `strconv.Atoi`/`ParseInt` (numeric
  coercion).

### Still open (honest)

XSS via `html/template` misuse beyond auto-escaping, taint through struct
fields / maps / slices (no field sensitivity), and reflection sinks — the same
class of limits as the Python/JS engine. Extraction is AST-precise but stays
**AST-only** (no `go/types`), so method sinks match by method name, not proven
receiver type. Cross-file Go flow remains the taint-analysis plugin's territory.

### Verification

`go build ./...`, `go test ./...`, `go test -race ./core/taint/...
./core/analyzers/... ./cli/...`, and `golangci-lint run` on the touched
packages all pass. The extractor, engine, catalog, and analyzer layers are each
covered by test-first unit tests.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom
