### PR TITLE
feat(taint): close Go tier-2 false negatives (XSS-to-response + container taint)

### DIFF
--- a/core/taint/catalog_go_test.go
+++ b/core/taint/catalog_go_test.go
@@ -23,6 +23,14 @@ func TestGoCatalogSinks(t *testing.T) {
 		{"gob.NewDecoder deser", "gob.NewDecoder", VulnUnsafeDeserialization, "CWE-502", "TAINT-005"},
 		{"yaml.Unmarshal deser", "yaml.Unmarshal", VulnUnsafeDeserialization, "CWE-502", "TAINT-005"},
 		{"template.New.Parse ssti", "template.New.Parse", VulnSSTI, "CWE-1336", "TAINT-003"},
+		// XSS-to-response sinks (tier-2): tainted data written as HTML to an
+		// http.ResponseWriter is reflected XSS — TAINT-003, xss, CWE-79.
+		{"fmt.Fprintf xss", "fmt.Fprintf", VulnXSS, "CWE-79", "TAINT-003"},
+		{"fmt.Fprint xss", "fmt.Fprint", VulnXSS, "CWE-79", "TAINT-003"},
+		{"fmt.Fprintln xss", "fmt.Fprintln", VulnXSS, "CWE-79", "TAINT-003"},
+		{"w.Write xss", "w.Write", VulnXSS, "CWE-79", "TAINT-003"},
+		{"io.WriteString xss", "io.WriteString", VulnXSS, "CWE-79", "TAINT-003"},
+		{"template.HTML autoescape bypass", "template.HTML", VulnXSS, "CWE-79", "TAINT-003"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -1119,7 +1119,7 @@
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "writing a tainted value as HTML to an http.ResponseWriter (the first arg is the writer) reflects unescaped markup into the response — reflected XSS. Safe html/template Execute is NOT modeled as a sink; only raw writes and the template.HTML bypass are."
+          "note": "tainted value written to an http.ResponseWriter (first arg is the writer); html/template Execute is intentionally not a sink"
         },
         {
           "call": "fmt.Fprint",
@@ -1138,21 +1138,21 @@
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "w.Write([]byte(...tainted HTML...)) on a response writer emits unescaped bytes — reflected XSS"
+          "note": "response-writer byte write; gated in extract_go on a co-located string literal (the HTML-concat shape)"
         },
         {
           "call": "io.WriteString",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "io.WriteString(w, tainted) writes an unescaped tainted string to the response writer"
+          "note": "tainted string written to the response writer"
         },
         {
           "call": "template.HTML",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "template.HTML(tainted) is the html/template auto-escape bypass: it marks a tainted string as trusted HTML, so contextual escaping is skipped and the value reaches the response unescaped — reflected XSS. Distinct from safe html/template interpolation, which is not a sink."
+          "note": "the html/template auto-escape bypass; distinct from safe html/template interpolation, which is not a sink"
         }
       ],
       "sanitizers": [

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -1113,6 +1113,46 @@
           "vuln_class": "ssti",
           "cwe": "CWE-1336",
           "rule_id": "TAINT-003"
+        },
+        {
+          "call": "fmt.Fprintf",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003",
+          "note": "writing a tainted value as HTML to an http.ResponseWriter (the first arg is the writer) reflects unescaped markup into the response — reflected XSS. Safe html/template Execute is NOT modeled as a sink; only raw writes and the template.HTML bypass are."
+        },
+        {
+          "call": "fmt.Fprint",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003"
+        },
+        {
+          "call": "fmt.Fprintln",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003"
+        },
+        {
+          "call": "w.Write",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003",
+          "note": "w.Write([]byte(...tainted HTML...)) on a response writer emits unescaped bytes — reflected XSS"
+        },
+        {
+          "call": "io.WriteString",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003",
+          "note": "io.WriteString(w, tainted) writes an unescaped tainted string to the response writer"
+        },
+        {
+          "call": "template.HTML",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003",
+          "note": "template.HTML(tainted) is the html/template auto-escape bypass: it marks a tainted string as trusted HTML, so contextual escaping is skipped and the value reaches the response unescaped — reflected XSS. Distinct from safe html/template interpolation, which is not a sink."
         }
       ],
       "sanitizers": [

--- a/core/taint/engine/extract_go.go
+++ b/core/taint/engine/extract_go.go
@@ -248,11 +248,18 @@ func (ex *goExtractor) emitReturn(u *unitDraft, st *ast.ReturnStmt) {
 // engine's assigns field is one variable; for a multi-value assign
 // (`out, _ := f()`, `tmp, err := f()`) we pick the first non-blank, non-error
 // identifier so the meaningful value — not the error — is tracked.
+//
+// A container/element or field target (`m["c"] = v`, `obj.Field = v`) resolves
+// to its BASE identifier (m, obj) so a tainted RHS taints the whole container — a
+// sound, container-level over-approximation that makes taint laundered through a
+// map value / slice element / struct field reach a later read of the container.
+// This is the only element/field sensitivity nox claims: container-level, not
+// key-level.
 func (ex *goExtractor) primaryLHS(lhs []ast.Expr) string {
 	names := make([]string, 0, len(lhs))
 	for _, e := range lhs {
-		if id, ok := e.(*ast.Ident); ok {
-			names = append(names, id.Name)
+		if name := lhsAssignedName(e); name != "" {
+			names = append(names, name)
 		} else {
 			names = append(names, "")
 		}
@@ -268,6 +275,33 @@ func (ex *goExtractor) primaryLHS(lhs []ast.Expr) string {
 		}
 	}
 	return ""
+}
+
+// lhsAssignedName returns the variable name an assignment LHS target attributes
+// taint to. A plain identifier (`x = v`) yields the identifier. A container or
+// field target resolves to its base identifier so the whole container is tainted:
+//   - `m["c"] = v` / `s[0] = v` (*ast.IndexExpr) → the base "m" / "s"
+//   - `obj.Field = v` (*ast.SelectorExpr)        → the receiver head "obj"
+//   - `(*p).Field = v` / `p.a.b = v` (nested)     → the leftmost identifier
+//
+// Container-level, not key-level: writing one key taints the container, so a read
+// of any element of it is treated as tainted (a sound over-approximation). Returns
+// "" for a shape with no identifier base (e.g. a literal or call target).
+func lhsAssignedName(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.IndexExpr:
+		return lhsAssignedName(x.X)
+	case *ast.SelectorExpr:
+		return lhsAssignedName(x.X)
+	case *ast.StarExpr:
+		return lhsAssignedName(x.X)
+	case *ast.ParenExpr:
+		return lhsAssignedName(x.X)
+	default:
+		return ""
+	}
 }
 
 // hoistInlineSources scans the given expressions for pure selector chains used as

--- a/core/taint/engine/extract_go.go
+++ b/core/taint/engine/extract_go.go
@@ -397,7 +397,18 @@ func (ex *goExtractor) collectExpr(st *stmtDraft, e ast.Expr) {
 		return
 	case *ast.CallExpr:
 		callee := renderCallChain(x.Fun)
-		if callee != "" {
+		// A raw `.Write` XSS-to-response sink (w.Write([]byte(...))) fires only on the
+		// reflected-HTML shape: a tainted value combined with a string LITERAL in the
+		// write argument (an HTML concatenation "<b>"+user+"</b>"). A bare write of a
+		// precomputed value — w.Write(out) where out is command/file output — is NOT
+		// reflected XSS (that value is already reported at its own upstream sink), so
+		// the callee is not registered as a sink here. This gate keeps the injection
+		// samples (tp_cmdinjection/pathtraversal/… all end in w.Write(out)) from
+		// double-firing an XSS false positive while w.Write([]byte("…"+user)) still
+		// fires. The fmt.Fprint*/io.WriteString string-writers and template.HTML
+		// bypass need no literal gate — a tainted string reaching them IS reflected
+		// content — so they always register and are gated only by taint.
+		if callee != "" && (!isGoRawWriteSink(callee) || xssWriteArgIsHTML(x)) {
 			st.calls = appendUnique(st.calls, callee)
 			st.sinkArgs[callee] = ex.callArgInfo(x)
 		}
@@ -625,6 +636,56 @@ func chainHead(chain string) string {
 func isStringLiteral(e ast.Expr) bool {
 	lit, ok := e.(*ast.BasicLit)
 	return ok && lit.Kind == token.STRING
+}
+
+// isGoRawWriteSink reports whether a rendered callee chain is a raw byte `.Write`
+// on a response writer (w.Write, rw.Write, …). Matched on the `.Write` suffix so an
+// aliased writer name still resolves. This is the only XSS-write sink whose danger
+// is gated on a co-located string literal (a bare w.Write(out) of precomputed bytes
+// is not reflected XSS); the fmt.Fprint*/io.WriteString string-writers are not
+// gated, and template.HTML is an unconditional bypass sink.
+func isGoRawWriteSink(callee string) bool {
+	return strings.HasSuffix(callee, ".Write")
+}
+
+// xssWriteArgIsHTML reports whether a write call carries the reflected-HTML shape:
+// a string LITERAL appears somewhere in its arguments (a format string like
+// "<div>%s</div>" or an HTML concatenation "<b>"+user+"</b>", including inside a
+// []byte(...) conversion). A bare write of a single precomputed value — w.Write(out)
+// — has no literal and is not treated as XSS. Deterministic, AST-only.
+func xssWriteArgIsHTML(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		if exprContainsStringLiteral(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// exprContainsStringLiteral reports whether an expression tree contains a string
+// basic literal, descending concatenations, conversions ([]byte(...)), and the
+// usual wrappers. It does not descend into nested unrelated calls' arguments
+// beyond the conversion/format spine we care about — a string literal anywhere in
+// the write argument's own spine is enough to mark it HTML-shaped.
+func exprContainsStringLiteral(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return x.Kind == token.STRING
+	case *ast.BinaryExpr:
+		return exprContainsStringLiteral(x.X) || exprContainsStringLiteral(x.Y)
+	case *ast.ParenExpr:
+		return exprContainsStringLiteral(x.X)
+	case *ast.CallExpr:
+		// Descend a conversion / wrapping call ([]byte("<b>"+user+"</b>"),
+		// string(...)) so a literal inside the converted expression counts.
+		for _, a := range x.Args {
+			if exprContainsStringLiteral(a) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // isCompositeVector reports whether an expression is a composite literal such as

--- a/core/taint/engine/extract_go_test.go
+++ b/core/taint/engine/extract_go_test.go
@@ -199,3 +199,101 @@ func (s *Server) handle(input string) {
 		t.Errorf("params = %v, want [s input] (receiver first)", u.params)
 	}
 }
+
+// stmtAssigningReading returns the first statement in u whose Assigns == name AND
+// which reads `read` — so a test can pinpoint the container-assignment statement
+// (`m["c"] = user`) rather than an earlier `m := ...{}` initializer that also
+// assigns the same base.
+func stmtAssigningReading(t *testing.T, u unitDraft, name, read string) stmtDraft {
+	t.Helper()
+	for i := range u.stmts {
+		if u.stmts[i].assigns == name && containsStr(u.stmts[i].reads, read) {
+			return u.stmts[i]
+		}
+	}
+	t.Fatalf("no statement assigning %q reading %q in unit %q; stmts=%+v", name, read, u.funcName, u.stmts)
+	return stmtDraft{}
+}
+
+// stmtAssigning returns the first statement in u whose Assigns == name.
+func stmtAssigning(t *testing.T, u unitDraft, name string) stmtDraft {
+	t.Helper()
+	for i := range u.stmts {
+		if u.stmts[i].assigns == name {
+			return u.stmts[i]
+		}
+	}
+	t.Fatalf("no statement assigning %q in unit %q; stmts=%+v", name, u.funcName, u.stmts)
+	return stmtDraft{}
+}
+
+// TestExtractGoMapIndexAssignTaintsBase covers container sensitivity for a map
+// index assignment `m["c"] = user`: the extractor must record the BASE identifier
+// (m), not the index expression, as the assignee so a tainted RHS taints the
+// whole container (a sound container-level over-approximation).
+func TestExtractGoMapIndexAssignTaintsBase(t *testing.T) {
+	src := []byte(`package j
+
+import "net/http"
+
+func runMap(r *http.Request) {
+	user := r.FormValue("c")
+	m := map[string]string{}
+	m["c"] = user
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "runMap")
+	// The index assignment must be attributed to the base variable m.
+	st := stmtAssigningReading(t, u, "m", "user")
+	if !containsStr(st.reads, "user") {
+		t.Errorf("m[..]=user reads = %v, want to include user", st.reads)
+	}
+}
+
+// TestExtractGoStructFieldAssignTaintsBase covers container sensitivity for a
+// struct-field assignment `obj.Field = user`: the base identifier (obj) is the
+// assignee, so the whole struct is tainted.
+func TestExtractGoStructFieldAssignTaintsBase(t *testing.T) {
+	src := []byte(`package j
+
+import "net/http"
+
+func runField(r *http.Request) {
+	user := r.FormValue("c")
+	var cmd Cmd
+	cmd.Arg = user
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "runField")
+	st := stmtAssigning(t, u, "cmd")
+	if !containsStr(st.reads, "user") {
+		t.Errorf("cmd.Arg=user reads = %v, want to include user", st.reads)
+	}
+}
+
+// TestExtractGoIndexAssignBaseNotOverwritingSanitized guards the clean_field_safe
+// path: when the RHS of a field assignment is a sanitized value, the base is still
+// the assignee (so the engine's per-class sanitizer clearing — not the extractor —
+// keeps it clean). The extractor must record the base and the sanitizer call.
+func TestExtractGoIndexAssignBaseRecordsSanitizerCall(t *testing.T) {
+	src := []byte(`package j
+
+import (
+	"net/http"
+	"strconv"
+)
+
+func runSafe(r *http.Request) {
+	var t Ticket
+	t.Count = strconv.Atoi(r.FormValue("count"))
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "runSafe")
+	st := stmtAssigning(t, u, "t")
+	if !containsStr(st.calls, "strconv.Atoi") {
+		t.Errorf("t.Count=strconv.Atoi(...) calls = %v, want to include strconv.Atoi", st.calls)
+	}
+}

--- a/core/taint/engine/extract_go_test.go
+++ b/core/taint/engine/extract_go_test.go
@@ -297,3 +297,91 @@ func runSafe(r *http.Request) {
 		t.Errorf("t.Count=strconv.Atoi(...) calls = %v, want to include strconv.Atoi", st.calls)
 	}
 }
+
+// TestExtractGoFprintfSinkArg covers the reflected-XSS-via-fmt.Fprintf shape:
+// fmt.Fprintf(w, "<div>%s</div>", name) — the callee renders to fmt.Fprintf and
+// the tainted interpolation variable name is captured as a tainted arg var (the
+// writer w is the first positional arg, name a later one).
+func TestExtractGoFprintfSinkArg(t *testing.T) {
+	src := []byte(`package web
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func greet(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	fmt.Fprintf(w, "<div>%s</div>", name)
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "greet")
+	sink := stmtWithCall(t, u, "fmt.Fprintf")
+	if !containsStr(sink.reads, "name") {
+		t.Errorf("fmt.Fprintf reads = %v, want to include name", sink.reads)
+	}
+	info, ok := sink.sinkArgs["fmt.Fprintf"]
+	if !ok {
+		t.Fatalf("no sinkArg for fmt.Fprintf: %+v", sink.sinkArgs)
+	}
+	if !containsStr(info.taintedArgVars, "name") {
+		t.Errorf("fmt.Fprintf taintedArgVars = %v, want to include name", info.taintedArgVars)
+	}
+}
+
+// TestExtractGoWriteBytesSinkArg covers w.Write([]byte("<b>"+user+"</b>")): the
+// callee renders to w.Write and the tainted concat variable user is captured even
+// though it is nested inside a []byte(...) conversion of a string concatenation.
+func TestExtractGoWriteBytesSinkArg(t *testing.T) {
+	src := []byte(`package web
+
+import "net/http"
+
+func greet(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("user")
+	_, _ = w.Write([]byte("<b>" + user + "</b>"))
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "greet")
+	sink := stmtWithCall(t, u, "w.Write")
+	if !containsStr(sink.reads, "user") {
+		t.Errorf("w.Write reads = %v, want to include user", sink.reads)
+	}
+	info := sink.sinkArgs["w.Write"]
+	if !containsStr(info.taintedArgVars, "user") {
+		t.Errorf("w.Write taintedArgVars = %v, want to include user", info.taintedArgVars)
+	}
+}
+
+// TestExtractGoTemplateHTMLBypassSinkArg covers the auto-escape bypass shape:
+// t.Execute(w, template.HTML(comment)). The nested template.HTML call must be
+// captured as its own sink call with the tainted variable comment as an arg — so
+// the catalog can flag template.HTML(tainted) as an XSS sink independent of the
+// enclosing Execute (which is NOT a sink).
+func TestExtractGoTemplateHTMLBypassSinkArg(t *testing.T) {
+	src := []byte(`package web
+
+import (
+	"html/template"
+	"net/http"
+)
+
+func greet(w http.ResponseWriter, r *http.Request) {
+	comment := r.URL.Query().Get("comment")
+	t := template.Must(template.New("c").Parse("<p>{{.}}</p>"))
+	_ = t.Execute(w, template.HTML(comment))
+}
+`)
+	units := extractUnits(lexctx.LangGo, src)
+	u := findUnit(t, units, "greet")
+	sink := stmtWithCall(t, u, "template.HTML")
+	info, ok := sink.sinkArgs["template.HTML"]
+	if !ok {
+		t.Fatalf("no sinkArg for template.HTML: %+v", sink.sinkArgs)
+	}
+	if !containsStr(info.taintedArgVars, "comment") {
+		t.Errorf("template.HTML taintedArgVars = %v, want to include comment", info.taintedArgVars)
+	}
+}

--- a/core/taint/engine/structural_go_test.go
+++ b/core/taint/engine/structural_go_test.go
@@ -143,6 +143,81 @@ func run(dir string) {
 	}
 }
 
+// TestStructuralGoXSSToResponse covers the three reflected-XSS-to-response shapes:
+// fmt.Fprintf of an interpolated tainted value, w.Write of a []byte HTML concat,
+// and the template.HTML auto-escape bypass. Each must fire TAINT-003 (xss).
+func TestStructuralGoXSSToResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "fmt.Fprintf interpolates tainted value into HTML",
+			src: `package web
+func greet(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	fmt.Fprintf(w, "<div>Hello, %s</div>", name)
+}`,
+		},
+		{
+			name: "w.Write of []byte HTML concat",
+			src: `package web
+func greet(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("user")
+	_, _ = w.Write([]byte("<b>" + user + "</b>"))
+}`,
+		},
+		{
+			name: "io.WriteString of tainted value",
+			src: `package web
+func greet(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("user")
+	_, _ = io.WriteString(w, user)
+}`,
+		},
+		{
+			name: "template.HTML auto-escape bypass",
+			src: `package web
+func greet(w http.ResponseWriter, r *http.Request) {
+	comment := r.URL.Query().Get("comment")
+	t := template.Must(template.New("c").Parse("<p>{{.}}</p>"))
+	_ = t.Execute(w, template.HTML(comment))
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := analyzeGoFile(t, tt.src)
+			found := false
+			for _, id := range ids {
+				if id == "TAINT-003" {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("xss-to-response: got %v, want TAINT-003", ids)
+			}
+		})
+	}
+}
+
+// TestStructuralGoSafeAutoescapeStaysClean guards clean_html_autoescape.go: safe
+// html/template rendering — user data passed as a plain struct field to
+// Execute, which contextually auto-escapes — must fire NOTHING. Execute is not
+// modeled as a sink; only the template.HTML bypass and raw writes are.
+func TestStructuralGoSafeAutoescapeStaysClean(t *testing.T) {
+	src := `package web
+var page = template.Must(template.New("page").Parse("<h1>{{.Name}}</h1>"))
+func render(w http.ResponseWriter, r *http.Request) {
+	data := struct{ Name string }{Name: r.URL.Query().Get("name")}
+	_ = page.Execute(w, data)
+}`
+	ids := analyzeGoFile(t, src)
+	if len(ids) != 0 {
+		t.Errorf("safe auto-escape: want zero findings, got %v", ids)
+	}
+}
+
 // TestStructuralGoContainerTaint covers container-level taint: a request value
 // stashed into a map value (m["c"]=user) then read back at the command sink
 // (m["c"]) must fire TAINT-002. The extractor attributes the index assignment to

--- a/core/taint/engine/structural_go_test.go
+++ b/core/taint/engine/structural_go_test.go
@@ -143,6 +143,53 @@ func run(dir string) {
 	}
 }
 
+// TestStructuralGoContainerTaint covers container-level taint: a request value
+// stashed into a map value (m["c"]=user) then read back at the command sink
+// (m["c"]) must fire TAINT-002. The extractor attributes the index assignment to
+// the base m, so the whole container is tainted and the later read of m is
+// dangerous.
+func TestStructuralGoContainerTaint(t *testing.T) {
+	src := `package j
+func runMap(r *Req) {
+	user := r.FormValue("c")
+	m := map[string]string{}
+	m["c"] = user
+	out, _ := exec.Command("sh", "-c", m["c"]).Output()
+	_ = out
+}`
+	ids := analyzeGoFile(t, src)
+	found := false
+	for _, id := range ids {
+		if id == "TAINT-002" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("container taint: got %v, want TAINT-002 (map value flows to sink)", ids)
+	}
+}
+
+// TestStructuralGoSanitizedFieldStaysClean guards clean_field_safe.go: a request
+// value sanitized into a local (strconv.Atoi) BEFORE being stored in a struct
+// field, then read at the sink, must fire nothing — the sanitized local carries
+// the cleared class into the field-assigned base, so the container-level base
+// attribution does not resurrect the taint.
+func TestStructuralGoSanitizedFieldStaysClean(t *testing.T) {
+	src := `package j
+func build(r *Req) {
+	raw := r.FormValue("count")
+	count := strconv.Atoi(raw)
+	var t Ticket
+	t.Count = count
+	out, _ := exec.Command("gen", "--count", t.Count).Output()
+	_ = out
+}`
+	ids := analyzeGoFile(t, src)
+	if len(ids) != 0 {
+		t.Errorf("sanitized field: want zero findings, got %v", ids)
+	}
+}
+
 // TestStructuralGoInterprocSameFile covers a source in a handler flowing through a
 // locally-defined helper to a sink (the same-file interprocedural summary path).
 func TestStructuralGoInterprocSameFile(t *testing.T) {

--- a/docs/design/go-taint.md
+++ b/docs/design/go-taint.md
@@ -109,16 +109,61 @@ same-file limits:
   chain suffix; a package imported under a *different* local name than its suffix
   (rare) would be missed.
 - **Inherited from the engine:** intraprocedural + same-file interprocedural only,
-  straight-line (no CFG/branch merging), no alias or field/element sensitivity.
+  straight-line (no CFG/branch merging), no alias analysis. Container taint is
+  tracked at the **container level** (see below), not per key/element.
+
+### XSS-to-response sinks (reflected XSS, CWE-79)
+
+Tainted request data written as HTML to an `http.ResponseWriter` fires `TAINT-003`
+(xss). The sinks, all AST-recognized on the call-chain suffix:
+
+- `fmt.Fprintf` / `fmt.Fprint` / `fmt.Fprintln` and `io.WriteString` — the first
+  argument is the writer; a tainted value among the args is reflected content. No
+  literal gate: a tainted string reaching a string-writer IS reflected output.
+- `w.Write([]byte("<b>"+user+"</b>"))` — a raw byte write. This one **is** gated
+  on a co-located string **literal** in the write argument (the reflected-HTML
+  concat shape). A bare `w.Write(out)` of a precomputed value — e.g. command or
+  file output — is *not* reflected XSS (that value is already reported at its own
+  upstream sink), so it does not fire. This gate is what stops the injection
+  samples (all of which end in `w.Write(out)`) from double-firing an XSS false
+  positive. It lives in `extract_go.go` (`isGoRawWriteSink` / `xssWriteArgIsHTML`),
+  keeping the change Go-local.
+- `template.HTML(tainted)` — the `html/template` **auto-escape bypass**. Converting
+  a tainted string to `template.HTML` marks it as trusted HTML, so contextual
+  escaping is skipped and it reaches the response unescaped. Modeled as an
+  unconditional sink.
+
+Crucially, safe `html/template` interpolation (`tmpl.Execute(w, structData)`) is
+**not** a sink: `Execute`/`ExecuteTemplate` auto-escape their inputs, so the
+guardrail `clean_html_autoescape.go` stays clean. Only the raw-write paths and the
+`template.HTML` bypass are sinks.
+
+### Container-level taint (index / field / element)
+
+An assignment whose LHS is an index (`m["c"] = v`), selector (`obj.Field = v`),
+star, or paren target attributes taint to the **base identifier** (`m`, `obj`), so
+a tainted RHS taints the whole container (`lhsAssignedName` in `extract_go.go`).
+A later read of any element of that container is then treated as tainted, so
+`m["c"] = user; exec.Command("sh","-c", m["c"])` fires. This is a sound
+over-approximation at the **container level, not the key level**: writing one key
+taints the container, so a read of a *different, clean* key of the same container
+is also treated as tainted. Key/element-level precision would tighten this at some
+risk to recall and is not modeled. The change is Go-local (`extract_go.go` only);
+the shared `StructuralEngine` is untouched, and per-class sanitizer clearing still
+holds (a value sanitized into a local before the field write stays clean, so
+`clean_field_safe.go` fires nothing).
 
 ### Vuln classes covered / not covered
 
 Covered (fire on the precision corpus): command injection (`exec.Command`),
 SQL injection (`.Query`/`.Exec` concatenation), path traversal
 (`os.ReadFile`/`os.Open`), SSRF (`http.Get`/`http.Post`), unsafe deserialization
-(`gob.NewDecoder`, `yaml.Unmarshal`), SSTI (`text/template` `.Parse`).
+(`gob.NewDecoder`, `yaml.Unmarshal`), SSTI (`text/template` `.Parse`), reflected
+XSS-to-response (`fmt.Fprintf`/`w.Write`/`template.HTML`; see above), and
+container-level taint through maps / slices / struct fields (see above).
 
-Not yet covered (honest): XSS via `html/template` misuse beyond auto-escaping,
-taint through struct fields / maps / slices (no field sensitivity), taint laundered
-through `fmt.Sprintf` into a struct then sunk, cross-file flow (the taint-analysis
-plugin's territory), and reflection-based sinks.
+Not yet covered (honest): key/element-level container precision (only
+container-level today), type-based confirmation that a `.Write`/`.Query` receiver
+is the expected type (AST-only, matched by method name), taint laundered through
+`fmt.Sprintf` into a struct then sunk across statements, cross-file flow (the
+taint-analysis plugin's territory), and reflection-based sinks.

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -13,8 +13,11 @@ first *lowered* recall (the six Go taint classes were genuine false negatives
 until a Go taint model existed); the Go taint model has since landed
 (`core/taint/data/catalog.json` `go` block + `core/taint/engine/extract_go.go`,
 AST-precise via `go/ast`), flipping all six from FN to TP and taking recall back
-to 1.00 — the measure → build → re-measure loop, extended to Go. See "Go
-coverage: what's caught, what's still open" below.
+to 1.00 — the measure → build → re-measure loop, extended to Go. A second Go
+tier then reopened recall to 0.89 (four honest tier-2 false negatives: three
+XSS-to-response, one map-value container taint) and has since been closed too,
+returning recall to 1.00. See "Go coverage: what's caught, what's still open"
+below.
 
 Run it:
 
@@ -41,23 +44,23 @@ nox bench --precision testdata/precision-suite --baseline testdata/precision-sui
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite` scores
-**precision 1.00 / recall 0.89 / F1 0.94** (31 TP, 0 FP, 4 FN). Precision is
-still perfect — every finding nox emits is a true positive, and both new clean
-stressors (`clean_html_autoescape.go`, `clean_field_safe.go`) fire nothing — but
-recall dropped from 1.00 to 0.89 the moment a second Go tier landed: five new Go
-samples (`tp_xss_response.go`, `tp_field_taint.go`, `tp_container_taint.go` plus
-the two clean guardrails) named **four honest false negatives** the variable-level
-Go engine misses. That drop is the corpus doing its job — it is the next
-indictment, and closing it (building the engine, not curating the corpus) is the
-next build phase. See "Go coverage" below for the exact FN list and the engine
-capability each one demands.
+**precision 1.00 / recall 1.00 / F1 1.00** (35 TP, 0 FP, 0 FN). Precision is
+perfect — every finding nox emits is a true positive, and both Go clean
+stressors (`clean_html_autoescape.go`, `clean_field_safe.go`) fire nothing — and
+recall is back to 1.00 now that the Go tier-2 gaps are closed. The second Go tier
+(`tp_xss_response.go`, `tp_field_taint.go`, `tp_container_taint.go` plus the two
+clean guardrails) had named **four honest false negatives** the variable-level Go
+engine missed — three XSS-to-response sinks and one map-value container taint —
+dropping recall to 0.89. Those were closed by building the engine (an
+XSS-to-response sink family + container-level index/field taint), not by curating
+the corpus. See "Go coverage" below for what each fix added.
 
-For the historical record, recall was previously 1.00: the six Go injection /
-traversal / SSRF / deserialization / SSTI positives fire as `TAINT-001..006`
-thanks to the first Go taint model (see "Go coverage" below). The earlier honest
-dip to recall 0.79 the moment the *first* realistic **Go** samples were added was
-the same mechanism — it named six real false negatives, and closing them moved the
-number back to 1.00, until this second tier reopened it to 0.89.
+For the historical record, recall dipped to 0.79 when the *first* realistic **Go**
+samples landed (six FNs: injection / traversal / SSRF / deserialization / SSTI),
+returned to 1.00 once the first Go taint model closed them, dipped again to 0.89
+when the tier-2 samples landed (the four FNs above), and returned to 1.00 once the
+tier-2 engine work closed those — the measure → build → re-measure loop, running
+on Go across two tiers.
 
 For reference, the earlier journey: precision rose from an original honest
 baseline of 0.30 / F1 0.47 (39 FP), through an interim 0.89 / F1 0.94, to
@@ -66,11 +69,12 @@ the corpus indicted (items 1–6 below), never by curating it. Recall then dippe
 to 0.79 when Go samples landed (six honest FNs) and returned to 1.00 once the Go
 taint model closed them.
 
-- **findings-per-issue: 0.94** — across the annotated issues nox emits ~0.94
-  findings each; it is now *below* 1.00 because the four Go tier-2 false negatives
-  (three XSS-to-response, one map-value taint) contribute annotated issues with
-  zero findings. The Go secret files fire the language-agnostic secret regexes
-  slightly above 1.00; the caught taint classes are all exactly 1.00. On the Python
+- **findings-per-issue: 1.06** — across the annotated issues nox emits ~1.06
+  findings each; it is now slightly *above* 1.00 only because the two Go secret
+  files fire the language-agnostic secret regexes above 1.00
+  (`tp_secrets.go` at 1.33). Every taint class — including the four newly-closed
+  tier-2 flows — is exactly 1.00 (`tp_xss_response.go` 3/3, `tp_container_taint.go`
+  2/2). On the Python
   secret files that once dominated, density
   collapsed to canonical: `tp_secrets_cloud.py` from **8.00 → 1.00** and
   `tp_secrets.py` from **5.33 → 1.33**, via specificity dedup + per-token owner
@@ -175,9 +179,9 @@ language for the first time):
 | `tp_ssrf.go` | `http.Get(userURL)` | TAINT-006 | TP (Go taint model) |
 | `tp_deserialization.go` | `gob.NewDecoder(r.Body).Decode` | TAINT-005 | TP (Go taint model) |
 | `tp_ssti.go` | `text/template` parse of user input | TAINT-003 | TP (Go taint model) |
-| `tp_xss_response.go` | reflected XSS to `http.ResponseWriter` (Fprintf / Write / `template.HTML`) | TAINT-003 (xss, CWE-79) | **FN** — no Go XSS-to-response sink |
-| `tp_field_taint.go` | cmd injection laundered through a struct field | TAINT-002 | TP (variable-level engine happens to reach it) |
-| `tp_container_taint.go` | cmd injection through a map value **and** a slice element | TAINT-002 (×2) | slice = TP, **map value = FN** (no container sensitivity) |
+| `tp_xss_response.go` | reflected XSS to `http.ResponseWriter` (Fprintf / Write / `template.HTML`) | TAINT-003 (xss, CWE-79) | TP (XSS-to-response sink family) |
+| `tp_field_taint.go` | cmd injection laundered through a struct field | TAINT-002 | TP (container-level field taint) |
+| `tp_container_taint.go` | cmd injection through a map value **and** a slice element | TAINT-002 (×2) | TP ×2 (container-level index/element taint) |
 
 Clean stressors (zero annotations — any finding is a false positive):
 
@@ -208,15 +212,16 @@ refresh `baseline.json`.
 
 ## Go coverage: what's caught, what's still open
 
-Adding realistic Go samples surfaced **six honest false negatives**, and the Go
-taint model has since closed all six. nox's taint catalog
-(`core/taint/data/catalog.json`) now carries a `go` language block, and
-`core/taint/engine/extract_go.go` does AST-precise extraction (built on `go/ast`,
-not the line recognizer Python/JS use — nox is itself Go, so the pure-Go stdlib
-parser is free, precise, and deterministic; see `docs/design/go-taint.md`). All
-six Go dataflow vulnerabilities now fire; the secret regexes were already
-language-agnostic, so Go secrets were true positives throughout. What nox catches
-in Go today:
+Adding realistic Go samples surfaced **six honest false negatives** (tier 1) then
+**four more** (tier 2), and the Go taint model has since closed all ten. nox's
+taint catalog (`core/taint/data/catalog.json`) now carries a `go` language block,
+and `core/taint/engine/extract_go.go` does AST-precise extraction (built on
+`go/ast`, not the line recognizer Python/JS use — nox is itself Go, so the pure-Go
+stdlib parser is free, precise, and deterministic; see `docs/design/go-taint.md`).
+All ten Go dataflow vulnerabilities now fire (six tier-1 injection/traversal/SSRF/
+deserialization/SSTI classes, plus tier-2 reflected XSS-to-response and
+container-level taint); the secret regexes were already language-agnostic, so Go
+secrets were true positives throughout. What nox catches in Go today:
 
 | Vuln class | Go sink (sample) | Fires | CWE |
 | --- | --- | --- | --- |
@@ -226,34 +231,46 @@ in Go today:
 | SSRF | `http.Get(userURL)` | TAINT-006 | CWE-918 |
 | Unsafe deserialization | `gob.NewDecoder(r.Body).Decode(&v)` | TAINT-005 | CWE-502 |
 | SSTI | `text/template … Parse(userInput)` | TAINT-003 | CWE-1336 |
+| Reflected XSS (Fprintf) | `fmt.Fprintf(w, "<div>%s</div>", userInput)` | TAINT-003 | CWE-79 |
+| Reflected XSS (Write) | `w.Write([]byte("<b>"+userInput+"</b>"))` | TAINT-003 | CWE-79 |
+| Reflected XSS (bypass) | `template.HTML(userInput)` → response | TAINT-003 | CWE-79 |
+| Container taint | `m["c"]=userInput; …exec(m["c"])` | TAINT-002 | CWE-78 |
 
-### Go coverage — next gaps (the tier-2 samples that are FN today)
+### Go coverage — tier-2 gaps, now closed
 
-A second tier of Go samples now carries these gaps as annotated ground truth, so
-they show up as concrete false negatives (recall 0.89) rather than prose. This is
-the precise target list for the next build phase:
+A second tier of Go samples carried four honest false negatives as annotated
+ground truth, dropping recall to 0.89. They have since been closed by building the
+engine (not curating the corpus), returning recall to 1.00:
 
-| Sample (line) | What flows | Fires? | Engine capability the next build must add |
+| Sample (line) | What flows | Fires now | How it was closed |
 | --- | --- | --- | --- |
-| `tp_xss_response.go` — `greetPrintf` (`fmt.Fprintf(w, "<div>%s</div>", name)`) | request query → response writer as HTML | **FN** | an **XSS-to-response sink**: model `http.ResponseWriter` written via `fmt.Fprintf`/`w.Write` of concatenated/interpolated HTML as a `TAINT-003` xss sink (CWE-79) |
-| `tp_xss_response.go` — `greetWrite` (`w.Write([]byte("<b>"+user+"</b>"))`) | request form value → `w.Write` as HTML | **FN** | same XSS-to-response sink (the `[]byte("…"+user)` HTML-concat form) |
-| `tp_xss_response.go` — `greetAutoescapeBypass` (`template.HTML(comment)`) | request query → `html/template` via the `template.HTML()` escape hatch | **FN** | recognize `template.HTML(tainted)` as an **auto-escape-bypass** xss sink, distinct from safe `html/template` interpolation (which `clean_html_autoescape.go` guards must stay clean) |
-| `tp_container_taint.go` — `runMap` (`m["c"]=user; …m["c"]`) | request value → **map value** → command sink | **FN** | **container sensitivity**: propagate taint through `m[k] = tainted` index-assignment and read it back at `m[k]` |
+| `tp_xss_response.go` — `greetPrintf` (`fmt.Fprintf(w, "<div>%s</div>", name)`) | request query → response writer as HTML | **TP** | `fmt.Fprintf`/`Fprint`/`Fprintln` + `io.WriteString` added as `TAINT-003` xss sinks (CWE-79); gated by taint only |
+| `tp_xss_response.go` — `greetWrite` (`w.Write([]byte("<b>"+user+"</b>"))`) | request form value → `w.Write` as HTML | **TP** | `w.Write` added as an xss sink, gated on a co-located string LITERAL (the reflected-HTML `[]byte("…"+user)` shape) so a bare `w.Write(out)` of command/file output does not over-fire |
+| `tp_xss_response.go` — `greetAutoescapeBypass` (`template.HTML(comment)`) | request query → `html/template` via the `template.HTML()` escape hatch | **TP** | `template.HTML(tainted)` modeled as an **auto-escape-bypass** xss sink, distinct from safe `html/template` `Execute` (which is deliberately NOT a sink, keeping `clean_html_autoescape.go` clean) |
+| `tp_container_taint.go` — `runMap` (`m["c"]=user; …m["c"]`) | request value → **map value** → command sink | **TP** | **container-level taint**: an assignment whose LHS is an index (`m["c"]`), selector (`obj.Field`), star, or paren target now taints the BASE identifier, so writing one key taints the whole container and a later read of it is tainted |
 
-Two closely-related flows are *already caught* by the variable-level engine, and
-their annotations score as TP — recorded here so the next build does not
-"re-fix" them: `tp_field_taint.go` (`Cmd{Arg: r.FormValue("c")}` then
-`req.Arg` at the sink — the source call inlined on the struct-literal statement
-reaches the sink) and `tp_container_taint.go` — `runSlice`
-(`args := []string{user}` then `args[0]` — the whole `args` variable is tainted,
-so the index read still references a tainted identifier). Field sensitivity and
-slice-element precision would make these *robustly* correct, but they are not FN
-today.
+The two closely-related flows the variable-level engine already reached
+(`tp_field_taint.go`; `tp_container_taint.go` — `runSlice`) are now *robustly*
+correct rather than incidentally caught: the same container-level base
+attribution makes a struct-field or slice-element write taint the container
+directly.
 
-Other still-open limits (no sample yet, the next indictment when one lands):
-reflection-based sinks, and cross-file Go flow (the taint-analysis plugin's
-territory). The extraction is AST-precise but stays **AST-only** (no `go/types`):
-method sinks like `.Query`/`.Exec`/`.Decode` are matched by method name, not by
-proving the receiver's type. This corpus carries the annotated ground truth, so
-the day a gap gets a sample, the number tells the truth — the measure → build →
-re-measure loop, now running on Go.
+Still-open limits (no sample yet, the next indictment when one lands):
+
+- **Key-level container precision.** The container fix is container-*level*, a
+  sound over-approximation: writing `m["a"]` taints all of `m`, so a later read of
+  a *different, clean* key `m["b"]` is treated as tainted. Key/element-level
+  precision (tracking which key is tainted) would tighten this but risks recall;
+  not modeled.
+- **XSS write-sink receiver typing.** The `w.Write` sink matches the `.Write`
+  method name (AST-only), not a proof the receiver is an `http.ResponseWriter`; a
+  `bytes.Buffer.Write` of tainted-but-not-reflected bytes with an inline HTML
+  literal could in principle over-fire (the literal gate makes this unlikely).
+- **Reflection-based sinks** and **cross-file Go flow** (the taint-analysis
+  plugin's territory). The extraction is AST-precise but stays **AST-only** (no
+  `go/types`): method sinks like `.Query`/`.Exec`/`.Decode`/`.Write` are matched
+  by method name, not by proving the receiver's type.
+
+This corpus carries the annotated ground truth, so the day a gap gets a sample,
+the number tells the truth — the measure → build → re-measure loop, now running on
+Go across two tiers.

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8857142857142857,
-  "f1": 0.9393939393939393,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 31,
-  "fn": 4,
-  "findings_per_issue": 0.9393939393939394,
+  "tp": 35,
+  "fn": 0,
+  "findings_per_issue": 1.0606060606060606,
   "rules": [
     {
       "rule_id": "AI-002",
@@ -55,12 +55,12 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.8
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",
       "precision": 1,
-      "recall": 0.25
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",


### PR DESCRIPTION
## Summary

Closes the **four honest Go tier-2 false negatives** the precision corpus pinned. The mixed suite `testdata/precision-suite/` moves from **precision 1.00 / recall 0.89 / F1 0.94** (31 TP, 0 FP, 4 FN) to **precision 1.00 / recall 1.00 / F1 1.00** (35 TP, 0 FP, 0 FN) — measured, not claimed. The corpus is the acceptance test; no `tp_*`/`clean_*` samples were edited.

### The four FNs, now TP
1. `tp_xss_response.go` · `greetPrintf` — `fmt.Fprintf(w, "<div>%s</div>", tainted)` → **TAINT-003** (xss, CWE-79)
2. `tp_xss_response.go` · `greetWrite` — `w.Write([]byte("<b>"+tainted+"</b>"))` → TAINT-003
3. `tp_xss_response.go` · `greetAutoescapeBypass` — `template.HTML(tainted)` to the response → TAINT-003
4. `tp_container_taint.go` · `runMap` — `m["c"]=tainted; exec.Command("sh","-c", m["c"])` → **TAINT-002**

## Part A — XSS-to-response sink

New Go catalog sinks (all `TAINT-003`, xss, CWE-79):
- **`fmt.Fprintf`/`Fprint`/`Fprintln` + `io.WriteString`** — the first arg is the writer; a tainted value among the args is reflected content. Gated by taint only.
- **`w.Write`** — a raw byte write, gated in `extract_go.go` on a **co-located string literal** (the reflected-HTML `[]byte("…"+user)` shape). A bare `w.Write(out)` of precomputed command/file output is *not* reflected XSS, so it does not fire — this is what keeps the injection samples (all end in `w.Write(out)`) from double-firing an XSS false positive.
- **`template.HTML(tainted)`** — the `html/template` auto-escape **bypass**, modeled as an unconditional sink.

**How `html/template` stays safe:** `Execute`/`ExecuteTemplate` are deliberately *not* sinks (they auto-escape), so `clean_html_autoescape.go` (`page.Execute(w, structData)`) fires nothing. Only the raw-write paths and the `template.HTML` bypass are sinks. AST-only, no `go/types` — call-chain heuristics with the clean sample as the over-fire guardrail.

## Part B — container/index taint

Fixed in `extract_go.go` only (shared `StructuralEngine`/`recognize.go` untouched): an assignment whose LHS is an index (`m["c"]`), selector (`obj.Field`), star, or paren target now attributes taint to the **base identifier**, so a tainted RHS taints the whole container. Container-level (not key-level) — a sound over-approximation. `clean_field_safe.go` stays clean because per-class sanitizer clearing survives the base attribution.

## Measurement & regression

- Go mixed suite: **recall 0.89 → 1.00**, precision stays 1.00, 0 FP / 0 FN. `baseline.json` regenerated (deterministic, byte-identical on re-run under `SOURCE_DATE_EPOCH`); `go test ./cli/ -run PrecisionSuiteBaseline` passes.
- **All 8 language suites stay precision 1.00** with no regression (Java/PHP/C# 1.00; Ruby 0.875, Rust 0.833 — their documented pre-existing recall). Every per-language baseline test passes.
- `go build ./...`, `go test ./...`, `go test -race ./core/taint/... ./core/analyzers/... ./cli/...`, `golangci-lint run` (v2.12.2) all green. Self-scan gate (`scan --changed-since origin/main --severity-threshold high .`) = **0 findings**.

## Docs
- `testdata/precision-suite/README.md`: four rows flipped FN→TP, headline recall 1.00, "Go coverage — next gaps" rewritten as closed.
- `docs/design/go-taint.md`: XSS-to-response semantics (incl. the `w.Write` literal gate and `template.HTML` bypass vs safe `Execute`) and container-level taint documented, with honest limits.

## Go gaps still open
Key/element-level container precision (only container-level today), type-based confirmation of `.Write`/`.Query` receivers (AST-only), cross-file flow, reflection-based sinks.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom