### PR TITLE
chore(deps): bump go.klarlabs.de/mcp to v1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.klarlabs.de/fortify v1.8.1 // indirect
-	go.klarlabs.de/mcp v1.21.0
+	go.klarlabs.de/mcp v1.22.0
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.klarlabs.de/fortify v1.8.1 h1:gyzJ7ESNe/Qf65DhGCT1WPWDyphgEDApb2QTx3Gd2m0=
 go.klarlabs.de/fortify v1.8.1/go.mod h1:x4Rnk8xt8ckJ8Pxe5SsXZVfGYjJIoOHx67DBl5Ncis8=
-go.klarlabs.de/mcp v1.21.0 h1:SFf0Cr2rPYhLw0VnW1eec7y77vFddfEGXsPCv1ixEWs=
-go.klarlabs.de/mcp v1.21.0/go.mod h1:ZeezqVm3aJFDN2+a7W0BVrLcEDhD2tdA+tQb+Klv5FE=
+go.klarlabs.de/mcp v1.22.0 h1:2ufVDqJT2/+kt5zd8B9HjbxJUbz3DYEVe43PqwTQ/QI=
+go.klarlabs.de/mcp v1.22.0/go.mod h1:ZeezqVm3aJFDN2+a7W0BVrLcEDhD2tdA+tQb+Klv5FE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=


### PR DESCRIPTION
Bumps the MCP framework to **v1.22.0**.

All changes across this range are additive / opt-in, so no source changes are required. Free wins:
- Deterministic `tools/list` ordering
- Full JSON Schema 2020-12 for `inputSchema`/`outputSchema`
- Modern MCP error codes and `server/discover` stateless foundation (opt-in)

**Verification:** `go mod tidy`, `go build ./...`, and `go test ./...` run locally.

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT