### PR TITLE
fix(scan): restore --baseline override flag + friendly unknown-flag error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restored the `nox scan --baseline <path>` flag** as an optional override.
+  It was removed in favour of auto-discovering `.nox/baseline.json`, which is a
+  good default but a breaking change on its own: a workflow still passing
+  `-baseline` errored (exit 2), and under a `nox scan … || true` pipeline that
+  silently disabled scanning. Auto-discovery remains the default; when set, the
+  flag (and its config equivalent `policy.baseline_path`) points the baseline at
+  a non-default location — an explicit flag takes precedence over config. An
+  unrecognized `scan` flag now prints an actionable hint (`run 'nox scan -h'`)
+  instead of a bare parser error, so a removed/typo'd flag can't quietly become
+  a silent-disable trap again.
+
 ## [1.7.0] - 2026-07-06
 
 This release turns nox's SAST layer from a 3-language proof of concept into a

--- a/cli/main.go
+++ b/cli/main.go
@@ -295,6 +295,8 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.IntVar(&historyDepthFlag, "history-depth", 0, "max number of commits to scan (0 = unlimited)")
 	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "disable incremental scan cache")
 	scanFS.StringVar(&changedSinceFlag, "changed-since", "", "scan only files changed since the given git ref")
+	var baselineFlag string
+	scanFS.StringVar(&baselineFlag, "baseline", "", "path to the baseline file whose fingerprints mark known findings as suppressed (default: auto-discover .nox/baseline.json, or .nox.yaml policy.baseline_path)")
 	scanFS.BoolVar(&noRespectGitignoreFlg, "no-respect-gitignore", false, "scan paths matched by .gitignore (default: skip them)")
 	scanFS.BoolVar(&trackedOnlyFlag, "tracked-only", false, "scan only git-tracked files (git ls-files); exclude untracked working-tree files and submodule contents")
 	scanFS.BoolVar(&noAutoInstallFlg, "no-auto-install", false, "skip auto-installing plugins listed in .nox.yaml plugins.required")
@@ -305,6 +307,16 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
 	positionals, err := parseInterspersed(scanFS, args)
 	if err != nil {
+		// flag.ErrHelp means the user asked for -h/--help; the flag package
+		// already printed usage, so exit quietly. For a genuine unknown/removed
+		// flag, add an actionable hint — a bare "flag provided but not defined"
+		// swallowed by a `nox scan … || true` pipeline is how scanning silently
+		// stops after an upgrade. Point at -h and the baseline default so the
+		// once-removed `-baseline` flag never becomes a silent-disable trap again.
+		if err != flag.ErrHelp {
+			fmt.Fprintln(os.Stderr, "nox scan: unrecognized flag. Run 'nox scan -h' for the supported flags.")
+			fmt.Fprintln(os.Stderr, "Note: the baseline is auto-discovered at .nox/baseline.json — override it with '--baseline <path>' if needed.")
+		}
 		return 2
 	}
 	// Wire fingerprint version: explicit flag wins, then env var (handled
@@ -394,6 +406,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			ChangedSince:       changedSinceFlag,
 			NoRespectGitignore: noRespectGitignoreFlg,
 			TrackedOnly:        trackedOnlyFlag,
+			BaselinePath:       baselineFlag,
 		}
 		result, err = nox.RunScanWithOptions(target, opts)
 	}

--- a/core/scan.go
+++ b/core/scan.go
@@ -119,6 +119,13 @@ type ScanOptions struct {
 	// committed — the same set a reviewer sees — for reproducible CI gates.
 	// Ignored outside a git repository.
 	TrackedOnly bool
+
+	// BaselinePath overrides the baseline file location for suppression
+	// matching. When empty, the scan uses .nox.yaml's policy.baseline_path,
+	// and if that is also empty, auto-discovers .nox/baseline.json under the
+	// target. The CLI --baseline flag sets this; an explicit override always
+	// takes precedence over the config value.
+	BaselinePath string
 }
 
 // RunScan executes the full scan pipeline against the given target path.
@@ -669,8 +676,13 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		}
 	}
 
-	// Baseline matching.
-	baselinePath := cfg.Policy.BaselinePath
+	// Baseline matching. An explicit --baseline override (opts.BaselinePath)
+	// wins over .nox.yaml's policy.baseline_path; when neither is set the
+	// baseline is auto-discovered at .nox/baseline.json under the target.
+	baselinePath := opts.BaselinePath
+	if baselinePath == "" {
+		baselinePath = cfg.Policy.BaselinePath
+	}
 	if baselinePath == "" {
 		baselinePath = baseline.DefaultPath(target)
 	} else if !filepath.IsAbs(baselinePath) {

--- a/core/scan_baseline_override_test.go
+++ b/core/scan_baseline_override_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// TestRunScanWithOptions_BaselinePathOverride verifies the restored --baseline
+// override (ScanOptions.BaselinePath): it applies a baseline from a NON-default
+// location, and without the override the same finding is NOT baselined — proving
+// the override is what suppressed it (and that the default .nox/baseline.json
+// auto-discovery is not silently in play).
+func TestRunScanWithOptions_BaselinePathOverride(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// A custom rule that fires on a TODO comment — a deterministic finding.
+	rulesFile := filepath.Join(tmpDir, "custom.yaml")
+	rules := `rules:
+  - id: "CUSTOM-BL"
+    version: "1.0"
+    description: "Detect TODO comments"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "TODO"
+    file_patterns:
+      - "*.go"
+`
+	if err := os.WriteFile(rulesFile, []byte(rules), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("// TODO: fix\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First scan (no baseline) — capture the finding and build a baseline from it.
+	res, err := RunScanWithOptions(tmpDir, ScanOptions{CustomRulesPath: rulesFile})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := res.Findings.Findings()
+	if !hasRule(got, "CUSTOM-BL") {
+		t.Fatal("expected the CUSTOM-BL finding on the first scan")
+	}
+	if isBaselined(got, "CUSTOM-BL") {
+		t.Fatal("finding was baselined with no override in play")
+	}
+
+	// Write a baseline at a NON-default path (not .nox/baseline.json).
+	blPath := filepath.Join(tmpDir, "custom-baseline.json")
+	bl := baseline.Baseline{SchemaVersion: "1.0.0", Entries: baseline.FromFindings(got)}
+	data, err := json.Marshal(bl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-scan WITH the override → the finding must be marked baselined.
+	res2, err := RunScanWithOptions(tmpDir, ScanOptions{CustomRulesPath: rulesFile, BaselinePath: blPath})
+	if err != nil {
+		t.Fatalf("scan with override: %v", err)
+	}
+	if !isBaselined(res2.Findings.Findings(), "CUSTOM-BL") {
+		t.Error("--baseline override did not suppress the finding from the custom path")
+	}
+
+	// Control: re-scan WITHOUT the override → not baselined (the custom baseline
+	// is not the auto-discovered default, so nothing should be suppressed).
+	res3, err := RunScanWithOptions(tmpDir, ScanOptions{CustomRulesPath: rulesFile})
+	if err != nil {
+		t.Fatalf("control scan: %v", err)
+	}
+	if isBaselined(res3.Findings.Findings(), "CUSTOM-BL") {
+		t.Error("finding baselined WITHOUT the override — override path leaked into default discovery")
+	}
+}
+
+func hasRule(fs []findings.Finding, ruleID string) bool {
+	for i := range fs {
+		if fs[i].RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func isBaselined(fs []findings.Finding, ruleID string) bool {
+	for i := range fs {
+		if fs[i].RuleID == ruleID && fs[i].Status == findings.StatusBaselined {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Restores `nox scan --baseline <path>` as an optional override (auto-discovery of `.nox/baseline.json` stays the default; an explicit flag beats `policy.baseline_path`), and replaces the bare `flag provided but not defined` error with an actionable hint.

**Why:** removing the flag was a breaking change — a workflow still passing `-baseline` exits 2, and under `nox scan … || true` that *silently disables scanning*. Keeps the good auto-discovery default while restoring the escape hatch (non-default baseline locations: monorepos, ephemeral CI baselines) and closing the silent-disable footgun for any future removed/typo'd flag.

Covered by `TestRunScanWithOptions_BaselinePathOverride` (override suppresses from a non-default path; control proves it doesn't leak into default discovery).

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom