### PR TITLE
feat(plugin): per-tool safety requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-tool safety requirements** (`ToolDef.safety`, `sdk.ToolSafety(...)`).
+  Safety was declared per-plugin and validated at registration, so a plugin
+  bundling tools with different needs had to declare the union — the strictest
+  requirement of any one tool — and that union then gated every tool it ships.
+  `nox/red-team` could not run its read-only `analyze` under a passive policy
+  purely because it also ships `validate`.
+
+  Registration now asks whether *at least one* tool is usable under the policy;
+  the binding check is `ValidateToolInvocation`, applied by the host to the tool
+  actually being called. A tool that declares no safety block inherits the
+  plugin-level one, so existing plugins are unaffected.
+
+  Note that this is deliberately **not** derived from the existing `read_only`
+  flag: that means "does not mutate the workspace", not "passive".
+  `nox/llm-triage` declares a `read_only` tool that sends source code to an
+  external chat endpoint, so inferring passiveness from it would have granted
+  egress to precisely the tool that exfiltrates source. The two checks are
+  independent and a tool must satisfy both.
+
+### Changed
+
+- `nox/red-team` declares per-tool safety: `analyze` passive, `validate` active
+  with network and confirmation. `nox/k8s-runtime` is intentionally unchanged —
+  both `scan` and `drift` genuinely need the cluster API, so neither can honestly
+  declare itself passive.
+
 ## [1.7.1] - 2026-07-06
 
 ### Fixed

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -104,7 +104,40 @@ type ToolRequest struct {
 
 ## Safety Model
 
-Every plugin declares its safety requirements in the manifest. The host validates these against the active policy before allowing registration.
+Every plugin declares its safety requirements in the manifest, and may additionally declare them **per tool**. The host validates the plugin-level block at registration, and the specific tool's requirements at invocation.
+
+### Plugin-level vs per-tool safety
+
+The plugin-level `Safety(...)` block is the **ceiling** — everything the plugin might ever need, declared up front so an operator can see it before anything runs. Individual tools may declare narrower requirements with `ToolSafety(...)`:
+
+```go
+Capability("red-team", "Attack path analysis").
+    // Reasons over findings the core scan already produced: no network,
+    // no mutation, nothing to confirm.
+    Tool("analyze", "Detect attack chains", true).
+    ToolSafety(sdk.WithRiskClass(sdk.RiskPassive)).
+    // Probes a live target, so it stays opt-in.
+    Tool("validate", "Validate exploitability", false).
+    ToolSafety(
+        sdk.WithRiskClass(sdk.RiskActive),
+        sdk.WithNeedsConfirmation(),
+        sdk.WithNetworkHosts("*"),
+    ).
+    Done().
+    Safety(  // the ceiling across both tools
+        sdk.WithRiskClass(sdk.RiskActive),
+        sdk.WithNeedsConfirmation(),
+        sdk.WithNetworkHosts("*"),
+    )
+```
+
+A tool with no `ToolSafety` inherits the plugin-level block, so plugins written before this existed behave exactly as they did.
+
+**Why it exists.** Safety used to be plugin-scoped only, and validated at registration. A plugin bundling tools with different needs had to declare the union — the strictest requirement of any one tool — and that union then gated *every* tool it shipped. `nox/red-team` could not run its read-only `analyze` under a passive policy purely because it also ships `validate`.
+
+Registration therefore now asks *"is at least one tool usable under this policy?"*, and the binding check happens per invocation.
+
+> **`read_only` does not mean passive.** It means "does not mutate the workspace". A read-only tool may still send data to the network — `nox/llm-triage` declares a read-only tool that ships source code to an external chat endpoint. Declare `ToolSafety` honestly per tool; do not infer passiveness from `readOnly: true`, and do not copy the narrowest block onto a tool that needs more. The host enforces exactly what you declare.
 
 ### Risk Classes
 

--- a/gen/nox/plugin/v1/plugin.pb.go
+++ b/gen/nox/plugin/v1/plugin.pb.go
@@ -274,8 +274,25 @@ type ToolDef struct {
 	InputSchema         *structpb.Struct       `protobuf:"bytes,3,opt,name=input_schema,json=inputSchema,proto3" json:"input_schema,omitempty"`
 	ReadOnly            bool                   `protobuf:"varint,4,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
 	RequiresScanContext bool                   `protobuf:"varint,5,opt,name=requires_scan_context,json=requiresScanContext,proto3" json:"requires_scan_context,omitempty"` // tool needs ScanContext as input
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Per-tool safety requirements. When unset, the plugin-level
+	// SafetyRequirements apply — so plugins that predate this field behave
+	// exactly as before.
+	//
+	// Why this exists: safety was declared only per-plugin and validated at
+	// REGISTRATION, so a plugin bundling one active tool with several passive
+	// ones had to declare the union — the strictest requirement of any tool —
+	// which then gated every tool it ships. nox/red-team could not run its
+	// read-only `analyze` under a passive policy purely because it also ships
+	// `validate`; nox/k8s-runtime's `scan` was blocked by its sibling `drift`.
+	//
+	// NOTE: this deliberately is NOT derived from `read_only`. That flag means
+	// "does not mutate the workspace", not "passive" — nox/llm-triage declares a
+	// read_only tool that sends source code to an external chat endpoint.
+	// Inferring passiveness from read_only would have granted unrestricted egress
+	// to precisely the tool that exfiltrates source.
+	Safety        *SafetyRequirements `protobuf:"bytes,6,opt,name=safety,proto3,oneof" json:"safety,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ToolDef) Reset() {
@@ -341,6 +358,13 @@ func (x *ToolDef) GetRequiresScanContext() bool {
 		return x.RequiresScanContext
 	}
 	return false
+}
+
+func (x *ToolDef) GetSafety() *SafetyRequirements {
+	if x != nil {
+		return x.Safety
+	}
+	return nil
 }
 
 // ResourceDef describes a resource that a plugin can serve.
@@ -838,13 +862,15 @@ const file_nox_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12,\n" +
 	"\x05tools\x18\x03 \x03(\v2\x16.nox.plugin.v1.ToolDefR\x05tools\x128\n" +
-	"\tresources\x18\x04 \x03(\v2\x1a.nox.plugin.v1.ResourceDefR\tresources\"\xcc\x01\n" +
+	"\tresources\x18\x04 \x03(\v2\x1a.nox.plugin.v1.ResourceDefR\tresources\"\x97\x02\n" +
 	"\aToolDef\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12:\n" +
 	"\finput_schema\x18\x03 \x01(\v2\x17.google.protobuf.StructR\vinputSchema\x12\x1b\n" +
 	"\tread_only\x18\x04 \x01(\bR\breadOnly\x122\n" +
-	"\x15requires_scan_context\x18\x05 \x01(\bR\x13requiresScanContext\"\x83\x01\n" +
+	"\x15requires_scan_context\x18\x05 \x01(\bR\x13requiresScanContext\x12>\n" +
+	"\x06safety\x18\x06 \x01(\v2!.nox.plugin.v1.SafetyRequirementsH\x00R\x06safety\x88\x01\x01B\t\n" +
+	"\a_safety\"\x83\x01\n" +
 	"\vResourceDef\x12!\n" +
 	"\furi_template\x18\x01 \x01(\tR\vuriTemplate\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -936,28 +962,29 @@ var file_nox_plugin_v1_plugin_proto_depIdxs = []int32{
 	4,  // 2: nox.plugin.v1.Capability.tools:type_name -> nox.plugin.v1.ToolDef
 	5,  // 3: nox.plugin.v1.Capability.resources:type_name -> nox.plugin.v1.ResourceDef
 	12, // 4: nox.plugin.v1.ToolDef.input_schema:type_name -> google.protobuf.Struct
-	12, // 5: nox.plugin.v1.InvokeToolRequest.input:type_name -> google.protobuf.Struct
-	13, // 6: nox.plugin.v1.InvokeToolRequest.scan_context:type_name -> nox.plugin.v1.ScanContext
-	14, // 7: nox.plugin.v1.InvokeToolResponse.findings:type_name -> nox.plugin.v1.Finding
-	15, // 8: nox.plugin.v1.InvokeToolResponse.packages:type_name -> nox.plugin.v1.Package
-	16, // 9: nox.plugin.v1.InvokeToolResponse.ai_components:type_name -> nox.plugin.v1.AIComponent
-	9,  // 10: nox.plugin.v1.InvokeToolResponse.diagnostics:type_name -> nox.plugin.v1.Diagnostic
-	17, // 11: nox.plugin.v1.InvokeToolResponse.graphs:type_name -> nox.plugin.v1.Graph
-	18, // 12: nox.plugin.v1.InvokeToolResponse.enrichments:type_name -> nox.plugin.v1.Enrichment
-	0,  // 13: nox.plugin.v1.Diagnostic.severity:type_name -> nox.plugin.v1.DiagnosticSeverity
-	19, // 14: nox.plugin.v1.StreamArtifactsRequest.artifact_types:type_name -> nox.plugin.v1.ArtifactType
-	20, // 15: nox.plugin.v1.StreamArtifactsResponse.artifact:type_name -> nox.plugin.v1.Artifact
-	1,  // 16: nox.plugin.v1.PluginService.GetManifest:input_type -> nox.plugin.v1.GetManifestRequest
-	7,  // 17: nox.plugin.v1.PluginService.InvokeTool:input_type -> nox.plugin.v1.InvokeToolRequest
-	10, // 18: nox.plugin.v1.PluginService.StreamArtifacts:input_type -> nox.plugin.v1.StreamArtifactsRequest
-	2,  // 19: nox.plugin.v1.PluginService.GetManifest:output_type -> nox.plugin.v1.GetManifestResponse
-	8,  // 20: nox.plugin.v1.PluginService.InvokeTool:output_type -> nox.plugin.v1.InvokeToolResponse
-	11, // 21: nox.plugin.v1.PluginService.StreamArtifacts:output_type -> nox.plugin.v1.StreamArtifactsResponse
-	19, // [19:22] is the sub-list for method output_type
-	16, // [16:19] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	6,  // 5: nox.plugin.v1.ToolDef.safety:type_name -> nox.plugin.v1.SafetyRequirements
+	12, // 6: nox.plugin.v1.InvokeToolRequest.input:type_name -> google.protobuf.Struct
+	13, // 7: nox.plugin.v1.InvokeToolRequest.scan_context:type_name -> nox.plugin.v1.ScanContext
+	14, // 8: nox.plugin.v1.InvokeToolResponse.findings:type_name -> nox.plugin.v1.Finding
+	15, // 9: nox.plugin.v1.InvokeToolResponse.packages:type_name -> nox.plugin.v1.Package
+	16, // 10: nox.plugin.v1.InvokeToolResponse.ai_components:type_name -> nox.plugin.v1.AIComponent
+	9,  // 11: nox.plugin.v1.InvokeToolResponse.diagnostics:type_name -> nox.plugin.v1.Diagnostic
+	17, // 12: nox.plugin.v1.InvokeToolResponse.graphs:type_name -> nox.plugin.v1.Graph
+	18, // 13: nox.plugin.v1.InvokeToolResponse.enrichments:type_name -> nox.plugin.v1.Enrichment
+	0,  // 14: nox.plugin.v1.Diagnostic.severity:type_name -> nox.plugin.v1.DiagnosticSeverity
+	19, // 15: nox.plugin.v1.StreamArtifactsRequest.artifact_types:type_name -> nox.plugin.v1.ArtifactType
+	20, // 16: nox.plugin.v1.StreamArtifactsResponse.artifact:type_name -> nox.plugin.v1.Artifact
+	1,  // 17: nox.plugin.v1.PluginService.GetManifest:input_type -> nox.plugin.v1.GetManifestRequest
+	7,  // 18: nox.plugin.v1.PluginService.InvokeTool:input_type -> nox.plugin.v1.InvokeToolRequest
+	10, // 19: nox.plugin.v1.PluginService.StreamArtifacts:input_type -> nox.plugin.v1.StreamArtifactsRequest
+	2,  // 20: nox.plugin.v1.PluginService.GetManifest:output_type -> nox.plugin.v1.GetManifestResponse
+	8,  // 21: nox.plugin.v1.PluginService.InvokeTool:output_type -> nox.plugin.v1.InvokeToolResponse
+	11, // 22: nox.plugin.v1.PluginService.StreamArtifacts:output_type -> nox.plugin.v1.StreamArtifactsResponse
+	20, // [20:23] is the sub-list for method output_type
+	17, // [17:20] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_nox_plugin_v1_plugin_proto_init() }
@@ -966,6 +993,7 @@ func file_nox_plugin_v1_plugin_proto_init() {
 		return
 	}
 	file_nox_plugin_v1_types_proto_init()
+	file_nox_plugin_v1_plugin_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -170,7 +170,44 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 
 	pluginName := p.Info().Name
 
+	// Per-tool safety enforcement.
+	//
+	// Registration only establishes that SOMETHING in this plugin is runnable
+	// (see ValidateManifest); the binding check is here, against the tool
+	// actually being called. A tool declaring its own safety is judged on that;
+	// one that does not inherits the plugin-level block, which is how every
+	// plugin behaved before ToolDef.safety existed.
+	//
+	// This is what lets a plugin ship a passive tool alongside an active one
+	// without the active sibling gating the passive one.
+	if ti := p.getToolInfo(resolvedName); ti != nil && ti.Safety != nil {
+		if violations := validateSafety(ti.Safety, &h.policy); len(violations) > 0 {
+			msgs := make([]string, 0, len(violations))
+			for _, pv := range violations {
+				msgs = append(msgs, pv.Error())
+			}
+			v := RuntimeViolation{
+				Type:       ViolationUnauthorizedAction,
+				PluginName: pluginName,
+				Message: fmt.Sprintf(
+					"tool %q requirements not allowed by policy: %s",
+					resolvedName, strings.Join(msgs, "; "),
+				),
+				Timestamp: time.Now(),
+			}
+			h.mu.Lock()
+			h.handleViolationLocked(v, p)
+			h.mu.Unlock()
+			return nil, v
+		}
+	}
+
 	// Read-only enforcement: reject non-read-only tools under passive policy.
+	//
+	// Deliberately a SEPARATE, independent check. `read_only` means "does not
+	// mutate the workspace" — not "passive": nox/llm-triage declares a read_only
+	// tool that ships source code to an external chat endpoint. Neither property
+	// implies the other, so a tool must satisfy both.
 	if h.policy.MaxRiskClass == RiskClassPassive {
 		ti := p.getToolInfo(resolvedName)
 		if ti != nil && !ti.ReadOnly {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -62,6 +62,11 @@ type ToolInfo struct {
 	Description         string
 	ReadOnly            bool
 	RequiresScanContext bool
+	// Safety, when non-nil, are this tool's own requirements, which override
+	// the plugin-level block for invocations of this tool. Nil means the tool
+	// inherits the plugin-level requirements — the behaviour of every plugin
+	// built before ToolDef.safety existed.
+	Safety *pluginv1.SafetyRequirements
 }
 
 // ResourceInfo describes a resource a plugin can serve.
@@ -291,6 +296,7 @@ func parseManifest(resp *pluginv1.GetManifestResponse) Info {
 				Description:         tool.GetDescription(),
 				ReadOnly:            tool.GetReadOnly(),
 				RequiresScanContext: tool.GetRequiresScanContext(),
+				Safety:              tool.GetSafety(),
 			})
 		}
 		for _, res := range cap.GetResources() {

--- a/plugin/safety.go
+++ b/plugin/safety.go
@@ -64,14 +64,87 @@ func (v PolicyViolation) Error() string {
 	return fmt.Sprintf("policy violation on %s: %s", v.Field, v.Message)
 }
 
-// ValidateManifest checks a plugin's manifest against the given policy.
-// It returns all violations found, not just the first.
-// A nil safety requirement in the manifest means no requirements, which always passes.
+// ValidateManifest checks whether a plugin may be REGISTERED under the policy.
+//
+// A plugin is admissible when at least one of its tools is. Safety is declared
+// per-plugin and, since ToolDef.safety was added, optionally per-tool; the
+// plugin-level block is the ceiling across everything the plugin might do.
+//
+// Rejecting on that ceiling alone was the old behaviour and it was too coarse: a
+// plugin bundling one active tool with several passive ones must declare the
+// union, so the active sibling gated every passive tool it ships. nox/red-team
+// could not run its read-only `analyze` under a passive policy purely because it
+// also ships `validate`. Registration therefore now asks "is anything here
+// usable?", and [ValidateToolInvocation] enforces the real constraint per call.
+//
+// Returns all violations found, not just the first. A manifest with no safety
+// requirements always passes.
 func ValidateManifest(manifest *pluginv1.GetManifestResponse, policy *Policy) []PolicyViolation {
 	if manifest == nil {
 		return nil
 	}
-	safety := manifest.GetSafety()
+	pluginSafety := manifest.GetSafety()
+	if pluginSafety == nil {
+		return nil
+	}
+
+	pluginViolations := validateSafety(pluginSafety, policy)
+	if len(pluginViolations) == 0 {
+		return nil
+	}
+
+	// The ceiling exceeds the policy. Admit the plugin anyway if some tool
+	// declares narrower requirements the policy does allow — that tool can still
+	// run, and the others are refused individually at invocation.
+	for _, capability := range manifest.GetCapabilities() {
+		for _, tool := range capability.GetTools() {
+			if tool.GetSafety() == nil {
+				continue // inherits the ceiling, which already violates
+			}
+			if len(validateSafety(tool.GetSafety(), policy)) == 0 {
+				return nil
+			}
+		}
+	}
+	return pluginViolations
+}
+
+// ValidateToolInvocation checks a SPECIFIC tool against the policy.
+//
+// This is the check that actually constrains what runs. A tool's own safety
+// block is used when present; otherwise it inherits the plugin-level block, so
+// plugins predating ToolDef.safety behave exactly as they did before.
+//
+// An unknown tool name is a violation rather than a pass: failing open on a name
+// typo would let an unvalidated call through.
+func ValidateToolInvocation(
+	manifest *pluginv1.GetManifestResponse,
+	toolName string,
+	policy *Policy,
+) []PolicyViolation {
+	if manifest == nil {
+		return nil
+	}
+	for _, capability := range manifest.GetCapabilities() {
+		for _, tool := range capability.GetTools() {
+			if tool.GetName() != toolName {
+				continue
+			}
+			if s := tool.GetSafety(); s != nil {
+				return validateSafety(s, policy)
+			}
+			return validateSafety(manifest.GetSafety(), policy)
+		}
+	}
+	return []PolicyViolation{{
+		Field:   "tool_name",
+		Message: fmt.Sprintf("tool %q is not declared in the manifest", toolName),
+	}}
+}
+
+// validateSafety checks one set of safety requirements against the policy.
+// Shared by the plugin-level and per-tool paths so the two cannot drift apart.
+func validateSafety(safety *pluginv1.SafetyRequirements, policy *Policy) []PolicyViolation {
 	if safety == nil {
 		return nil
 	}

--- a/plugin/safety_pertool_test.go
+++ b/plugin/safety_pertool_test.go
@@ -1,0 +1,121 @@
+package plugin
+
+import (
+	"testing"
+
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+)
+
+// The shape that motivated per-tool safety: one plugin, one passive tool, one
+// active tool. Before ToolDef.safety the plugin could only declare the union,
+// so the active tool gated the passive one.
+func mixedManifest() *pluginv1.GetManifestResponse {
+	return &pluginv1.GetManifestResponse{
+		Safety: &pluginv1.SafetyRequirements{
+			RiskClass:         "active",
+			NeedsConfirmation: true,
+			NetworkHosts:      []string{"*"},
+		},
+		Capabilities: []*pluginv1.Capability{{
+			Name: "red-team",
+			Tools: []*pluginv1.ToolDef{
+				{
+					Name:     "analyze",
+					ReadOnly: true,
+					Safety:   &pluginv1.SafetyRequirements{RiskClass: "passive"},
+				},
+				{
+					Name:     "validate",
+					ReadOnly: false,
+					Safety: &pluginv1.SafetyRequirements{
+						RiskClass:         "active",
+						NeedsConfirmation: true,
+						NetworkHosts:      []string{"*"},
+					},
+				},
+				// No Safety block: must inherit the plugin-level ceiling, which
+				// is how every plugin behaved before this field existed.
+				{Name: "legacy", ReadOnly: true},
+			},
+		}},
+	}
+}
+
+func passivePolicy() *Policy {
+	return &Policy{MaxRiskClass: RiskClassPassive}
+}
+
+func TestValidateManifest_AdmitsPluginWhenSomeToolIsUsable(t *testing.T) {
+	// The ceiling (active + "*" + confirmation) exceeds a passive policy, but
+	// `analyze` is admissible, so the plugin must register rather than be
+	// rejected outright — that rejection was the bug.
+	if v := ValidateManifest(mixedManifest(), passivePolicy()); len(v) != 0 {
+		t.Fatalf("expected registration to succeed, got violations: %v", v)
+	}
+}
+
+func TestValidateManifest_StillRejectsWhenNoToolIsUsable(t *testing.T) {
+	m := mixedManifest()
+	// Drop the one admissible tool; nothing usable remains.
+	m.Capabilities[0].Tools = m.Capabilities[0].Tools[1:]
+	if v := ValidateManifest(m, passivePolicy()); len(v) == 0 {
+		t.Fatal("expected rejection when no tool is admissible")
+	}
+}
+
+func TestValidateToolInvocation_EnforcesPerToolRequirements(t *testing.T) {
+	m, pol := mixedManifest(), passivePolicy()
+
+	if v := ValidateToolInvocation(m, "analyze", pol); len(v) != 0 {
+		t.Errorf("passive tool should be allowed under a passive policy, got %v", v)
+	}
+	if v := ValidateToolInvocation(m, "validate", pol); len(v) == 0 {
+		t.Error("active tool must be refused under a passive policy")
+	}
+	// Inheritance: no per-tool block => the plugin ceiling applies.
+	if v := ValidateToolInvocation(m, "legacy", pol); len(v) == 0 {
+		t.Error("tool without its own safety must inherit the plugin ceiling")
+	}
+	// Fail closed on an unknown name rather than silently passing.
+	if v := ValidateToolInvocation(m, "no-such-tool", pol); len(v) == 0 {
+		t.Error("unknown tool must be refused, not allowed through unvalidated")
+	}
+}
+
+func TestValidateToolInvocation_PermissivePolicyAllowsEverything(t *testing.T) {
+	pol := &Policy{
+		MaxRiskClass:          RiskClassActive,
+		AllowConfirmationReqd: true,
+		AllowedNetworkHosts:   []string{"*"},
+	}
+	for _, name := range []string{"analyze", "validate", "legacy"} {
+		if v := ValidateToolInvocation(mixedManifest(), name, pol); len(v) != 0 {
+			t.Errorf("tool %q refused under permissive policy: %v", name, v)
+		}
+	}
+}
+
+// read_only does NOT imply passive: nox/llm-triage ships a read_only tool that
+// sends source to an external endpoint. Inferring passiveness from read_only
+// would grant egress to exactly the tool that exfiltrates source, so the two
+// checks must stay independent.
+func TestReadOnlyDoesNotImplyPassive(t *testing.T) {
+	m := &pluginv1.GetManifestResponse{
+		Safety: &pluginv1.SafetyRequirements{RiskClass: "active"},
+		Capabilities: []*pluginv1.Capability{{
+			Name: "triage",
+			Tools: []*pluginv1.ToolDef{{
+				Name:     "llm_triage",
+				ReadOnly: true, // read-only, yet egresses source code
+				Safety: &pluginv1.SafetyRequirements{
+					RiskClass:         "active",
+					NeedsConfirmation: true,
+					NetworkHosts:      []string{"*"},
+				},
+			}},
+		}},
+	}
+	if v := ValidateToolInvocation(m, "llm_triage", passivePolicy()); len(v) == 0 {
+		t.Fatal("a read_only tool that egresses must still be refused by a passive policy")
+	}
+}

--- a/plugins/nox-plugin-red-team/README.md
+++ b/plugins/nox-plugin-red-team/README.md
@@ -8,8 +8,19 @@ Analyzes security findings to detect multi-step attack chains and optionally val
 
 ## Tools
 
-- **analyze** — Detect attack chains from security findings (passive, read-only)
-- **validate** — Validate exploitability against a target URL (active, needs confirmation)
+- **analyze** — Detect attack chains from security findings (passive, read-only).
+  Runs under the **default policy**: it reasons over findings the core scan
+  already produced, so it needs no network access, mutates nothing, and requires
+  no confirmation.
+- **validate** — Validate exploitability against a target URL (active, needs
+  confirmation). Requires an explicit policy opt-in, because it probes a live
+  target.
+
+The two declare their requirements separately (`ToolSafety`), so `validate`
+being active does not gate `analyze`. Before per-tool safety existed, the
+plugin could only declare the union of both, and `analyze` was rejected under a
+passive policy despite needing nothing — this README described it as passive and
+was right about the tool; the manifest simply could not express it.
 
 ## Rules
 

--- a/plugins/nox-plugin-red-team/main.go
+++ b/plugins/nox-plugin-red-team/main.go
@@ -15,9 +15,29 @@ var version = "dev"
 func buildServer() *sdk.PluginServer {
 	manifest := sdk.NewManifest("nox/red-team", version).
 		Capability("red-team", "Attack path analysis and exploit validation for security findings").
+		// analyze reasons over findings the core scan already produced. No
+		// network, no mutation, nothing to confirm -- so it declares passive and
+		// runs under a default policy.
 		Tool("analyze", "Analyze attack chains from security findings (passive, read-only)", true).
+		ToolSafety(sdk.WithRiskClass(sdk.RiskPassive)).
+		// validate actually probes a live target, so it keeps the full
+		// requirements and stays opt-in.
 		Tool("validate", "Validate exploitability of specific findings (active, needs confirmation)", false).
+		ToolSafety(
+			sdk.WithRiskClass(sdk.RiskActive),
+			sdk.WithNeedsConfirmation(),
+			sdk.WithNetworkHosts("*"),
+		).
 		Done().
+		// Plugin-level safety remains the CEILING across every tool -- what this
+		// plugin might ever need. It is no longer what gates each call: the host
+		// enforces the per-tool blocks above at invocation.
+		//
+		// Before per-tool safety existed, this ceiling was the only declaration,
+		// so `analyze` was rejected under a passive policy purely because
+		// `validate` ships alongside it. The README described analyze as
+		// "passive, read-only" and was accurate about the tool -- the manifest
+		// simply could not express it.
 		Safety(
 			sdk.WithRiskClass(sdk.RiskActive),
 			sdk.WithNeedsConfirmation(),

--- a/proto/nox/plugin/v1/plugin.proto
+++ b/proto/nox/plugin/v1/plugin.proto
@@ -48,6 +48,24 @@ message ToolDef {
   google.protobuf.Struct input_schema = 3;
   bool read_only = 4;
   bool requires_scan_context = 5;  // tool needs ScanContext as input
+
+  // Per-tool safety requirements. When unset, the plugin-level
+  // SafetyRequirements apply — so plugins that predate this field behave
+  // exactly as before.
+  //
+  // Why this exists: safety was declared only per-plugin and validated at
+  // REGISTRATION, so a plugin bundling one active tool with several passive
+  // ones had to declare the union — the strictest requirement of any tool —
+  // which then gated every tool it ships. nox/red-team could not run its
+  // read-only `analyze` under a passive policy purely because it also ships
+  // `validate`; nox/k8s-runtime's `scan` was blocked by its sibling `drift`.
+  //
+  // NOTE: this deliberately is NOT derived from `read_only`. That flag means
+  // "does not mutate the workspace", not "passive" — nox/llm-triage declares a
+  // read_only tool that sends source code to an external chat endpoint.
+  // Inferring passiveness from read_only would have granted unrestricted egress
+  // to precisely the tool that exfiltrates source.
+  optional SafetyRequirements safety = 6;
 }
 
 // ResourceDef describes a resource that a plugin can serve.

--- a/sdk/manifest.go
+++ b/sdk/manifest.go
@@ -76,6 +76,44 @@ func (cb *CapabilityBuilder) ToolWithContext(name, description string, readOnly 
 	return cb
 }
 
+// ToolSafety declares safety requirements for the most recently added tool,
+// overriding the plugin-level block for invocations of that tool.
+//
+// Use this whenever a plugin ships tools with genuinely different needs.
+// Without it the plugin-level block must be the union — the strictest
+// requirement of any single tool — and that union then gates every tool the
+// plugin ships:
+//
+//	// analyze is read-only and local, yet was unusable under a passive policy
+//	// purely because `validate` (same plugin) needs network + confirmation.
+//	Tool("analyze", "...", true).
+//	    ToolSafety(WithRiskClass(RiskPassive)).
+//	Tool("validate", "...", false).
+//	    ToolSafety(WithRiskClass(RiskActive), WithNeedsConfirmation(), WithNetworkHosts("*")).
+//
+// A tool with no ToolSafety inherits the plugin-level block, so plugins written
+// before this existed are unaffected.
+//
+// Declare requirements honestly per tool rather than copying the narrowest one:
+// this is what the host enforces at invocation. In particular, do not treat
+// `readOnly: true` as implying passive — read-only means "does not mutate the
+// workspace", and a read-only tool may still send data to the network.
+//
+// Panics if called before any Tool/ToolWithContext on this capability: there
+// would be nothing to attach to, which is a programming error worth surfacing
+// at startup rather than silently dropping the requirements.
+func (cb *CapabilityBuilder) ToolSafety(opts ...SafetyOption) *CapabilityBuilder {
+	if len(cb.cap.Tools) == 0 {
+		panic("sdk: ToolSafety called before any Tool was added to the capability")
+	}
+	sr := &pluginv1.SafetyRequirements{}
+	for _, opt := range opts {
+		opt(sr)
+	}
+	cb.cap.Tools[len(cb.cap.Tools)-1].Safety = sr
+	return cb
+}
+
 // Resource adds a resource definition to the capability.
 func (cb *CapabilityBuilder) Resource(uriTemplate, name, description, mimeType string) *CapabilityBuilder {
 	cb.cap.Resources = append(cb.cap.Resources, &pluginv1.ResourceDef{


### PR DESCRIPTION
## Problem

Safety was declared **per-plugin** and validated at **registration**. A plugin bundling tools with different needs had to declare the union — the strictest requirement of any single tool — and that union then gated *every* tool it ships.

Concretely: `nox/red-team` could not run its read-only `analyze` under a passive policy purely because it also ships `validate`. The README described `analyze` as "passive, read-only" and was accurate about the tool; the manifest simply had no way to say it.

## Change

Adds `optional SafetyRequirements safety = 6` to `ToolDef`, plus `sdk.ToolSafety(...)`.

- **`ValidateManifest`** (registration) now asks *"is at least one tool usable under this policy?"* rather than judging the ceiling alone.
- **`ValidateToolInvocation`** (new) is the binding check, applied by the host to the specific tool being called.
- Plugin-level `Safety(...)` remains the **ceiling** — what the plugin might ever need, visible to an operator before anything runs.

A tool with no `ToolSafety` inherits the plugin-level block, so **every existing plugin behaves exactly as before**.

## Why not just use `read_only`?

That was the obvious cheaper fix and it would have been a security hole.

`read_only` means *"does not mutate the workspace"*, **not** *"passive"*. `nox/llm-triage` declares a `read_only` tool that sends source code to an external chat endpoint — its own description says *"active: egress of source"*. Inferring passiveness from `read_only` would have granted unrestricted egress to precisely the tool that exfiltrates source.

The two checks are kept independent and a tool must satisfy both. There's a regression test asserting exactly this (`TestReadOnlyDoesNotImplyPassive`).

## Scope

- `nox/red-team` declares per-tool safety: `analyze` passive, `validate` active + network + confirmation.
- **`nox/k8s-runtime` is deliberately unchanged.** Both `scan` and `drift` genuinely need network access to the cluster API, so declaring either passive would be false. Per-tool safety does not unblock that plugin, and pretending otherwise would be worse than leaving it.

## Verification

`go build`, `go vet`, `make build`, full suite (**48 packages**), and the **SAST precision gate** all pass. `gofmt` clean on all changed files.

Tests cover: registration admitting a mixed plugin, still rejecting when no tool is usable, per-tool enforcement, inheritance for tools without their own block, permissive policies, and failing closed on an unknown tool name.

**Not verified end-to-end:** the installed plugin binaries are published release artifacts, so seeing `analyze` actually run under a passive policy needs a nox + red-team release.

## Note on the proto change

Field 6 was free on `ToolDef`; the change is additive and backward-compatible. Regenerated with protoc-gen-go v1.36.11 to match the existing generated code, and I reverted an unrelated `protoc (unknown)` → `v7.35.0` version-comment churn from my local toolchain to keep the diff honest.