### PR TITLE
test(precision-suite): grow Go corpus to indict XSS-to-response + container taint gaps

### DIFF
--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -41,14 +41,23 @@ nox bench --precision testdata/precision-suite --baseline testdata/precision-sui
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite` scores
-**precision 1.00 / recall 1.00 / F1 1.00** (29 TP, 0 FP, 0 FN). Precision is
-perfect — every finding nox emits is a true positive — and recall is back to
-1.00: the six Go injection / traversal / SSRF / deserialization / SSTI positives
-now fire as `TAINT-001..006` thanks to the Go taint model (see "Go coverage"
-below). The earlier honest dip to recall 0.79 the moment realistic **Go** samples
-were added was the corpus working as designed — it named six real false negatives,
-and closing them (building the engine, not curating the corpus) is what moved the
-number back.
+**precision 1.00 / recall 0.89 / F1 0.94** (31 TP, 0 FP, 4 FN). Precision is
+still perfect — every finding nox emits is a true positive, and both new clean
+stressors (`clean_html_autoescape.go`, `clean_field_safe.go`) fire nothing — but
+recall dropped from 1.00 to 0.89 the moment a second Go tier landed: five new Go
+samples (`tp_xss_response.go`, `tp_field_taint.go`, `tp_container_taint.go` plus
+the two clean guardrails) named **four honest false negatives** the variable-level
+Go engine misses. That drop is the corpus doing its job — it is the next
+indictment, and closing it (building the engine, not curating the corpus) is the
+next build phase. See "Go coverage" below for the exact FN list and the engine
+capability each one demands.
+
+For the historical record, recall was previously 1.00: the six Go injection /
+traversal / SSRF / deserialization / SSTI positives fire as `TAINT-001..006`
+thanks to the first Go taint model (see "Go coverage" below). The earlier honest
+dip to recall 0.79 the moment the *first* realistic **Go** samples were added was
+the same mechanism — it named six real false negatives, and closing them moved the
+number back to 1.00, until this second tier reopened it to 0.89.
 
 For reference, the earlier journey: precision rose from an original honest
 baseline of 0.30 / F1 0.47 (39 FP), through an interim 0.89 / F1 0.94, to
@@ -57,9 +66,11 @@ the corpus indicted (items 1–6 below), never by curating it. Recall then dippe
 to 0.79 when Go samples landed (six honest FNs) and returned to 1.00 once the Go
 taint model closed them.
 
-- **findings-per-issue: 1.07** — across the annotated issues nox emits ~1.07
-  findings each (the Go secret files fire the language-agnostic secret regexes
-  slightly above 1.00; the taint classes are all exactly 1.00). On the Python
+- **findings-per-issue: 0.94** — across the annotated issues nox emits ~0.94
+  findings each; it is now *below* 1.00 because the four Go tier-2 false negatives
+  (three XSS-to-response, one map-value taint) contribute annotated issues with
+  zero findings. The Go secret files fire the language-agnostic secret regexes
+  slightly above 1.00; the caught taint classes are all exactly 1.00. On the Python
   secret files that once dominated, density
   collapsed to canonical: `tp_secrets_cloud.py` from **8.00 → 1.00** and
   `tp_secrets.py` from **5.33 → 1.33**, via specificity dedup + per-token owner
@@ -164,6 +175,9 @@ language for the first time):
 | `tp_ssrf.go` | `http.Get(userURL)` | TAINT-006 | TP (Go taint model) |
 | `tp_deserialization.go` | `gob.NewDecoder(r.Body).Decode` | TAINT-005 | TP (Go taint model) |
 | `tp_ssti.go` | `text/template` parse of user input | TAINT-003 | TP (Go taint model) |
+| `tp_xss_response.go` | reflected XSS to `http.ResponseWriter` (Fprintf / Write / `template.HTML`) | TAINT-003 (xss, CWE-79) | **FN** — no Go XSS-to-response sink |
+| `tp_field_taint.go` | cmd injection laundered through a struct field | TAINT-002 | TP (variable-level engine happens to reach it) |
+| `tp_container_taint.go` | cmd injection through a map value **and** a slice element | TAINT-002 (×2) | slice = TP, **map value = FN** (no container sensitivity) |
 
 Clean stressors (zero annotations — any finding is a false positive):
 
@@ -184,6 +198,8 @@ Clean stressors (zero annotations — any finding is a false positive):
 | `clean_placeholders.go` | placeholder creds + `os.Getenv` | clean |
 | `clean_generated.go` | `DO NOT EDIT` banner, descriptor bytes, struct tags | clean |
 | `clean_identifiers.go` | UUID, git SHA, hex colors, **SRI integrity hash** | clean (SRI fix) |
+| `clean_html_autoescape.go` | `html/template` context-aware auto-escaping of user data | clean (correct escaping → not a sink) |
+| `clean_field_safe.go` | struct field sanitized (`strconv.Atoi`, `filepath.Base`) before the sink | clean (sanitizer recognized) |
 
 Grow this corpus over time; the honest way to raise the number is to fix the
 rules the corpus indicts, not to curate the corpus to pass. When a rule fix
@@ -211,12 +227,33 @@ in Go today:
 | Unsafe deserialization | `gob.NewDecoder(r.Body).Decode(&v)` | TAINT-005 | CWE-502 |
 | SSTI | `text/template … Parse(userInput)` | TAINT-003 | CWE-1336 |
 
-Still open (honest, the next indictment when a sample lands): XSS via `html/template`
-misuse beyond auto-escaping, taint laundered through struct fields / maps / slices
-(no field sensitivity), and reflection-based sinks — the same class of limits the
-Python/JS engine has. The extraction is AST-precise but stays **AST-only** (no
-`go/types`): method sinks like `.Query`/`.Exec`/`.Decode` are matched by method
-name, not by proving the receiver's type. Cross-file Go flow remains the
-taint-analysis plugin's territory. This corpus carries the annotated ground truth,
-so the day a new Go gap gets a sample, the number will tell the truth again — the
-measure → build → re-measure loop, now running on Go.
+### Go coverage — next gaps (the tier-2 samples that are FN today)
+
+A second tier of Go samples now carries these gaps as annotated ground truth, so
+they show up as concrete false negatives (recall 0.89) rather than prose. This is
+the precise target list for the next build phase:
+
+| Sample (line) | What flows | Fires? | Engine capability the next build must add |
+| --- | --- | --- | --- |
+| `tp_xss_response.go` — `greetPrintf` (`fmt.Fprintf(w, "<div>%s</div>", name)`) | request query → response writer as HTML | **FN** | an **XSS-to-response sink**: model `http.ResponseWriter` written via `fmt.Fprintf`/`w.Write` of concatenated/interpolated HTML as a `TAINT-003` xss sink (CWE-79) |
+| `tp_xss_response.go` — `greetWrite` (`w.Write([]byte("<b>"+user+"</b>"))`) | request form value → `w.Write` as HTML | **FN** | same XSS-to-response sink (the `[]byte("…"+user)` HTML-concat form) |
+| `tp_xss_response.go` — `greetAutoescapeBypass` (`template.HTML(comment)`) | request query → `html/template` via the `template.HTML()` escape hatch | **FN** | recognize `template.HTML(tainted)` as an **auto-escape-bypass** xss sink, distinct from safe `html/template` interpolation (which `clean_html_autoescape.go` guards must stay clean) |
+| `tp_container_taint.go` — `runMap` (`m["c"]=user; …m["c"]`) | request value → **map value** → command sink | **FN** | **container sensitivity**: propagate taint through `m[k] = tainted` index-assignment and read it back at `m[k]` |
+
+Two closely-related flows are *already caught* by the variable-level engine, and
+their annotations score as TP — recorded here so the next build does not
+"re-fix" them: `tp_field_taint.go` (`Cmd{Arg: r.FormValue("c")}` then
+`req.Arg` at the sink — the source call inlined on the struct-literal statement
+reaches the sink) and `tp_container_taint.go` — `runSlice`
+(`args := []string{user}` then `args[0]` — the whole `args` variable is tainted,
+so the index read still references a tainted identifier). Field sensitivity and
+slice-element precision would make these *robustly* correct, but they are not FN
+today.
+
+Other still-open limits (no sample yet, the next indictment when one lands):
+reflection-based sinks, and cross-file Go flow (the taint-analysis plugin's
+territory). The extraction is AST-precise but stays **AST-only** (no `go/types`):
+method sinks like `.Query`/`.Exec`/`.Decode` are matched by method name, not by
+proving the receiver's type. This corpus carries the annotated ground truth, so
+the day a gap gets a sample, the number tells the truth — the measure → build →
+re-measure loop, now running on Go.

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 1,
-  "f1": 1,
+  "recall": 0.8857142857142857,
+  "f1": 0.9393939393939393,
   "fp": 0,
-  "tp": 29,
-  "fn": 0,
-  "findings_per_issue": 1.0740740740740742,
+  "tp": 31,
+  "fn": 4,
+  "findings_per_issue": 0.9393939393939394,
   "rules": [
     {
       "rule_id": "AI-002",
@@ -55,12 +55,12 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 1
+      "recall": 0.8
     },
     {
       "rule_id": "TAINT-003",
       "precision": 1,
-      "recall": 1
+      "recall": 0.25
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite/clean_field_safe.go
+++ b/testdata/precision-suite/clean_field_safe.go
@@ -1,0 +1,42 @@
+// Safe struct-field flow: an attacker-controlled request value is sanitized
+// before it is stored in a struct field, and only the sanitized field reaches
+// the sink. strconv.Atoi coerces the value to an int (a recognized sanitizer
+// that strips injection metacharacters) and filepath.Clean+Base canonicalizes
+// the path field, so no injection or traversal is possible. A precise scanner
+// fires nothing — this is a precision guardrail for field-sensitive taint.
+// Zero findings expected.
+package job
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+)
+
+// Ticket carries only already-sanitized values through its fields.
+type Ticket struct {
+	Count int
+	Path  string
+}
+
+// build validates and coerces the request values BEFORE storing them in the
+// struct, so the fields are clean by construction.
+func build(r *http.Request) Ticket {
+	count, err := strconv.Atoi(r.FormValue("count"))
+	if err != nil {
+		count = 0
+	}
+	// filepath.Base drops any directory components; the result cannot traverse.
+	safePath := filepath.Base(filepath.Clean(r.URL.Query().Get("path")))
+	return Ticket{Count: count, Path: safePath}
+}
+
+// process reads the sanitized fields into the sinks — the int is formatted as a
+// decimal (no metacharacters) and the path is already a bare filename.
+func process(w http.ResponseWriter, r *http.Request) {
+	t := build(r)
+	out, _ := exec.Command("gen", "--count", strconv.Itoa(t.Count), "--file", t.Path).Output()
+	_, _ = fmt.Fprintf(w, "generated %d records into %s\n%s", t.Count, t.Path, out)
+}

--- a/testdata/precision-suite/clean_html_autoescape.go
+++ b/testdata/precision-suite/clean_html_autoescape.go
@@ -1,0 +1,29 @@
+// Safe HTML rendering: user-controlled data is rendered through html/template,
+// which performs context-aware auto-escaping on every interpolation. Injected
+// markup is escaped to entities, so no XSS is possible. A precise scanner fires
+// nothing — this is a precision guardrail for the XSS-to-response sink. Zero
+// findings expected.
+package web
+
+import (
+	"html/template"
+	"net/http"
+)
+
+// page is the auto-escaping template; {{.Name}} and {{.Bio}} are contextually
+// escaped by html/template, so any HTML in the values is neutralized.
+var page = template.Must(template.New("page").Parse(
+	`<div class="user"><h1>{{.Name}}</h1><p>{{.Bio}}</p></div>`))
+
+// render passes the raw request values straight into html/template. Because the
+// values are plain strings (not template.HTML), the engine escapes them — safe.
+func render(w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		Name string
+		Bio  string
+	}{
+		Name: r.URL.Query().Get("name"),
+		Bio:  r.FormValue("bio"),
+	}
+	_ = page.Execute(w, data)
+}

--- a/testdata/precision-suite/tp_container_taint.go
+++ b/testdata/precision-suite/tp_container_taint.go
@@ -1,0 +1,33 @@
+// Container-sensitive taint: an attacker-controlled request value is written
+// into a map value (and a slice element), then read back out of the container
+// and passed to a command sink. The taint must propagate through the container
+// element to reach the sink — CWE-78. A correct scanner fires TAINT-002.
+//
+// nox's Go taint engine is variable-level (AST-only, no container element
+// tracking), so the flow through m["c"] / args[0] is expected to be a false
+// negative until container sensitivity lands. The annotation is ground truth.
+package job
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+// runMap stashes the request value into a map, then reads it back into the
+// shell command — the taint flows through the map value m["c"].
+func runMap(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("c")
+	m := map[string]string{}
+	m["c"] = user
+	out, _ := exec.Command("sh", "-c", m["c"]).Output() // nox-expect: TAINT-002
+	_, _ = w.Write(out)
+}
+
+// runSlice stashes the request value into a slice element, then reads it back
+// into the shell command — the taint flows through the slice element args[0].
+func runSlice(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("c")
+	args := []string{user}
+	out, _ := exec.Command("sh", "-c", args[0]).Output() // nox-expect: TAINT-002
+	_, _ = w.Write(out)
+}

--- a/testdata/precision-suite/tp_field_taint.go
+++ b/testdata/precision-suite/tp_field_taint.go
@@ -1,0 +1,27 @@
+// Field-sensitive taint: an attacker-controlled request value is stored in a
+// struct field, then the field is read back and passed to a command sink. The
+// taint must propagate through the struct field to reach the sink — CWE-78.
+// A correct scanner fires TAINT-002.
+//
+// nox's Go taint engine is variable-level (AST-only, no field sensitivity), so
+// the flow through Cmd.Arg is expected to be a false negative until field
+// sensitivity lands. The annotation is the ground truth a correct scanner meets.
+package job
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+// Cmd carries the command argument through a struct field between source and sink.
+type Cmd struct {
+	Arg string
+}
+
+// run reads a request parameter, stashes it in a struct field, then reads that
+// field back into a shell invocation — the vulnerability flows through Cmd.Arg.
+func run(w http.ResponseWriter, r *http.Request) {
+	req := Cmd{Arg: r.FormValue("c")}
+	out, _ := exec.Command("sh", "-c", req.Arg).Output() // nox-expect: TAINT-002
+	_, _ = w.Write(out)
+}

--- a/testdata/precision-suite/tp_xss_response.go
+++ b/testdata/precision-suite/tp_xss_response.go
@@ -1,0 +1,40 @@
+// Reflected XSS: an attacker-controlled request value is written into an HTTP
+// response as HTML without escaping, so injected markup executes in the
+// victim's browser — CWE-79. A correct scanner fires TAINT-003 (the taint
+// engine's xss vuln_class, the same rule the Python/JS XSS samples annotate).
+//
+// This is distinct from the SSTI sink (tp_ssti.go): here the sink is the
+// http.ResponseWriter itself, reached via fmt.Fprintf, w.Write, and the
+// template.HTML() auto-escape bypass — three idiomatic ways Go reflects
+// untrusted input into an HTML response.
+package web
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+)
+
+// greetPrintf reflects the raw query value into the HTML body via fmt.Fprintf —
+// the classic reflected-XSS sink. The %s interpolation performs no escaping.
+func greetPrintf(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	fmt.Fprintf(w, "<div>Hello, %s</div>", name) // nox-expect: TAINT-003
+}
+
+// greetWrite concatenates the form value into an HTML fragment and writes the
+// raw bytes to the response — no escaping, so markup in the input executes.
+func greetWrite(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("user")
+	_, _ = w.Write([]byte("<b>" + user + "</b>")) // nox-expect: TAINT-003
+}
+
+// greetAutoescapeBypass renders through html/template but launders the
+// untrusted value through template.HTML(), which tells the engine the string
+// is already-safe HTML and skips contextual escaping — the documented
+// auto-escape escape hatch, and a reflected-XSS sink.
+func greetAutoescapeBypass(w http.ResponseWriter, r *http.Request) {
+	comment := r.URL.Query().Get("comment")
+	t := template.Must(template.New("c").Parse(`<p>{{.}}</p>`))
+	_ = t.Execute(w, template.HTML(comment)) // nox-expect: TAINT-003
+}


### PR DESCRIPTION
## What & why

This is the **measure** half of the measure → build → re-measure loop, mirroring #199 (which honestly recorded 6 Go FNs before #200 closed them). It grows the honest SAST precision suite with a **second tier of Go samples** that exposes the documented LIMITS of the AST-only, variable-level Go taint model landed in #200 — and records the result honestly. **No engine work** (that's the next build phase).

## Samples added

**True positives** (`tp_*.go` — annotate what a *correct* scanner should fire, verified rule id `TAINT-003`/xss/CWE-79 from `core/taint/data/catalog.json`, not guessed):
- `tp_xss_response.go` — reflected XSS to `http.ResponseWriter` via `fmt.Fprintf`, `w.Write`, and the `template.HTML()` auto-escape bypass. **All 3 variants FN today** — no Go XSS-to-response sink is modeled.
- `tp_field_taint.go` — command injection laundered through a struct field (`Cmd{Arg: r.FormValue("c")}`). **Caught (TP)** — the variable-level engine happens to reach it.
- `tp_container_taint.go` — command injection through a **map value** and a **slice element**. Slice = TP; **map value (`m["c"]`) = FN** (no container sensitivity).

**Clean guardrails** (zero annotations — any finding is a false positive):
- `clean_html_autoescape.go` — `html/template` context-aware auto-escaping (safe → must not fire).
- `clean_field_safe.go` — struct field sanitized (`strconv.Atoi`, `filepath.Base`) before the sink (safe → must not fire).

## Measured before → after

`nox bench --precision testdata/precision-suite`:

| | precision | recall | F1 | TP | FP | FN |
| --- | --- | --- | --- | --- | --- | --- |
| before | 1.00 | 1.00 | 1.00 | 29 | 0 | 0 |
| **after** | **1.00** | **0.886** | **0.939** | **31** | **0** | **4** |

- **Precision holds at 1.00** — both clean stressors fire nothing. Comfortably above the `--min-precision 0.90` SAST precision gate.
- **Recall drops by design** to 0.886 — the 4 FN are the corpus doing its job.
- `baseline.json` refreshed to the honest floor; `TestPrecisionSuiteBaseline` passes at the new (lower-recall) floor.
- No root-cause FP fix needed: neither clean stressor false-fired, so no engine change was made.

## The honest FN list (the deliverable that drives the next build)

| Sample (line) | Flow | Engine capability the next build must add |
| --- | --- | --- |
| `tp_xss_response.go` — `greetPrintf` | query → `fmt.Fprintf(w, "<div>%s</div>", name)` | **XSS-to-response sink** (`ResponseWriter` HTML write → `TAINT-003`, CWE-79) |
| `tp_xss_response.go` — `greetWrite` | form value → `w.Write([]byte("<b>"+user+"</b>"))` | same XSS-to-response sink (byte-slice HTML-concat form) |
| `tp_xss_response.go` — `greetAutoescapeBypass` | query → `template.HTML(comment)` | recognize `template.HTML(tainted)` as an **auto-escape-bypass** xss sink (distinct from safe `html/template`, which `clean_html_autoescape.go` guards) |
| `tp_container_taint.go` — `runMap` | value → `m["c"]=user` → sink | **container sensitivity** (taint through map index-assignment/read) |

Already caught (TP, recorded so the next build doesn't re-fix them): `tp_field_taint.go` (struct-field flow) and `tp_container_taint.go` `runSlice` (slice element — whole `args` var is tainted).

## Verification
- `go build ./...`, `go test ./cli/... ./core/bench/... ./core/taint/...` — green.
- `go test ./cli/ -run PrecisionSuiteBaseline` — passes at the refreshed floor.
- `golangci-lint run` (v2.12.2) — no issues in the new samples (`testdata/` is skipped).
- Self-scan gate: new samples add **zero** findings (`testdata/precision-suite/` is `.nox.yaml`-excluded; verified the changed-set delta is empty).

Changes are confined to `testdata/precision-suite/` + its README. No `core/bench/` or `.github/workflows/` touched. No field-sensitivity or new-sink engine work.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom