### PR TITLE
feat(taint): close Ruby render inline: SSTI/XSS false negative (recall 0.875→0.941)

### DIFF
--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -1523,6 +1523,13 @@
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
           "note": "template body built from tainted data enables injection"
+        },
+        {
+          "call": "render_inline",
+          "vuln_class": "xss",
+          "cwe": "CWE-79",
+          "rule_id": "TAINT-003",
+          "note": "render inline:/text: builds an unescaped ERB template body from tainted data (SSTI/XSS); render plain:/json:/:template are auto-escaped and safe. Synthetic callee emitted by the Ruby recognizer only for the inline:/interpolated-text: keyword form."
         }
       ],
       "sanitizers": [

--- a/core/taint/engine/extract_ruby.go
+++ b/core/taint/engine/extract_ruby.go
@@ -349,13 +349,121 @@ var rubyNoArgSinkMethods = map[string]bool{
 
 // augmentRubyStatement adds Ruby-only sink shapes to an already-recognized
 // statement: a backtick / %x command literal (a command-injection sink whose
-// callee has no identifier form), and a no-argument `.html_safe` / `.raw` XSS
-// sink. Both read the interpolated / receiver variable(s) already present in the
-// statement's reads, so taint propagation is unchanged — only the sink call and
-// its argument shape are added.
+// callee has no identifier form), a no-argument `.html_safe` / `.raw` XSS sink,
+// and a `render inline:` / `render text:` template-injection sink. All read the
+// interpolated / receiver variable(s) already present in the statement's reads,
+// so taint propagation is unchanged — only the sink call and its argument shape
+// are added.
 func augmentRubyStatement(st *stmtDraft, orig, shaped logicalLine) {
 	addRubyCommandLiteral(st, orig, shaped)
 	addRubyNoArgSink(st, shaped)
+	addRubyRenderInlineSink(st, shaped)
+}
+
+// renderInlineSink is the synthetic catalog callee key for a Rails `render` that
+// builds an unescaped template body from a keyword argument (`inline:` or an
+// interpolated `text:`). It is emitted ONLY by the Ruby recognizer, never by the
+// shared call recognizer, so the catalog `render_inline` XSS sink cannot fire on
+// the auto-escaped `render plain:` / `render json:` / `render :template` forms.
+const renderInlineSink = "render_inline"
+
+// renderInlineKeywords are the `render` options whose value becomes an unescaped
+// ERB template body: `inline:` (an inline ERB template) and `text:` (a raw text
+// body). A tainted value interpolated into either is SSTI/XSS. The auto-escaped
+// options (`plain:`, `json:`, `html:` with escaping, a bare `:template` symbol)
+// are deliberately NOT listed, so they never synthesize the sink.
+var renderInlineKeywords = []string{"inline", "text"}
+
+// addRubyRenderInlineSink detects a `render` call carrying an `inline:` (or
+// `text:`) keyword argument and synthesizes a `render_inline` XSS sink whose
+// tainted arguments are the variables interpolated into that keyword's value.
+// This is the co-located-keyword gate that closes the `render inline:` template
+// injection false negative WITHOUT over-firing on the safe auto-escaped renders:
+// `render plain:` / `render json:` / `render :template` carry no `inline:`/`text:`
+// keyword, so no sink is added. Mirrors the Go XSS `w.Write` sink, which fires
+// only when a co-located string literal is present.
+//
+// The shaped CODE view has string-literal text blanked to spaces while `#{...}`
+// interpolation fields survive as code, so the free identifiers of the keyword's
+// value are exactly the interpolated variables (an inline template with no
+// interpolation yields no tainted read and therefore no flow, which is correct —
+// a constant template body is not injectable).
+func addRubyRenderInlineSink(st *stmtDraft, shaped logicalLine) {
+	value, ok := rubyRenderInlineValue(shaped.code)
+	if !ok {
+		return
+	}
+	vars := freeIdentifiers(langRuby, value)
+	if st.sinkArgs == nil {
+		st.sinkArgs = map[string]sinkArgDraft{}
+	}
+	st.calls = append(st.calls, renderInlineSink)
+	st.sinkArgs[renderInlineSink] = sinkArgDraft{
+		taintedArgVars:  append([]string(nil), vars...),
+		argCount:        1,
+		firstArgTainted: len(vars) > 0,
+		positionalVars:  [][]string{append([]string(nil), vars...)},
+	}
+	for _, v := range vars {
+		st.reads = appendUnique(st.reads, v)
+	}
+	sortStrings(st.reads)
+}
+
+// rubyRenderInlineValue reports whether the shaped code view is a `render` call
+// carrying an `inline:` / `text:` keyword argument, returning that keyword's
+// value text (with string literals already blanked, interpolation preserved) for
+// free-identifier extraction. The call head must be `render` so an unrelated
+// method that happens to take an `inline:` option is not matched. Best-effort and
+// deterministic: an unparsable slot yields ok=false (a missed flow, never a
+// spurious sink).
+func rubyRenderInlineValue(code string) (value string, ok bool) {
+	head, end := leadingCallHead(code)
+	if head != "render" {
+		return "", false
+	}
+	// Locate the argument list `(...)` shapeRubyLine synthesized for the call.
+	open := strings.IndexByte(code[end:], '(')
+	if open < 0 {
+		return "", false
+	}
+	open += end
+	args, _ := balancedArgs(code, open)
+	for _, part := range splitTopLevelArgs(args) {
+		key, val, isKW := rubyKeywordArg(part)
+		if !isKW {
+			continue
+		}
+		for _, kw := range renderInlineKeywords {
+			if key == kw {
+				return val, true
+			}
+		}
+	}
+	return "", false
+}
+
+// rubyKeywordArg splits a Ruby keyword argument `name: value` into its bare key
+// and value text, reporting ok=false when the slot is not a `name:` keyword. It
+// recognizes the Ruby 1.9+ symbol-key form (`inline: x`), not the hash-rocket
+// form (`:inline => x`), which shaping does not produce for render options. A
+// top-level `:` after a bare identifier (not `::` scope resolution, already
+// normalized away by shaping) marks the key/value boundary.
+func rubyKeywordArg(part string) (key, value string, ok bool) {
+	part = strings.TrimSpace(part)
+	i := 0
+	for i < len(part) && isIdentPart(part[i]) {
+		i++
+	}
+	if i == 0 || i >= len(part) || part[i] != ':' {
+		return "", "", false
+	}
+	key = part[:i]
+	value = strings.TrimSpace(part[i+1:])
+	if key == "" {
+		return "", "", false
+	}
+	return key, value, true
 }
 
 // addRubyCommandLiteral detects a backtick “ `...` “ or `%x(...)` command
@@ -453,6 +561,7 @@ func rubySpecialStatement(orig, shaped logicalLine) (stmtDraft, bool) {
 	st := stmtDraft{line: orig.line, sinkArgs: map[string]sinkArgDraft{}}
 	addRubyCommandLiteral(&st, orig, shaped)
 	addRubyNoArgSink(&st, shaped)
+	addRubyRenderInlineSink(&st, shaped)
 	if len(st.calls) == 0 {
 		return stmtDraft{}, false
 	}

--- a/core/taint/engine/extract_ruby_test.go
+++ b/core/taint/engine/extract_ruby_test.go
@@ -130,3 +130,87 @@ end
 		t.Errorf("no User.where call found in %+v", u.stmts)
 	}
 }
+
+// TestExtractRubyRenderInlineSink: `render inline: "...#{x}..."` synthesizes a
+// `render_inline` sink call whose tainted argument is the interpolated variable,
+// so an SSTI/XSS flow is recognized. The safe auto-escaped forms (`render plain:`,
+// `render json:`, `render :template`) must NOT synthesize the sink.
+func TestExtractRubyRenderInlineSink(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantSink bool
+		wantRead string
+	}{
+		{
+			name:     "render inline with interpolation",
+			line:     `render inline: "<h1>Hello #{name}</h1>"`,
+			wantSink: true,
+			wantRead: "name",
+		},
+		{
+			name:     "render inline paren form",
+			line:     `render(inline: "<h1>#{name}</h1>")`,
+			wantSink: true,
+			wantRead: "name",
+		},
+		{
+			name:     "render text with interpolation",
+			line:     `render text: "Value: #{val}"`,
+			wantSink: true,
+			wantRead: "val",
+		},
+		{
+			name:     "render plain is safe (no sink)",
+			line:     `render plain: output`,
+			wantSink: false,
+		},
+		{
+			name:     "render json is safe (no sink)",
+			line:     `render json: data`,
+			wantSink: false,
+		},
+		{
+			name:     "render template symbol is safe (no sink)",
+			line:     `render :show`,
+			wantSink: false,
+		},
+		{
+			name:     "render inline without interpolation (constant, no read)",
+			line:     `render inline: "<h1>static</h1>"`,
+			wantSink: true, // sink present but no tainted read → won't flow
+			wantRead: "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			src := []byte("def show\n  name = params[:name]\n  val = params[:v]\n  output = params[:o]\n  data = params[:d]\n  " + tt.line + "\nend\n")
+			units := extractUnits(lexctx.LangRuby, src)
+			u := findUnit(t, units, "show")
+			var sink stmtDraft
+			for i := range u.stmts {
+				for _, c := range u.stmts[i].calls {
+					if c == renderInlineSink {
+						sink = u.stmts[i]
+					}
+				}
+			}
+			hasSink := sink.line != 0
+			if hasSink != tt.wantSink {
+				t.Fatalf("render_inline sink present = %v, want %v (stmts: %+v)", hasSink, tt.wantSink, u.stmts)
+			}
+			if tt.wantSink && tt.wantRead != "" {
+				found := false
+				for _, r := range sink.reads {
+					if r == tt.wantRead {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("render_inline sink reads = %v, want to include %q", sink.reads, tt.wantRead)
+				}
+			}
+		})
+	}
+}

--- a/core/taint/engine/structural_ruby_test.go
+++ b/core/taint/engine/structural_ruby_test.go
@@ -123,6 +123,24 @@ end
 `,
 			want: "TAINT-003",
 		},
+		{
+			name: "ssti/xss via render inline: interpolation",
+			src: `def show
+  name = params[:name]
+  render inline: "<h1>Hello #{name}</h1>"
+end
+`,
+			want: "TAINT-003",
+		},
+		{
+			name: "ssti/xss via render text: interpolation",
+			src: `def show
+  val = params[:v]
+  render text: "Value: #{val}"
+end
+`,
+			want: "TAINT-003",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -181,6 +199,31 @@ end
   raw = params[:name]
   safe = CGI.escapeHTML(raw)
   out = safe.html_safe
+end
+`,
+		},
+		{
+			name: "render plain: is auto-escaped (no ssti sink)",
+			src: `def show
+  output = params[:o]
+  render plain: output
+end
+`,
+		},
+		{
+			name: "render json: is auto-escaped (no ssti sink)",
+			src: `def show
+  data = params[:d]
+  render json: data
+end
+`,
+		},
+		{
+			name: "render inline: sanitized with html_escape stays clean",
+			src: `def show
+  raw = params[:name]
+  name = CGI.escapeHTML(raw)
+  render inline: "<h1>Hello #{name}</h1>"
 end
 `,
 		},

--- a/testdata/precision-suite-ruby/README.md
+++ b/testdata/precision-suite-ruby/README.md
@@ -31,12 +31,12 @@ nox bench --precision testdata/precision-suite-ruby --baseline testdata/precisio
 ## What this corpus reveals
 
 As committed, `nox bench --precision testdata/precision-suite-ruby` scores
-**precision 1.00 / recall 0.875 / F1 0.933** (14 TP, 0 FP, 2 FN). Precision is
+**precision 1.00 / recall 0.941 / F1 0.970** (16 TP, 0 FP, 1 FN). Precision is
 perfect — every finding nox emits on Ruby is a true positive, and every clean
-stressor stays clean. Recall is honestly below 1.0: two genuine flows are missed
+stressor stays clean. Recall is honestly below 1.0: one genuine flow is missed
 because the Ruby extractor is a **line/statement recognizer**, not a full parser
-(pure-Go, no CGo, no tree-sitter, by design). Those gaps are annotated in
-`tp_known_fns.rb` so they score as recall, not silence.
+(pure-Go, no CGo, no tree-sitter, by design). That gap is annotated in
+`tp_known_fns.rb` so it scores as recall, not silence.
 
 ### Caught (true positives)
 
@@ -48,7 +48,7 @@ because the Ruby extractor is a **line/statement recognizer**, not a full parser
 | SSRF | TAINT-006 | CWE-918 | `Net::HTTP.get(URI(url))`, `URI.open(url)` |
 | Unsafe deserialization | TAINT-005 | CWE-502 | `Marshal.load`, `YAML.load` (unsafe loader) |
 | Code injection | TAINT-005 | CWE-95 | `eval(...)`, `Object#send(tainted_name, ...)` |
-| XSS | TAINT-003 | CWE-79 | `tainted.html_safe` |
+| XSS | TAINT-003 | CWE-79 | `tainted.html_safe`, `render inline:`/`text:` (interpolated) |
 
 ### Clean (no false positives)
 
@@ -61,33 +61,48 @@ Every `clean_*.rb` sample stays clean, including the SAFE counterpart of each
 - `File.basename` before `File.read`
 - `YAML.safe_load` instead of `YAML.load`
 - `CGI.escapeHTML` before `.html_safe`
+- auto-escaped `render plain:` / `render json:` / `render :template` /
+  `render template:` (vs the unescaped `render inline:` / `text:` that DO fire)
 - placeholder creds, base64 data-URI heredocs, `%w[]` arrays, public checksums,
   a generated-code banner
 
+## Closed gap — `render inline:` template injection (TAINT-003)
+
+Previously an honest FN, now caught (`tp_render_inline.rb`). A tainted value
+interpolated into an **inline ERB template** (`render inline:`) or a raw text
+body (`render text:`) is real XSS/SSTI — Rails renders it WITHOUT the automatic
+output escaping a normal view gives you. The obstacle was that the catalog keys
+sinks by call *name* and a bare `render` sink over-fired on the safe auto-escaped
+renders (`render plain:` / `render json:` / `render :template`).
+
+The fix is a **co-located-keyword gate** in the Ruby recognizer
+(`extract_ruby.go`), analogous to how the Go XSS `w.Write` sink is gated on a
+co-located string literal: `render` is recognized as an XSS sink (via the
+synthetic `render_inline` catalog callee) ONLY when the call carries an `inline:`
+or interpolated `text:` keyword argument in the same statement; the tainted
+arguments are the variables interpolated into that keyword's value. The safe
+forms carry no such keyword, so they synthesize no sink and stay clean (see
+`clean_render.rb`). A constant inline body (`render inline: "<h1>static</h1>"`)
+registers the sink but has no tainted read, so it correctly does not flow.
+
 ## Known gaps (honest false negatives)
 
-Recall is 0.875, not 1.0. The two misses in `tp_known_fns.rb` are real bugs a
+Recall is 0.941, not 1.0. The one miss in `tp_known_fns.rb` is a real bug a
 correct scanner should flag; nox's line recognizer does not, and we record that
 rather than hide it:
 
-1. **`render inline:` template injection (TAINT-003).** A tainted value in an
-   inline ERB template is real XSS/SSTI. The catalog keys sinks by call *name*
-   and cannot distinguish `render inline:` (dangerous) from `render plain:` /
-   `render json:` (auto-escaped, safe). A bare `render` sink over-fired on the
-   safe auto-escaped renders (5 false positives), so it was intentionally
-   dropped — trading one recall gap for zero false positives, the right call for
-   a precision-first tool. Closing this needs keyword-argument awareness
-   (`inline:` vs `plain:`) in the recognizer.
-
-2. **Cross-method flow through an instance variable (TAINT-002).** A source that
+1. **Cross-method flow through an instance variable (TAINT-002).** A source that
    lands in `@cmd` in one action and is read by a sink in another action is a
    real flow, but nox's same-file interprocedural pass tracks **local helper
    calls** via function summaries, not shared object/instance state, so an
-   `@ivar` laundered across two methods is not joined. This is the documented
-   boundary of the intraprocedural + local-summary model (identical to the
-   Python/JS limit), not a Ruby-specific defect.
+   `@ivar` laundered across two methods is not joined. Closing it soundly needs
+   object-scoped ivar taint shared across methods of the same class — a
+   cross-method boundary the intraprocedural + local-summary model does not cross
+   (identical to the Python/JS limit), not a Ruby-specific defect. Forcing it
+   with a text heuristic risks precision (conditional/reassigned ivars, method
+   ordering), so it is left as a documented FN rather than faked.
 
-Both are the "measure → build → re-measure" loop working as intended: the corpus
+This is the "measure → build → re-measure" loop working as intended: the corpus
 names the gaps as numbers so future work on the recognizer can be measured
 against them. **Samples are never edited to fake the score** — the engine is
 built to catch what it honestly can, and the rest is recorded as recall.

--- a/testdata/precision-suite-ruby/baseline.json
+++ b/testdata/precision-suite-ruby/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.875,
-  "f1": 0.9333333333333333,
+  "recall": 0.9411764705882353,
+  "f1": 0.9696969696969697,
   "fp": 0,
-  "tp": 14,
-  "fn": 2,
-  "findings_per_issue": 0.875,
+  "tp": 16,
+  "fn": 1,
+  "findings_per_issue": 0.9411764705882353,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -20,7 +20,7 @@
     {
       "rule_id": "TAINT-003",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-ruby/clean_render.rb
+++ b/testdata/precision-suite-ruby/clean_render.rb
@@ -1,0 +1,30 @@
+# Clean: the SAFE `render` forms. Rails auto-escapes `render plain:`, serializes
+# `render json:`, and looks up a template by name for `render :symbol` /
+# `render template:` — none build an unescaped ERB body from the tainted value,
+# so none is XSS. A finding on any line here is a false positive. These are the
+# counterparts the `inline:`/`text:` gate must distinguish from tp_render_inline.rb.
+class SafeRenderController
+  # Plain-text render: the body is escaped/served verbatim as text/plain, not HTML.
+  def as_text
+    output = params[:output]
+    render plain: output
+  end
+
+  # JSON render: the value is serialized, not interpolated into a template.
+  def as_json
+    data = params[:data]
+    render json: data
+  end
+
+  # Template lookup by symbol: no tainted template body at all.
+  def show
+    @row = params[:id]
+    render :show
+  end
+
+  # Named template option: renders a fixed on-disk view, not an inline body.
+  def named
+    @row = params[:id]
+    render template: "records/show"
+  end
+end

--- a/testdata/precision-suite-ruby/tp_known_fns.rb
+++ b/testdata/precision-suite-ruby/tp_known_fns.rb
@@ -1,39 +1,30 @@
-# Honest false negatives: real vulnerabilities a CORRECT scanner should flag but
-# nox's intraprocedural Ruby LINE recognizer does NOT catch yet. Each is
-# annotated with the rule a correct scanner would fire, so it scores as a
-# recall gap (FN) rather than being quietly omitted — the whole point of an
-# honest measurement corpus. See README "Known gaps" for why each is missed.
+# Mixed corpus of real vulnerabilities that stress the boundary of nox's
+# intraprocedural Ruby LINE recognizer. Each line is annotated with the rule a
+# correct scanner would fire. Some are caught (they score as recall); one is an
+# honest false negative the line-recognizer cannot join, recorded here rather than
+# quietly omitted — the whole point of an honest measurement corpus. See README
+# "Known gaps" for why the miss is missed.
 class KnownGapsController
-  # FN #1 — `render inline:` template injection. A tainted value in an inline
-  # ERB template is real XSS/SSTI, but the recognizer keys sinks by call NAME and
-  # cannot distinguish `render inline:` (dangerous) from `render plain:`/`json:`
-  # (auto-escaped, safe). Firing on bare `render` over-fired the clean auto-
-  # escaped renders, so the `render` sink was intentionally dropped. Result: this
-  # genuine flow is missed.
-  def template
-    name = params[:name]
-    render inline: "<h1>Hello #{name}</h1>" # nox-expect: TAINT-003
+  # CAUGHT — metaprogramming via Object#send. A tainted method name dispatched
+  # through `send` is code injection; nox models `send` as a sink whose first
+  # argument is the dispatched method name, so this fires TAINT-005.
+  def dispatch
+    action = params[:action]
+    target.send(action, params[:arg]) # nox-expect: TAINT-005
   end
 
-  # FN #2 — cross-method flow through an instance variable. The source lands in
+  # FN — cross-method flow through an instance variable. The source lands in
   # @cmd in one action and the sink reads @cmd in another. nox's same-file
   # interprocedural pass tracks LOCAL HELPER CALLS via summaries, not shared
   # object/instance state, so a taint laundered through an @ivar across two
-  # methods is not joined.
+  # methods is not joined. This is the documented boundary of the
+  # intraprocedural + local-summary model (identical to the Python/JS limit),
+  # not a Ruby-specific defect.
   def capture
     @cmd = params[:cmd]
   end
 
   def execute_captured
     system @cmd # nox-expect: TAINT-002
-  end
-
-  # FN #3 — metaprogramming via Object#send. A tainted method name dispatched
-  # through `send` is code injection, but the argument is a method-name string,
-  # not a value flowing into a recognized sink shape; the line recognizer does
-  # not model dynamic dispatch.
-  def dispatch
-    action = params[:action]
-    target.send(action, params[:arg]) # nox-expect: TAINT-005
   end
 end

--- a/testdata/precision-suite-ruby/tp_render_inline.rb
+++ b/testdata/precision-suite-ruby/tp_render_inline.rb
@@ -1,0 +1,22 @@
+# Template injection via `render inline:` — a request-controlled value is
+# interpolated into an inline ERB template body, which Rails renders WITHOUT the
+# automatic output escaping a normal view gives you. Injected markup / ERB
+# executes in the browser (XSS) — CWE-79. A correct scanner fires TAINT-003.
+#
+# The recognizer gates the `render` sink on a co-located `inline:` / interpolated
+# `text:` keyword argument, so ONLY the dangerous unescaped forms fire; the safe
+# auto-escaped `render plain:` / `render json:` / `render :template` in
+# clean_render.rb must NOT fire.
+class TemplatesController
+  # `render inline:` with interpolation — classic SSTI/XSS.
+  def greeting
+    name = params[:name]
+    render inline: "<h1>Hello #{name}</h1>" # nox-expect: TAINT-003
+  end
+
+  # `render text:` with interpolation — raw unescaped body.
+  def echo
+    msg = params[:msg]
+    render text: "You said: #{msg}" # nox-expect: TAINT-003
+  end
+end


### PR DESCRIPTION
## Mission

Lift **Ruby** taint recall by closing documented false negatives without losing precision. Localized to `extract_ruby.go`, the `ruby` catalog block, and `testdata/precision-suite-ruby/`.

## Result

`nox bench --precision testdata/precision-suite-ruby`:

| Metric | Before | After |
|--------|--------|-------|
| Precision | 1.000 | **1.000** (0 FP) |
| Recall | 0.875 | **0.941** |
| F1 | 0.933 | **0.970** |
| TP / FP / FN | 14 / 0 / 2 | **16 / 0 / 1** |
| TAINT-003 recall | 0.50 | **1.00** |

## FN 1 — `render inline:` template injection (CLOSED)

A tainted value interpolated into an inline ERB body (`render inline:`) or a raw `render text:` body is unescaped XSS/SSTI (TAINT-003, CWE-79). The obstacle was that the catalog keys sinks by call name, so a bare `render` sink over-fired on the safe auto-escaped `render plain:` / `render json:` / `render :template`.

**Fix — a co-located-keyword gate** in the Ruby recognizer, analogous to the Go XSS `w.Write` sink gated on a co-located string literal: `render` is recognized as an XSS sink (via a new synthetic `render_inline` ruby-catalog callee that the shared recognizer never emits on its own) **only when the call carries an `inline:` or interpolated `text:` keyword argument** in the same statement. The tainted arguments are the variables interpolated into that keyword's value. The safe forms carry no such keyword, synthesize no sink, and stay clean (`clean_render.rb`). A constant inline body registers the sink but has no tainted read, so it correctly does not flow.

## FN 2 — cross-method `@ivar` flow (KEPT HONEST)

A value tainted into `@cmd` in one method and sunk in another is the same cross-method boundary the intraprocedural + local-summary model does not cross (identical to the Python/JS limit). Closing it soundly needs object-scoped ivar taint shared across methods of the same class — a shared-engine change, and a text heuristic would risk precision (conditional/reassigned ivars, method ordering). Per the mission's guidance this is left as the single documented FN rather than forced. Recall 0.941 with one honest FN.

## Scope & verification

- Only `extract_ruby.go`, the `ruby` catalog block, and `testdata/precision-suite-ruby/` touched. Shared `StructuralEngine` untouched.
- `go build ./...`, `go test ./...`, `go test -race ./core/taint/... ./cli/...` green.
- All-language baseline gates pass (`go test ./cli/ -run PrecisionSuiteBaseline`) — no other suite regressed.
- `TestPrecisionSuiteBaselineRuby` passes against the refreshed `baseline.json`.
- `golangci-lint run` (v2.12.2): changed files clean.
- Self-scan (`scan --changed-since origin/main --severity-threshold high .`): exit 0.

TDD: red tests → gated sink implementation → suite/baseline refresh.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom
