### PR TITLE
chore(release): 1.7.1 — restore --baseline override flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-07-06
+
 ### Fixed
 
 - **Restored the `nox scan --baseline <path>` flag** as an optional override.


### PR DESCRIPTION
Patch release. Restores `nox scan --baseline <path>` (removed in 1.7.0) as an optional override, plus a friendly unknown-flag error. See CHANGELOG. Tag `v1.7.1` on merge triggers GoReleaser.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom