### PR TITLE
feat(taint): open redirect as a taint-gated sink (TAINT-007, CWE-601)

### DIFF
--- a/core/taint/catalog.go
+++ b/core/taint/catalog.go
@@ -46,6 +46,7 @@ const (
 	VulnSSRF                  VulnClass = "ssrf"                   // CWE-918
 	VulnUnsafeDeserialization VulnClass = "unsafe_deserialization" // CWE-502
 	VulnPromptInjection       VulnClass = "prompt_injection"       // CWE-77 / CWE-200
+	VulnOpenRedirect          VulnClass = "open_redirect"          // CWE-601
 )
 
 // SourceKind describes the provenance of untrusted input. It is informational

--- a/core/taint/catalog_go_test.go
+++ b/core/taint/catalog_go_test.go
@@ -85,3 +85,45 @@ func TestGoCatalogSanitizers(t *testing.T) {
 		}
 	}
 }
+
+// Open redirect (TAINT-007, CWE-601) was folded in from nox-plugin-sast's
+// SAST-008 when that plugin was retired. In the catalogue it is taint-gated:
+// the plugin matched `res.redirect(...req.query)` textually, whereas a sink
+// only fires when untrusted input actually reaches it — so a redirect to a
+// constant path is correctly silent.
+func TestCatalog_OpenRedirectSink(t *testing.T) {
+	c := MustDefault()
+	s, ok := c.IsSink("go", "http.Redirect")
+	if !ok {
+		t.Fatal("http.Redirect should be an open-redirect sink")
+	}
+	if s.VulnClass != VulnOpenRedirect {
+		t.Errorf("vuln class = %q, want %q", s.VulnClass, VulnOpenRedirect)
+	}
+	if s.CWE != "CWE-601" {
+		t.Errorf("cwe = %q, want CWE-601", s.CWE)
+	}
+	if s.RuleID != "TAINT-007" {
+		t.Errorf("rule id = %q, want TAINT-007", s.RuleID)
+	}
+}
+
+func TestCatalog_OpenRedirectAcrossLanguages(t *testing.T) {
+	c := MustDefault()
+	for _, tc := range []struct{ lang, call string }{
+		{"python", "redirect"},
+		{"python", "HttpResponseRedirect"},
+		{"javascript", "res.redirect"},
+		{"java", "sendRedirect"},
+		{"ruby", "redirect_to"},
+	} {
+		s, ok := c.IsSink(tc.lang, tc.call)
+		if !ok {
+			t.Errorf("%s/%s should be a sink", tc.lang, tc.call)
+			continue
+		}
+		if s.VulnClass != VulnOpenRedirect {
+			t.Errorf("%s/%s class = %q, want %q", tc.lang, tc.call, s.VulnClass, VulnOpenRedirect)
+		}
+	}
+}

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -384,6 +384,20 @@
           "vuln_class": "prompt_injection",
           "cwe": "CWE-200",
           "rule_id": "TAINT-AI-002"
+        },
+        {
+          "call": "redirect",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "Flask redirect() to a request-derived value"
+        },
+        {
+          "call": "HttpResponseRedirect",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "Django redirect to a request-derived value"
         }
       ],
       "sanitizers": [
@@ -819,6 +833,13 @@
           "vuln_class": "prompt_injection",
           "cwe": "CWE-200",
           "rule_id": "TAINT-AI-002"
+        },
+        {
+          "call": "res.redirect",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "Express redirect to a request-derived value"
         }
       ],
       "sanitizers": [
@@ -1153,6 +1174,13 @@
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
           "note": "the html/template auto-escape bypass; distinct from safe html/template interpolation, which is not a sink"
+        },
+        {
+          "call": "http.Redirect",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "the redirect target is taken from the request; an absolute attacker-controlled URL sends the user off-site"
         }
       ],
       "sanitizers": [
@@ -1530,6 +1558,13 @@
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
           "note": "render inline:/text: builds an unescaped ERB template body from tainted data (SSTI/XSS); render plain:/json:/:template are auto-escaped and safe. Synthetic callee emitted by the Ruby recognizer only for the inline:/interpolated-text: keyword form."
+        },
+        {
+          "call": "redirect_to",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "Rails redirect_to a request-derived value"
         }
       ],
       "sanitizers": [
@@ -1621,7 +1656,7 @@
       ]
     },
     "php": {
-      "comment": "PHP source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_php.go). Superglobals ($_GET/$_POST/…) are ARRAY-INDEX source reads, captured as bare chains with the leading `$` stripped (so `$_GET['x']` reads source `_GET`). Method calls on a value ($pdo->query, $mysqli->query) are normalized to a dotted chain (pdo.query, mysqli.query) so the engine's suffixKeys fallback matches the method suffix regardless of the receiver variable name. Rule IDs mirror the shared TAINT-00x space.",
+      "comment": "PHP source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_php.go). Superglobals ($_GET/$_POST/\u2026) are ARRAY-INDEX source reads, captured as bare chains with the leading `$` stripped (so `$_GET['x']` reads source `_GET`). Method calls on a value ($pdo->query, $mysqli->query) are normalized to a dotted chain (pdo.query, mysqli.query) so the engine's suffixKeys fallback matches the method suffix regardless of the receiver variable name. Rule IDs mirror the shared TAINT-00x space.",
       "sources": [
         {
           "call": "_GET",
@@ -1814,6 +1849,13 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005"
+        },
+        {
+          "call": "header",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "Location: header built from request input"
         }
       ],
       "sanitizers": [
@@ -1906,7 +1948,7 @@
       ]
     },
     "java": {
-      "comment": "Java source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes, matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (Files.readAllBytes, ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .println, .exec, .start). Method-suffix matching is imprecise on purpose: it is AST-only, so a .executeQuery on a non-JDBC object still matches. This is the same precision trade documented for Go's method sinks; the corpus README records the resulting honest FNs (chained fluent calls the flat recognizer cannot follow). See core/taint/engine/extract_java.go.",
+      "comment": "Java source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes, matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (Files.readAllBytes, ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .println, .exec, .start). Method-suffix matching is imprecise on purpose: it is AST-only, so a .executeQuery on a non-JDBC object still matches. This is the same precision trade documented for Go's method sinks; the corpus README records the resulting honest FNs (chained fluent calls the flat recognizer cannot follow). See core/taint/engine/extract_java.go.",
       "sources": [
         {
           "call": "request.getParameter",
@@ -1971,7 +2013,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command — matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
+          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command \u2014 matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
         },
         {
           "call": "ProcessBuilder",
@@ -1985,7 +2027,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation"
+          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation"
         },
         {
           "call": "executeUpdate",
@@ -1998,7 +2040,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) — matched on the method suffix"
+          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
         },
         {
           "call": "createQuery",
@@ -2012,7 +2054,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) opens a file named by input — matched on the File constructor name"
+          "note": "new File(path) opens a file named by input \u2014 matched on the File constructor name"
         },
         {
           "call": "Files.readAllBytes",
@@ -2044,14 +2086,14 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openConnection() — matched on the method suffix"
+          "note": "new URL(u).openConnection() \u2014 matched on the method suffix"
         },
         {
           "call": "ObjectInputStream.readObject",
@@ -2065,7 +2107,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "ObjectInputStream.readObject() — matched on the method suffix"
+          "note": "ObjectInputStream.readObject() \u2014 matched on the method suffix"
         },
         {
           "call": "ScriptEngine.eval",
@@ -2079,14 +2121,14 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "ScriptEngine.eval(script) — matched on the method suffix"
+          "note": "ScriptEngine.eval(script) \u2014 matched on the method suffix"
         },
         {
           "call": "println",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response.getWriter().println(taintedHtml) reflects unescaped input — reflected XSS"
+          "note": "response.getWriter().println(taintedHtml) reflects unescaped input \u2014 reflected XSS"
         },
         {
           "call": "print",
@@ -2099,7 +2141,14 @@
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .write(taintedHtml) — reflected XSS"
+          "note": "response writer .write(taintedHtml) \u2014 reflected XSS"
+        },
+        {
+          "call": "sendRedirect",
+          "vuln_class": "open_redirect",
+          "cwe": "CWE-601",
+          "rule_id": "TAINT-007",
+          "note": "HttpServletResponse.sendRedirect to a request-derived value"
         }
       ],
       "sanitizers": [
@@ -2147,7 +2196,7 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Encoder.forHtml — matched on the method suffix"
+          "note": "OWASP Encoder.forHtml \u2014 matched on the method suffix"
         },
         {
           "call": "FilenameUtils.getName",
@@ -2166,7 +2215,7 @@
       ]
     },
     "rust": {
-      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser — only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps. The web-extractor sources (`web.Query`/`web.Form`/`web.Json`/`web.Path` for actix, bare `Query`/`Form`/`Json`/`Path` for axum) are matched not only as constructor calls but also as PARAMETER TYPES: extract_rust.go seeds a function parameter whose type is one of these extractors as tainted-on-entry (via a synthetic `binding = <source>()` statement), because a `web::Query<Params>` handler argument is untrusted input even though it never appears as a source call.",
+      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser \u2014 only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps. The web-extractor sources (`web.Query`/`web.Form`/`web.Json`/`web.Path` for actix, bare `Query`/`Form`/`Json`/`Path` for axum) are matched not only as constructor calls but also as PARAMETER TYPES: extract_rust.go seeds a function parameter whose type is one of these extractors as tainted-on-entry (via a synthetic `binding = <source>()` statement), because a `web::Query<Params>` handler argument is untrusted input even though it never appears as a source call.",
       "sources": [
         {
           "call": "env.args",
@@ -2254,7 +2303,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Command::new(\"sh\").arg(\"-c\").arg(user) — the tainted value flows through .arg into the shell"
+          "note": "Command::new(\"sh\").arg(\"-c\").arg(user) \u2014 the tainted value flows through .arg into the shell"
         },
         {
           "call": "args",
@@ -2386,7 +2435,7 @@
           "neutralizes": [
             "sql_injection"
           ],
-          "note": "sqlx bind parameters ($1/?) — the value is passed to the driver as data, never concatenated into SQL"
+          "note": "sqlx bind parameters ($1/?) \u2014 the value is passed to the driver as data, never concatenated into SQL"
         },
         {
           "call": "file_name",
@@ -2431,7 +2480,7 @@
             "code_injection",
             "ssrf"
           ],
-          "note": "str::parse::<i64>() etc. — numeric/typed coercion removes injection metacharacters"
+          "note": "str::parse::<i64>() etc. \u2014 numeric/typed coercion removes injection metacharacters"
         }
       ]
     },
@@ -2675,7 +2724,7 @@
       ]
     },
     "cpp": {
-      "comment": "C/C++ taint model: INJECTION-CLASS dataflow only (command injection, path traversal, format string, SSRF, SQLi). Memory-safety bugs (buffer overflow strcpy/strcat/sprintf/gets -> CWE-120/787, use-after-free, OOB) are a DIFFERENT analysis than source->sink taint and are OUT OF SCOPE for this engine — see testdata/precision-suite-cpp/README.md. Call keys are the short/bare form; the extractor normalizes C++ `::` to `.` and the engine suffix-matches, so `system` matches `std::system` and `getenv` matches `std::getenv`.",
+      "comment": "C/C++ taint model: INJECTION-CLASS dataflow only (command injection, path traversal, format string, SSRF, SQLi). Memory-safety bugs (buffer overflow strcpy/strcat/sprintf/gets -> CWE-120/787, use-after-free, OOB) are a DIFFERENT analysis than source->sink taint and are OUT OF SCOPE for this engine \u2014 see testdata/precision-suite-cpp/README.md. Call keys are the short/bare form; the extractor normalizes C++ `::` to `.` and the engine suffix-matches, so `system` matches `std::system` and `getenv` matches `std::getenv`.",
       "sources": [
         {
           "call": "getenv",
@@ -2844,7 +2893,7 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-134",
           "rule_id": "TAINT-005",
-          "note": "FORMAT-STRING (CWE-134): mapped to the TAINT-005 code-injection rule id (no dedicated CWE-134 class). The vuln is a TAINTED FORMAT argument — printf(user) — which the engine gates on FirstArgTainted; printf(\"%s\", user) with a fixed format is SAFE and does not fire"
+          "note": "FORMAT-STRING (CWE-134): mapped to the TAINT-005 code-injection rule id (no dedicated CWE-134 class). The vuln is a TAINTED FORMAT argument \u2014 printf(user) \u2014 which the engine gates on FirstArgTainted; printf(\"%s\", user) with a fixed format is SAFE and does not fire"
         },
         {
           "call": "vprintf",
@@ -2884,7 +2933,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "curl_easy_setopt(h, CURLOPT_URL, tainted) fetches an attacker-controlled URL — SSRF; validate the host against an allow-list first"
+          "note": "curl_easy_setopt(h, CURLOPT_URL, tainted) fetches an attacker-controlled URL \u2014 SSRF; validate the host against an allow-list first"
         }
       ],
       "sanitizers": [
@@ -2990,7 +3039,7 @@
       ]
     },
     "scala": {
-      "comment": "Scala source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/object-qualified calls matched on the full dotted chain (Files.readAllBytes, Source.fromFile), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .execute, .openStream, .exec). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (fluent iterator chains and the postfix `.!` process operator the flat recognizer cannot follow). The Slick `sql\"...\"` and Anorm `SQL(\"...\")` string interpolators are recognized as calls named `sql`/`SQL`. See core/taint/engine/extract_scala.go.",
+      "comment": "Scala source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/object-qualified calls matched on the full dotted chain (Files.readAllBytes, Source.fromFile), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .execute, .openStream, .exec). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (fluent iterator chains and the postfix `.!` process operator the flat recognizer cannot follow). The Slick `sql\"...\"` and Anorm `SQL(\"...\")` string interpolators are recognized as calls named `sql`/`SQL`. See core/taint/engine/extract_scala.go.",
       "sources": [
         {
           "call": "request.getQueryString",
@@ -3007,12 +3056,12 @@
         {
           "call": "getQueryString",
           "kind": "http_query",
-          "note": "Play request.getQueryString(\"id\") — matched on the method suffix"
+          "note": "Play request.getQueryString(\"id\") \u2014 matched on the method suffix"
         },
         {
           "call": "queryString",
           "kind": "http_query",
-          "note": "Play request.queryString attribute — matched on the suffix"
+          "note": "Play request.queryString attribute \u2014 matched on the suffix"
         },
         {
           "call": "params",
@@ -3044,7 +3093,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) — matched on the .exec method suffix"
+          "note": "Runtime.getRuntime().exec(cmd) \u2014 matched on the .exec method suffix"
         },
         {
           "call": ".!",
@@ -3058,7 +3107,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation/interpolation"
+          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation/interpolation"
         },
         {
           "call": "executeUpdate",
@@ -3071,7 +3120,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) — matched on the method suffix"
+          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
         },
         {
           "call": "sql",
@@ -3099,14 +3148,14 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "Source.fromFile — matched on the method suffix"
+          "note": "Source.fromFile \u2014 matched on the method suffix"
         },
         {
           "call": "File",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) / File(path) opens a file named by input — matched on the File constructor name"
+          "note": "new File(path) / File(path) opens a file named by input \u2014 matched on the File constructor name"
         },
         {
           "call": "Files.readAllBytes",
@@ -3119,7 +3168,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "Files.readAllBytes(Paths.get(path)) — matched on the method suffix"
+          "note": "Files.readAllBytes(Paths.get(path)) \u2014 matched on the method suffix"
         },
         {
           "call": "Files.readAllLines",
@@ -3132,7 +3181,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is not catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is not catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "fromURL",
@@ -3152,14 +3201,14 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "new ObjectInputStream(bytesFromInput) over attacker-controlled bytes primes a native-serialization RCE; the tainted bytes enter at construction, which is where this is keyed. The trailing .readObject() takes no tainted argument (its receiver is the stream, not the bytes), so keying on the constructor — not the read method — reports the flow exactly once per site and avoids double-counting `new ObjectInputStream(blob).readObject()`."
+          "note": "new ObjectInputStream(bytesFromInput) over attacker-controlled bytes primes a native-serialization RCE; the tainted bytes enter at construction, which is where this is keyed. The trailing .readObject() takes no tainted argument (its receiver is the stream, not the bytes), so keying on the constructor \u2014 not the read method \u2014 reports the flow exactly once per site and avoids double-counting `new ObjectInputStream(blob).readObject()`."
         },
         {
           "call": "Html",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "play.twirl.api.Html(taintedHtml) marks a tainted string as trusted HTML, bypassing Twirl auto-escaping — reflected XSS. Safe when the value is HTML-escaped first."
+          "note": "play.twirl.api.Html(taintedHtml) marks a tainted string as trusted HTML, bypassing Twirl auto-escaping \u2014 reflected XSS. Safe when the value is HTML-escaped first."
         },
         {
           "call": "Html.apply",
@@ -3225,7 +3274,7 @@
       ]
     },
     "kotlin": {
-      "comment": "Kotlin source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Kotlin runs on the JVM, so its dangerous APIs are the Java ones (Runtime.exec, JDBC executeQuery, java.io.File, URL.openStream, ObjectInputStream.readObject) plus the Android idioms (intent.getStringExtra source, SQLiteDatabase.rawQuery sink). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .exec, .readText, .openStream, .rawQuery). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (scope-function/lambda chains the flat recognizer cannot follow). See core/taint/engine/extract_kotlin.go.",
+      "comment": "Kotlin source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Kotlin runs on the JVM, so its dangerous APIs are the Java ones (Runtime.exec, JDBC executeQuery, java.io.File, URL.openStream, ObjectInputStream.readObject) plus the Android idioms (intent.getStringExtra source, SQLiteDatabase.rawQuery sink). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .exec, .readText, .openStream, .rawQuery). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (scope-function/lambda chains the flat recognizer cannot follow). See core/taint/engine/extract_kotlin.go.",
       "sources": [
         {
           "call": "request.getParameter",
@@ -3302,7 +3351,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command — matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
+          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command \u2014 matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
         },
         {
           "call": "ProcessBuilder",
@@ -3316,7 +3365,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation or a template string with a $-interpolated value"
+          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation or a template string with a $-interpolated value"
         },
         {
           "call": "executeUpdate",
@@ -3329,7 +3378,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) — matched on the method suffix"
+          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
         },
         {
           "call": "rawQuery",
@@ -3343,7 +3392,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Android SQLiteDatabase.execSQL(sql) — matched on the method suffix"
+          "note": "Android SQLiteDatabase.execSQL(sql) \u2014 matched on the method suffix"
         },
         {
           "call": "createQuery",
@@ -3357,7 +3406,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path) opens a file named by input — matched on the File constructor name"
+          "note": "File(path) opens a file named by input \u2014 matched on the File constructor name"
         },
         {
           "call": "FileInputStream",
@@ -3371,14 +3420,14 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path).readText() reads a file named by tainted input — matched on the .readText method suffix"
+          "note": "File(path).readText() reads a file named by tainted input \u2014 matched on the .readText method suffix"
         },
         {
           "call": "readBytes",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path).readBytes() — matched on the method suffix"
