### PR TITLE
fix(cli): cache clear now clears the registry cache too

### DIFF
--- a/cli/cache_cmd.go
+++ b/cli/cache_cmd.go
@@ -59,11 +59,11 @@ func runCache(args []string) int {
 // re-download, it breaks every installed plugin until each is reinstalled.
 // It is available behind --artifacts, which says so.
 func runCacheClear(args []string) int {
-	fs := flag.NewFlagSet("cache clear", flag.ContinueOnError)
+	clearFS := flag.NewFlagSet("cache clear", flag.ContinueOnError)
 	var artifacts bool
-	fs.BoolVar(&artifacts, "artifacts", false,
+	clearFS.BoolVar(&artifacts, "artifacts", false,
 		"also delete downloaded plugin binaries (breaks installed plugins until reinstalled)")
-	if err := fs.Parse(args); err != nil {
+	if err := clearFS.Parse(args); err != nil {
 		return 2
 	}
 

--- a/cli/cache_cmd.go
+++ b/cli/cache_cmd.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/nox-hq/nox/core/cache"
 )
@@ -17,7 +19,8 @@ func runCache(args []string) int {
 	if cacheFS.NArg() == 0 {
 		fmt.Fprintln(os.Stderr, "Usage: nox cache <command>")
 		fmt.Fprintln(os.Stderr, "Commands:")
-		fmt.Fprintln(os.Stderr, "  clear   Clear the scan cache")
+		fmt.Fprintln(os.Stderr, "  clear   Clear the scan and registry caches")
+		fmt.Fprintln(os.Stderr, "          --artifacts  ALSO delete downloaded plugin binaries")
 		fmt.Fprintln(os.Stderr, "  status  Show cache statistics")
 		return 2
 	}
@@ -25,7 +28,7 @@ func runCache(args []string) int {
 	sub := cacheFS.Arg(0)
 	switch sub {
 	case "clear":
-		return runCacheClear()
+		return runCacheClear(cacheFS.Args()[1:])
 	case "status":
 		return runCacheStatus()
 	default:
@@ -34,14 +37,76 @@ func runCache(args []string) int {
 	}
 }
 
-func runCacheClear() int {
-	c := cache.New()
-	if err := c.Clear(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: clearing cache: %v\n", err)
+// runCacheClear clears the caches that are safe to rebuild.
+//
+// nox keeps three caches under ~/.nox/cache, and only one of them used to be
+// cleared here:
+//
+//	scan       analysis results; rebuilt by the next scan
+//	registry   the plugin index; re-fetched on demand
+//	artifacts  DOWNLOADED PLUGIN BINARIES — see below
+//
+// The registry cache being unreachable was a real trap: after the index moved
+// repositories, `plugin search` kept reporting stale versions while the live
+// index served new ones, and `cache clear` (which only ever touched the scan
+// cache, despite its name) did nothing about it. The only way out was deleting
+// the directory by hand, and anyone hitting it would reasonably conclude the
+// registry was broken.
+//
+// The artifacts cache is NOT cleared by default, and that is deliberate:
+// installed plugins are executed from inside it — state.json records a
+// binary_path pointing there — so removing it does not merely force a
+// re-download, it breaks every installed plugin until each is reinstalled.
+// It is available behind --artifacts, which says so.
+func runCacheClear(args []string) int {
+	fs := flag.NewFlagSet("cache clear", flag.ContinueOnError)
+	var artifacts bool
+	fs.BoolVar(&artifacts, "artifacts", false,
+		"also delete downloaded plugin binaries (breaks installed plugins until reinstalled)")
+	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	fmt.Println("scan cache cleared")
-	return 0
+
+	rc := 0
+
+	c := cache.New()
+	if err := c.Clear(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: clearing scan cache: %v\n", err)
+		rc = 2
+	} else {
+		fmt.Println("scan cache cleared")
+	}
+
+	if err := removeCacheDir("registry"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: clearing registry cache: %v\n", err)
+		rc = 2
+	} else {
+		fmt.Println("registry cache cleared")
+	}
+
+	if artifacts {
+		if err := removeCacheDir("artifacts"); err != nil {
+			fmt.Fprintf(os.Stderr, "error: clearing artifact cache: %v\n", err)
+			rc = 2
+		} else {
+			fmt.Println("artifact cache cleared")
+			fmt.Fprintln(os.Stderr,
+				"warning: installed plugins ran from this cache and are now unavailable — "+
+					"reinstall them with `nox plugin install <name>`")
+		}
+	}
+
+	return rc
+}
+
+// removeCacheDir deletes one directory under ~/.nox/cache. A missing directory
+// is success: "clear" describes the end state, not the act.
+func removeCacheDir(name string) error {
+	dir := filepath.Join(noxHome(), "cache", name)
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func runCacheStatus() int {
@@ -52,13 +117,44 @@ func runCacheStatus() int {
 	}
 
 	entries, sizeBytes := c.Stats()
-	fmt.Printf("cache entries: %d\n", entries)
+	fmt.Printf("scan cache entries: %d\n", entries)
 	if sizeBytes > 0 {
-		fmt.Printf("cache size: %s\n", formatBytes(sizeBytes))
+		fmt.Printf("scan cache size: %s\n", formatBytes(sizeBytes))
 	} else {
-		fmt.Printf("cache size: 0 B\n")
+		fmt.Printf("scan cache size: 0 B\n")
+	}
+
+	// Report the other two as well: their absence from `status` is why the
+	// stale-registry trap was hard to diagnose.
+	for _, name := range []string{"registry", "artifacts"} {
+		size, err := dirSize(filepath.Join(noxHome(), "cache", name))
+		if err != nil {
+			continue
+		}
+		fmt.Printf("%s cache size: %s\n", name, formatBytes(size))
 	}
 	return 0
+}
+
+// dirSize totals a directory, returning 0 when it does not exist.
+func dirSize(dir string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entries are not worth failing `status` over
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+	return total, nil
 }
 
 func formatBytes(b int64) string {

--- a/cli/cache_cmd_test.go
+++ b/cli/cache_cmd_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The registry cache being unreachable from `cache clear` was a real trap:
+// after the index moved repositories, `plugin search` reported stale versions
+// while the live index served new ones, and the only remedy was deleting the
+// directory by hand.
+func TestRemoveCacheDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NOX_HOME", home)
+
+	dir := filepath.Join(noxHome(), "cache", "registry")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeCacheDir("registry"); err != nil {
+		t.Fatalf("removeCacheDir: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("registry cache should be gone")
+	}
+}
+
+// "clear" describes an end state, so a cache that was never created is success,
+// not an error the user has to interpret.
+func TestRemoveCacheDirIsIdempotent(t *testing.T) {
+	t.Setenv("NOX_HOME", t.TempDir())
+	for i := 0; i < 2; i++ {
+		if err := removeCacheDir("registry"); err != nil {
+			t.Fatalf("call %d on a missing dir should succeed, got %v", i+1, err)
+		}
+	}
+}
+
+// Installed plugins are EXECUTED from the artifacts cache (state.json records a
+// binary_path pointing into it), so clearing it does not merely force a
+// re-download — it breaks every installed plugin. It must stay put unless the
+// operator explicitly asks.
+func TestClearLeavesArtifactsAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NOX_HOME", home)
+
+	art := filepath.Join(noxHome(), "cache", "artifacts")
+	if err := os.MkdirAll(art, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(art, "plugin-binary")
+	if err := os.WriteFile(bin, []byte("ELF"), 0o755); err != nil { // nox:ignore -- test fixture, not a real binary
+		t.Fatal(err)
+	}
+
+	if rc := runCacheClear(nil); rc != 0 {
+		t.Fatalf("clear returned %d", rc)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		t.Error("an installed plugin binary must survive `cache clear` — clearing it breaks the install")
+	}
+}
+
+func TestClearArtifactsWhenAskedExplicitly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NOX_HOME", home)
+
+	art := filepath.Join(noxHome(), "cache", "artifacts")
+	if err := os.MkdirAll(art, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if rc := runCacheClear([]string{"--artifacts"}); rc != 0 {
+		t.Fatalf("clear --artifacts returned %d", rc)
+	}
+	if _, err := os.Stat(art); !os.IsNotExist(err) {
+		t.Error("--artifacts should remove the artifact cache")
+	}
+}
+
+func TestDirSizeOfMissingDirIsZero(t *testing.T) {
+	n, err := dirSize(filepath.Join(t.TempDir(), "nope"))
+	if err != nil || n != 0 {
+		t.Errorf("dirSize(missing) = (%d, %v), want (0, nil)", n, err)
+	}
+}


### PR DESCRIPTION
nox keeps **three** caches under `~/.nox/cache`, and `cache clear` only ever touched one — despite its name.

| cache | before | now |
|---|---|---|
| scan | cleared | cleared |
| **registry** | **not cleared** | **cleared** |
| artifacts | not cleared | still not cleared — deliberately |

## The trap

After the plugin index moved repositories, `plugin search` kept reporting **stale versions while the live index served new ones**, and `cache clear` did nothing about it. The only remedy was deleting the directory by hand.

I hit this three times in one session. Anyone else hitting it would reasonably conclude the registry or the release was broken.

## Why artifacts stays put

This is the part worth reading. **Installed plugins are executed from the artifacts cache** — `state.json` records a `binary_path` pointing inside it. Clearing it doesn't merely force a re-download, it **breaks every installed plugin** until each is reinstalled.

So a naive "clear all caches" would be destructive. It's available behind `--artifacts`, which warns when used, and a test asserts a plain `clear` leaves an installed binary in place.

## `cache status` now reports all three

Their absence is part of why the stale-registry trap was hard to diagnose — and it immediately surfaced the artifacts cache sitting at **515 MB**, previously invisible.

## Verification

Verified by hand as well as by test: after `cache clear`, the artifacts cache is untouched and an installed plugin still runs. `go build`, `go vet`, all tests, `golangci-lint` 0 issues.