### PR TITLE
fix(release): a stale tap token must not skip cosign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,34 @@ jobs:
         with:
           syft-version: v1.22.0
 
+      # Probe the Homebrew tap credential BEFORE running goreleaser.
+      #
+      # WHY: publishing the tap formula is a packaging convenience, but it ran
+      # inside the same goreleaser invocation as everything else, so when the
+      # token expired the whole `release` job failed — and `sign`, `docker` and
+      # `update-major-tag` all declare `needs: release`, so they were SKIPPED.
+      #
+      # The result (observed on v1.9.0): binaries and SBOMs published, but the
+      # artifacts left UNSIGNED, no container image, and the floating `v1` tag
+      # not moved. A stale packaging token silently downgraded the
+      # supply-chain guarantees this project exists to provide. That is exactly
+      # backwards, and it failed loudly in the wrong place: the release looked
+      # "failed" while actually being published-but-unsigned.
+      #
+      # Now a bad tap token degrades to a warning and a skipped formula update.
+      # Signing is never collateral damage.
+      - name: Check Homebrew tap credential
+        id: tap
+        run: |
+          if gh api repos/felixgeelhaar/homebrew-tap --silent 2>/dev/null; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Homebrew tap skipped::TAP_GITHUB_TOKEN cannot access felixgeelhaar/homebrew-tap (rotate the secret and re-run to publish the formula). The release itself, signing and the container image are unaffected."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: '~> v2'
@@ -33,6 +61,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          SKIP_BREW: ${{ steps.tap.outputs.skip }}
 
   update-major-tag:
     # Move the floating `v1` action tag to this release so `nox-hq/nox@v1`

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,7 +137,12 @@ brews:
     test: |
       system "#{bin}/nox", "--help"
       system "#{bin}/nox-plugin-reachability", "--help" rescue true
-    skip_upload: auto
+    # "auto" already skips prereleases/snapshots. SKIP_BREW additionally skips
+    # when the release workflow found TAP_GITHUB_TOKEN cannot reach the tap, so
+    # an expired packaging credential cannot fail the release and take cosign
+    # signing down with it. Defaults to "auto" for local/manual runs where the
+    # variable is unset.
+    skip_upload: '{{ if eq (envOrDefault "SKIP_BREW" "") "true" }}true{{ else }}auto{{ end }}'
 
 sboms:
   - artifacts: archive


### PR DESCRIPTION
## What happened on v1.9.0

Binaries and SBOMs published, but the artifacts were left **unsigned**, no container image was pushed, and the floating `v1` tag wasn't moved.

**Cause:** the Homebrew tap formula update runs inside the same goreleaser invocation as everything else. An expired `TAP_GITHUB_TOKEN` returned 401, failing the `release` job — and `sign`, `docker` and `update-major-tag` all declare `needs: release`, so all three were **skipped**.

A packaging convenience took down the supply-chain guarantees this project exists to provide. It also failed misleadingly: the run reported *failure* while the release was in fact **published, just unsigned** — arguably worse than a clean failure, because the artifacts are out there.

## Fix

The workflow probes the tap credential first and passes `SKIP_BREW` into goreleaser, whose `skip_upload` honours it.

- token good → formula updates, as today
- token bad → **warning annotation**, formula skipped, and the release, signing, image push and tag move all still run

`skip_upload` falls back to `auto` when `SKIP_BREW` is unset, so local and manual runs are unchanged.

## What this does not do

**It does not rotate the token** — that's an operator action, and not something I should perform. It removes the token's ability to cause collateral damage.

You'll still want to rotate `TAP_GITHUB_TOKEN` so the formula actually publishes; until then releases will succeed with a visible warning rather than silently shipping unsigned artifacts.

## Follow-up, deliberately not folded in

`goreleaser check` reports `brews` as deprecated in favour of `homebrew_casks`. Pre-existing, and a separate migration.