+          "note": "File(path).readBytes() \u2014 matched on the method suffix"
         },
         {
           "call": "readLines",
@@ -3397,14 +3446,14 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "URL(u).openConnection() — matched on the method suffix"
+          "note": "URL(u).openConnection() \u2014 matched on the method suffix"
         },
         {
           "call": "ObjectInputStream.readObject",
@@ -3418,28 +3467,28 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "ObjectInputStream.readObject() — matched on the method suffix"
+          "note": "ObjectInputStream.readObject() \u2014 matched on the method suffix"
         },
         {
           "call": "write",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .write(taintedHtml) reflects unescaped input — reflected XSS"
+          "note": "response writer .write(taintedHtml) reflects unescaped input \u2014 reflected XSS"
         },
         {
           "call": "print",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response.getWriter().print(taintedHtml) — reflected XSS"
+          "note": "response.getWriter().print(taintedHtml) \u2014 reflected XSS"
         },
         {
           "call": "println",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .println(taintedHtml) — reflected XSS"
+          "note": "response writer .println(taintedHtml) \u2014 reflected XSS"
         }
       ],
       "sanitizers": [
@@ -3494,14 +3543,14 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "Apache Commons StringEscapeUtils.escapeHtml4 — matched on the method suffix"
+          "note": "Apache Commons StringEscapeUtils.escapeHtml4 \u2014 matched on the method suffix"
         },
         {
           "call": "forHtml",
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Encoder.forHtml — matched on the method suffix"
+          "note": "OWASP Encoder.forHtml \u2014 matched on the method suffix"
         },
         {
           "call": "htmlEscape",
@@ -3515,7 +3564,7 @@
           "neutralizes": [
             "path_traversal"
           ],
-          "note": "File(path).name returns the last path component only, stripping directory traversal — matched on the .name accessor when used call-shaped"
+          "note": "File(path).name returns the last path component only, stripping directory traversal \u2014 matched on the .name accessor when used call-shaped"
         },
         {
           "call": "getName",
@@ -3833,7 +3882,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "session.dataTask(with: tainted URL/request) — fetching an attacker-controlled URL is SSRF; folded from the with: label so it does not collide with unrelated .with(...) calls"
+          "note": "session.dataTask(with: tainted URL/request) \u2014 fetching an attacker-controlled URL is SSRF; folded from the with: label so it does not collide with unrelated .with(...) calls"
         },
         {
           "call": "dataTask",
@@ -3872,7 +3921,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "receiver-varies NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(tainted) — non-secure unarchiving of attacker bytes is an RCE vector; the secure NSSecureCoding form (unarchivedObject(ofClass:from:) requiring secure coding) is the safe path"
+          "note": "receiver-varies NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(tainted) \u2014 non-secure unarchiving of attacker bytes is an RCE vector; the secure NSSecureCoding form (unarchivedObject(ofClass:from:) requiring secure coding) is the safe path"
         },
         {
           "call": "unarchiveObject.with",
@@ -4216,7 +4265,7 @@
         {
           "call": "NSProcessInfo.environment",
           "kind": "environment",
-          "note": "[[NSProcessInfo processInfo] environment] shaped to the NSProcessInfo.environment attribute — the ObjC environment dictionary"
+          "note": "[[NSProcessInfo processInfo] environment] shaped to the NSProcessInfo.environment attribute \u2014 the ObjC environment dictionary"
         },
         {
           "call": "environment",
@@ -4231,7 +4280,7 @@
         {
           "call": "text",
           "kind": "http_body",
-          "note": "receiver-varies textField.text / textView.text — untrusted UI input"
+          "note": "receiver-varies textField.text / textView.text \u2014 untrusted UI input"
         },
         {
           "call": "objectForKey",
@@ -4241,12 +4290,12 @@
         {
           "call": "stringForKey",
           "kind": "user_input",
-          "note": "NSUserDefaults stringForKey: — user-controlled persisted value"
+          "note": "NSUserDefaults stringForKey: \u2014 user-controlled persisted value"
         },
         {
           "call": "valueForKey",
           "kind": "http_query",
-          "note": "receiver-varies request/params valueForKey: — request parameter access"
+          "note": "receiver-varies request/params valueForKey: \u2014 request parameter access"
         },
         {
           "call": "queryParameters",
@@ -4256,7 +4305,7 @@
         {
           "call": "HTTPBody",
           "kind": "http_body",
-          "note": "request.HTTPBody — the untrusted request body"
+          "note": "request.HTTPBody \u2014 the untrusted request body"
         }
       ],
       "sinks": [
@@ -4413,7 +4462,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "[NSURLSession dataTaskWithURL:tainted] fetches an attacker-controlled URL — SSRF; safe with a host allow-list"
+          "note": "[NSURLSession dataTaskWithURL:tainted] fetches an attacker-controlled URL \u2014 SSRF; safe with a host allow-list"
         },
         {
           "call": "dataTaskWithRequest",
@@ -4448,7 +4497,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "[NSKeyedUnarchiver unarchiveObjectWithData:tainted] does non-secure unarchiving of attacker bytes — an RCE vector; the secure NSSecureCoding form (unarchivedObjectOfClass:fromData:error: requiring secure coding) is the safe path"
+          "note": "[NSKeyedUnarchiver unarchiveObjectWithData:tainted] does non-secure unarchiving of attacker bytes \u2014 an RCE vector; the secure NSSecureCoding form (unarchivedObjectOfClass:fromData:error: requiring secure coding) is the safe path"
         },
         {
           "call": "unarchiveObjectWithFile",
@@ -4565,7 +4614,7 @@
       ]
     },
     "powershell": {
-      "comment": "PowerShell source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_powershell.go). PowerShell shapes are normalized before recognition: the `$` variable sigil is stripped (like PHP), the static-member `::` becomes `.` with the `[Namespace.Type]` accelerator unwrapped (so `[IO.File]::ReadAllText` keys as `IO.File.ReadAllText`, matched by the `.ReadAllText` suffix), a `[int]`/`[long]` cast becomes an `int(...)`/`long(...)` sanitizer call, the `$env:` provider becomes a bare `env` read, and — CRUCIALLY — a cmdlet's `Verb-Noun` hyphen is normalized to an UNDERSCORE (`Invoke-Expression` -> `Invoke_Expression`) because the shared identifier scanner treats `-` as an operator. Every hyphenated cmdlet key below therefore uses the underscore form. Paren-less cmdlet calls (`Get-Content $p`) are wrapped into `Get_Content($p)`, and the call operator `& $cmd` is modeled as the synthetic sink `InvokeOperator`. Rule IDs mirror the shared TAINT-00x space. PowerShell recall is moderate (pipelines, splatting, and paren-less pipeline arguments are only partially modeled) — see testdata/precision-suite-powershell/README.md.",
+      "comment": "PowerShell source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_powershell.go). PowerShell shapes are normalized before recognition: the `$` variable sigil is stripped (like PHP), the static-member `::` becomes `.` with the `[Namespace.Type]` accelerator unwrapped (so `[IO.File]::ReadAllText` keys as `IO.File.ReadAllText`, matched by the `.ReadAllText` suffix), a `[int]`/`[long]` cast becomes an `int(...)`/`long(...)` sanitizer call, the `$env:` provider becomes a bare `env` read, and \u2014 CRUCIALLY \u2014 a cmdlet's `Verb-Noun` hyphen is normalized to an UNDERSCORE (`Invoke-Expression` -> `Invoke_Expression`) because the shared identifier scanner treats `-` as an operator. Every hyphenated cmdlet key below therefore uses the underscore form. Paren-less cmdlet calls (`Get-Content $p`) are wrapped into `Get_Content($p)`, and the call operator `& $cmd` is modeled as the synthetic sink `InvokeOperator`. Rule IDs mirror the shared TAINT-00x space. PowerShell recall is moderate (pipelines, splatting, and paren-less pipeline arguments are only partially modeled) \u2014 see testdata/precision-suite-powershell/README.md.",
       "sources": [
         {
           "call": "args",
@@ -4612,7 +4661,7 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "Invoke-Expression (iex) evaluates a string as PowerShell code — the canonical PowerShell code-injection sink"
+          "note": "Invoke-Expression (iex) evaluates a string as PowerShell code \u2014 the canonical PowerShell code-injection sink"
         },
         {
           "call": "iex",
@@ -4688,7 +4737,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "[IO.File]::ReadAllText($p) shaped to IO.File.ReadAllText — matched on the .ReadAllText suffix"
+          "note": "[IO.File]::ReadAllText($p) shaped to IO.File.ReadAllText \u2014 matched on the .ReadAllText suffix"
         },
         {
           "call": "ReadAllBytes",
@@ -4792,7 +4841,7 @@
           "neutralizes": [
             "sql_injection"
           ],
-          "note": "receiver-varies $cmd.Parameters.AddWithValue(...) — matched on the method suffix"
+          "note": "receiver-varies $cmd.Parameters.AddWithValue(...) \u2014 matched on the method suffix"
         },
         {
           "call": "Split_Path",
@@ -5482,7 +5531,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "slurp of a tainted path reads an attacker-chosen file (slurp of a URL is SSRF instead — an ambiguity the recognizer cannot resolve; documented FN)"
+          "note": "slurp of a tainted path reads an attacker-chosen file (slurp of a URL is SSRF instead \u2014 an ambiguity the recognizer cannot resolve; documented FN)"
         },
         {
           "call": "clojure.java.io/reader",
@@ -5507,7 +5556,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "clj-http fetches a tainted URL — SSRF regardless of validation"
+          "note": "clj-http fetches a tainted URL \u2014 SSRF regardless of validation"
         },
         {
           "call": "client/get",
@@ -5619,14 +5668,14 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "\"cmd\".execute() runs an external command via the String.execute() extension — matched on the .execute method suffix; the idiomatic Groovy shell-out."
+          "note": "\"cmd\".execute() runs an external command via the String.execute() extension \u2014 matched on the .execute method suffix; the idiomatic Groovy shell-out."
         },
         {
           "call": "exec",
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) — matched on the .exec method suffix."
+          "note": "Runtime.getRuntime().exec(cmd) \u2014 matched on the .exec method suffix."
         },
         {
           "call": "ProcessBuilder",
@@ -5654,14 +5703,14 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "groovy.util.Eval.me(script) evaluates arbitrary Groovy — RCE with a tainted script."
+          "note": "groovy.util.Eval.me(script) evaluates arbitrary Groovy \u2014 RCE with a tainted script."
         },
         {
           "call": "evaluate",
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "GroovyShell.evaluate(script) / script.evaluate(...) executes a tainted Groovy string — matched on the .evaluate method suffix."
+          "note": "GroovyShell.evaluate(script) / script.evaluate(...) executes a tainted Groovy string \u2014 matched on the .evaluate method suffix."
         },
         {
           "call": "GroovyShell.evaluate",
@@ -5675,7 +5724,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "groovy.sql.Sql.rows(query) — safe only when the query is a constant or a parameterized GString/placeholder, not a tainted concatenation. Matched on the .rows suffix."
+          "note": "groovy.sql.Sql.rows(query) \u2014 safe only when the query is a constant or a parameterized GString/placeholder, not a tainted concatenation. Matched on the .rows suffix."
         },
         {
           "call": "executeQuery",
@@ -5689,35 +5738,35 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Sql.firstRow(query) — matched on the .firstRow suffix."
+          "note": "Sql.firstRow(query) \u2014 matched on the .firstRow suffix."
         },
         {
           "call": "eachRow",
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Sql.eachRow(query){...} — matched on the .eachRow suffix."
+          "note": "Sql.eachRow(query){...} \u2014 matched on the .eachRow suffix."
         },
         {
           "call": "File",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) opens a file named by input — matched on the File constructor name."
+          "note": "new File(path) opens a file named by input \u2014 matched on the File constructor name."
         },
         {
           "call": "readLines",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path).readLines() reads an attacker-named file — matched on the .readLines suffix."
+          "note": "new File(path).readLines() reads an attacker-named file \u2014 matched on the .readLines suffix."
         },
         {
           "call": "getText",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path).getText() / file.text reads an attacker-named file — matched on the .getText suffix."
+          "note": "new File(path).getText() / file.text reads an attacker-named file \u2014 matched on the .getText suffix."
         },
         {
           "call": "FileInputStream",
@@ -5731,21 +5780,21 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() / url.text fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor is not catalogued (constructing a URL performs no request); keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() / url.text fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor is not catalogued (constructing a URL performs no request); keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openConnection() — matched on the method suffix."
+          "note": "new URL(u).openConnection() \u2014 matched on the method suffix."
         },
         {
           "call": "toURL",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "u.toURL().text / u.toURL().openStream() fetches a tainted URL — matched on the .toURL suffix."
+          "note": "u.toURL().text / u.toURL().openStream() fetches a tainted URL \u2014 matched on the .toURL suffix."
         }
       ],
       "sanitizers": [
@@ -5797,7 +5846,7 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Java Encoder.forHtml — matched on the method suffix."
+          "note": "OWASP Java Encoder.forHtml \u2014 matched on the method suffix."
         },
         {
           "call": "getName",


### PR DESCRIPTION
Adds `VulnOpenRedirect` and sinks for **Go** (`http.Redirect`), **Python** (Flask `redirect`, Django `HttpResponseRedirect`), **JavaScript** (`res.redirect`), **Java** (`sendRedirect`), **PHP** (`header`) and **Ruby** (`redirect_to`).

## An upgrade, not a port

This is the second half of retiring `nox-plugin-sast`. That plugin's `SAST-008` matched redirects with a regex:

```
res\.redirect\([^)]*req\.
```

which fires on the *shape* of the code regardless of whether untrusted input actually reaches the call. As a **taint sink** it only fires when it does.

**Verified on real code:**

| handler | result |
|---|---|
| redirects to `r.URL.Query().Get("next")` | **TAINT-007** ✅ |
| redirects to constant `"/dashboard"` | silent ✅ |

The regex version couldn't tell those apart.

## Retiring the plugin

`CRYPTO-001` (#242) covered weak crypto, the other additive rule. The remaining **seven** SAST rules duplicate classes core's taint engine already detects — SQLi, XSS, path traversal, command injection, deserialization, SSRF, SSTI — under a second rule-ID namespace, so the plugin reported the same vulnerability twice. It can now be retired without losing coverage.

## Verification

`go build`, `go vet`, all test packages, `golangci-lint` 0 issues, and the SAST precision gate. Catalogue tests assert the class, CWE and rule ID across all six languages.