### PR TITLE
fix(iac): anchor IAC-351 to line start; advance sotw queue (mcp-servers)

### DIFF
--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -986,7 +986,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-351", severity: findings.SeverityCritical, confidence: findings.ConfidenceMedium,
-			pattern:      `(?i)(?:PASSWORD|SECRET_KEY|TOKEN)\s*:\s*['"]?[A-Za-z0-9]`,
+			pattern:      `(?im)^\s*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)\s*:\s*['"]?[A-Za-z0-9]`,
 			description:  "CI variable with hardcoded secret",
 			cwe:          "CWE-798",
 			keywords:     []string{"PASSWORD", "SECRET", "TOKEN"},

--- a/core/analyzers/iac/rules_expanded_test.go
+++ b/core/analyzers/iac/rules_expanded_test.go
@@ -488,6 +488,56 @@ jobs:
 	}
 }
 
+// TestExpandedDetect_IAC351_HardcodedSecret verifies that IAC-351 fires on
+// genuine hardcoded secret variables but does NOT fire on GHA OIDC permission
+// lines (`id-token: write`), which previously triggered a critical false positive
+// because the unanchored TOKEN pattern matched the suffix of `id-token`.
+func TestExpandedDetect_IAC351_HardcodedSecret(t *testing.T) {
+	a := NewAnalyzer()
+
+	// TRUE POSITIVE: a real hardcoded token variable in a GitLab CI file.
+	tpContent := []byte(`variables:
+  DEPLOY_TOKEN: hardcoded123secret
+  OTHER_VAR: safe
+`)
+	tpResults, err := a.ScanFile(".gitlab-ci.yml", tpContent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, f := range tpResults {
+		if f.RuleID == "IAC-351" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("IAC-351: expected finding on hardcoded TOKEN variable, got none")
+	}
+
+	// FALSE POSITIVE guard: GHA OIDC permission line must NOT trigger IAC-351.
+	fpContent := []byte(`name: Deploy
+on: push
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+`)
+	fpResults, err := a.ScanFile(".github/workflows/deploy.yml", fpContent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range fpResults {
+		if f.RuleID == "IAC-351" {
+			t.Errorf("IAC-351 false positive: fired on 'id-token: write' GHA permission line at %s:%d",
+				f.Location.FilePath, f.Location.StartLine)
+		}
+	}
+}
+
 func TestExpandedDetect_IAC308_WorkflowDispatch(t *testing.T) {
 	a := NewAnalyzer()
 	// keywords: ["workflow_dispatch"] -- lowercase

--- a/docs/scan-of-the-week-queue.txt
+++ b/docs/scan-of-the-week-queue.txt
@@ -24,7 +24,7 @@
 # DONE 2026-06-07: huggingface/smolagents — 323 findings (65% from one example dir); 0 true positives; fixed VULN-002 PEP503 typosquat FP
 # DONE 2026-06-21: langchain-ai/langgraph — 134,614 findings (99.8% examples/ notebook image data + lockfile hashes); 0 true positives; fixed AI-019 DB-pipeline FP; MCP-011 docstring FP tracked
 # DONE 2026-07-05: microsoft/autogen — 304,629 findings (99.5% SVG/lock/notebook FPs); 1 low-sev AI-019 model-hash gap; fixed 10 broad-pattern SEC rules missing \b+secretShape
-modelcontextprotocol/servers
+# DONE 2026-07-15: modelcontextprotocol/servers — 41 findings (2 critical FPs: IAC-351 on id-token permission; 3 real high: mutable GH Action tags); fixed IAC-351 line-anchor FP
 openai/openai-agents-python
 phidatahq/phidata
 princeton-nlp/SWE-agent


### PR DESCRIPTION
## Summary

IAC-351 ("CI variable with hardcoded secret") was misfiring as **critical** on standard GitHub Actions OIDC permission lines (`id-token: write`), because the unanchored `TOKEN` pattern matched as a suffix of the YAML key `id-token`. Found during the 2026-07-15 scan of `modelcontextprotocol/servers`.

Also advances the scan-of-the-week queue.

## Motivation

The false positive produced two spurious critical-severity findings on `modelcontextprotocol/servers` — the canonical MCP reference implementation. Both fired on `permissions: id-token: write`, the standard GHA pattern for OIDC trusted publishing. This is the second consecutive scan (after autogen's SEC-* FPs) where a broad pattern with no anchor caused a critical false positive.

## Changes

- `core/analyzers/iac/rules_expanded.go` — IAC-351 pattern:
  ```
  - (?i)(?:PASSWORD|SECRET_KEY|TOKEN)\s*:\s*['"]?[A-Za-z0-9]
  + (?im)^\s*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)\s*:\s*['"]?[A-Za-z0-9]
  ```
  `(?im)^\s*` requires the keyword to begin a YAML key at line start. `(?:[A-Z0-9_]*_)?TOKEN` admits `MY_TOKEN` / `DEPLOY_TOKEN` while excluding `id-token`, since `-` is not in `[A-Z0-9_]` so the optional prefix group cannot consume `id-`. RE2-compatible; no lookbehind.
- `core/analyzers/iac/rules_expanded_test.go` — regression test covering the true positive (`DEPLOY_TOKEN: hardcoded123secret`) and the false-positive guard (`id-token: write`).
- `docs/scan-of-the-week-queue.txt` — mark `modelcontextprotocol/servers` done.

## Verification

Rebased onto current `main` and re-verified end to end.

**Measured before/after on this repository's own workflows**, which use `id-token: write` in `release.yml` and `slsa-provenance.yml`:

| Pattern | IAC-351 findings on `.github/workflows` |
|---|---|
| old (main) | **2** (both false-positive criticals) |
| new (this PR) | **0** |

- `golangci-lint` — 0 issues
- `go build`, `go vet`, `make build` — clean
- `go test ./...` — **48 packages pass**
- SAST precision gates (`precision-suite`, `-php`, `-java`) — all pass, no regression

### Correction to the original test plan

The earlier draft noted "two pre-existing failures in `TestRunScanWithOptions_*`". **That is no longer accurate** — those tests pass on the rebased branch, and the full suite is green. The claim was left in from the 2026-07-15 branch point and has been corrected rather than carried forward.

### Known trade-off

Anchoring to line start means IAC-351 no longer matches secrets written in **inline YAML flow mappings** (e.g. `env: {TOKEN: abc}`). That is a deliberate narrowing: the rule is `SeverityCritical`, so a false positive is expensive, and block-style keys are the overwhelmingly common form in CI config. Worth revisiting if a real-world miss shows up.

## Checklist

- [x] Code follows Go conventions
- [x] Conventional commit messages
- [x] No breaking changes to IAC-351 semantics for legitimate uses
- [x] Regression test covers both TP and FP

---

**Companion blog post PR:** Nox-HQ/nox-hq.dev#8