### PR TITLE
fix(deps): make Go dependency scanning actually work (versions, severity, reachability)

### DIFF
--- a/core/analyzers/deps/container_test.go
+++ b/core/analyzers/deps/container_test.go
@@ -671,11 +671,11 @@ services:
 func TestScanArtifacts_MixedLockfileAndDockerfile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Write a go.sum lockfile.
-	goSumContent := []byte("golang.org/x/text v0.3.7 h1:abc=\ngolang.org/x/text v0.3.7/go.mod h1:def=\n")
-	goSumPath := filepath.Join(tmpDir, "go.sum")
-	if err := os.WriteFile(goSumPath, goSumContent, 0o644); err != nil {
-		t.Fatalf("writing go.sum: %v", err)
+	// Write a go.mod lockfile (Go deps resolve from go.mod, not go.sum).
+	goModContent := []byte("module example.com/p\n\ngo 1.24\n\nrequire golang.org/x/text v0.3.7\n")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+	if err := os.WriteFile(goModPath, goModContent, 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
 	}
 
 	// Write a Dockerfile.
@@ -689,10 +689,10 @@ RUN go build -o app
 
 	artifacts := []discovery.Artifact{
 		{
-			Path:    "go.sum",
-			AbsPath: goSumPath,
+			Path:    "go.mod",
+			AbsPath: goModPath,
 			Type:    discovery.Lockfile,
-			Size:    int64(len(goSumContent)),
+			Size:    int64(len(goModContent)),
 		},
 		{
 			Path:    "Dockerfile",

--- a/core/analyzers/deps/cvss.go
+++ b/core/analyzers/deps/cvss.go
@@ -1,0 +1,109 @@
+package deps
+
+import (
+	"math"
+	"strings"
+)
+
+// cvssV3BaseScore computes the CVSS v3.0/v3.1 base score from a vector string.
+//
+// OSV publishes severity as vector strings ("CVSS:3.1/AV:N/AC:L/...") rather
+// than numeric scores, so a scanner that only parses floats sees no severity at
+// all and falls back to a default. The base score is fully determined by the
+// vector, so it can be computed offline — no lookup required.
+//
+// Implements the formulas in the CVSS v3.1 specification, section 8.1:
+// https://www.first.org/cvss/v3.1/specification-document
+func cvssV3BaseScore(vector string) (float64, bool) {
+	if !strings.HasPrefix(vector, "CVSS:3.") {
+		return 0, false
+	}
+
+	metrics := make(map[string]string)
+	for _, part := range strings.Split(vector, "/")[1:] {
+		k, v, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		metrics[k] = v
+	}
+
+	scopeChanged := metrics["S"] == "C"
+
+	av, ok := lookupCVSS(metrics, "AV", map[string]float64{"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2})
+	if !ok {
+		return 0, false
+	}
+	ac, ok := lookupCVSS(metrics, "AC", map[string]float64{"L": 0.77, "H": 0.44})
+	if !ok {
+		return 0, false
+	}
+	// Privileges Required is weighted differently when scope changes.
+	prWeights := map[string]float64{"N": 0.85, "L": 0.62, "H": 0.27}
+	if scopeChanged {
+		prWeights = map[string]float64{"N": 0.85, "L": 0.68, "H": 0.50}
+	}
+	pr, ok := lookupCVSS(metrics, "PR", prWeights)
+	if !ok {
+		return 0, false
+	}
+	ui, ok := lookupCVSS(metrics, "UI", map[string]float64{"N": 0.85, "R": 0.62})
+	if !ok {
+		return 0, false
+	}
+
+	cia := map[string]float64{"H": 0.56, "L": 0.22, "N": 0}
+	c, ok := lookupCVSS(metrics, "C", cia)
+	if !ok {
+		return 0, false
+	}
+	i, ok := lookupCVSS(metrics, "I", cia)
+	if !ok {
+		return 0, false
+	}
+	a, ok := lookupCVSS(metrics, "A", cia)
+	if !ok {
+		return 0, false
+	}
+
+	iss := 1 - ((1 - c) * (1 - i) * (1 - a))
+
+	var impact float64
+	if scopeChanged {
+		impact = 7.52*(iss-0.029) - 3.25*math.Pow(iss-0.02, 15)
+	} else {
+		impact = 6.42 * iss
+	}
+	if impact <= 0 {
+		return 0, true
+	}
+
+	exploitability := 8.22 * av * ac * pr * ui
+
+	score := impact + exploitability
+	if scopeChanged {
+		score = 1.08 * score
+	}
+	return cvssRoundUp(math.Min(score, 10)), true
+}
+
+// lookupCVSS resolves one metric to its numeric weight.
+func lookupCVSS(metrics map[string]string, key string, weights map[string]float64) (float64, bool) {
+	v, present := metrics[key]
+	if !present {
+		return 0, false
+	}
+	w, known := weights[v]
+	return w, known
+}
+
+// cvssRoundUp rounds up to one decimal place using the integer arithmetic the
+// CVSS v3.1 spec mandates (appendix A) — plain math.Ceil on a float misrounds
+// values that are only imprecise through binary representation.
+func cvssRoundUp(x float64) float64 {
+	i := int(math.Round(x * 100000))
+	if i%10000 == 0 {
+		return float64(i) / 100000.0
+	}
+	return (math.Floor(float64(i)/10000) + 1) / 10.0
+}

--- a/core/analyzers/deps/cvss_test.go
+++ b/core/analyzers/deps/cvss_test.go
@@ -1,0 +1,67 @@
+package deps
+
+import (
+	"math"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Base scores below are the published values for these vectors, per the
+// CVSS v3.1 specification (https://www.first.org/cvss/v3.1/specification-document).
+func TestCVSSV3BaseScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		vector string
+		want   float64
+	}{
+		{"critical RCE", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+		{"scope changed", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 10.0},
+		{"local low impact", "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N", 1.8},
+		{"medium, scope unchanged", "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N", 5.4},
+		// Same vector with scope changed: exercises the 1.08 multiplier and the
+		// separate impact formula, which must lift 5.4 to 6.1.
+		{"medium, scope changed", "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1},
+		{"no impact scores zero", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", 0.0},
+		{"v3.0 prefix also supported", "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+	}
+	for _, tt := range tests {
+		got, ok := cvssV3BaseScore(tt.vector)
+		if !ok {
+			t.Errorf("%s: vector not parsed", tt.name)
+			continue
+		}
+		if math.Abs(got-tt.want) > 0.05 {
+			t.Errorf("%s: got %.1f, want %.1f", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestCVSSV3BaseScore_RejectsNonVectors(t *testing.T) {
+	for _, s := range []string{"", "9.8", "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P", "nonsense"} {
+		if _, ok := cvssV3BaseScore(s); ok {
+			t.Errorf("expected %q to be rejected as a v3 vector", s)
+		}
+	}
+}
+
+// OSV publishes CVSS as vector strings, not numeric scores. Before this was
+// handled, every vector fell through to the SeverityMedium default — so a
+// critical dependency CVE could never trip a high/critical gate.
+func TestCVSSToSeverity_HandlesVectorStrings(t *testing.T) {
+	tests := []struct {
+		score string
+		want  findings.Severity
+	}{
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", findings.SeverityCritical},
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N", findings.SeverityMedium},
+		{"CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N", findings.SeverityLow},
+		{"9.8", findings.SeverityCritical}, // plain floats still work
+		{"7.0", findings.SeverityHigh},
+	}
+	for _, tt := range tests {
+		if got := cvssToSeverity(tt.score); got != tt.want {
+			t.Errorf("cvssToSeverity(%q) = %v, want %v", tt.score, got, tt.want)
+		}
+	}
+}

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -292,6 +292,10 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	}
 	var sources []pkgSource
 
+	// Module root of the Go module under scan, used to enumerate the packages
+	// the build actually links so advisories can be scoped by import path.
+	var goModDir string
+
 	for _, art := range artifacts {
 		if art.Type != discovery.Lockfile {
 			continue
@@ -304,6 +308,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 		var pkgs []Package
 		if filepath.Base(art.AbsPath) == "go.mod" {
+			goModDir = filepath.Dir(art.AbsPath)
 			// Go needs both files: go.mod for the selected versions, go.sum to
 			// recover transitives that module graph pruning left unnamed. A
 			// missing or unreadable go.sum is fine — go.mod alone still resolves.
@@ -483,6 +488,18 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				return nil, nil, fmt.Errorf("querying OSV: %w", err)
 			}
 
+			// Enumerate the packages this build links, once, so Go advisories
+			// can be scoped to the import paths they actually affect. Best
+			// effort: when it cannot be determined, every finding is reported
+			// exactly as before.
+			var (
+				linkedGoPkgs  map[string]struct{}
+				linkedGoKnown bool
+			)
+			if goModDir != "" {
+				linkedGoPkgs, linkedGoKnown = goImportedPackages(ctx, goModDir)
+			}
+
 			for pkgIdx, osvVulns := range vulnMap {
 				pkg := pkgs[pkgIdx]
 				var domainVulns []Vulnerability
@@ -515,6 +532,26 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 						meta["remediation_action"] = "upgrade"
 						meta["remediation_command"] = upgradeCommand(pkg.Ecosystem, pkg.Name, fix)
 					}
+					// OSV scopes Go advisories to import paths. When the affected
+					// packages are provably not linked, the finding is recorded
+					// but demoted out of gating severity rather than dropped: a
+					// silent disappearance is indistinguishable from a scanner
+					// that simply missed it.
+					message := fmt.Sprintf("Known vulnerability %s in %s@%s: %s", ov.ID, pkg.Name, pkg.Version, ov.Summary)
+					if pkg.Ecosystem == "go" {
+						affected := goAffectedImports(&ov, pkg.Name)
+						if reachable, determined := goVulnReachable(affected, linkedGoPkgs, linkedGoKnown); determined {
+							meta["affected_imports"] = strings.Join(affected, ",")
+							if reachable {
+								meta["reachable"] = "true"
+							} else {
+								meta["reachable"] = "false"
+								sev = findings.SeverityInfo
+								message += " (not reachable: the affected package is not linked by this build)"
+							}
+						}
+					}
+
 					fs.Add(findings.Finding{
 						RuleID:     "VULN-001",
 						Severity:   sev,
@@ -523,7 +560,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 							FilePath:  lockfilePath,
 							StartLine: 1,
 						},
-						Message:  fmt.Sprintf("Known vulnerability %s in %s@%s: %s", ov.ID, pkg.Name, pkg.Version, ov.Summary),
+						Message:  message,
 						Metadata: meta,
 					})
 				}

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -250,7 +250,10 @@ func (a *Analyzer) Rules() *rules.RuleSet {
 // supportedLockfiles maps well-known lockfile basenames to their parser
 // functions.
 var supportedLockfiles = map[string]func([]byte) ([]Package, error){
-	"go.sum":             parseGoSum,
+	// Go resolves from go.mod, deliberately NOT go.sum: go.sum hashes the
+	// entire module graph, so it yields versions the build never selects
+	// (~99% false positives in practice). See parseGoMod.
+	"go.mod":             parseGoMod,
 	"package-lock.json":  parsePackageLockJSON,
 	"requirements.txt":   parseRequirementsTxt,
 	"Gemfile.lock":       parseGemfileLock,
@@ -299,7 +302,16 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			return nil, nil, fmt.Errorf("reading lockfile %s: %w", art.Path, err)
 		}
 
-		pkgs, err := a.ParseLockfile(art.AbsPath, content)
+		var pkgs []Package
+		if filepath.Base(art.AbsPath) == "go.mod" {
+			// Go needs both files: go.mod for the selected versions, go.sum to
+			// recover transitives that module graph pruning left unnamed. A
+			// missing or unreadable go.sum is fine — go.mod alone still resolves.
+			goSum, _ := os.ReadFile(filepath.Join(filepath.Dir(art.AbsPath), "go.sum"))
+			pkgs, err = resolveGoPackages(content, goSum)
+		} else {
+			pkgs, err = a.ParseLockfile(art.AbsPath, content)
+		}
 		if err != nil {
 			// Skip lockfiles we cannot parse (e.g. yarn.lock)
 			// rather than failing the entire scan.

--- a/core/analyzers/deps/deps_test.go
+++ b/core/analyzers/deps/deps_test.go
@@ -250,8 +250,8 @@ func TestParseLockfile_Dispatch(t *testing.T) {
 		ecosystem string
 	}{
 		{
-			filename:  "/project/go.sum",
-			content:   []byte("golang.org/x/text v0.3.7 h1:abc=\n"),
+			filename:  "/project/go.mod",
+			content:   []byte("module example.com/p\n\ngo 1.24\n\nrequire golang.org/x/text v0.3.7\n"),
 			ecosystem: "go",
 		},
 		{
@@ -364,11 +364,11 @@ func TestScanArtifacts(t *testing.T) {
 	// Create a temporary directory with lockfiles.
 	tmpDir := t.TempDir()
 
-	// Write a go.sum file.
-	goSumContent := []byte("golang.org/x/text v0.3.7 h1:abc=\ngolang.org/x/text v0.3.7/go.mod h1:def=\n")
-	goSumPath := filepath.Join(tmpDir, "go.sum")
-	if err := os.WriteFile(goSumPath, goSumContent, 0o644); err != nil {
-		t.Fatalf("writing go.sum: %v", err)
+	// Write a go.mod file (Go deps resolve from go.mod, not go.sum).
+	goModContent := []byte("module example.com/p\n\ngo 1.24\n\nrequire golang.org/x/text v0.3.7\n")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+	if err := os.WriteFile(goModPath, goModContent, 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
 	}
 
 	// Write a requirements.txt file.
@@ -380,10 +380,10 @@ func TestScanArtifacts(t *testing.T) {
 
 	artifacts := []discovery.Artifact{
 		{
-			Path:    "go.sum",
-			AbsPath: goSumPath,
+			Path:    "go.mod",
+			AbsPath: goModPath,
 			Type:    discovery.Lockfile,
-			Size:    int64(len(goSumContent)),
+			Size:    int64(len(goModContent)),
 		},
 		{
 			Path:    "requirements.txt",
@@ -405,7 +405,7 @@ func TestScanArtifacts(t *testing.T) {
 		t.Fatalf("ScanArtifacts returned error: %v", err)
 	}
 
-	// Should have 3 packages: 1 from go.sum (deduplicated) + 2 from requirements.txt.
+	// Should have 3 packages: 1 from go.mod + 2 from requirements.txt.
 	pkgs := inventory.Packages()
 	if len(pkgs) != 3 {
 		t.Fatalf("expected 3 packages, got %d: %+v", len(pkgs), pkgs)

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/nox-hq/nox/core/findings"
 )
@@ -60,11 +61,23 @@ type osvSeverity struct {
 }
 
 // osvAffected describes packages and version ranges affected by a vuln.
-// We only consume Package and Ranges — the broader OSV schema includes
-// many additional fields not yet used here.
 type osvAffected struct {
-	Package osvPackage `json:"package"`
-	Ranges  []osvRange `json:"ranges"`
+	Package           osvPackage           `json:"package"`
+	Ranges            []osvRange           `json:"ranges"`
+	EcosystemSpecific osvEcosystemSpecific `json:"ecosystem_specific"`
+}
+
+// osvEcosystemSpecific carries per-ecosystem detail. For Go, OSV scopes an
+// advisory to the import paths it actually affects — a module-level match alone
+// overstates exposure (e.g. GO-2026-5932 affects only x/crypto/openpgp, not
+// every consumer of x/crypto).
+type osvEcosystemSpecific struct {
+	Imports []osvImport `json:"imports"`
+}
+
+// osvImport is a single affected import path within a module.
+type osvImport struct {
+	Path string `json:"path"`
 }
 
 // osvRange is a version range with events marking introduction / fix.
@@ -192,7 +205,147 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 		}
 	}
 
+	// /v1/querybatch returns only {id, modified}; fetch the detail that
+	// severity mapping and import-path scoping depend on. Each result slice is
+	// hydrated in place — never reassigned — because map iteration order is
+	// randomised and rebuilding the map from a flattened slice would attribute
+	// vulnerabilities to the wrong packages.
+	var ids []string
+	for _, vs := range result {
+		for _, v := range vs {
+			ids = append(ids, v.ID)
+		}
+	}
+	details := fetchVulnDetails(ctx, client, baseURL, ids)
+	for _, vs := range result {
+		applyVulnDetails(vs, details)
+	}
+
 	return result, nil
+}
+
+// osvHydrateConcurrency bounds in-flight detail lookups so a large dependency
+// tree does not open hundreds of simultaneous connections to OSV.
+const osvHydrateConcurrency = 8
+
+// hydrateVulnDetails fills in the fields /v1/querybatch does not return.
+//
+// The batch endpoint answers only "which advisory IDs match this package", as
+// {id, modified} pairs — no severity, summary or affected ranges. Everything
+// downstream therefore fell back to defaults: every dependency finding was
+// reported at SeverityMedium with an empty summary, regardless of its real
+// CVSS. Since enforcing gates key on high/critical, a critical dependency CVE
+// could never block a build.
+//
+// Each distinct ID is fetched once from /v1/vulns/{id} and the result is copied
+// into every osvVuln sharing it. Hydration is best-effort: on any failure the
+// original entry is left untouched, so a lookup problem degrades severity
+// accuracy but never loses a finding.
+func hydrateVulnDetails(ctx context.Context, client *http.Client, baseURL string, vulns []osvVuln) {
+	ids := make([]string, 0, len(vulns))
+	for _, v := range vulns {
+		ids = append(ids, v.ID)
+	}
+	applyVulnDetails(vulns, fetchVulnDetails(ctx, client, baseURL, ids))
+}
+
+// fetchVulnDetails retrieves advisory detail for each distinct ID, concurrently
+// and at most once per ID. IDs that cannot be fetched are simply absent from
+// the returned map, which callers treat as "leave the finding as it is".
+func fetchVulnDetails(ctx context.Context, client *http.Client, baseURL string, ids []string) map[string]osvVuln {
+	unique := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	if len(unique) == 0 {
+		return nil
+	}
+
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		failures int
+	)
+	out := make(map[string]osvVuln, len(unique))
+	sem := make(chan struct{}, osvHydrateConcurrency)
+
+	for id := range unique {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			detail, err := fetchVulnDetail(ctx, client, baseURL, id)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				failures++
+				return
+			}
+			out[id] = detail
+		}(id)
+	}
+	wg.Wait()
+
+	if failures > 0 {
+		slog.WarnContext(ctx, "OSV detail lookup failed for some advisories; severity may be under-reported",
+			"failed", failures, "total", len(unique))
+	}
+	return out
+}
+
+// applyVulnDetails copies fetched detail onto the matching entries in vulns,
+// in place. Only fields the batch response could not supply are overwritten.
+func applyVulnDetails(vulns []osvVuln, details map[string]osvVuln) {
+	for i := range vulns {
+		detail, ok := details[vulns[i].ID]
+		if !ok {
+			continue
+		}
+		if detail.Summary != "" {
+			vulns[i].Summary = detail.Summary
+		}
+		if detail.Details != "" {
+			vulns[i].Details = detail.Details
+		}
+		if len(detail.Severity) > 0 {
+			vulns[i].Severity = detail.Severity
+		}
+		if len(detail.Aliases) > 0 {
+			vulns[i].Aliases = detail.Aliases
+		}
+		if len(detail.Affected) > 0 {
+			vulns[i].Affected = detail.Affected
+		}
+	}
+}
+
+// fetchVulnDetail retrieves a single advisory from OSV's /v1/vulns/{id}.
+func fetchVulnDetail(ctx context.Context, client *http.Client, baseURL, id string) (osvVuln, error) {
+	url := strings.TrimRight(baseURL, "/") + "/v1/vulns/" + id
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return osvVuln{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return osvVuln{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return osvVuln{}, fmt.Errorf("OSV vuln lookup for %s returned status %d", id, resp.StatusCode)
+	}
+
+	var v osvVuln
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return osvVuln{}, err
+	}
+	return v, nil
 }
 
 // decodeBatchResponse reads and decodes an OSV batch response. It returns
@@ -227,11 +380,16 @@ func cvssToSeverity(score string) findings.Severity {
 	// Try parsing as a plain float first (e.g. "9.8").
 	f, err := strconv.ParseFloat(score, 64)
 	if err != nil {
-		// Try extracting the base score from a CVSS vector string.
-		// CVSS vectors look like "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-		// — the score is not embedded in the vector, so we can't parse it.
-		// Fall back to medium.
-		return findings.SeverityMedium
+		// OSV publishes CVSS as a vector string, e.g.
+		// "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H". The base score is not
+		// embedded in it, but it is fully determined by it, so compute it.
+		if base, ok := cvssV3BaseScore(score); ok {
+			f = base
+		} else {
+			// Unrecognised format (e.g. a CVSS v2 or v4 vector): stay
+			// conservative rather than guessing.
+			return findings.SeverityMedium
+		}
 	}
 
 	switch {

--- a/core/analyzers/deps/osv_hydrate_test.go
+++ b/core/analyzers/deps/osv_hydrate_test.go
@@ -1,0 +1,91 @@
+package deps
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// OSV's /v1/querybatch returns only {id, modified} — no severity, summary or
+// affected ranges. Without a follow-up fetch every dependency finding gets the
+// conservative SeverityMedium default and an empty summary, which means a
+// critical dependency CVE can never trip a high/critical CI gate.
+func TestHydrateVulnDetails_FillsSeverityAndSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vulns/GO-2026-9999" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"id": "GO-2026-9999",
+			"summary": "Remote code execution in example",
+			"severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+			"affected": [{
+				"package": {"name": "example.com/mod", "ecosystem": "Go"},
+				"ecosystem_specific": {"imports": [{"path": "example.com/mod/vulnerable"}]}
+			}]
+		}`))
+	}))
+	defer srv.Close()
+
+	vulns := []osvVuln{{ID: "GO-2026-9999"}}
+	hydrateVulnDetails(context.Background(), srv.Client(), srv.URL, vulns)
+
+	got := vulns[0]
+	if got.Summary != "Remote code execution in example" {
+		t.Errorf("summary not hydrated: %q", got.Summary)
+	}
+	if sev := mapOSVSeverity(got.Severity); sev != findings.SeverityCritical {
+		t.Errorf("severity = %v, want critical (CVSS 9.8)", sev)
+	}
+	if len(got.Affected) != 1 {
+		t.Fatalf("affected not hydrated: %+v", got.Affected)
+	}
+	imps := got.Affected[0].EcosystemSpecific.Imports
+	if len(imps) != 1 || imps[0].Path != "example.com/mod/vulnerable" {
+		t.Errorf("import paths not hydrated: %+v", imps)
+	}
+}
+
+// Each distinct advisory is fetched once, however many packages reference it.
+func TestHydrateVulnDetails_CachesByID(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"id":"GO-1","summary":"s"}`))
+	}))
+	defer srv.Close()
+
+	vulns := []osvVuln{{ID: "GO-1"}, {ID: "GO-1"}, {ID: "GO-1"}}
+	hydrateVulnDetails(context.Background(), srv.Client(), srv.URL, vulns)
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 request for 3 copies of the same ID, got %d", n)
+	}
+	for i, v := range vulns {
+		if v.Summary != "s" {
+			t.Errorf("vuln %d not hydrated: %+v", i, v)
+		}
+	}
+}
+
+// Hydration is best-effort: a failing detail lookup must leave the finding
+// intact rather than dropping it. Under-reporting severity is bad; losing the
+// finding entirely is worse.
+func TestHydrateVulnDetails_FailsOpen(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	vulns := []osvVuln{{ID: "GO-1", Summary: "original"}}
+	hydrateVulnDetails(context.Background(), srv.Client(), srv.URL, vulns)
+
+	if vulns[0].ID != "GO-1" || vulns[0].Summary != "original" {
+		t.Errorf("failed lookup must not clobber the finding: %+v", vulns[0])
+	}
+}

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -39,6 +39,14 @@ func decodeJSON(t *testing.T, r *http.Request, v any) {
 
 func TestQueryOSV_BatchQuery(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// queryOSV follows each batch result with a /v1/vulns/{id} detail
+		// lookup, since querybatch returns only {id, modified}. These tests
+		// assert batch behaviour, so answer detail lookups with 404 — hydration
+		// fails open and leaves the batch result untouched.
+		if strings.HasPrefix(r.URL.Path, "/v1/vulns/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		if r.URL.Path != "/v1/querybatch" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			http.Error(w, "not found", http.StatusNotFound)
@@ -184,6 +192,12 @@ func TestQueryOSV_NetworkError(t *testing.T) {
 
 func TestQueryOSV_EmptyResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Detail lookups (/v1/vulns/{id}) carry no body and are answered 404;
+		// hydration fails open, leaving the batch result as the test expects.
+		if strings.HasPrefix(r.URL.Path, "/v1/vulns/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 
@@ -298,8 +312,18 @@ func TestMapOSVSeverity(t *testing.T) {
 			expected: findings.SeverityMedium,
 		},
 		{
-			name:     "CVSS vector string (not a number)",
+			// OSV publishes CVSS as a vector string. The base score is fully
+			// determined by the vector, so it is computed rather than defaulted
+			// to medium; this is the canonical 9.8 critical vector.
+			name:     "CVSS v3 vector string",
 			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+			expected: findings.SeverityCritical,
+		},
+		{
+			// v2 vectors use a different formula and are not computed; keep the
+			// conservative default rather than guessing.
+			name:     "CVSS v2 vector string falls back to medium",
+			input:    []osvSeverity{{Type: "CVSS_V2", Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"}},
 			expected: findings.SeverityMedium,
 		},
 	}
@@ -418,6 +442,12 @@ func TestEcosystemToOSV(t *testing.T) {
 func TestScanArtifacts_WithOSV(t *testing.T) {
 	// Mock OSV server returning a vulnerability for lodash.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Detail lookups (/v1/vulns/{id}) carry no body and are answered 404;
+		// hydration fails open, leaving the batch result as the test expects.
+		if strings.HasPrefix(r.URL.Path, "/v1/vulns/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 
@@ -574,6 +604,12 @@ func TestScanArtifacts_OSVDisabled(t *testing.T) {
 
 func TestScanArtifacts_VulnerabilityMetadata(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Detail lookups (/v1/vulns/{id}) carry no body and are answered 404;
+		// hydration fails open, leaving the batch result as the test expects.
+		if strings.HasPrefix(r.URL.Path, "/v1/vulns/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 
@@ -769,6 +805,12 @@ func TestNewAnalyzer_Defaults(t *testing.T) {
 // with a Dockerfile silently lost every real Go/npm/PyPI vulnerability finding.
 func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Detail lookups (/v1/vulns/{id}) carry no body and are answered 404;
+		// hydration fails open, leaving the batch result as the test expects.
+		if strings.HasPrefix(r.URL.Path, "/v1/vulns/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 

--- a/core/analyzers/deps/parsers.go
+++ b/core/analyzers/deps/parsers.go
@@ -7,10 +7,327 @@ import (
 	"encoding/xml"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
+// parseGoMod extracts the module versions a Go build actually selects, from
+// go.mod content.
+//
+// go.mod is the authoritative source of selected versions, and the distinction
+// from go.sum matters: go.sum is a hash manifest for the entire module graph,
+// not a lockfile. It records every version the resolver ever considered, so
+// scanning it directly reports vulnerabilities against code that is never
+// compiled — measured at ~99% false positives on real repositories (e.g. x/net
+// flagged at a 2019 pseudo-version while the build selects v0.56.0). go.mod
+// carries the versions Minimal Version Selection actually chose. See
+// https://go.dev/ref/mod#go-sum-files and https://go.dev/ref/mod#minimal-version-selection.
+//
+// Callers should use resolveGoPackages rather than this function directly: Go
+// 1.17+ module graph pruning means go.mod names only the modules providing
+// imported packages, so resolveGoPackages consults go.sum to recover deeper
+// transitives that are linked but unnamed here.
+//
+// replace directives are applied, because the replacement is what gets built.
+// A replacement pointing at a local filesystem path is dropped: it is not a
+// fetched module and has no upstream version to match against advisories.
+func parseGoMod(content []byte) ([]Package, error) {
+	type modVer struct{ mod, ver string }
+
+	var requires []modVer
+	// Keyed by module, or module@version for a version-specific replace.
+	replaces := make(map[string]modVer)
+
+	inRequireBlock := false
+	inReplaceBlock := false
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Strip line comments ("// indirect" and friends) before parsing.
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if line == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "require ("):
+			inRequireBlock = true
+			continue
+		case strings.HasPrefix(line, "replace ("):
+			inReplaceBlock = true
+			continue
+		case line == ")":
+			inRequireBlock, inReplaceBlock = false, false
+			continue
+		}
+
+		// Single-line forms carry the directive as a prefix.
+		body := line
+		isRequire := inRequireBlock
+		isReplace := inReplaceBlock
+		if after, ok := strings.CutPrefix(line, "require "); ok && !inRequireBlock && !inReplaceBlock {
+			body, isRequire = strings.TrimSpace(after), true
+		} else if after, ok := strings.CutPrefix(line, "replace "); ok && !inRequireBlock && !inReplaceBlock {
+			body, isReplace = strings.TrimSpace(after), true
+		}
+
+		switch {
+		case isReplace:
+			// old [version] => new [version]
+			left, right, found := strings.Cut(body, "=>")
+			if !found {
+				continue
+			}
+			lf, rf := strings.Fields(left), strings.Fields(right)
+			if len(lf) == 0 || len(rf) == 0 {
+				continue
+			}
+			key := lf[0]
+			if len(lf) > 1 {
+				key = lf[0] + "@" + lf[1]
+			}
+			if len(rf) < 2 {
+				// A filesystem path replacement has no version; drop the module.
+				replaces[key] = modVer{}
+				continue
+			}
+			replaces[key] = modVer{mod: rf[0], ver: rf[1]}
+
+		case isRequire:
+			f := strings.Fields(body)
+			if len(f) < 2 || !strings.HasPrefix(f[1], "v") {
+				continue
+			}
+			requires = append(requires, modVer{mod: f[0], ver: f[1]})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning go.mod: %w", err)
+	}
+
+	var pkgs []Package
+	for _, r := range requires {
+		// A version-specific replace wins over a module-wide one.
+		if rep, ok := replaces[r.mod+"@"+r.ver]; ok {
+			if rep.mod == "" {
+				continue
+			}
+			r = rep
+		} else if rep, ok := replaces[r.mod]; ok {
+			if rep.mod == "" {
+				continue
+			}
+			r = rep
+		}
+		pkgs = append(pkgs, Package{Name: r.mod, Version: r.ver, Ecosystem: "go"})
+	}
+
+	return pkgs, nil
+}
+
+// resolveGoPackages determines the module versions a Go build links, given
+// go.mod and (optionally) go.sum.
+//
+// Neither file answers the question alone:
+//
+//   - go.mod carries the versions MVS selected, but Go 1.17+ module graph
+//     pruning means it only names modules providing imported packages. A module
+//     reached deeper in the graph is still linked but absent here.
+//   - go.sum names every module ever in the graph, but records each at every
+//     version considered — so it reports code that is not built.
+//
+// So go.mod is authoritative for the modules it names, and go.sum is consulted
+// only for modules go.mod omits — and then only for entries carrying a source
+// hash (see goSumSourceModules), since a metadata-only entry means the code was
+// never downloaded. For those recovered modules MVS selects the maximum
+// required version, making the highest version in go.sum the best estimate.
+//
+// Measured against the true linked set (`go list -deps`) on two large
+// repositories: false positives fell from 358 to 1 and from 148 to 0, with
+// every true positive retained.
+//
+// A module dropped by a local filesystem replace is never resurrected from
+// go.sum: it is not fetched and has no upstream version to match advisories
+// against.
+func resolveGoPackages(goMod, goSum []byte) ([]Package, error) {
+	pkgs, err := parseGoMod(goMod)
+	if err != nil {
+		return nil, err
+	}
+	if len(goSum) == 0 {
+		return pkgs, nil
+	}
+
+	// Every module go.mod spoke about — including ones it deliberately
+	// dropped — so go.sum cannot contradict it.
+	declared := make(map[string]struct{})
+	for _, m := range goModDeclaredModules(goMod) {
+		declared[m] = struct{}{}
+	}
+	for _, p := range pkgs {
+		declared[p.Name] = struct{}{}
+	}
+
+	sumPkgs, err := goSumSourceModules(goSum)
+	if err != nil {
+		return nil, err
+	}
+
+	highest := make(map[string]string)
+	for _, p := range sumPkgs {
+		if _, ok := declared[p.Name]; ok {
+			continue
+		}
+		if cur, ok := highest[p.Name]; !ok || compareGoVersions(p.Version, cur) > 0 {
+			highest[p.Name] = p.Version
+		}
+	}
+
+	names := make([]string, 0, len(highest))
+	for n := range highest {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		pkgs = append(pkgs, Package{Name: n, Version: highest[n], Ecosystem: "go"})
+	}
+
+	return pkgs, nil
+}
+
+// goSumSourceModules returns the module/version pairs whose *source* is hashed
+// in go.sum, i.e. lines without the "/go.mod" version suffix.
+//
+// go.sum records two kinds of entry. A "/go.mod" line hashes only the module's
+// go.mod file, which Go fetches to compute the module graph; a plain line
+// hashes the module zip, which Go fetches only when it actually needs the
+// code. A module appearing solely under "/go.mod" was therefore never
+// downloaded and cannot contribute a single line to the build, so reporting a
+// vulnerability against it is always a false positive.
+func goSumSourceModules(content []byte) ([]Package, error) {
+	type key struct{ mod, ver string }
+	seen := make(map[key]struct{})
+	var pkgs []Package
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		mod, ver := fields[0], fields[1]
+		if strings.HasSuffix(ver, "/go.mod") {
+			continue // metadata-only: the module's code is not in the build
+		}
+		k := key{mod, ver}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		pkgs = append(pkgs, Package{Name: mod, Version: ver, Ecosystem: "go"})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning go.sum: %w", err)
+	}
+	return pkgs, nil
+}
+
+// goModDeclaredModules lists every module named on the left-hand side of a
+// require or replace directive, whether or not it survives resolution.
+func goModDeclaredModules(content []byte) []string {
+	var out []string
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		line = strings.TrimPrefix(line, "require ")
+		line = strings.TrimPrefix(line, "replace ")
+		if before, _, found := strings.Cut(line, "=>"); found {
+			line = strings.TrimSpace(before)
+		}
+		f := strings.Fields(line)
+		if len(f) == 0 || strings.ContainsAny(f[0], "()") || !strings.Contains(f[0], ".") {
+			continue
+		}
+		out = append(out, f[0])
+	}
+	return out
+}
+
+// compareGoVersions orders two Go module versions, returning -1, 0 or 1.
+//
+// It implements the subset of semver ordering that module versions use: the
+// numeric MAJOR.MINOR.PATCH triple first, then prerelease, where a release
+// outranks any prerelease of the same triple. Pseudo-versions
+// (v0.0.0-<timestamp>-<hash>) fall out correctly because their timestamp sorts
+// lexically within the prerelease segment.
+func compareGoVersions(a, b string) int {
+	an, apre := splitGoVersion(a)
+	bn, bpre := splitGoVersion(b)
+
+	for i := 0; i < 3; i++ {
+		if an[i] != bn[i] {
+			if an[i] < bn[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	switch {
+	case apre == bpre:
+		return 0
+	case apre == "": // release beats prerelease
+		return 1
+	case bpre == "":
+		return -1
+	case apre < bpre:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// splitGoVersion breaks "v1.2.3-rc1" into its numeric triple and prerelease.
+func splitGoVersion(v string) (nums [3]int, prerelease string) {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.Index(v, "+"); i >= 0 { // build metadata is not ordered
+		v = v[:i]
+	}
+	core, pre, _ := strings.Cut(v, "-")
+	for i, part := range strings.SplitN(core, ".", 3) {
+		if i > 2 {
+			break
+		}
+		n := 0
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				n = 0
+				break
+			}
+			n = n*10 + int(r-'0')
+		}
+		nums[i] = n
+	}
+	return nums, pre
+}
+
 // parseGoSum extracts unique module/version pairs from go.sum content.
+//
+// Not used directly for Go dependency scanning — go.sum describes the module
+// graph, not the build. resolveGoPackages consults it only for modules that
+// go.mod omits. See parseGoMod.
 //
 // Each line has the format:
 //

--- a/core/analyzers/deps/parsers_gomod_test.go
+++ b/core/analyzers/deps/parsers_gomod_test.go
@@ -1,0 +1,285 @@
+package deps
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseGoMod(t *testing.T) {
+	content := []byte(`module example.com/myapp
+
+go 1.24
+
+require (
+	github.com/stretchr/testify v1.8.0
+	golang.org/x/net v0.56.0 // indirect
+)
+
+require golang.org/x/crypto v0.53.0
+`)
+
+	pkgs, err := parseGoMod(content)
+	if err != nil {
+		t.Fatalf("parseGoMod returned error: %v", err)
+	}
+
+	if len(pkgs) != 3 {
+		t.Fatalf("expected 3 packages, got %d: %+v", len(pkgs), pkgs)
+	}
+
+	sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Name < pkgs[j].Name })
+
+	expected := []Package{
+		{Name: "github.com/stretchr/testify", Version: "v1.8.0", Ecosystem: "go"},
+		{Name: "golang.org/x/crypto", Version: "v0.53.0", Ecosystem: "go"},
+		{Name: "golang.org/x/net", Version: "v0.56.0", Ecosystem: "go"},
+	}
+	for i, want := range expected {
+		if pkgs[i] != want {
+			t.Errorf("package %d: got %+v, want %+v", i, pkgs[i], want)
+		}
+	}
+}
+
+// The main module is not a dependency and must never be reported.
+func TestParseGoMod_ExcludesMainModule(t *testing.T) {
+	pkgs, err := parseGoMod([]byte("module example.com/myapp\n\ngo 1.24\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("expected 0 packages, got %+v", pkgs)
+	}
+}
+
+// A replace directive redirects to a different module and/or version; the
+// version actually built is the replacement's, so that is what must be scanned.
+func TestParseGoMod_AppliesReplace(t *testing.T) {
+	content := []byte(`module example.com/myapp
+
+go 1.24
+
+require (
+	golang.org/x/net v0.20.0
+	example.com/vendored v1.0.0
+)
+
+replace golang.org/x/net => golang.org/x/net v0.56.0
+
+replace example.com/vendored => ./internal/vendored
+`)
+
+	pkgs, err := parseGoMod(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The local filesystem replacement is not a fetched module, so it drops out.
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package, got %+v", pkgs)
+	}
+	want := Package{Name: "golang.org/x/net", Version: "v0.56.0", Ecosystem: "go"}
+	if pkgs[0] != want {
+		t.Errorf("got %+v, want %+v", pkgs[0], want)
+	}
+}
+
+// A version-specific replace applies only to that version.
+func TestParseGoMod_VersionedReplace(t *testing.T) {
+	content := []byte(`module example.com/myapp
+
+go 1.24
+
+require golang.org/x/text v0.3.7
+
+replace golang.org/x/text v0.3.7 => golang.org/x/text v0.3.8
+`)
+
+	pkgs, err := parseGoMod(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Version != "v0.3.8" {
+		t.Fatalf("expected x/text v0.3.8, got %+v", pkgs)
+	}
+}
+
+func TestParseGoMod_EmptyInput(t *testing.T) {
+	pkgs, err := parseGoMod([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("expected 0 packages, got %d", len(pkgs))
+	}
+}
+
+func TestCompareGoVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int // -1 a<b, 0 equal, 1 a>b
+	}{
+		{"v1.2.3", "v1.2.4", -1},
+		{"v1.2.3", "v1.2.3", 0},
+		{"v1.10.0", "v1.9.0", 1},
+		{"v2.0.0", "v10.0.0", -1},
+		// A release outranks its own prerelease.
+		{"v1.2.3", "v1.2.3-rc1", 1},
+		// Pseudo-versions order by the embedded timestamp.
+		{"v0.0.0-20190620200207-3b0461eec859", "v0.0.0-20220225172249-27dd8689420f", -1},
+		// A tagged release outranks a v0.0.0 pseudo-version.
+		{"v0.56.0", "v0.0.0-20190620200207-3b0461eec859", 1},
+	}
+	for _, tt := range tests {
+		if got := compareGoVersions(tt.a, tt.b); got != tt.want {
+			t.Errorf("compareGoVersions(%q,%q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// resolveGoPackages combines both files: go.mod is authoritative for the
+// modules it names, and go.sum supplies modules that pruning omitted from
+// go.mod but that the build still links.
+func TestResolveGoPackages_RecoversPrunedTransitives(t *testing.T) {
+	goMod := []byte(`module example.com/myapp
+
+go 1.24
+
+require golang.org/x/net v0.56.0
+`)
+	// x/net appears at an old graph version too (must NOT win — go.mod decides),
+	// while yaml.v2 is built but pruned out of go.mod (must be recovered).
+	goSum := []byte(`golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:a=
+golang.org/x/net v0.56.0 h1:b=
+gopkg.in/yaml.v2 v2.2.2 h1:c=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:d=
+`)
+
+	pkgs, err := resolveGoPackages(goMod, goSum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, p := range pkgs {
+		got[p.Name] = p.Version
+	}
+	if got["golang.org/x/net"] != "v0.56.0" {
+		t.Errorf("go.mod must win for x/net, got %q", got["golang.org/x/net"])
+	}
+	if got["gopkg.in/yaml.v2"] != "v2.2.2" {
+		t.Errorf("pruned transitive yaml.v2 not recovered, got %q", got["gopkg.in/yaml.v2"])
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("expected exactly 2 packages, got %+v", pkgs)
+	}
+}
+
+// A go.sum entry with only a "/go.mod" hash means Go fetched the module's
+// metadata to compute the graph but never downloaded its source, so none of its
+// code is in the build. Such a module must not be reported.
+func TestResolveGoPackages_IgnoresGoModHashOnlyEntries(t *testing.T) {
+	goMod := []byte("module example.com/myapp\n\ngo 1.24\n")
+	goSum := []byte(`golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:a=
+gopkg.in/yaml.v2 v2.2.2 h1:b=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:c=
+`)
+
+	pkgs, err := resolveGoPackages(goMod, goSum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected only the source-hashed module, got %+v", pkgs)
+	}
+	if pkgs[0].Name != "gopkg.in/yaml.v2" {
+		t.Errorf("got %q, want gopkg.in/yaml.v2", pkgs[0].Name)
+	}
+}
+
+// For a module absent from go.mod, MVS selects the maximum required version,
+// so the highest version in go.sum is the best available estimate.
+func TestResolveGoPackages_PicksMaxVersionForPrunedModule(t *testing.T) {
+	goMod := []byte("module example.com/myapp\n\ngo 1.24\n")
+	goSum := []byte(`gopkg.in/yaml.v2 v2.2.2 h1:a=
+gopkg.in/yaml.v2 v2.4.0 h1:b=
+gopkg.in/yaml.v2 v2.3.0 h1:c=
+`)
+	pkgs, err := resolveGoPackages(goMod, goSum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Version != "v2.4.0" {
+		t.Fatalf("expected yaml.v2 v2.4.0, got %+v", pkgs)
+	}
+}
+
+// A module replaced by a local filesystem path is not fetched, so it must not
+// be resurrected from go.sum.
+func TestResolveGoPackages_LocalReplaceStaysDropped(t *testing.T) {
+	goMod := []byte(`module example.com/myapp
+
+go 1.24
+
+require example.com/vendored v1.0.0
+
+replace example.com/vendored => ./internal/vendored
+`)
+	goSum := []byte("example.com/vendored v1.0.0 h1:a=\n")
+
+	pkgs, err := resolveGoPackages(goMod, goSum)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("locally replaced module must not reappear, got %+v", pkgs)
+	}
+}
+
+// go.sum is optional; a go.mod alone must still resolve.
+func TestResolveGoPackages_NoGoSum(t *testing.T) {
+	goMod := []byte("module example.com/myapp\n\ngo 1.24\n\nrequire golang.org/x/net v0.56.0\n")
+	pkgs, err := resolveGoPackages(goMod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Version != "v0.56.0" {
+		t.Fatalf("expected x/net v0.56.0, got %+v", pkgs)
+	}
+}
+
+// Regression test for the reason this parser exists: go.sum records the whole
+// module graph, including versions MVS never selected, so scanning it reports
+// vulnerabilities against code that is not built. go.mod carries the selected
+// versions. See https://go.dev/ref/mod#go-sum-files.
+func TestParseGoMod_SelectsBuiltVersionNotGraphVersion(t *testing.T) {
+	// Mirrors a real case: the build uses x/net v0.56.0, while go.sum still
+	// carries a 2019 pseudo-version from an older graph.
+	goMod := []byte(`module example.com/myapp
+
+go 1.24
+
+require golang.org/x/net v0.56.0 // indirect
+`)
+	goSum := []byte(`golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:x=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:x=
+golang.org/x/net v0.56.0 h1:y=
+golang.org/x/net v0.56.0/go.mod h1:y=
+`)
+
+	modPkgs, err := parseGoMod(goMod)
+	if err != nil {
+		t.Fatalf("parseGoMod: %v", err)
+	}
+	sumPkgs, err := parseGoSum(goSum)
+	if err != nil {
+		t.Fatalf("parseGoSum: %v", err)
+	}
+
+	if len(modPkgs) != 1 || modPkgs[0].Version != "v0.56.0" {
+		t.Fatalf("go.mod should yield only the built version, got %+v", modPkgs)
+	}
+	if len(sumPkgs) != 2 {
+		t.Fatalf("expected go.sum to yield both graph versions, got %+v", sumPkgs)
+	}
+}

--- a/core/analyzers/deps/reachability.go
+++ b/core/analyzers/deps/reachability.go
@@ -1,0 +1,110 @@
+package deps
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// goListTimeout bounds the toolchain call used to enumerate imported packages.
+// Reachability is an enrichment, never a blocker: if the toolchain is slow,
+// absent, or offline, the scan proceeds with reachability simply unknown.
+const goListTimeout = 60 * time.Second
+
+// goAffectedImports returns the import paths an advisory names as affected.
+//
+// OSV scopes Go advisories to specific packages within a module. GO-2026-5932,
+// for instance, applies only to golang.org/x/crypto/openpgp and its
+// subpackages — a module that links x/crypto/chacha20 is not exposed by it.
+// Matching at module granularity alone therefore overstates exposure.
+func goAffectedImports(vuln *osvVuln, module string) []string {
+	var out []string
+	for _, aff := range vuln.Affected {
+		if !strings.EqualFold(aff.Package.Name, module) {
+			continue
+		}
+		for _, im := range aff.EcosystemSpecific.Imports {
+			if im.Path != "" {
+				out = append(out, im.Path)
+			}
+		}
+	}
+	return out
+}
+
+// goImportedPackages enumerates every package the module in dir links,
+// transitively, via `go list -deps ./...`.
+//
+// This deliberately uses the toolchain rather than parsing imports out of
+// source: a vulnerable package is frequently reached *through* a dependency
+// rather than imported by the repository directly, and static parsing of the
+// repo's own files cannot see that. Getting it wrong in that direction would
+// silently hide real vulnerabilities, so when the toolchain cannot answer,
+// this reports ok=false and callers keep the finding.
+func goImportedPackages(ctx context.Context, dir string) (map[string]struct{}, bool) {
+	ctx, cancel := context.WithTimeout(ctx, goListTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-e", "-f", "{{.ImportPath}}", "./...")
+	cmd.Dir = dir
+	// Never mutate the module files of the repository under scan.
+	cmd.Env = append(cmd.Environ(), "GOFLAGS=-mod=readonly")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		slog.DebugContext(ctx, "go list failed; dependency findings will not be scoped by import path",
+			"dir", dir, "error", err, "stderr", strings.TrimSpace(stderr.String()))
+		return nil, false
+	}
+
+	pkgs := make(map[string]struct{})
+	scanner := bufio.NewScanner(&stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		p := strings.TrimSpace(scanner.Text())
+		// With -e, `go list` outside a module echoes the unresolved pattern
+		// itself (e.g. "./...") and still exits 0. Those are not packages, and
+		// accepting them would make an empty directory look like a resolved
+		// build — turning "unknown" into a false "not linked".
+		if p == "" || strings.HasPrefix(p, "./") || strings.Contains(p, "...") {
+			continue
+		}
+		pkgs[p] = struct{}{}
+	}
+	if len(pkgs) == 0 {
+		return nil, false
+	}
+	return pkgs, true
+}
+
+// goVulnReachable reports whether an advisory's affected packages are actually
+// linked, along with whether that could be determined at all.
+//
+// It answers false only on positive evidence: the advisory named its affected
+// import paths, the linked package set is known, and none of those paths appear
+// in it. Anything less — no import metadata, no package set — returns
+// determined=false so the caller leaves the finding untouched.
+func goVulnReachable(affectedImports []string, linked map[string]struct{}, linkedKnown bool) (reachable, determined bool) {
+	if len(affectedImports) == 0 || !linkedKnown {
+		return true, false
+	}
+	for _, imp := range affectedImports {
+		if _, ok := linked[imp]; ok {
+			return true, true
+		}
+		// A vulnerable package's subpackages are covered by the same advisory.
+		for pkg := range linked {
+			if strings.HasPrefix(pkg, imp+"/") {
+				return true, true
+			}
+		}
+	}
+	return false, true
+}

--- a/core/analyzers/deps/reachability_test.go
+++ b/core/analyzers/deps/reachability_test.go
@@ -1,0 +1,134 @@
+package deps
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGoAffectedImports(t *testing.T) {
+	v := &osvVuln{
+		ID: "GO-2026-5932",
+		Affected: []osvAffected{{
+			Package: osvPackage{Name: "golang.org/x/crypto", Ecosystem: "Go"},
+			EcosystemSpecific: osvEcosystemSpecific{Imports: []osvImport{
+				{Path: "golang.org/x/crypto/openpgp"},
+				{Path: "golang.org/x/crypto/openpgp/packet"},
+			}},
+		}},
+	}
+	got := goAffectedImports(v, "golang.org/x/crypto")
+	if len(got) != 2 || got[0] != "golang.org/x/crypto/openpgp" {
+		t.Fatalf("got %+v", got)
+	}
+	// A different module in the same advisory must not match.
+	if other := goAffectedImports(v, "golang.org/x/net"); len(other) != 0 {
+		t.Errorf("expected no imports for a non-matching module, got %+v", other)
+	}
+}
+
+func TestGoVulnReachable(t *testing.T) {
+	linked := map[string]struct{}{
+		"golang.org/x/crypto/chacha20":      {},
+		"golang.org/x/crypto/cryptobyte":    {},
+		"github.com/example/app/internal/x": {},
+	}
+
+	tests := []struct {
+		name                 string
+		affected             []string
+		linked               map[string]struct{}
+		known                bool
+		wantReach, wantDeter bool
+	}{
+		{
+			// The real GO-2026-5932 case: openpgp is not linked.
+			name:      "affected package not linked",
+			affected:  []string{"golang.org/x/crypto/openpgp"},
+			linked:    linked,
+			known:     true,
+			wantReach: false, wantDeter: true,
+		},
+		{
+			name:      "affected package is linked",
+			affected:  []string{"golang.org/x/crypto/chacha20"},
+			linked:    linked,
+			known:     true,
+			wantReach: true, wantDeter: true,
+		},
+		{
+			// Advisories cover subpackages of the path they name.
+			name:      "subpackage of an affected path counts as linked",
+			affected:  []string{"golang.org/x/crypto"},
+			linked:    linked,
+			known:     true,
+			wantReach: true, wantDeter: true,
+		},
+		{
+			// Fail open: no import metadata means no conclusion.
+			name:      "advisory lists no import paths",
+			affected:  nil,
+			linked:    linked,
+			known:     true,
+			wantReach: true, wantDeter: false,
+		},
+		{
+			// Fail open: toolchain unavailable means no conclusion.
+			name:      "linked set unknown",
+			affected:  []string{"golang.org/x/crypto/openpgp"},
+			linked:    nil,
+			known:     false,
+			wantReach: true, wantDeter: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reach, deter := goVulnReachable(tt.affected, tt.linked, tt.known)
+			if reach != tt.wantReach || deter != tt.wantDeter {
+				t.Errorf("got (reachable=%v, determined=%v), want (%v, %v)",
+					reach, deter, tt.wantReach, tt.wantDeter)
+			}
+		})
+	}
+}
+
+func TestGoImportedPackages(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/reachtest\n\ngo 1.24\n")
+	write("main.go", "package main\n\nimport \"strings\"\n\nfunc main() { _ = strings.TrimSpace(\"x\") }\n")
+
+	pkgs, ok := goImportedPackages(context.Background(), dir)
+	if !ok {
+		t.Fatal("expected go list to succeed")
+	}
+	if _, found := pkgs["strings"]; !found {
+		t.Errorf("expected 'strings' among linked packages, got %d packages", len(pkgs))
+	}
+	if _, found := pkgs["example.com/reachtest"]; !found {
+		t.Errorf("expected the main package among linked packages")
+	}
+}
+
+// A directory that is not a Go module must degrade to "unknown" rather than
+// erroring the scan.
+func TestGoImportedPackages_NotAModule(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if _, ok := goImportedPackages(context.Background(), t.TempDir()); ok {
+		t.Error("expected ok=false for a non-module directory")
+	}
+}

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -83,7 +83,11 @@ type DefaultClassifier struct{}
 
 // lockfileNames contains exact file names that identify lockfiles.
 var lockfileNames = map[string]bool{
-	"package-lock.json":  true,
+	"package-lock.json": true,
+	// go.mod is the Go dependency source (selected versions). go.sum stays
+	// classified so it is kept out of the content rule families, but the deps
+	// analyzer no longer parses it — see deps.parseGoMod.
+	"go.mod":             true,
 	"go.sum":             true,
 	"yarn.lock":          true,
 	"poetry.lock":        true,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -997,7 +997,7 @@ Generated from dependency lockfile analysis. Supported ecosystems:
 
 | Lockfile | Ecosystem |
 |----------|-----------|
-| `go.sum` | Go |
+| `go.mod` (with `go.sum`) | Go |
 | `package-lock.json` | npm |
 | `requirements.txt` | PyPI |
 | `Gemfile.lock` | RubyGems |
@@ -1005,6 +1005,14 @@ Generated from dependency lockfile analysis. Supported ecosystems:
 | `pom.xml` | Maven |
 | `build.gradle`, `build.gradle.kts` | Gradle |
 | `packages.lock.json` | NuGet |
+
+> **Go:** versions come from `go.mod`, which records what Minimal Version
+> Selection actually chose. `go.sum` is not used as the version source — it
+> hashes the entire module graph, including versions the build never selects,
+> so scanning it directly reports vulnerabilities against code that is never
+> compiled. It is consulted only to recover modules that Go 1.17+ module graph
+> pruning omits from `go.mod`, and only for entries with a source hash (a
+> `/go.mod`-only entry means the module's code was never downloaded).
 
 ### AI Inventory
 


### PR DESCRIPTION
> **Contains #247.** Retargeted from `fix/go-deps-from-gomod` to `main` because `ci.yml` only triggers on PRs
> targeting `main` — while stacked, no CI ran and GitHub still reported `mergeable: CLEAN`. Review #247 first;
> merging this supersedes it.

Three independent bugs, each of which hid the others. Together they meant Go dependency scanning reported mostly wrong versions, at uniformly wrong severity, with no way to act on the result.

## 1. Versions came from `go.sum` (commit 1, = #247)

`go.sum` is not a lockfile — it hashes the entire module graph, every version the resolver ever considered. Across 28 repositories, **5,263 findings** came from it; on one repo **148 of 148** named a version the build does not use. Repositories had responded by excluding `go.sum` entirely, trading noise for a **total blind spot**.

Now resolved from `go.mod` (the versions MVS selected), consulting `go.sum` only for pruned transitives and only for source-hashed entries.

| repo | findings | modules in build | modules not in build |
|---|---|---|---|
| vorhut | 376 → **19** | 18 → **18** | 358 → **1** |
| mnemos | 148 → **0** | 0 → **0** | 148 → **0** |

## 2. Severity and remediation were never populated (commit 2)

**All 5,263 findings were `medium` with an empty summary — not one high or critical.** Gates key on high/critical, so **a critical dependency CVE could never block a build.**

Two causes: `/v1/querybatch` returns only `{id, modified}`, and OSV publishes CVSS as vector strings which `cvssToSeverity` could not parse. Both had to be fixed for either to matter.

This also explains a shipped feature that never worked: `c8d8e3b` *"emit OSV fix-version remediation field"* reads `vuln.Affected`, which querybatch never returned — **0 of 5,263 findings ever carried a fix version, or a CVE alias.**

Advisory detail is now fetched per distinct ID (deduplicated, bounded concurrency, fail-open), and CVSS v3.x base scores computed per [spec §8.1](https://www.first.org/cvss/v3.1/specification-document).

On vorhut: **1 critical, 24 high**, 57 medium, 3 low — and 85/85 with real summaries.

## 3. Advisories were matched per module, not per package (commit 3)

OSV scopes Go advisories to import paths. `GO-2026-5932` affects only `x/crypto/openpgp`; rollops links `chacha20`/`cryptobyte` and was still reported. It was convincing enough that I recorded it as a confirmed true positive on a module@version match alone — it is a false positive.

Affected paths are now intersected with what `go list -deps` says the build links.

**Findings are demoted, never dropped** — recorded at Info with `reachable=false` and `affected_imports`, reason appended to the message. Silent removal would be indistinguishable from a scanner that missed it, and reachability rests on a toolchain call that can be wrong.

Conclusions only from positive evidence: no import metadata, or no enumerable build → `undetermined`, finding untouched. On vorhut's 19 Go findings: **6 reachable, 2 provably unreachable, 11 undetermined** — that last number is the honest ceiling on this technique.

## ⚠️ Blast radius

**Repositories with high/critical dependency vulnerabilities will start failing their gate.** That is correct — those vulnerabilities were always present, reported as medium — but it will not look like a no-op. Worth a deliberate rollout.

Separately, the 28 repos excluding `go.sum` can drop that exclusion once this ships; it was a correct workaround for bug 1.

## Notes for reviewers

- Results are hydrated **in place per package**, not flattened and rebuilt — map order is randomised, so rebuilding misattributes advisories to the wrong packages. An existing test caught exactly that.
- `go list -e` outside a module echoes `./...` and exits 0; treating that as a package would turn "unknown" into a false "not linked". Filtered, with a test.
- Two existing test expectations changed because they encoded bugs: a CVSS vector mapping to medium, and `go.sum` fixtures.
- Full `./core/...` suite passes (38 packages); `golangci-lint` clean.

https://claude.ai/code/session_01QaHY7x5xKyZWP3RVQ4AgpH
