### PR TITLE
feat(taint): lift Rust taint recall by modeling web-extractor params as sources

### DIFF
--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -1719,7 +1719,7 @@
       ]
     },
     "rust": {
-      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser — only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps.",
+      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser — only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps. The web-extractor sources (`web.Query`/`web.Form`/`web.Json`/`web.Path` for actix, bare `Query`/`Form`/`Json`/`Path` for axum) are matched not only as constructor calls but also as PARAMETER TYPES: extract_rust.go seeds a function parameter whose type is one of these extractors as tainted-on-entry (via a synthetic `binding = <source>()` statement), because a `web::Query<Params>` handler argument is untrusted input even though it never appears as a source call.",
       "sources": [
         {"call": "env.args", "kind": "argv"},
         {"call": "std.env.args", "kind": "argv"},
@@ -1728,8 +1728,11 @@
         {"call": "web.Query", "kind": "http_query"},
         {"call": "web.Path", "kind": "http_query"},
         {"call": "web.Form", "kind": "http_body"},
+        {"call": "web.Json", "kind": "http_body"},
         {"call": "Query", "kind": "http_query"},
         {"call": "Path", "kind": "http_query"},
+        {"call": "Form", "kind": "http_body"},
+        {"call": "Json", "kind": "http_body"},
         {"call": "req.body", "kind": "http_body"},
         {"call": "request.body", "kind": "http_body"},
         {"call": "body.text", "kind": "http_body"},

--- a/core/taint/engine/extract_rust.go
+++ b/core/taint/engine/extract_rust.go
@@ -38,6 +38,18 @@ func extractRust(lines []logicalLine) []unitDraft {
 		}
 		if name, params, ok := rustFnHeader(trimmed); ok {
 			u := &unitDraft{funcName: name, params: params}
+			// Seed web-framework extractor parameters as taint sources: when a
+			// parameter's TYPE is a known untrusted-input extractor (actix
+			// `web::Query<_>`/`web::Form<_>`/`web::Json<_>`/`web::Path<_>`, axum
+			// `Query<_>`/`Form<_>`/`Json<_>`/`Path<_>`), the value it binds is
+			// attacker-controlled even though it arrives as a typed parameter, not a
+			// source CALL. The engine has no "tainted parameter" concept, so we emit a
+			// synthetic entry statement `binding = <extractor-source>()` that the
+			// engine already understands: resolveSource matches the source call and
+			// marks the binding tainted-on-entry. Only extractor types seed taint — a
+			// plain `id: i64` never does. See rustExtractorSeeds.
+			seeds := rustExtractorSeeds(ll.line, trimmed)
+			u.stmts = append(u.stmts, seeds...)
 			units = append(units, u)
 			cur = u
 			// Blank the header text (`fn name(params) -> Ret {`) in both views so it
@@ -172,6 +184,171 @@ func parseRustParams(inner string) []string {
 		}
 	}
 	return out
+}
+
+// rustExtractorSourceKey maps a Rust web-framework extractor type constructor to
+// the catalog source key it should seed under (the normalized dotted form the
+// `rust` catalog block keys extractor sources by). It recognizes the actix
+// `web::Xxx<_>` wrappers and the bare axum `Xxx<_>` wrappers. A non-extractor
+// type returns ("", false) — the precision guardrail: only these exact types
+// seed taint, so a normal typed parameter (`id: i64`, `cfg: &Config`) never
+// becomes a source.
+func rustExtractorSourceKey(typeHead string) (string, bool) {
+	switch typeHead {
+	// actix-web: fully-qualified `web::Query<_>` etc.
+	case "web::Query":
+		return "web.Query", true
+	case "web::Form":
+		return "web.Form", true
+	case "web::Json":
+		return "web.Json", true
+	case "web::Path":
+		return "web.Path", true
+	// axum: bare `Query<_>` etc. (also matches actix when `web::` is elided).
+	case "Query":
+		return "Query", true
+	case "Form":
+		return "Form", true
+	case "Json":
+		return "Json", true
+	case "Path":
+		return "Path", true
+	default:
+		return "", false
+	}
+}
+
+// rustExtractorSeeds parses a `fn` header's parameter list and returns a
+// synthetic source-seed statement for every parameter whose TYPE is a web
+// extractor. Each seed is `binding = <sourceKey>()`-shaped (assigns the binding,
+// calls the catalog source), which the engine's resolveSource matches to mark
+// the binding tainted at function entry. Both parameter shapes are handled:
+//
+//   - named:        `query: web::Query<Params>`   -> binding `query`
+//   - destructured: `Query(params): Query<Params>` -> binding `params` (axum's
+//     idiom, where the tuple-struct pattern binds the inner value directly)
+//
+// A destructured pattern with multiple/complex bindings, or a non-extractor
+// type, yields no seed (safe: a missed seed only weakens recall, never invents a
+// flow).
+func rustExtractorSeeds(line int, trimmed string) []stmtDraft {
+	paren := strings.IndexByte(trimmed, '(')
+	if paren < 0 {
+		return nil
+	}
+	closeParen := matchParen(trimmed, paren)
+	if closeParen < 0 {
+		return nil
+	}
+	var seeds []stmtDraft
+	for _, part := range splitTopLevelArgs(trimmed[paren+1 : closeParen]) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		// A parameter is `pattern: Type`. Split on the FIRST top-level ':' — the
+		// pattern (which may itself contain `::` in a path, handled by depth) is on
+		// the left, the type on the right.
+		colon := topLevelColon(part)
+		if colon < 0 {
+			continue // receiver (`&self`) or malformed: no type to inspect.
+		}
+		pattern := strings.TrimSpace(part[:colon])
+		typ := strings.TrimSpace(part[colon+1:])
+		key, ok := rustExtractorSourceKey(rustTypeHead(typ))
+		if !ok {
+			continue
+		}
+		binding, ok := rustExtractorBinding(pattern)
+		if !ok {
+			continue
+		}
+		seeds = append(seeds, stmtDraft{
+			line:     line,
+			assigns:  binding,
+			calls:    []string{key},
+			sinkArgs: map[string]sinkArgDraft{},
+		})
+	}
+	return seeds
+}
+
+// rustTypeHead returns the type constructor at the head of a parameter type,
+// dropping a leading reference/mutability marker and truncating at the generic
+// `<`. For `web::Query<Params>` it returns `web::Query`; for `&web::Path<u32>`,
+// `web::Path`; for `i64`, `i64`. The `::` path separator is preserved here (the
+// seed's source key is chosen by rustExtractorSourceKey, which knows both the
+// `web::Query` and the collapsed forms).
+func rustTypeHead(typ string) string {
+	typ = strings.TrimSpace(typ)
+	typ = strings.TrimPrefix(typ, "&")
+	typ = strings.TrimSpace(typ)
+	typ = strings.TrimPrefix(typ, "mut ")
+	typ = strings.TrimSpace(typ)
+	if i := strings.IndexByte(typ, '<'); i >= 0 {
+		typ = typ[:i]
+	}
+	return strings.TrimSpace(typ)
+}
+
+// rustExtractorBinding extracts the single binding name a parameter pattern
+// introduces. It handles the two shapes the extractor seeds:
+//
+//   - a bare identifier `query` (named parameter) -> `query`
+//   - a single-field tuple-struct pattern `Query(params)` (axum destructure) ->
+//     `params`
+//
+// Any other pattern (a multi-field tuple, a struct pattern, `mut x` is
+// normalized) returns ok=false so no seed is emitted.
+func rustExtractorBinding(pattern string) (string, bool) {
+	pattern = strings.TrimSpace(pattern)
+	pattern = strings.TrimPrefix(pattern, "mut ")
+	pattern = strings.TrimSpace(pattern)
+	if isSimpleIdent(pattern) {
+		return pattern, true
+	}
+	// Tuple-struct destructure `Wrapper(inner)`: take the single inner binding.
+	if open := strings.IndexByte(pattern, '('); open >= 0 && strings.HasSuffix(pattern, ")") {
+		inner := strings.TrimSpace(pattern[open+1 : len(pattern)-1])
+		inner = strings.TrimPrefix(inner, "mut ")
+		inner = strings.TrimSpace(inner)
+		if isSimpleIdent(inner) {
+			return inner, true
+		}
+	}
+	return "", false
+}
+
+// topLevelColon returns the index of the first ':' in s that is not inside
+// brackets/angle-generics and is not part of a `::` path separator. It locates
+// the `pattern : Type` boundary in a parameter without splitting inside a
+// `web::Query` path or a `<A: Bound>` generic. Returns -1 when none exists.
+func topLevelColon(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '[', '{', '<':
+			depth++
+		case ')', ']', '}', '>':
+			if depth > 0 {
+				depth--
+			}
+		case ':':
+			if depth != 0 {
+				continue
+			}
+			// Skip a `::` path separator (consume both colons).
+			if i+1 < len(s) && s[i+1] == ':' {
+				i++
+				continue
+			}
+			if i > 0 && s[i-1] == ':' {
+				continue
+			}
+			return i
+		}
+	}
+	return -1
 }
 
 // rustReturnStatement recognizes an explicit `return <expr>;` line and produces

--- a/core/taint/engine/extract_rust_test.go
+++ b/core/taint/engine/extract_rust_test.go
@@ -174,6 +174,112 @@ fn f(url: String) {
 	}
 }
 
+// extractorSeedFor returns the synthetic source-seed statement the extractor
+// emits for a web-extractor parameter binding `name` (assigns == name and a
+// catalog-source call), or nil if none was emitted. The seed lets the engine
+// treat the parameter as tainted-on-entry.
+func extractorSeedFor(u unitDraft, name string) *stmtDraft {
+	for i := range u.stmts {
+		if u.stmts[i].assigns == name && len(u.stmts[i].calls) > 0 {
+			return &u.stmts[i]
+		}
+	}
+	return nil
+}
+
+// TestExtractRustExtractorParamActix: an actix handler whose parameter type is a
+// `web::Query<_>` extractor seeds the binding as a taint source. The synthetic
+// seed statement assigns the binding and carries a catalog source call
+// (normalized `web.Query`).
+func TestExtractRustExtractorParamActix(t *testing.T) {
+	src := []byte(`
+async fn run(query: web::Query<Params>) {
+    let _ = query.cmd;
+}
+`)
+	units := extractUnits(lexctx.LangRust, src)
+	u := findUnit(t, units, "run")
+	if len(u.params) != 1 || u.params[0] != "query" {
+		t.Fatalf("params = %v, want [query]", u.params)
+	}
+	seed := extractorSeedFor(u, "query")
+	if seed == nil {
+		t.Fatalf("no extractor seed statement for `query` in %+v", u.stmts)
+	}
+	if seed.calls[0] != "web.Query" {
+		t.Errorf("seed call = %q, want web.Query", seed.calls[0])
+	}
+}
+
+// TestExtractRustExtractorParamAxumDestructured: an axum handler whose parameter
+// is the destructured `Query(params): Query<Params>` form seeds the INNER
+// binding `params` (the value actually used), not the type name.
+func TestExtractRustExtractorParamAxumDestructured(t *testing.T) {
+	src := []byte(`
+async fn run(Query(params): Query<Params>) {
+    let _ = params.cmd;
+}
+`)
+	units := extractUnits(lexctx.LangRust, src)
+	u := findUnit(t, units, "run")
+	seed := extractorSeedFor(u, "params")
+	if seed == nil {
+		t.Fatalf("no extractor seed statement for `params` in %+v (params=%v)", u.stmts, u.params)
+	}
+	if seed.calls[0] != "Query" {
+		t.Errorf("seed call = %q, want Query", seed.calls[0])
+	}
+}
+
+// TestExtractRustExtractorParamForms covers the other actix/axum extractor
+// wrappers (Form/Json/Path) in both the named and destructured shapes.
+func TestExtractRustExtractorParamForms(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		binding  string
+		wantCall string
+	}{
+		{"actix web::Form", "async fn h(form: web::Form<P>) {}", "form", "web.Form"},
+		{"actix web::Json", "async fn h(body: web::Json<P>) {}", "body", "web.Json"},
+		{"actix web::Path", "async fn h(p: web::Path<String>) {}", "p", "web.Path"},
+		{"axum Json destructured", "async fn h(Json(payload): Json<P>) {}", "payload", "Json"},
+		{"axum Path destructured", "async fn h(Path(id): Path<String>) {}", "id", "Path"},
+		{"axum Form named", "async fn h(form: Form<P>) {}", "form", "Form"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			units := extractUnits(lexctx.LangRust, []byte("\n"+tc.src+"\n"))
+			u := findUnit(t, units, "h")
+			seed := extractorSeedFor(u, tc.binding)
+			if seed == nil {
+				t.Fatalf("no extractor seed for %q in %+v", tc.binding, u.stmts)
+			}
+			if seed.calls[0] != tc.wantCall {
+				t.Errorf("seed call = %q, want %q", seed.calls[0], tc.wantCall)
+			}
+		})
+	}
+}
+
+// TestExtractRustNonExtractorParamNoSeed is the precision guardrail: a normal
+// typed parameter (`id: i64`, `cfg: &Config`) must NOT be seeded as a source, or
+// nox would false-positive on every function. No seed statement is emitted.
+func TestExtractRustNonExtractorParamNoSeed(t *testing.T) {
+	src := []byte(`
+async fn run(id: i64, cfg: &Config, name: String) {
+    let _ = id;
+}
+`)
+	units := extractUnits(lexctx.LangRust, src)
+	u := findUnit(t, units, "run")
+	for _, p := range []string{"id", "cfg", "name"} {
+		if seed := extractorSeedFor(u, p); seed != nil {
+			t.Errorf("param %q was seeded as a source (%+v); non-extractor params must not taint", p, seed)
+		}
+	}
+}
+
 // firstAssign is a tiny test helper returning the first statement's assigns
 // (or "" when there are none) for clearer failure messages.
 func firstAssign(u unitDraft) string {

--- a/core/taint/engine/structural_rust_test.go
+++ b/core/taint/engine/structural_rust_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// analyzeRust is the end-to-end helper for Rust: source bytes → units → flows,
+// using the default embedded catalog. It mirrors analyze() (which defaults to
+// Python/JS extensions) but attaches a .rs path.
+func analyzeRust(t *testing.T, src string) []flowResult {
+	t.Helper()
+	eng := NewStructuralEngine(nil)
+	units := ExtractUnits("t.rs", lexctx.LangRust, []byte(src))
+	var out []flowResult
+	for i := range units {
+		flows := eng.Analyze(units[i])
+		for j := range flows {
+			out = append(out, flowResult{ruleID: flows[j].Sink.RuleID, sinkCall: flows[j].SinkCall})
+		}
+	}
+	return out
+}
+
+type flowResult struct {
+	ruleID   string
+	sinkCall string
+}
+
+func hasRuleID(flows []flowResult, id string) bool {
+	for _, f := range flows {
+		if f.ruleID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStructuralRustExtractorParamActixCmdInjection is the closed-FN case: an
+// actix handler where the untrusted value arrives as a `web::Query<_>` extractor
+// parameter and flows into a Command::new("sh").arg(...) sink. Modeling the
+// extractor-typed parameter as a taint source lets TAINT-002 fire.
+func TestStructuralRustExtractorParamActixCmdInjection(t *testing.T) {
+	src := `use actix_web::web;
+use std::process::Command;
+async fn run(query: web::Query<Params>) {
+    let out = Command::new("sh").arg("-c").arg(&query.cmd).output();
+    let _ = out;
+}
+`
+	flows := analyzeRust(t, src)
+	if !hasRuleID(flows, "TAINT-002") {
+		t.Fatalf("expected TAINT-002 (command injection) from extractor param, got %+v", flows)
+	}
+}
+
+// TestStructuralRustExtractorParamAxumDestructured: the axum destructured form
+// `Query(params): Query<Params>` seeds `params`, and `params.cmd` reaching a
+// Command sink fires TAINT-002.
+func TestStructuralRustExtractorParamAxumDestructured(t *testing.T) {
+	src := `async fn run(Query(params): Query<Params>) {
+    let out = Command::new("sh").arg("-c").arg(&params.cmd).output();
+    let _ = out;
+}
+`
+	flows := analyzeRust(t, src)
+	if !hasRuleID(flows, "TAINT-002") {
+		t.Fatalf("expected TAINT-002 from axum destructured extractor param, got %+v", flows)
+	}
+}
+
+// TestStructuralRustExtractorParamPathTraversal: a `web::Path<String>` extractor
+// param reaching a std::fs::read sink fires TAINT-004.
+func TestStructuralRustExtractorParamPathTraversal(t *testing.T) {
+	src := `async fn h(p: web::Path<String>) {
+    let data = std::fs::read(&p);
+    let _ = data;
+}
+`
+	flows := analyzeRust(t, src)
+	if !hasRuleID(flows, "TAINT-004") {
+		t.Fatalf("expected TAINT-004 from web::Path extractor param, got %+v", flows)
+	}
+}
+
+// TestStructuralRustNonExtractorParamNoFlow is the precision guardrail at the
+// engine level: a normal typed parameter reaching a sink-shaped call must NOT
+// fire — it is not untrusted input.
+func TestStructuralRustNonExtractorParamNoFlow(t *testing.T) {
+	src := `fn h(user_id: i64, cfg: &Config) {
+    let data = std::fs::read(cfg.path());
+    let out = Command::new(cfg.shell()).arg(user_id).output();
+    let _ = (data, out);
+}
+`
+	flows := analyzeRust(t, src)
+	if len(flows) != 0 {
+		t.Fatalf("non-extractor params must not taint; got flows %+v", flows)
+	}
+}

--- a/testdata/precision-suite-rust/README.md
+++ b/testdata/precision-suite-rust/README.md
@@ -20,17 +20,20 @@ nox bench --precision testdata/precision-suite-rust --baseline testdata/precisio
 ```
 RULE       TP  FP  FN  PRECISION  RECALL  F1
 TAINT-001  1   0   0   1.000      1.000   1.000
-TAINT-002  1   0   1   1.000      0.500   0.667
+TAINT-002  2   0   0   1.000      1.000   1.000
 TAINT-004  1   0   0   1.000      1.000   1.000
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    5   0   1   1.000      0.833   0.909
+OVERALL    6   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.83 / F1 0.909** (5 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (6 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.83, the lowest of nox's
-supported languages, by design and honestly** — see the gap below.
+`clean_*` sample false-positives. Recall reached 1.00 once the last documented
+false negative (a web-framework **extractor parameter** as an untrusted source)
+was closed — see "The closed gap" below. The recall lift was won without any
+precision loss: `clean_typed_param.rs` proves an ordinary typed parameter is
+still not treated as a source.
 
 ## Ground-truth philosophy
 
@@ -52,6 +55,7 @@ untrusted input) reaching a **sink** with no sanitizer on the path:
 | Sample | Class | Rule | Sink idiom |
 |---|---|---|---|
 | `tp_cmdinjection.rs` | command injection | TAINT-002 | `Command::new("sh").arg("-c").arg(format!(…, user))` |
+| `tp_cmdinjection_extractor.rs` | command injection | TAINT-002 | `web::Query<_>` extractor param → `Command::new("sh").arg("-c").arg(&query.cmd)` |
 | `tp_sqlinjection.rs` | SQL injection | TAINT-001 | `sqlx::query(&format!("… {} …", id))` |
 | `tp_pathtraversal.rs` | path traversal | TAINT-004 | `std::fs::read(user_path)` |
 | `tp_ssrf.rs` | SSRF | TAINT-006 | `reqwest::get(&user_url)` |
@@ -60,28 +64,38 @@ untrusted input) reaching a **sink** with no sanitizer on the path:
 The `clean_*` counterparts prove each is suppressed when made safe:
 `clean_safe_db.rs` (sqlx `.bind()` parameterization), `clean_parse_id.rs`
 (`str::parse::<i64>()` numeric coercion), `clean_safe_path.rs`
-(`Path::file_name()` component-stripping).
+(`Path::file_name()` component-stripping), and `clean_typed_param.rs` (an
+ordinary `i64` / `&Config` parameter is **not** a source, so the
+extractor-parameter modeling does not over-taint normal parameters).
 
-## The honest gap (false negative) — why Rust recall is the lowest
+## The closed gap — extractor-parameter-as-source
 
-`tp_cmdinjection_extractor.rs` is a **labeled FN**: a genuine command-injection
-bug nox's Rust model does **not** catch. It is kept in the corpus, not deleted —
-inflating recall by removing a hard TP would defeat the point of an honest
-measurement suite.
+`tp_cmdinjection_extractor.rs` was the suite's **labeled false negative**: a
+genuine command-injection bug where the untrusted value arrives as a
+web-framework **extractor parameter** — `async fn run(query: web::Query<Params>)`
+(actix) or the destructured `Query(params): Query<Params>` (axum) — rather than
+as a source **call**. nox's taint model introduces taint from source *calls* and
+attribute chains; a function parameter's *type* was never a source, so
+`query.cmd` was never marked tainted and the sink did not fire.
 
-The idiom is a standard actix-web handler where the untrusted value arrives as a
-destructured **extractor parameter** — `async fn run(query: web::Query<Params>)`
-— rather than as a source **call**. nox's taint model (Python/JS/Go/Rust alike)
-introduces taint from source *calls* and attribute chains, never from a function
-parameter's *type*, so `query.cmd` is never marked tainted and the sink does not
-fire. Closing it needs parameter-as-source modeling for web extractors — future
-work, not a curation trick.
+It is now **caught**. `core/taint/engine/extract_rust.go` seeds any parameter
+whose type is a known untrusted-input extractor — actix `web::Query<_>` /
+`web::Form<_>` / `web::Json<_>` / `web::Path<_>`, and the bare axum `Query<_>` /
+`Form<_>` / `Json<_>` / `Path<_>` — as tainted-on-entry, by emitting a synthetic
+`binding = <extractor-source>()` statement the engine already understands. Both
+the named (`query: web::Query<_>`) and the destructured (`Query(params): …`)
+shapes are handled, binding the value actually used. The shared `StructuralEngine`
+is untouched — the change is Rust-local, in the extractor and the `rust` catalog
+block. Only these specific extractor wrappers seed taint: a plain typed parameter
+does not, which `clean_typed_param.rs` verifies.
 
-## Why Rust recall is structurally lower than Python/JS/Go
+## Remaining recognizer limits (honest, still un-modeled)
 
 nox's Rust extractor (`core/taint/engine/extract_rust.go`) is a **line/statement
-recognizer**, not a real parser — only Go gets `go/ast`. That, plus Rust's
-richer surface, makes line recognition coarse in ways that cost recall:
+recognizer**, not a real parser — only Go gets `go/ast`. Rust's richer surface
+still makes line recognition coarse in ways that can cost recall on idioms this
+suite does not yet exercise. These are documented honestly so recall of 1.00 on
+*this* corpus is not mistaken for perfect coverage of all Rust:
 
 - **Ownership & moves.** A value moved into a closure, borrowed as `&x`, or
   `.clone()`d is not tracked as a distinct binding, so taint can be lost across a
@@ -98,13 +112,15 @@ richer surface, makes line recognition coarse in ways that cost recall:
   `println!` are macros the recognizer cannot expand. It matches the macro
   **call** by name (the extractor normalizes `name!(` → `name(` and `::` → `.`),
   but a value that only becomes dangerous *inside* the expansion is missed.
-- **Parameter-as-source.** As above — web-framework extractor parameters are
-  untrusted but are not source calls, the single largest recall gap here.
+- **Extractor coverage is a fixed list.** Parameter-as-source seeding recognizes
+  the actix/axum `Query`/`Form`/`Json`/`Path` wrappers; a custom `FromRequest`
+  extractor or a less-common framework type is not seeded, so its parameter is
+  not tainted. Extending the list is a catalog + recognizer change, not a
+  structural one.
 
 These are the same "recognizer, not a parser" limits documented for Python/JS,
-amplified by Rust's ownership/Result/macro idioms — which is why recall is
-expected to sit below the other languages and why the FN above is honest rather
-than a bug to paper over.
+amplified by Rust's ownership/Result/macro idioms. They are why the suite keeps
+measuring against ground truth rather than assuming full coverage.
 
 ## Regeneration
 

--- a/testdata/precision-suite-rust/baseline.json
+++ b/testdata/precision-suite-rust/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8333333333333334,
-  "f1": 0.9090909090909091,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 5,
-  "fn": 1,
-  "findings_per_issue": 0.8333333333333334,
+  "tp": 6,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-rust/clean_typed_param.rs
+++ b/testdata/precision-suite-rust/clean_typed_param.rs
@@ -1,0 +1,32 @@
+// Clean: the precision guardrail for extractor-parameter-as-source modeling.
+// nox now seeds a web-framework EXTRACTOR parameter (web::Query<_>, web::Path<_>,
+// web::Form<_>, web::Json<_>, and the bare axum forms) as tainted-on-entry. This
+// handler takes ONLY ordinary typed parameters — an `i64` id, a borrowed
+// `&Config` — neither of which is untrusted input, and drives sink-shaped calls
+// (Command::new / std::fs::read) with values derived from them. A correct
+// scanner emits nothing here: a plain typed parameter is NOT a source, only the
+// specific extractor wrappers are. Any finding on this file is a false positive
+// proving nox over-tainted a normal parameter.
+use std::process::Command;
+use std::fs;
+
+struct Config {
+    shell: String,
+    root: String,
+}
+
+// build_report takes a trusted numeric id and a trusted config reference. The id
+// is a value type coerced by the framework (not attacker-controlled text) and
+// the config is internal state, so shelling out and reading a file with them is
+// safe — no extractor type appears in the signature.
+fn build_report(id: i64, cfg: &Config) {
+    let out = Command::new(&cfg.shell)
+        .arg("-c")
+        .arg(format!("generate-report {}", id))
+        .output();
+    let _ = out;
+
+    let path = format!("{}/report-{}.dat", cfg.root, id);
+    let data = fs::read(path);
+    let _ = data;
+}

--- a/testdata/precision-suite-rust/tp_cmdinjection_extractor.rs
+++ b/testdata/precision-suite-rust/tp_cmdinjection_extractor.rs
@@ -1,17 +1,18 @@
-// Command injection via a web-framework EXTRACTOR parameter — an HONEST FALSE
-// NEGATIVE nox's Rust model does not catch (recall gap, documented in README).
+// Command injection via a web-framework EXTRACTOR parameter — a TRUE POSITIVE
+// nox's Rust model now catches (previously the suite's honest false negative).
 //
 // This is a real, idiomatic actix-web handler: the untrusted input arrives as a
-// destructured `web::Query(params)` PARAMETER, not as a source CALL. nox's taint
-// model (Python/JS/Go/Rust alike) introduces taint from source CALLS and
-// attribute chains, never from a function parameter's TYPE — so `params.cmd`
-// here is never marked tainted, and the Command::new(...).arg(...) sink below
-// does not fire. A correct scanner SHOULD fire TAINT-002; nox misses it.
+// `web::Query<Params>` PARAMETER, not as a source CALL. nox's taint model
+// introduces taint from source CALLS and attribute chains; on top of that, the
+// Rust extractor (core/taint/engine/extract_rust.go) now seeds a parameter whose
+// TYPE is a web extractor (web::Query/Form/Json/Path, or the bare axum forms) as
+// tainted-on-entry via a synthetic `binding = <source>()` statement. So
+// `query.cmd` here IS marked tainted, and the Command::new(...).arg(...) sink
+// below fires TAINT-002 — matching a correct scanner.
 //
-// It is kept in the corpus as a labeled FN (not deleted to inflate recall): the
-// annotation scores as a false negative, which is exactly the honest signal the
-// suite exists to surface. Closing it needs parameter-as-source modeling for
-// web extractors — future work, not a curation trick.
+// Only these specific extractor wrappers seed taint; a plain typed parameter
+// (`id: i64`, `cfg: &Config`) never does — see clean_typed_param.rs, the
+// precision guardrail proving normal parameters are not over-tainted.
 use actix_web::web;
 use std::process::Command;
 


### PR DESCRIPTION
## Summary

Closes the documented Rust taint false negative: a web-framework **extractor parameter** is untrusted input, but it arrives as a typed function PARAMETER rather than a source call, so nox's taint model never marked it tainted. This lifts the Rust precision suite from **precision 1.00 / recall 0.833 / F1 0.909** (5 TP, 1 FN) to **precision 1.00 / recall 1.00 / F1 1.00** (6 TP, 0 FN) — recall up, precision held at 1.00, zero new false positives.

## How extractor-typed params are modeled as sources

`core/taint/engine/extract_rust.go` now seeds any `fn` parameter whose TYPE is a known untrusted-input extractor as **tainted-on-entry**, by emitting a synthetic `binding = <source>()` entry statement that the shared `StructuralEngine` already understands (`resolveSource` matches the source call and marks the binding tainted). The shared engine is **untouched** — the change is Rust-local, in the extractor and the `rust` catalog block.

Extractor types recognized:
- **actix**: `web::Query<_>`, `web::Form<_>`, `web::Json<_>`, `web::Path<_>`
- **axum**: bare `Query<_>`, `Form<_>`, `Json<_>`, `Path<_>`

Both parameter shapes are handled, extracting the correct binding name:
- named — `query: web::Query<Params>` → binds `query`
- destructured — `Query(params): Query<Params>` (axum tuple-struct pattern) → binds the inner `params`

## Avoiding over-taint (precision guardrail)

Only the specific extractor wrappers seed taint. A normal typed parameter (`id: i64`, `cfg: &Config`) is **never** seeded — `rustExtractorSourceKey` returns false for anything but the known extractors. The new `clean_typed_param.rs` sample drives `Command::new` / `std::fs::read` with values derived from ordinary typed params and stays at **0 findings**, proving normal parameters are not over-tainted. `clean_*` samples remain 0 findings.

## Before → after (Rust suite)

| Metric | Before | After |
|---|---|---|
| Precision | 1.00 | 1.00 |
| Recall | 0.833 | 1.00 |
| F1 | 0.909 | 1.00 |
| TP / FP / FN | 5 / 0 / 1 | 6 / 0 / 0 |
| TAINT-002 recall | 0.500 | 1.000 |

`testdata/precision-suite-rust/baseline.json` regenerated; `go test ./cli/ -run PrecisionSuiteBaselineRust` passes. All other language baseline gates (`PrecisionSuiteBaseline`, PHP/Java/CSharp/Ruby) still pass — no other suite regressed.

## TDD

1. `test(taint)`: failing extractor-level + end-to-end flow tests (Red).
2. `feat(taint)`: `extract_rust.go` parameter-as-source seeding + catalog source keys (Green).
3. `test(taint)`: flip the FN sample to TP, add the clean guardrail, refresh baseline, update README.

## Verification

- `go build ./...`, `go test ./...` — pass
- `go test -race ./core/taint/... ./cli/...` — clean
- `golangci-lint run` (v2.12.2) — my changed files clean (pre-existing issues in unrelated files unchanged)
- Self-scan of the changed Rust areas at `--severity-threshold high` — 0 findings

## Scope

Confined to `core/taint/engine/extract_rust.go`, the `rust` block of `core/taint/data/catalog.json`, and `testdata/precision-suite-rust/`. No other languages touched. (Sibling agents concurrently touch other catalog blocks; parent resolves any `catalog.json` overlap at merge.)

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom