### PR TITLE
fix: make core scan reliable — OSV hydration, visible degradation, plugin trust boundary

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,19 @@ var (
 )
 
 func main() {
+	// Route slog to stderr at warn level. Without an explicit handler the
+	// default writes to stderr but only at info+, and nothing configured the
+	// output format — in practice warnings the pipeline emits about degraded
+	// checks were reaching nobody. NOX_LOG_LEVEL=debug surfaces the rest.
+	level := slog.LevelWarn
+	if lvl := os.Getenv("NOX_LOG_LEVEL"); lvl != "" {
+		var parsed slog.Level
+		if err := parsed.UnmarshalText([]byte(lvl)); err == nil {
+			level = parsed
+		}
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
 	os.Exit(run(os.Args[1:]))
 }
 
@@ -283,14 +297,22 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		noAutoInstallFlg      bool
 		failOnUnwaivedFlg     bool
 		offlineFlag           bool
+		failOnDegraded        bool
 	)
 	scanFS.BoolVar(&historyFlag, "history", false, "scan git history for secrets in past commits")
 	scanFS.IntVar(&historyDepthFlag, "history-depth", 0, "max number of commits to scan (0 = unlimited)")
-	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "disable incremental scan cache")
+	// Accepted for compatibility with existing scripts, but the scan pipeline
+	// does not consult an incremental cache — every run is already a full
+	// re-scan. The flag previously set ScanOptions.NoCache, which nothing read.
+	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "no-op: scans are never cached (accepted for compatibility)")
 	scanFS.StringVar(&changedSinceFlag, "changed-since", "", "scan only files changed since the given git ref")
 	scanFS.BoolVar(&noRespectGitignoreFlg, "no-respect-gitignore", false, "scan paths matched by .gitignore (default: skip them)")
 	scanFS.BoolVar(&noAutoInstallFlg, "no-auto-install", false, "skip auto-installing plugins listed in .nox.yaml plugins.required")
 	scanFS.BoolVar(&failOnUnwaivedFlg, "fail-on-unwaived", false, "with --vex: only exit non-zero on findings NOT covered by an OpenVEX waiver")
+	// For CI that must treat "could not check" as failure rather than success —
+	// e.g. a runner where OSV is firewalled off, or a required plugin is
+	// missing. Without this, an incomplete scan exits 0 like a clean one.
+	scanFS.BoolVar(&failOnDegraded, "fail-on-degraded", false, "exit non-zero if any check could not complete (OSV lookup, plugin, lockfile parse)")
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
 	var fingerprintVersionFlag string
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
@@ -381,7 +403,6 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			Offline:            offlineFlag,
 			VEXPath:            vexFlag,
 			TerraformPlanPath:  tfPlanFlag,
-			NoCache:            noCacheFlag,
 			ChangedSince:       changedSinceFlag,
 			NoRespectGitignore: noRespectGitignoreFlg,
 		}
@@ -451,6 +472,17 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		if summary := familySummary(activeFindings); summary != "" {
 			fmt.Printf("[families] %s\n", summary)
 		}
+	}
+
+	// Report incomplete checks even under --quiet, and on stderr. A scan that
+	// could not run part of itself must never look like a clean scan: quiet
+	// mode suppresses noise, not warnings that the results are partial.
+	for _, d := range result.Degradations {
+		fmt.Fprintf(os.Stderr, "[degraded] %s\n  impact: %s\n", d.Detail, d.Impact)
+	}
+	if len(result.Degradations) > 0 && failOnDegraded {
+		fmt.Fprintf(os.Stderr, "error: %d check(s) did not complete and --fail-on-degraded is set\n", len(result.Degradations))
+		return 2
 	}
 
 	// Generate reports.

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -11,9 +11,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	nox "github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/plugin"
 	"github.com/nox-hq/nox/registry"
-	nox "github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/registry/oci"
 	"github.com/nox-hq/nox/registry/trust"
 )
@@ -184,10 +184,49 @@ func runPluginSearch(args []string) int {
 		if track == "" {
 			track = "-"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, track, p.Description, latest)
+		desc := p.Description
+		if p.Deprecated {
+			desc = "[DEPRECATED] " + desc
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, track, desc, latest)
 	}
 	_ = w.Flush()
+
+	// Migration guidance goes to stderr so the table above stays
+	// pipeable, while operators still see where to go next.
+	for i := range results {
+		warnIfDeprecated(&results[i])
+	}
 	return 0
+}
+
+// warnIfDeprecated prints a migration notice for a deprecated plugin.
+// It is purely advisory — no caller treats it as a failure.
+func warnIfDeprecated(p *registry.PluginEntry) {
+	if p == nil || !p.Deprecated {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: %s is deprecated\n", p.Name)
+	if p.DeprecationNote != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", p.DeprecationNote)
+	}
+}
+
+// lookupPluginEntry returns the registry entry exactly matching name,
+// or nil when no registry carries it. Search is index-backed and
+// cached, so callers that already resolved a version pay little for
+// the extra lookup.
+func lookupPluginEntry(ctx context.Context, client *registry.Client, name string) *registry.PluginEntry {
+	results, err := client.Search(ctx, name)
+	if err != nil {
+		return nil
+	}
+	for i := range results {
+		if results[i].Name == name {
+			return &results[i]
+		}
+	}
+	return nil
 }
 
 // runPluginInfo shows detailed information about a plugin.
@@ -212,21 +251,7 @@ func runPluginInfo(args []string) int {
 	client := newRegistryClient(st)
 	ctx := context.Background()
 
-	results, err := client.Search(ctx, name)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: searching registries: %v\n", err)
-		return 2
-	}
-
-	// Find exact match.
-	var found *registry.PluginEntry
-	for i := range results {
-		if results[i].Name == name {
-			found = &results[i]
-			break
-		}
-	}
-
+	found := lookupPluginEntry(ctx, client, name)
 	if found == nil {
 		fmt.Fprintf(os.Stderr, "Plugin %q not found in registries.\n", name)
 		return 2
@@ -234,6 +259,13 @@ func runPluginInfo(args []string) int {
 
 	fmt.Printf("Name:        %s\n", found.Name)
 	fmt.Printf("Description: %s\n", found.Description)
+	if found.Deprecated {
+		note := found.DeprecationNote
+		if note == "" {
+			note = "No replacement recorded."
+		}
+		fmt.Printf("Status:      DEPRECATED — %s\n", note)
+	}
 	if found.Track != "" {
 		fmt.Printf("Track:       %s\n", found.Track)
 	}
@@ -327,6 +359,11 @@ func runPluginInstall(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: resolving %s@%s: %v\n", name, constraint, err)
 		return 2
 	}
+
+	// Warn before downloading anything, but never block: operators
+	// with a deprecated plugin already in their pipeline must be able
+	// to reinstall it until they have migrated.
+	warnIfDeprecated(lookupPluginEntry(ctx, client, name))
 
 	// If already installed at the resolved version, skip.
 	if ip := st.FindPlugin(name); ip != nil && ip.Version == ve.Version {

--- a/cli/plugin_deprecation_test.go
+++ b/cli/plugin_deprecation_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nox-hq/nox/registry"
+)
+
+// captureStderr mirrors captureStdout for the warning channel —
+// deprecation notices are diagnostics, so they must not pollute the
+// stdout table that operators pipe into other tools.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// serveDeprecatedIndex serves an index where one plugin is deprecated
+// and points at a replacement.
+func serveDeprecatedIndex(t *testing.T) *httptest.Server {
+	t.Helper()
+	idx := registry.Index{
+		SchemaVersion: "2",
+		GeneratedAt:   time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		Plugins: []registry.PluginEntry{
+			{
+				Name:            "nox/policy-gate",
+				Description:     "Policy gating for CI",
+				Track:           registry.TrackPolicyGovernance,
+				Deprecated:      true,
+				DeprecationNote: "Superseded by nox/grc. Install nox/grc instead.",
+				Versions: []registry.VersionEntry{
+					{Version: "0.2.0", APIVersion: "v1", Digest: "sha256:aaa"},
+				},
+			},
+			{
+				Name:        "nox/grc",
+				Description: "Governance, risk and compliance",
+				Track:       registry.TrackPolicyGovernance,
+				Versions: []registry.VersionEntry{
+					{Version: "0.3.0", APIVersion: "v1", Digest: "sha256:bbb"},
+				},
+			},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(idx)
+	}))
+}
+
+func TestPluginSearch_MarksDeprecatedEntries(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	out := captureStdout(t, func() {
+		if code := runPlugin([]string{"search", "policy-gate"}); code != 0 {
+			t.Errorf("search: expected exit 0, got %d", code)
+		}
+	})
+
+	if !strings.Contains(out, "DEPRECATED") {
+		t.Errorf("search output should mark the deprecated plugin, got:\n%s", out)
+	}
+}
+
+func TestPluginSearch_LeavesActiveEntriesUnmarked(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	out := captureStdout(t, func() {
+		if code := runPlugin([]string{"search", "grc"}); code != 0 {
+			t.Errorf("search: expected exit 0, got %d", code)
+		}
+	})
+
+	if strings.Contains(out, "DEPRECATED") {
+		t.Errorf("active plugin must not be marked deprecated, got:\n%s", out)
+	}
+}
+
+func TestPluginSearch_WarnsWithReplacementOnStderr(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	errOut := captureStderr(t, func() {
+		_ = runPlugin([]string{"search", "policy-gate"})
+	})
+
+	if !strings.Contains(errOut, "nox/grc") {
+		t.Errorf("search warning should name the replacement, got:\n%s", errOut)
+	}
+}
+
+func TestPluginInfo_ShowsDeprecation(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	out := captureStdout(t, func() {
+		if code := runPlugin([]string{"info", "nox/policy-gate"}); code != 0 {
+			t.Errorf("info: expected exit 0, got %d", code)
+		}
+	})
+
+	if !strings.Contains(out, "DEPRECATED") {
+		t.Errorf("info should surface deprecation, got:\n%s", out)
+	}
+	if !strings.Contains(out, "nox/grc") {
+		t.Errorf("info should name the replacement, got:\n%s", out)
+	}
+}
+
+// TestPluginInstall_WarnsButDoesNotBlock — deprecated plugins stay
+// installable on purpose: existing users must keep working, so the
+// deprecation must never be the reason an install fails.
+func TestPluginInstall_WarnsButDoesNotBlock(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	errOut := captureStderr(t, func() {
+		// The install proceeds past the deprecation check and only
+		// fails later at the artifact fetch (no real artifact here).
+		_ = runPlugin([]string{"install", "nox/policy-gate@0.2.0"})
+	})
+
+	if !strings.Contains(errOut, "deprecated") {
+		t.Errorf("install should warn about deprecation, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "nox/grc") {
+		t.Errorf("install warning should name the replacement, got:\n%s", errOut)
+	}
+	// The warning must be advisory — it must not short-circuit before
+	// the fetch, which is what "still proceed" means in practice.
+	if !strings.Contains(errOut, "fetching") {
+		t.Errorf("install should proceed to the fetch step, got:\n%s", errOut)
+	}
+}
+
+func TestPluginInstall_NoWarningForActivePlugin(t *testing.T) {
+	srv := serveDeprecatedIndex(t)
+	defer srv.Close()
+	setupPluginTestState(t, srv)
+
+	errOut := captureStderr(t, func() {
+		_ = runPlugin([]string{"install", "nox/grc@0.3.0"})
+	})
+
+	if strings.Contains(errOut, "deprecated") {
+		t.Errorf("active plugin install must not warn, got:\n%s", errOut)
+	}
+}

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -97,17 +97,17 @@ func runPluginBinaries(ctx context.Context, target string, binaries []string, po
 	}
 
 	out := &core.PluginScanOutput{}
-	for _, resp := range responses {
-		if resp == nil {
+	for _, r := range responses {
+		if r.Response == nil {
 			continue
 		}
-		for _, pf := range resp.GetFindings() {
-			out.Findings = append(out.Findings, plugin.ProtoFindingToGo(pf))
+		for _, pf := range r.Response.GetFindings() {
+			out.Findings = append(out.Findings, plugin.ProtoFindingToGo(pf, r.PluginName))
 		}
-		for _, pe := range resp.GetEnrichments() {
+		for _, pe := range r.Response.GetEnrichments() {
 			out.Enrichments = append(out.Enrichments, plugin.ProtoEnrichmentToGo(pe))
 		}
-		for _, pg := range resp.GetGraphs() {
+		for _, pg := range r.Response.GetGraphs() {
 			out.Graphs = append(out.Graphs, plugin.ProtoGraphToGo(pg))
 		}
 	}

--- a/cmd/marketplace-build/assets/style.css
+++ b/cmd/marketplace-build/assets/style.css
@@ -123,6 +123,29 @@ nav a { color: var(--muted); }
 .tag { background: rgba(125,109,255,0.08); color: var(--accent); }
 .risk { color: #1a1a1a; font-weight: 500; }
 
+/* Deprecated plugins stay listed and installable, so they are dimmed
+   rather than hidden — operators still need to find their docs. */
+.card.deprecated { opacity: 0.62; }
+.card.deprecated:hover { opacity: 1; }
+.deprecated-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: rgba(255,138,0,0.16);
+  color: #ff8a00;
+  border-radius: 4px;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.deprecation-notice {
+  border-left: 3px solid #ff8a00;
+  background: rgba(255,138,0,0.08);
+  padding: 12px 16px;
+  border-radius: 0 6px 6px 0;
+  margin: 12px 0 24px;
+  font-size: 15px;
+}
+
 /* ---------- detail page ---------- */
 .detail h1 { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 28px; margin-bottom: 4px; }
 .detail .lede { color: var(--muted); font-size: 18px; margin-bottom: 32px; }

--- a/cmd/marketplace-build/templates/index.html
+++ b/cmd/marketplace-build/templates/index.html
@@ -40,9 +40,10 @@ nox plugin install nox/ai-eval</code></pre>
   <section class="grid">
   {{range .Plugins}}
     {{$v := firstVersion .}}
-    <a class="card" data-track="{{.Track}}" href="{{$.BaseURL}}/plugins/{{slug .Name}}.html">
+    <a class="card{{if .Deprecated}} deprecated{{end}}" data-track="{{.Track}}" href="{{$.BaseURL}}/plugins/{{slug .Name}}.html">
       <header>
         <h2>{{.Name}}</h2>
+        {{if .Deprecated}}<span class="deprecated-badge">deprecated</span>{{end}}
         {{if .Track}}<span class="track">{{trackName .Track}}</span>{{end}}
       </header>
       <p>{{.Description}}</p>

--- a/cmd/marketplace-build/templates/plugin.html
+++ b/cmd/marketplace-build/templates/plugin.html
@@ -24,6 +24,9 @@
 
     <p style="color:#8a92a3;margin-top:32px"><a href="{{$.BaseURL}}/">← All plugins</a></p>
     <h1>{{.Name}}</h1>
+    {{if .Deprecated}}
+    <p class="deprecation-notice"><strong>Deprecated.</strong> {{if .DeprecationNote}}{{.DeprecationNote}}{{else}}This plugin is no longer maintained.{{end}} Existing installs keep working.</p>
+    {{end}}
     <p class="lede">{{.Description}}</p>
 
     <div class="meta">

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -475,8 +475,9 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				pkg := pkgs[pkgIdx]
 				var domainVulns []Vulnerability
 
-				for _, ov := range osvVulns {
-					sev := mapOSVSeverity(ov.Severity)
+				for i := range osvVulns {
+					ov := &osvVulns[i]
+					sev := mapOSVSeverity(ov.Severity, ov.DatabaseSpecific)
 					domainVulns = append(domainVulns, Vulnerability{
 						ID:       ov.ID,
 						Summary:  ov.Summary,
@@ -498,7 +499,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 						"ecosystem": pkg.Ecosystem,
 						"aliases":   aliases,
 					}
-					if fix := fixedVersion(&ov, pkg.Name, pkg.Ecosystem); fix != "" {
+					if fix := fixedVersion(ov, pkg.Name, pkg.Ecosystem); fix != "" {
 						meta["fixed_in"] = fix
 						meta["remediation_action"] = "upgrade"
 						meta["remediation_command"] = upgradeCommand(pkg.Ecosystem, pkg.Name, fix)

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
@@ -160,6 +161,18 @@ type Analyzer struct {
 	httpClient    *http.Client
 	osvEnabled    bool
 	licensePolicy *LicensePolicy
+
+	// degradations collects the checks this analyzer could not complete. It is
+	// optional: a nil collector discards records, so library callers that do
+	// not supply one behave exactly as before.
+	degradations *degrade.Degradations
+}
+
+// WithDegradations gives the analyzer a collector to report incomplete checks
+// to. Without one, a failed OSV lookup or an unparseable lockfile is
+// indistinguishable from a clean result.
+func WithDegradations(d *degrade.Degradations) AnalyzerOption {
+	return func(a *Analyzer) { a.degradations = d }
 }
 
 // NewAnalyzer returns an Analyzer with the default OSV API endpoint.
@@ -301,8 +314,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 		pkgs, err := a.ParseLockfile(art.AbsPath, content)
 		if err != nil {
-			// Skip lockfiles we cannot parse (e.g. yarn.lock)
-			// rather than failing the entire scan.
+			// Skip lockfiles we cannot parse (e.g. yarn.lock) rather than
+			// failing the entire scan — but record it, because every package
+			// in this file is now absent from vulnerability matching.
+			a.degradations.Add(degrade.Lockfile,
+				fmt.Sprintf("%s could not be parsed: %v", art.Path, err),
+				"dependencies declared in this file were not scanned for vulnerabilities")
 			continue
 		}
 
@@ -466,7 +483,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancel()
 
-			vulnMap, err := queryOSV(ctx, a.httpClient, a.OSVBaseURL, pkgs)
+			vulnMap, err := queryOSV(ctx, a.httpClient, a.OSVBaseURL, pkgs, a.degradations)
 			if err != nil {
 				return nil, nil, fmt.Errorf("querying OSV: %w", err)
 			}

--- a/core/analyzers/deps/license.go
+++ b/core/analyzers/deps/license.go
@@ -149,24 +149,24 @@ func matchesLicenseList(license string, list []string) bool {
 // name to license string.
 func detectNPMLicenses(basePath string) map[string]string {
 	result := make(map[string]string)
+
+	// Read the root manifest's own license if present. A missing or malformed
+	// root package.json must not stop us: the dependency licences we actually
+	// evaluate live in node_modules, and returning early here meant a project
+	// whose root manifest was absent got no license findings at all.
 	path := filepath.Join(basePath, "package.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return result
-	}
-
-	var pkg struct {
-		Name    string          `json:"name"`
-		License json.RawMessage `json:"license"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return result
-	}
-
-	// The license field can be a string or an object {type: "MIT"}.
-	license := extractJSONLicense(pkg.License)
-	if license != "" && pkg.Name != "" {
-		result[pkg.Name] = license
+	if data, err := os.ReadFile(path); err == nil {
+		var pkg struct {
+			Name    string          `json:"name"`
+			License json.RawMessage `json:"license"`
+		}
+		if err := json.Unmarshal(data, &pkg); err == nil {
+			// The license field can be a string or an object {type: "MIT"}.
+			license := extractJSONLicense(pkg.License)
+			if license != "" && pkg.Name != "" {
+				result[pkg.Name] = license
+			}
+		}
 	}
 
 	// Read license info from node_modules package.json files.

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -6,9 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
+	urlpkg "net/url"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/nox-hq/nox/core/findings"
 )
@@ -44,6 +48,11 @@ type osvBatchResult struct {
 }
 
 // osvVuln is a single vulnerability from OSV.
+//
+// Note that /v1/querybatch populates ONLY ID (and "modified"). Every other
+// field here arrives exclusively from the per-vulnerability hydration call,
+// GET /v1/vulns/{id} — see hydrateVulns. Consuming these fields off a raw
+// querybatch response yields empty severity, summary, aliases and fix data.
 type osvVuln struct {
 	ID       string        `json:"id"`
 	Summary  string        `json:"summary"`
@@ -51,6 +60,17 @@ type osvVuln struct {
 	Aliases  []string      `json:"aliases"`
 	Details  string        `json:"details"`
 	Affected []osvAffected `json:"affected"`
+
+	// DatabaseSpecific carries source-database annotations. GitHub advisories
+	// populate a coarse severity label here, which we use as a fallback when
+	// no machine-parsable CVSS vector is present (notably for CVSS v4-only
+	// records).
+	DatabaseSpecific osvDatabaseSpecific `json:"database_specific"`
+}
+
+// osvDatabaseSpecific holds the subset of source-specific annotations we read.
+type osvDatabaseSpecific struct {
+	Severity string `json:"severity"`
 }
 
 // osvSeverity holds a CVSS or other severity score.
@@ -192,7 +212,119 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 		}
 	}
 
+	// /v1/querybatch answers only "which packages are affected, by which IDs".
+	// Every field an operator actually needs — severity, summary, aliases, and
+	// the fixed version — lives on the full record, so hydrate each distinct ID
+	// via GET /v1/vulns/{id}. Cost scales with vulnerabilities found, not
+	// packages scanned: a 62-package Go module with one affected dependency
+	// costs 7 extra requests.
+	hydrateVulns(ctx, client, baseURL, result)
+
 	return result, nil
+}
+
+// osvHydrateConcurrency bounds in-flight per-vulnerability detail requests so a
+// badly vulnerable repo cannot open hundreds of sockets against OSV at once.
+const osvHydrateConcurrency = 8
+
+// hydrateVulns replaces each stub vulnerability in result (as returned by
+// /v1/querybatch, which carries only an ID) with its full OSV record fetched
+// from GET /v1/vulns/{id}. Distinct IDs are fetched once each, concurrently.
+//
+// Hydration is best-effort: an ID that fails to fetch keeps its stub record, so
+// the finding is still reported — with a conservative severity — rather than
+// dropped. Failures are logged, because a silently under-described finding is
+// indistinguishable from a fully-described one.
+//
+// Results are written back deterministically: concurrency affects only fetch
+// order, never the contents or ordering of result.
+func hydrateVulns(ctx context.Context, client *http.Client, baseURL string, result map[int][]osvVuln) {
+	ids := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, vulns := range result {
+		for i := range vulns {
+			if id := vulns[i].ID; id != "" && !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	sort.Strings(ids)
+
+	var mu sync.Mutex
+	details := make(map[string]osvVuln, len(ids))
+	var failed int
+
+	sem := make(chan struct{}, osvHydrateConcurrency)
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			detail, err := fetchVulnDetail(ctx, client, baseURL, id)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				failed++
+				return
+			}
+			details[id] = detail
+		}(id)
+	}
+	wg.Wait()
+
+	if failed > 0 {
+		slog.WarnContext(ctx, "some OSV vulnerability details could not be fetched; those findings keep a conservative severity and carry no fix version",
+			"failed", failed, "total", len(ids))
+	}
+
+	for pkgIdx, vulns := range result {
+		for i := range vulns {
+			if detail, ok := details[vulns[i].ID]; ok {
+				result[pkgIdx][i] = detail
+			}
+		}
+	}
+}
+
+// fetchVulnDetail retrieves the full OSV record for a single vulnerability ID.
+func fetchVulnDetail(ctx context.Context, client *http.Client, baseURL, id string) (osvVuln, error) {
+	url := strings.TrimRight(baseURL, "/") + "/v1/vulns/" + urlpkg.PathEscape(id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return osvVuln{}, fmt.Errorf("creating OSV detail request for %s: %w", id, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return osvVuln{}, fmt.Errorf("fetching OSV detail for %s: %w", id, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return osvVuln{}, fmt.Errorf("OSV detail for %s returned status %d", id, resp.StatusCode)
+	}
+
+	var detail osvVuln
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		return osvVuln{}, fmt.Errorf("decoding OSV detail for %s: %w", id, err)
+	}
+
+	// Confirm we got back the record we asked for. Any JSON object decodes
+	// into osvVuln without error — an intercepting proxy or captive portal
+	// answering 200 with unrelated JSON would otherwise yield a well-formed
+	// but entirely empty vulnerability, silently blanking a real finding's
+	// severity and fix version.
+	if detail.ID != id {
+		return osvVuln{}, fmt.Errorf("OSV detail for %s returned mismatched record %q", id, detail.ID)
+	}
+	return detail, nil
 }
 
 // decodeBatchResponse reads and decodes an OSV batch response. It returns
@@ -208,32 +340,59 @@ func decodeBatchResponse(resp *http.Response) ([]osvBatchResult, error) {
 	return batchResp.Results, nil
 }
 
-// mapOSVSeverity converts OSV severity entries to a nox Severity.
-// It looks for a CVSS_V3 score first, then falls back to CVSS_V2.
-// If no score is found, it returns SeverityMedium as a conservative default.
-func mapOSVSeverity(sev []osvSeverity) findings.Severity {
-	for _, s := range sev {
-		if s.Type == "CVSS_V3" || s.Type == "CVSS_V2" {
-			return cvssToSeverity(s.Score)
+// mapOSVSeverity converts an OSV record's severity information to a nox
+// Severity, preferring the most precise source available:
+//
+//  1. A CVSS v3 vector in severity[] — the base score is computed from the
+//     vector per the CVSS v3.1 specification.
+//  2. A bare numeric score in severity[] (some databases publish this).
+//  3. The coarse database_specific.severity label (CRITICAL / HIGH /
+//     MODERATE / LOW), which is how we recover a real severity for records
+//     that carry only a CVSS v4 vector.
+//
+// It returns SeverityMedium only when none of the above is present, which is
+// a genuine "unknown", not — as was previously the case — the outcome for
+// every record OSV actually publishes.
+func mapOSVSeverity(sev []osvSeverity, dbSpecific osvDatabaseSpecific) findings.Severity {
+	// Prefer v3 over v2 regardless of ordering in the record.
+	for _, want := range []string{"CVSS_V3", "CVSS_V2"} {
+		for _, s := range sev {
+			if s.Type != want {
+				continue
+			}
+			if score, ok := cvssBaseScore(s.Score); ok {
+				return scoreToSeverity(score)
+			}
 		}
 	}
+
+	if s, ok := severityFromLabel(dbSpecific.Severity); ok {
+		return s
+	}
+
 	return findings.SeverityMedium
 }
 
-// cvssToSeverity converts a CVSS vector string or numeric score to a Severity.
-// It extracts the base score from either a bare number ("9.8") or a CVSS
-// vector string by looking for a trailing numeric value.
-func cvssToSeverity(score string) findings.Severity {
-	// Try parsing as a plain float first (e.g. "9.8").
-	f, err := strconv.ParseFloat(score, 64)
-	if err != nil {
-		// Try extracting the base score from a CVSS vector string.
-		// CVSS vectors look like "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-		// — the score is not embedded in the vector, so we can't parse it.
-		// Fall back to medium.
-		return findings.SeverityMedium
+// severityFromLabel maps a coarse textual severity label to a nox Severity.
+// GitHub advisories use "MODERATE" where most other sources say "MEDIUM".
+func severityFromLabel(label string) (findings.Severity, bool) {
+	switch strings.ToUpper(strings.TrimSpace(label)) {
+	case "CRITICAL":
+		return findings.SeverityCritical, true
+	case "HIGH":
+		return findings.SeverityHigh, true
+	case "MODERATE", "MEDIUM":
+		return findings.SeverityMedium, true
+	case "LOW":
+		return findings.SeverityLow, true
+	default:
+		return "", false
 	}
+}
 
+// scoreToSeverity buckets a CVSS base score using the standard qualitative
+// severity rating scale.
+func scoreToSeverity(f float64) findings.Severity {
 	switch {
 	case f >= 9.0:
 		return findings.SeverityCritical
@@ -246,6 +405,121 @@ func cvssToSeverity(score string) findings.Severity {
 	default:
 		return findings.SeverityInfo
 	}
+}
+
+// cvssBaseScore returns the CVSS base score for the given score field, which
+// OSV publishes either as a bare number ("9.8") or — far more commonly — as a
+// full CVSS vector string ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H").
+//
+// Vectors are scored per the CVSS v3.1 specification, section 7.1. CVSS v4
+// vectors use a different, substantially more complex scoring algorithm and
+// are deliberately not attempted here; callers fall back to the coarse
+// database_specific label for those.
+func cvssBaseScore(score string) (float64, bool) {
+	score = strings.TrimSpace(score)
+	if score == "" {
+		return 0, false
+	}
+
+	if f, err := strconv.ParseFloat(score, 64); err == nil {
+		return f, true
+	}
+	if !strings.HasPrefix(score, "CVSS:3.") {
+		return 0, false
+	}
+	return cvss3BaseScore(score)
+}
+
+// cvss3Weights maps each CVSS v3 base metric abbreviation to its numeric
+// weight. Privileges Required is scope-dependent and handled separately.
+var cvss3Weights = map[string]map[string]float64{
+	"AV": {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2},
+	"AC": {"L": 0.77, "H": 0.44},
+	"UI": {"N": 0.85, "R": 0.62},
+	"C":  {"H": 0.56, "L": 0.22, "N": 0},
+	"I":  {"H": 0.56, "L": 0.22, "N": 0},
+	"A":  {"H": 0.56, "L": 0.22, "N": 0},
+}
+
+// cvss3PRWeights maps Privileges Required to its weight. The value depends on
+// Scope: a changed scope raises the weight for L and H.
+var cvss3PRWeights = map[bool]map[string]float64{
+	false: {"N": 0.85, "L": 0.62, "H": 0.27}, // scope unchanged
+	true:  {"N": 0.85, "L": 0.68, "H": 0.50}, // scope changed
+}
+
+// cvss3BaseScore computes the CVSS v3.1 base score from a vector string.
+// It returns false when a required base metric is absent or carries an
+// unrecognised value — a malformed vector must not silently score as 0.0.
+func cvss3BaseScore(vector string) (float64, bool) {
+	metrics := make(map[string]string)
+	for _, part := range strings.Split(vector, "/") {
+		key, val, found := strings.Cut(part, ":")
+		if found {
+			metrics[key] = val
+		}
+	}
+
+	scopeChanged := metrics["S"] == "C"
+	if metrics["S"] != "C" && metrics["S"] != "U" {
+		return 0, false
+	}
+
+	weight := func(metric string) (float64, bool) {
+		val, ok := metrics[metric]
+		if !ok {
+			return 0, false
+		}
+		if metric == "PR" {
+			w, ok := cvss3PRWeights[scopeChanged][val]
+			return w, ok
+		}
+		w, ok := cvss3Weights[metric][val]
+		return w, ok
+	}
+
+	av, okAV := weight("AV")
+	ac, okAC := weight("AC")
+	pr, okPR := weight("PR")
+	ui, okUI := weight("UI")
+	c, okC := weight("C")
+	i, okI := weight("I")
+	a, okA := weight("A")
+	if !okAV || !okAC || !okPR || !okUI || !okC || !okI || !okA {
+		return 0, false
+	}
+
+	iss := 1 - ((1 - c) * (1 - i) * (1 - a))
+
+	var impact float64
+	if scopeChanged {
+		impact = 7.52*(iss-0.029) - 3.25*math.Pow(iss-0.02, 15)
+	} else {
+		impact = 6.42 * iss
+	}
+	if impact <= 0 {
+		return 0, true
+	}
+
+	exploitability := 8.22 * av * ac * pr * ui
+
+	base := impact + exploitability
+	if scopeChanged {
+		base *= 1.08
+	}
+	return cvssRoundUp(math.Min(base, 10)), true
+}
+
+// cvssRoundUp implements the CVSS v3.1 Roundup function: the smallest number
+// to one decimal place that is greater than or equal to the input. The integer
+// arithmetic mirrors the specification's reference implementation, which avoids
+// the floating-point edge cases a naive math.Ceil(x*10)/10 hits.
+func cvssRoundUp(x float64) float64 {
+	i := int(math.Round(x * 100000))
+	if i%10000 == 0 {
+		return float64(i) / 100000.0
+	}
+	return (math.Floor(float64(i)/10000) + 1) / 10.0
 }
 
 // upgradeCommand returns the canonical one-liner an operator can run to

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/findings"
 )
 
@@ -133,7 +134,7 @@ func fixedVersion(vuln *osvVuln, pkgName, ecosystem string) string {
 //
 // On network errors the function returns an empty map (graceful degradation)
 // rather than failing the scan, honouring Nox's offline-first design.
-func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []Package) (map[int][]osvVuln, error) {
+func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []Package, deg *degrade.Degradations) (map[int][]osvVuln, error) {
 	result := make(map[int][]osvVuln)
 
 	// Only query packages whose ecosystem OSV.dev actually understands. Other
@@ -192,6 +193,9 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 			// result is indistinguishable from "no vulnerabilities found".
 			slog.WarnContext(ctx, "OSV query failed; dependency vulnerabilities may be under-reported",
 				"error", err, "queries", len(queries))
+			deg.Add(degrade.OSV,
+				fmt.Sprintf("vulnerability lookup failed for %d packages: %v", len(queries), err),
+				"dependency vulnerabilities are under-reported; this scan cannot confirm the absence of known CVEs")
 			return result, nil
 		}
 
@@ -202,6 +206,9 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 			// clean scan when the lookup actually failed.
 			slog.WarnContext(ctx, "OSV query returned an error; dependency vulnerabilities may be under-reported",
 				"error", decodeErr, "queries", len(queries))
+			deg.Add(degrade.OSV,
+				fmt.Sprintf("vulnerability lookup failed for %d packages: %v", len(queries), decodeErr),
+				"dependency vulnerabilities are under-reported; this scan cannot confirm the absence of known CVEs")
 			return result, nil
 		}
 
@@ -218,7 +225,7 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 	// via GET /v1/vulns/{id}. Cost scales with vulnerabilities found, not
 	// packages scanned: a 62-package Go module with one affected dependency
 	// costs 7 extra requests.
-	hydrateVulns(ctx, client, baseURL, result)
+	hydrateVulns(ctx, client, baseURL, result, deg)
 
 	return result, nil
 }
@@ -238,7 +245,7 @@ const osvHydrateConcurrency = 8
 //
 // Results are written back deterministically: concurrency affects only fetch
 // order, never the contents or ordering of result.
-func hydrateVulns(ctx context.Context, client *http.Client, baseURL string, result map[int][]osvVuln) {
+func hydrateVulns(ctx context.Context, client *http.Client, baseURL string, result map[int][]osvVuln, deg *degrade.Degradations) {
 	ids := make([]string, 0)
 	seen := make(map[string]bool)
 	for _, vulns := range result {
@@ -282,6 +289,9 @@ func hydrateVulns(ctx context.Context, client *http.Client, baseURL string, resu
 	if failed > 0 {
 		slog.WarnContext(ctx, "some OSV vulnerability details could not be fetched; those findings keep a conservative severity and carry no fix version",
 			"failed", failed, "total", len(ids))
+		deg.Add(degrade.OSV,
+			fmt.Sprintf("%d of %d vulnerability records could not be fetched", failed, len(ids)),
+			"affected findings carry a conservative severity and no fix version; their real severity may be higher")
 	}
 
 	for pkgIdx, vulns := range result {

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -111,7 +111,7 @@ func TestQueryOSV_BatchQuery(t *testing.T) {
 		{Name: "lodash", Version: "4.17.20", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestQueryOSV_HydrationFailureKeepsFinding(t *testing.T) {
 
 	pkgs := []Package{{Name: "lodash", Version: "4.17.20", Ecosystem: "npm"}}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestQueryOSV_LargeBatch(t *testing.T) {
 		pkgs[i] = Package{Name: "pkg", Version: "1.0.0", Ecosystem: "npm"}
 	}
 
-	_, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	_, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestQueryOSV_NetworkError(t *testing.T) {
 		{Name: "express", Version: "4.17.1", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestQueryOSV_EmptyResponse(t *testing.T) {
 		{Name: "lodash", Version: "4.17.21", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestQueryOSV_Non200Status(t *testing.T) {
 		{Name: "express", Version: "4.17.1", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
@@ -964,7 +964,7 @@ func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 		{Name: "esbuild", Version: "0.27.7", Ecosystem: "npm"},
 	}
 
-	got, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	got, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -999,7 +999,7 @@ func TestQueryOSV_WarnsOnNon200(t *testing.T) {
 	defer slog.SetDefault(prev)
 
 	got, err := queryOSV(context.Background(), srv.Client(), srv.URL,
-		[]Package{{Name: "lodash", Version: "4.17.0", Ecosystem: "npm"}})
+		[]Package{{Name: "lodash", Version: "4.17.0", Ecosystem: "npm"}}, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -37,8 +38,31 @@ func decodeJSON(t *testing.T, r *http.Request, v any) {
 // queryOSV tests
 // ---------------------------------------------------------------------------
 
-func TestQueryOSV_BatchQuery(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// osvFakeAPI returns a test server that models the REAL OSV API contract:
+// /v1/querybatch answers with vulnerability IDs ONLY (no severity, summary,
+// aliases or affected ranges), and full records are served exclusively from
+// /v1/vulns/{id}. Mocking querybatch as if it returned full records — as this
+// suite previously did — hides the fact that nox must hydrate, which is
+// precisely how every dependency finding came to be reported as "medium" with
+// an empty description and no fix version.
+//
+// details maps vulnerability ID to the full record served from /v1/vulns/{id};
+// an ID absent from the map yields 404 so callers can exercise the
+// hydration-failure path. vulnsFor maps a package name to the IDs querybatch
+// reports for it.
+func osvFakeAPI(t *testing.T, vulnsFor map[string][]string, details map[string]osvVuln) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id, ok := strings.CutPrefix(r.URL.Path, "/v1/vulns/"); ok {
+			detail, found := details[id]
+			if !found {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			encodeJSON(t, w, detail)
+			return
+		}
+
 		if r.URL.Path != "/v1/querybatch" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			http.Error(w, "not found", http.StatusNotFound)
@@ -48,41 +72,37 @@ func TestQueryOSV_BatchQuery(t *testing.T) {
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 
-		// Return vulns for lodash and express, none for others.
 		results := make([]osvBatchResult, len(req.Queries))
 		for i, q := range req.Queries {
-			switch q.Package.Name {
-			case "lodash":
-				results[i] = osvBatchResult{
-					Vulns: []osvVuln{
-						{
-							ID:      "GHSA-1234-5678-9012",
-							Summary: "Prototype pollution in lodash",
-							Severity: []osvSeverity{
-								{Type: "CVSS_V3", Score: "7.5"},
-							},
-							Aliases: []string{"CVE-2020-28500"},
-						},
-					},
-				}
-			case "express":
-				results[i] = osvBatchResult{
-					Vulns: []osvVuln{
-						{
-							ID:      "GHSA-abcd-efgh-ijkl",
-							Summary: "Path traversal in express",
-							Severity: []osvSeverity{
-								{Type: "CVSS_V3", Score: "9.1"},
-							},
-							Aliases: []string{"CVE-2024-1234"},
-						},
-					},
-				}
+			for _, id := range vulnsFor[q.Package.Name] {
+				// Deliberately ID-only: this is all the real API returns.
+				results[i].Vulns = append(results[i].Vulns, osvVuln{ID: id})
 			}
 		}
-
 		encodeJSON(t, w, osvBatchResponse{Results: results})
 	}))
+}
+
+func TestQueryOSV_BatchQuery(t *testing.T) {
+	srv := osvFakeAPI(t,
+		map[string][]string{
+			"lodash":  {"GHSA-1234-5678-9012"},
+			"express": {"GHSA-abcd-efgh-ijkl"},
+		},
+		map[string]osvVuln{
+			"GHSA-1234-5678-9012": {
+				ID:       "GHSA-1234-5678-9012",
+				Summary:  "Prototype pollution in lodash",
+				Severity: []osvSeverity{{Type: "CVSS_V3", Score: "7.5"}},
+				Aliases:  []string{"CVE-2020-28500"},
+			},
+			"GHSA-abcd-efgh-ijkl": {
+				ID:       "GHSA-abcd-efgh-ijkl",
+				Summary:  "Path traversal in express",
+				Severity: []osvSeverity{{Type: "CVSS_V3", Score: "9.1"}},
+				Aliases:  []string{"CVE-2024-1234"},
+			},
+		})
 	defer srv.Close()
 
 	pkgs := []Package{
@@ -113,6 +133,49 @@ func TestQueryOSV_BatchQuery(t *testing.T) {
 	}
 	if result[2][0].ID != "GHSA-1234-5678-9012" {
 		t.Errorf("expected GHSA-1234-5678-9012, got %s", result[2][0].ID)
+	}
+
+	// The fields below exist ONLY on the hydrated record. Asserting them is
+	// what makes this test capable of catching a regression to the ID-only
+	// querybatch data — the bug that made every finding medium-severity with
+	// an empty message and no fix version.
+	lodash := result[2][0]
+	if lodash.Summary != "Prototype pollution in lodash" {
+		t.Errorf("summary not hydrated: got %q", lodash.Summary)
+	}
+	if len(lodash.Severity) != 1 || lodash.Severity[0].Score != "7.5" {
+		t.Errorf("severity not hydrated: got %+v", lodash.Severity)
+	}
+	if len(lodash.Aliases) != 1 || lodash.Aliases[0] != "CVE-2020-28500" {
+		t.Errorf("aliases not hydrated: got %v", lodash.Aliases)
+	}
+	if got := mapOSVSeverity(lodash.Severity, lodash.DatabaseSpecific); got != findings.SeverityHigh {
+		t.Errorf("expected high severity after hydration, got %s", got)
+	}
+}
+
+// TestQueryOSV_HydrationFailureKeepsFinding pins the degradation contract: a
+// vulnerability whose detail fetch fails is still reported (with a
+// conservative severity) rather than silently dropped.
+func TestQueryOSV_HydrationFailureKeepsFinding(t *testing.T) {
+	// vulnsFor names an ID that details deliberately does not contain, so
+	// /v1/vulns/{id} answers 404.
+	srv := osvFakeAPI(t,
+		map[string][]string{"lodash": {"GHSA-missing-detail"}},
+		map[string]osvVuln{})
+	defer srv.Close()
+
+	pkgs := []Package{{Name: "lodash", Version: "4.17.20", Ecosystem: "npm"}}
+
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	if err != nil {
+		t.Fatalf("queryOSV returned error: %v", err)
+	}
+	if len(result[0]) != 1 {
+		t.Fatalf("expected the finding to survive a failed detail fetch, got %d", len(result[0]))
+	}
+	if result[0][0].ID != "GHSA-missing-detail" {
+		t.Errorf("expected the stub ID to be preserved, got %s", result[0][0].ID)
 	}
 }
 
@@ -297,18 +360,133 @@ func TestMapOSVSeverity(t *testing.T) {
 			input:    []osvSeverity{},
 			expected: findings.SeverityMedium,
 		},
+		// The cases below carry CVSS vector strings, which is the form OSV
+		// actually publishes. These previously all collapsed to medium.
 		{
-			name:     "CVSS vector string (not a number)",
+			name:     "CVSS v3 vector scores 9.8 critical",
 			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+			expected: findings.SeverityCritical,
+		},
+		{
+			// CVE-2021-3121 (gogo/protobuf) — the record that exposed the bug.
+			name:     "CVSS v3 vector scores 8.6 high",
+			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"}},
+			expected: findings.SeverityHigh,
+		},
+		{
+			name:     "CVSS v3 vector with changed scope",
+			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"}},
 			expected: findings.SeverityMedium,
+		},
+		{
+			name:     "CVSS v3 vector with no impact scores info",
+			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"}},
+			expected: findings.SeverityInfo,
+		},
+		{
+			name:     "malformed vector falls back to medium",
+			input:    []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:X/AC:L"}},
+			expected: findings.SeverityMedium,
+		},
+		{
+			name:     "prefers v3 over v2 regardless of order",
+			input:    []osvSeverity{{Type: "CVSS_V2", Score: "2.1"}, {Type: "CVSS_V3", Score: "9.8"}},
+			expected: findings.SeverityCritical,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := mapOSVSeverity(tt.input)
+			result := mapOSVSeverity(tt.input, osvDatabaseSpecific{})
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestMapOSVSeverity_DatabaseSpecificFallback covers records that carry no
+// parsable CVSS vector — notably CVSS v4-only advisories — where the coarse
+// GitHub severity label is the only signal available.
+func TestMapOSVSeverity_DatabaseSpecificFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		sev      []osvSeverity
+		label    string
+		expected findings.Severity
+	}{
+		{"critical label", nil, "CRITICAL", findings.SeverityCritical},
+		{"high label", nil, "HIGH", findings.SeverityHigh},
+		{"github moderate means medium", nil, "MODERATE", findings.SeverityMedium},
+		{"low label", nil, "LOW", findings.SeverityLow},
+		{"lowercase label", nil, "high", findings.SeverityHigh},
+		{"unknown label falls back to medium", nil, "SPICY", findings.SeverityMedium},
+		{"no signal at all falls back to medium", nil, "", findings.SeverityMedium},
+		{
+			name:     "cvss v4 vector is not scored, label wins",
+			sev:      []osvSeverity{{Type: "CVSS_V4", Score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"}},
+			label:    "CRITICAL",
+			expected: findings.SeverityCritical,
+		},
+		{
+			name:     "parsable vector beats the coarse label",
+			sev:      []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+			label:    "LOW",
+			expected: findings.SeverityCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapOSVSeverity(tt.sev, osvDatabaseSpecific{Severity: tt.label})
+			if got != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}
+
+// TestCVSS3BaseScore checks the base-score computation against vectors with
+// scores published in the CVSS v3.1 specification and the NVD.
+func TestCVSS3BaseScore(t *testing.T) {
+	tests := []struct {
+		vector string
+		want   float64
+	}{
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H", 8.6},
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", 7.5},
+		{"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N", 5.5},
+		{"CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N", 4.7},
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", 0.0},
+		{"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.vector, func(t *testing.T) {
+			got, ok := cvssBaseScore(tt.vector)
+			if !ok {
+				t.Fatalf("expected %s to score, got ok=false", tt.vector)
+			}
+			if math.Abs(got-tt.want) > 0.05 {
+				t.Errorf("expected %.1f, got %.1f", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCVSSBaseScore_Rejects(t *testing.T) {
+	for _, vector := range []string{
+		"",
+		"not a vector",
+		"CVSS:3.1/AV:N/AC:L", // missing required metrics
+		"CVSS:3.1/AV:Z/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", // unknown AV value
+		"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:X/C:H/I:H/A:H", // invalid scope
+		"CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+	} {
+		t.Run(vector, func(t *testing.T) {
+			if score, ok := cvssBaseScore(vector); ok {
+				t.Errorf("expected %q to be rejected, got score %.1f", vector, score)
 			}
 		})
 	}
@@ -417,31 +595,17 @@ func TestEcosystemToOSV(t *testing.T) {
 
 func TestScanArtifacts_WithOSV(t *testing.T) {
 	// Mock OSV server returning a vulnerability for lodash.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req osvBatchRequest
-		decodeJSON(t, r, &req)
-
-		results := make([]osvBatchResult, len(req.Queries))
-		for i, q := range req.Queries {
-			if q.Package.Name == "lodash" {
-				results[i] = osvBatchResult{
-					Vulns: []osvVuln{
-						{
-							ID:      "GHSA-test-vuln-0001",
-							Summary: "Prototype Pollution in lodash",
-							Severity: []osvSeverity{
-								{Type: "CVSS_V3", Score: "7.4"},
-							},
-							Aliases: []string{"CVE-2021-23337"},
-							Details: "lodash versions prior to 4.17.21 are vulnerable.",
-						},
-					},
-				}
-			}
-		}
-
-		encodeJSON(t, w, osvBatchResponse{Results: results})
-	}))
+	srv := osvFakeAPI(t,
+		map[string][]string{"lodash": {"GHSA-test-vuln-0001"}},
+		map[string]osvVuln{
+			"GHSA-test-vuln-0001": {
+				ID:       "GHSA-test-vuln-0001",
+				Summary:  "Prototype Pollution in lodash",
+				Severity: []osvSeverity{{Type: "CVSS_V3", Score: "7.4"}},
+				Aliases:  []string{"CVE-2021-23337"},
+				Details:  "lodash versions prior to 4.17.21 are vulnerable.",
+			},
+		})
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
@@ -573,31 +737,17 @@ func TestScanArtifacts_OSVDisabled(t *testing.T) {
 }
 
 func TestScanArtifacts_VulnerabilityMetadata(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req osvBatchRequest
-		decodeJSON(t, r, &req)
-
-		results := make([]osvBatchResult, len(req.Queries))
-		for i, q := range req.Queries {
-			if q.Package.Name == "Django" {
-				results[i] = osvBatchResult{
-					Vulns: []osvVuln{
-						{
-							ID:      "GHSA-django-xss",
-							Summary: "XSS in Django admin",
-							Severity: []osvSeverity{
-								{Type: "CVSS_V3", Score: "6.1"},
-							},
-							Aliases: []string{"CVE-2023-12345", "PYSEC-2023-001"},
-							Details: "A cross-site scripting vulnerability exists in the Django admin.",
-						},
-					},
-				}
-			}
-		}
-
-		encodeJSON(t, w, osvBatchResponse{Results: results})
-	}))
+	srv := osvFakeAPI(t,
+		map[string][]string{"Django": {"GHSA-django-xss"}},
+		map[string]osvVuln{
+			"GHSA-django-xss": {
+				ID:       "GHSA-django-xss",
+				Summary:  "XSS in Django admin",
+				Severity: []osvSeverity{{Type: "CVSS_V3", Score: "6.1"}},
+				Aliases:  []string{"CVE-2023-12345", "PYSEC-2023-001"},
+				Details:  "A cross-site scripting vulnerability exists in the Django admin.",
+			},
+		})
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
@@ -769,6 +919,18 @@ func TestNewAnalyzer_Defaults(t *testing.T) {
 // with a Dockerfile silently lost every real Go/npm/PyPI vulnerability finding.
 func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id, ok := strings.CutPrefix(r.URL.Path, "/v1/vulns/"); ok {
+			if id != "GHSA-g7r4-m6w7-qqqr" {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			encodeJSON(t, w, osvVuln{
+				ID:      id,
+				Summary: "arbitrary file read in esbuild dev server",
+			})
+			return
+		}
+
 		var req osvBatchRequest
 		decodeJSON(t, r, &req)
 
@@ -785,13 +947,11 @@ func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 			}
 		}
 
+		// ID-only, as the real querybatch endpoint returns.
 		results := make([]osvBatchResult, len(req.Queries))
 		for i, q := range req.Queries {
 			if q.Package.Name == "esbuild" {
-				results[i] = osvBatchResult{Vulns: []osvVuln{{
-					ID:      "GHSA-g7r4-m6w7-qqqr",
-					Summary: "arbitrary file read in esbuild dev server",
-				}}}
+				results[i] = osvBatchResult{Vulns: []osvVuln{{ID: "GHSA-g7r4-m6w7-qqqr"}}}
 			}
 		}
 		encodeJSON(t, w, osvBatchResponse{Results: results})

--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -1,0 +1,219 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover the degradation-reporting and fail-loud behaviour added to
+// close a class of bug where nox reported a clean scan without having run the
+// check. Each one previously passed silently with exit 0.
+
+func TestRefine_MalformedVEXIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	vexPath := filepath.Join(dir, "broken.vex.json")
+	if err := os.WriteFile(vexPath, []byte("{ this is not valid json"), 0o644); err != nil {
+		t.Fatalf("writing vex: %v", err)
+	}
+
+	// An operator who passes --vex expects those waivers to be applied. Before
+	// this change the load error was discarded, so a typo'd or corrupt document
+	// silently applied no waivers at all.
+	_, err := RunScanWithOptions(dir, ScanOptions{VEXPath: vexPath, Offline: true})
+	if err == nil {
+		t.Fatal("expected an error for a malformed VEX document, got nil")
+	}
+	if !strings.Contains(err.Error(), "VEX") {
+		t.Errorf("expected the error to name VEX, got: %v", err)
+	}
+}
+
+func TestRefine_MissingVEXFileIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	_, err := RunScanWithOptions(dir, ScanOptions{
+		VEXPath: filepath.Join(dir, "does-not-exist.json"),
+		Offline: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing VEX document, got nil")
+	}
+}
+
+func TestRefine_MissingTerraformPlanIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Silently scanning nothing would let a typo'd plan path masquerade as a
+	// clean infrastructure review.
+	_, err := RunScanWithOptions(dir, ScanOptions{
+		TerraformPlanPath: filepath.Join(dir, "no-such-plan.json"),
+		Offline:           true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing terraform plan, got nil")
+	}
+	if !strings.Contains(err.Error(), "terraform") {
+		t.Errorf("expected the error to name the terraform plan, got: %v", err)
+	}
+}
+
+func TestRefine_MalformedTerraformPlanIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(planPath, []byte("not json at all"), 0o644); err != nil {
+		t.Fatalf("writing plan: %v", err)
+	}
+
+	_, err := RunScanWithOptions(dir, ScanOptions{TerraformPlanPath: planPath, Offline: true})
+	if err == nil {
+		t.Fatal("expected an error for a malformed terraform plan, got nil")
+	}
+}
+
+func TestScan_CorruptBaselineIsReportedAsDegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A file the secrets analyzer will flag, so there is something to classify.
+	if err := os.WriteFile(filepath.Join(dir, "cfg.env"),
+		[]byte("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY\n"), 0o644); err != nil {
+		t.Fatalf("writing target file: %v", err)
+	}
+
+	cfg := "policy:\n  baseline_path: .nox-baseline.json\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox-baseline.json"),
+		[]byte("{ corrupt"), 0o644); err != nil {
+		t.Fatalf("writing baseline: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	// A corrupt baseline must not fail the scan — but under baseline_mode it
+	// changes what the gate enforces, so it cannot pass unnoticed either.
+	if !hasDegradationKind(result, "baseline") {
+		t.Errorf("expected a baseline degradation, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_AbsentBaselineIsNotADegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Having no baseline is the normal state before the first
+	// `nox baseline write`. Reporting it would train operators to ignore
+	// degradation output entirely.
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if hasDegradationKind(result, "baseline") {
+		t.Errorf("absent baseline should be silent, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_UnparseableLockfileIsReportedAsDegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Valid filename so it is classified as a lockfile, invalid content so the
+	// parse fails. Every dependency it declares is now absent from CVE matching.
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"),
+		[]byte("{ not valid json at all"), 0o644); err != nil {
+		t.Fatalf("writing lockfile: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	if !hasDegradationKind(result, "lockfile_parse") {
+		t.Errorf("expected a lockfile degradation, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_CleanScanReportsNoDegradations(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# hello\n"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if len(result.Degradations) != 0 {
+		t.Errorf("expected no degradations on a clean offline scan, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_LicensePolicyIsWiredThrough(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A dependency in the inventory (from the lockfile) whose license the
+	// policy denies (from its node_modules manifest). Before this change
+	// license.deny parsed cleanly and then produced no findings whatsoever.
+	lock := `{"packages":{"node_modules/leftpad":{"version":"1.0.0"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(lock), 0o644); err != nil {
+		t.Fatalf("writing lockfile: %v", err)
+	}
+	modDir := filepath.Join(dir, "node_modules", "leftpad")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatalf("creating node_modules: %v", err)
+	}
+	manifest := `{"name":"leftpad","version":"1.0.0","license":"GPL-3.0"}`
+	if err := os.WriteFile(filepath.Join(modDir, "package.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+
+	cfg := "license:\n  deny:\n    - GPL-3.0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var found bool
+	for _, f := range result.Findings.Findings() {
+		if strings.HasPrefix(f.RuleID, "LIC-") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a LIC-* finding from the configured license policy; license config is not wired through")
+	}
+}
+
+func hasDegradationKind(result *ScanResult, kind string) bool {
+	for _, d := range result.Degradations {
+		if string(d.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/core/degrade/degrade.go
+++ b/core/degrade/degrade.go
@@ -1,0 +1,117 @@
+package degrade
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Kind classifies why part of a scan could not run.
+type Kind string
+
+const (
+	// OSV means a vulnerability lookup against OSV.dev failed, so
+	// dependency vulnerabilities are under-reported.
+	OSV Kind = "osv_lookup"
+
+	// Lockfile means a lockfile was found but could not be parsed,
+	// so its packages are absent from the inventory and from vulnerability
+	// matching.
+	Lockfile Kind = "lockfile_parse"
+
+	// VulnData means an embedded vulnerability dataset (known
+	// malicious packages, popular-package lists) failed to load, silently
+	// disabling the detections built on it.
+	VulnData Kind = "vuln_data_load"
+
+	// Plugin means an analysis plugin failed to run, so any findings
+	// it would have produced are missing.
+	Plugin Kind = "plugin"
+
+	// Baseline means a baseline file existed but could not be read,
+	// so new-vs-known classification is not being applied.
+	Baseline Kind = "baseline"
+
+	// Suppression means a file could not be re-read to apply inline
+	// suppression comments, so its findings are reported unsuppressed.
+	Suppression Kind = "suppression"
+)
+
+// Degradation records that some part of the scan did not run to completion.
+//
+// This type exists because a security scanner's most dangerous failure mode is
+// not crashing — it is reporting "no findings" when it never actually looked.
+// Nox degrades gracefully in many places by design (an OSV outage should not
+// fail a build), but graceful degradation is only safe if it is *visible*.
+// Every site that swallows an error to keep the scan running records a
+// Degradation here so the operator, and CI, can tell the difference between
+// "clean" and "did not check".
+type Degradation struct {
+	// Kind classifies the failure so callers can filter programmatically.
+	Kind Kind
+
+	// Detail is a human-readable explanation naming the affected subject
+	// (a file path, package count, plugin name).
+	Detail string
+
+	// Impact states, in the operator's terms, what may now be missing from
+	// the results. This is the field that answers "should I trust this scan?".
+	Impact string
+}
+
+// String renders a degradation as a single diagnostic line.
+func (d Degradation) String() string {
+	return fmt.Sprintf("%s: %s (%s)", d.Kind, d.Detail, d.Impact)
+}
+
+// Degradations is a concurrency-safe collector for Degradation records.
+//
+// Analyzers run in parallel, so the collector is shared across goroutines. The
+// zero value is ready to use; a nil *Degradations silently discards records so
+// that callers which do not care (tests, library users) need not construct one.
+type Degradations struct {
+	mu    sync.Mutex
+	items []Degradation
+}
+
+// Add records a degradation. It is safe to call concurrently, and safe to call
+// on a nil receiver.
+func (d *Degradations) Add(kind Kind, detail, impact string) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.items = append(d.items, Degradation{Kind: kind, Detail: detail, Impact: impact})
+}
+
+// Items returns the collected degradations in a deterministic order: by kind,
+// then detail. Analyzers run concurrently, so insertion order varies between
+// runs — sorting keeps scan output reproducible, which nox guarantees.
+func (d *Degradations) Items() []Degradation {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	out := make([]Degradation, len(d.items))
+	copy(out, d.items)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Detail < out[j].Detail
+	})
+	return out
+}
+
+// Len reports how many degradations were recorded.
+func (d *Degradations) Len() int {
+	if d == nil {
+		return 0
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.items)
+}

--- a/core/degrade/degrade_test.go
+++ b/core/degrade/degrade_test.go
@@ -1,0 +1,108 @@
+package degrade
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestDegradations_NilReceiverIsSafe(t *testing.T) {
+	t.Parallel()
+
+	// Library callers that do not want degradation reporting pass nil. That
+	// must not panic, or every optional call site would need a guard.
+	var d *Degradations
+	d.Add(OSV, "detail", "impact")
+
+	if got := d.Len(); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+	if got := d.Items(); got != nil {
+		t.Errorf("expected nil items, got %v", got)
+	}
+}
+
+func TestDegradations_ItemsAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Analyzers run in parallel, so insertion order varies run to run. Nox
+	// guarantees identical output for identical input, so Items must sort.
+	build := func(order []Kind) []Degradation {
+		d := &Degradations{}
+		for _, k := range order {
+			d.Add(k, string(k)+"-detail", "impact")
+		}
+		return d.Items()
+	}
+
+	forward := build([]Kind{OSV, Lockfile, Plugin, Baseline})
+	reverse := build([]Kind{Baseline, Plugin, Lockfile, OSV})
+
+	if len(forward) != len(reverse) {
+		t.Fatalf("length mismatch: %d vs %d", len(forward), len(reverse))
+	}
+	for i := range forward {
+		if forward[i] != reverse[i] {
+			t.Errorf("index %d differs: %+v vs %+v", i, forward[i], reverse[i])
+		}
+	}
+}
+
+func TestDegradations_SortsByKindThenDetail(t *testing.T) {
+	t.Parallel()
+
+	d := &Degradations{}
+	d.Add(OSV, "zzz", "impact")
+	d.Add(Lockfile, "bbb", "impact")
+	d.Add(OSV, "aaa", "impact")
+
+	items := d.Items()
+	want := []struct{ kind, detail string }{
+		{string(Lockfile), "bbb"},
+		{string(OSV), "aaa"},
+		{string(OSV), "zzz"},
+	}
+	if len(items) != len(want) {
+		t.Fatalf("expected %d items, got %d", len(want), len(items))
+	}
+	for i, w := range want {
+		if string(items[i].Kind) != w.kind || items[i].Detail != w.detail {
+			t.Errorf("index %d: expected %s/%s, got %s/%s", i, w.kind, w.detail, items[i].Kind, items[i].Detail)
+		}
+	}
+}
+
+func TestDegradations_ConcurrentAdd(t *testing.T) {
+	t.Parallel()
+
+	// The collector is shared across the parallel analyzer errgroup, so it
+	// must tolerate concurrent writes. Run with -race to make this meaningful.
+	d := &Degradations{}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.Add(OSV, "concurrent", "impact")
+		}()
+	}
+	wg.Wait()
+
+	if got := d.Len(); got != 50 {
+		t.Errorf("expected 50 degradations, got %d", got)
+	}
+}
+
+func TestDegradation_StringIncludesImpact(t *testing.T) {
+	t.Parallel()
+
+	// The impact text is the part that tells an operator whether to trust the
+	// scan, so it must not be dropped from the rendered form.
+	d := Degradation{Kind: OSV, Detail: "lookup failed", Impact: "CVEs under-reported"}
+	got := d.String()
+	for _, want := range []string{"osv_lookup", "lookup failed", "CVEs under-reported"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/iac"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/git"
@@ -57,7 +58,17 @@ type ScanResult struct {
 	Rules        *rules.RuleSet
 	Graphs       []graph.Graph         // relationship graphs from plugins
 	Enrichments  []findings.Enrichment // finding annotations from plugins
+
+	// Degradations lists the parts of the scan that could not run. An empty
+	// slice means every configured check completed; a non-empty one means the
+	// findings are incomplete and "no findings" must not be read as "clean".
+	Degradations []Degradation
 }
+
+// Degradation re-exports degrade.Degradation so callers holding a ScanResult
+// need not import the leaf package. It lives in its own package because
+// analyzers report degradations too, and they cannot import core.
+type Degradation = degrade.Degradation
 
 // ScanOptions holds optional parameters for RunScanWithOptions. The zero
 // value means no additional options are applied.
@@ -91,9 +102,6 @@ type ScanOptions struct {
 	// Sequential forces analyzers to run sequentially instead of in parallel.
 	// Useful for debugging analyzer interactions.
 	Sequential bool
-
-	// NoCache disables the incremental scan cache, forcing a full re-scan.
-	NoCache bool
 
 	// ChangedSince limits the scan to files changed since the given git ref.
 	// Only files in the diff between the ref and HEAD are analyzed.
@@ -139,7 +147,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	}
 
 	// Stage 1: Discover artifacts.
-	artifacts, err := discoverArtifacts(target, cfg, opts)
+	artifacts, err := discoverArtifacts(target, cfg, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -162,9 +170,23 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	dataAnalyzer := data.NewAnalyzer()
 	iacAnalyzer := iac.NewAnalyzer()
 	aiAnalyzer := ai.NewAnalyzer()
-	var depsOpts []deps.AnalyzerOption
+	// degradations collects checks that could not complete. Analyzers write to
+	// it concurrently; it is surfaced on ScanResult so "no findings" can be
+	// distinguished from "did not look".
+	degradations := &degrade.Degradations{}
+
+	depsOpts := []deps.AnalyzerOption{deps.WithDegradations(degradations)}
 	if opts.Offline || opts.DisableOSV || cfg.Scan.OSV.Disabled {
 		depsOpts = append(depsOpts, deps.WithOSVDisabled())
+	}
+	// Wire the project's license policy through. Without this, license.deny /
+	// license.allow in .nox.yaml parsed cleanly and then produced no LIC-*
+	// findings at all — configured policy that silently did nothing.
+	if len(cfg.License.Deny) > 0 || len(cfg.License.Allow) > 0 {
+		depsOpts = append(depsOpts, deps.WithLicensePolicy(deps.LicensePolicy{
+			Deny:  cfg.License.Deny,
+			Allow: cfg.License.Allow,
+		}))
 	}
 	depsAnalyzer := deps.NewAnalyzer(depsOpts...)
 
@@ -335,6 +357,12 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		out, hookErr := ScanPluginHook(ctx, target, cfg.Plugins.Required)
 		if hookErr != nil {
 			slog.WarnContext(ctx, "analysis plugins failed; continuing with built-in findings only", "error", hookErr)
+			// A required detector that fails silently is the worst outcome for
+			// a security scanner: the build stays green precisely because the
+			// check that would have failed it never ran.
+			degradations.Add(degrade.Plugin,
+				fmt.Sprintf("required plugins %v failed to run: %v", cfg.Plugins.Required, hookErr),
+				"findings these plugins would have produced are missing from this scan")
 		}
 		if out != nil {
 			for i := range out.Findings {
@@ -348,7 +376,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// Stage 3: Refine findings — apply rule config, generated/noise filters,
 	// conditional severity, dedup, inline suppressions, terraform plan,
 	// baseline matching, and VEX.
-	refineFindings(allFindings, cfg, opts, target)
+	if err := refineFindings(allFindings, cfg, &opts, target, degradations); err != nil {
+		return nil, err
+	}
 
 	// Stage 4: Evaluate policy gates.
 	policyResult := evaluatePolicy(cfg, allFindings)
@@ -361,13 +391,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		AIInventory:  aiInventory,
 		PolicyResult: policyResult,
 		Rules:        allRules,
+		Degradations: degradations.Items(),
 	}, nil
 }
 
 // discoverArtifacts walks the target, honoring .gitignore and config excludes,
 // optionally restricting to files changed since a git ref, and filtering out
 // excluded artifact types. It is stage 1 of the scan pipeline.
-func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]discovery.Artifact, error) {
+func discoverArtifacts(target string, cfg *ScanConfig, opts *ScanOptions) ([]discovery.Artifact, error) {
 	walker := discovery.NewWalker(target)
 	walker.IgnorePatterns = append(walker.IgnorePatterns, cfg.Scan.Exclude...)
 	if opts.NoRespectGitignore {
@@ -406,7 +437,7 @@ func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]disc
 // conditional severity, dedup + deterministic sort, inline suppressions,
 // optional terraform-plan findings, baseline matching, and VEX. It is stage 3
 // of the scan pipeline.
-func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts ScanOptions, target string) {
+func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts *ScanOptions, target string, deg *degrade.Degradations) error {
 	// Config rule disabling and severity overrides.
 	if len(cfg.Scan.Rules.Disable) > 0 {
 		allFindings.RemoveByRuleIDs(cfg.Scan.Rules.Disable)
@@ -457,16 +488,22 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	allFindings.Deduplicate()
 	allFindings.SortDeterministic()
 
-	applySuppressions(allFindings, target)
+	applySuppressions(allFindings, target, deg)
 
-	// Scan a terraform plan if provided.
+	// Scan a terraform plan if provided. A plan path is only ever set because
+	// the operator asked for it, so a plan that cannot be read or parsed is an
+	// error: silently scanning nothing while reporting success would let a
+	// typo'd path masquerade as a clean infrastructure review.
 	if opts.TerraformPlanPath != "" {
 		tfPlanPath := opts.TerraformPlanPath
 		if !filepath.IsAbs(tfPlanPath) {
 			tfPlanPath = filepath.Join(target, tfPlanPath)
 		}
 		tfFindings, tfErr := iac.ScanTerraformPlan(tfPlanPath)
-		if tfErr == nil && tfFindings != nil {
+		if tfErr != nil {
+			return fmt.Errorf("scanning terraform plan %s: %w", opts.TerraformPlanPath, tfErr)
+		}
+		if tfFindings != nil {
 			tfItems := tfFindings.Findings()
 			for i := range tfItems {
 				allFindings.Add(tfItems[i])
@@ -474,16 +511,21 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		}
 	}
 
-	// Baseline matching.
+	// Baseline matching. Unlike the plan and VEX paths, a missing baseline is
+	// normal (the first scan has none), so absence is not an error — but a
+	// baseline that exists and cannot be read silently changes gate semantics,
+	// which the operator must hear about.
 	baselinePath := cfg.Policy.BaselinePath
 	if baselinePath == "" {
 		baselinePath = baseline.DefaultPath(target)
 	} else if !filepath.IsAbs(baselinePath) {
 		baselinePath = filepath.Join(target, baselinePath)
 	}
-	applyBaseline(allFindings, baselinePath)
+	applyBaseline(allFindings, baselinePath, deg)
 
-	// VEX document.
+	// VEX document. As with the terraform plan, the path is explicit — from a
+	// flag or from .nox.yaml — so failing to load it is an error rather than a
+	// silent no-op that would leave waivers unapplied.
 	vexPath := opts.VEXPath
 	if vexPath == "" {
 		vexPath = cfg.Policy.VEXPath
@@ -492,10 +534,14 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		if !filepath.IsAbs(vexPath) {
 			vexPath = filepath.Join(target, vexPath)
 		}
-		if vexDoc, vexErr := vex.LoadVEX(vexPath); vexErr == nil {
-			vex.ApplyVEX(allFindings, vexDoc)
+		vexDoc, vexErr := vex.LoadVEX(vexPath)
+		if vexErr != nil {
+			return fmt.Errorf("loading VEX document %s: %w", vexPath, vexErr)
 		}
+		vex.ApplyVEX(allFindings, vexDoc)
 	}
+
+	return nil
 }
 
 // evaluatePolicy runs the configured fail-on / baseline policy gate over the
@@ -629,7 +675,18 @@ func RunStagedScanWithOptions(repoRoot string, opts ScanOptions) (*ScanResult, e
 	// Run the standard scan against the temp directory. Paths in findings
 	// will be relative to tmpDir, which mirrors the repository-relative
 	// structure, so no remapping is needed.
-	result, err := RunScan(tmpDir)
+	//
+	// opts is threaded through deliberately: it previously called RunScan(tmpDir)
+	// and dropped every option, so `--rules`, `--offline`, `--vex` and friends
+	// were silently ignored whenever `--staged` was used.
+	//
+	// ChangedSince is cleared because the temp directory is not a git
+	// repository — a staged scan already *is* a changed-files scan, and leaving
+	// the ref set would make discovery fail.
+	stagedOpts := opts
+	stagedOpts.ChangedSince = ""
+
+	result, err := RunScanWithOptions(tmpDir, stagedOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -662,11 +719,32 @@ func RunHistoryScan(repoRoot string, opts *HistoryScanOptions) (*ScanResult, err
 	allRules := rules.NewRuleSet()
 
 	secretsAnalyzer := secrets.NewAnalyzer()
-	for _, r := range secretsAnalyzer.Rules().Rules() {
+	scanRules := secretsAnalyzer.Rules()
+	for _, r := range scanRules.Rules() {
 		allRules.Add(r)
 	}
 
-	engine := rules.NewEngine(secretsAnalyzer.Rules())
+	// Honour --rules here too. HistoryScanOptions carried a ScanOptions field
+	// that nothing ever read, so custom rules were silently dropped for
+	// --history scans — the flag appeared to work and quietly did nothing.
+	if path := opts.ScanOptions.CustomRulesPath; path != "" {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(repoRoot, path)
+		}
+		customRules, err := loadCustomRules(path)
+		if err != nil {
+			return nil, fmt.Errorf("loading custom rules: %w", err)
+		}
+		for _, r := range customRules.Rules() {
+			if scanRules.HasID(r.ID) {
+				return nil, fmt.Errorf("custom rule %s conflicts with a built-in rule ID", r.ID)
+			}
+			scanRules.Add(r)
+			allRules.Add(r)
+		}
+	}
+
+	engine := rules.NewEngine(scanRules)
 
 	walkOpts := git.WalkHistoryOptions{
 		MaxDepth: opts.MaxDepth,
@@ -749,7 +827,7 @@ func ConfidenceMeetsThreshold(confidence, threshold findings.Confidence) bool {
 }
 
 // applySuppressions reads files that have findings and marks suppressed findings.
-func applySuppressions(fs *findings.FindingSet, target string) {
+func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degradations) {
 	// Group findings by file.
 	byFile := make(map[string][]int)
 	items := fs.Findings()
@@ -765,6 +843,12 @@ func applySuppressions(fs *findings.FindingSet, target string) {
 
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
+			// Fails safe — findings stay reported rather than being wrongly
+			// suppressed — but the operator's nox:ignore comments in this file
+			// are not being honoured, which is surprising enough to surface.
+			deg.Add(degrade.Suppression,
+				fmt.Sprintf("%s could not be re-read to apply inline suppressions: %v", filePath, err),
+				"nox:ignore comments in this file were not applied; its findings may be reported despite being waived")
 			continue
 		}
 
@@ -787,9 +871,21 @@ func applySuppressions(fs *findings.FindingSet, target string) {
 }
 
 // applyBaseline loads a baseline file and marks matched findings.
-func applyBaseline(fs *findings.FindingSet, baselinePath string) {
+func applyBaseline(fs *findings.FindingSet, baselinePath string, deg *degrade.Degradations) {
 	bl, err := baseline.Load(baselinePath)
-	if err != nil || bl.Len() == 0 {
+	if err != nil {
+		// No baseline is the normal state before the first `nox baseline write`,
+		// so absence is silent. A baseline that exists but will not load is
+		// different: under baseline_mode strict it changes what the gate
+		// enforces, so it must not pass unnoticed.
+		if !os.IsNotExist(err) {
+			deg.Add(degrade.Baseline,
+				fmt.Sprintf("%s could not be loaded: %v", baselinePath, err),
+				"findings are not being classified against the baseline; known-vs-new status is unreliable")
+		}
+		return
+	}
+	if bl.Len() == 0 {
 		return
 	}
 

--- a/plugin/convert.go
+++ b/plugin/convert.go
@@ -11,19 +11,26 @@ import (
 
 // --- Proto → Go conversion ---
 
+// pluginRuleNamespace prefixes the rule ID fed into the fingerprint hash for
+// plugin-supplied findings, keeping their digests disjoint from core findings'.
+const pluginRuleNamespace = "plugin:"
+
 // ProtoFindingToGo converts a protobuf Finding to the domain Finding type.
-func ProtoFindingToGo(pf *pluginv1.Finding) findings.Finding {
+// pluginName identifies the plugin that produced the finding and is required:
+// it namespaces the fingerprint (see pluginFingerprint).
+func ProtoFindingToGo(pf *pluginv1.Finding, pluginName string) findings.Finding {
 	if pf == nil {
 		return findings.Finding{}
 	}
+	loc := ProtoLocationToGo(pf.GetLocation())
 	f := findings.Finding{
 		ID:          pf.GetId(),
 		RuleID:      pf.GetRuleId(),
 		Severity:    ProtoSeverityToGo(pf.GetSeverity()),
 		Confidence:  ProtoConfidenceToGo(pf.GetConfidence()),
-		Location:    ProtoLocationToGo(pf.GetLocation()),
+		Location:    loc,
 		Message:     pf.GetMessage(),
-		Fingerprint: pf.GetFingerprint(),
+		Fingerprint: pluginFingerprint(pluginName, pf, loc),
 	}
 	if m := pf.GetMetadata(); len(m) > 0 {
 		f.Metadata = make(map[string]string, len(m))
@@ -32,6 +39,33 @@ func ProtoFindingToGo(pf *pluginv1.Finding) findings.Finding {
 		}
 	}
 	return f
+}
+
+// pluginFingerprint derives the fingerprint nox stores for a plugin-supplied
+// finding.
+//
+// Plugin findings are merged into the same FindingSet as core findings, which
+// dedupes first-wins by fingerprint, and baseline/VEX suppression keys on the
+// same value. Storing the plugin's claimed fingerprint verbatim therefore hands
+// every plugin a forgery primitive: collide with a core finding to suppress it,
+// or match a baselined entry to hide itself. Hashing the plugin's name into the
+// digest confines each plugin to its own fingerprint space.
+//
+// The claimed fingerprint is demoted to hash input, never used as the output,
+// so a plugin keeps control over which of *its own* findings are considered the
+// same across runs — that is what makes plugin findings baseline-able — without
+// any say over collisions outside its namespace.
+func pluginFingerprint(pluginName string, pf *pluginv1.Finding, loc findings.Location) string {
+	// A plugin that supplies no fingerprint still needs a stable identity, so
+	// its message stands in. The fp:/msg: tags keep the two cases from aliasing
+	// (a claimed fingerprint that happens to equal another finding's message).
+	seed := "fp:" + pf.GetFingerprint()
+	if pf.GetFingerprint() == "" {
+		seed = "msg:" + pf.GetMessage()
+	}
+	// Reuse the core scheme so plugin fingerprints inherit its determinism and
+	// path normalisation, and so a fingerprint-version bump moves both in step.
+	return findings.ComputeFingerprint(pluginRuleNamespace+pluginName+":"+pf.GetRuleId(), loc, seed)
 }
 
 // ProtoLocationToGo converts a protobuf Location to the domain Location type.

--- a/plugin/convert_test.go
+++ b/plugin/convert_test.go
@@ -139,7 +139,7 @@ func TestFindingRoundTrip(t *testing.T) {
 	}
 
 	proto := GoFindingToProto(&original)
-	roundTrip := ProtoFindingToGo(proto)
+	roundTrip := ProtoFindingToGo(proto, "acme")
 
 	if roundTrip.ID != original.ID {
 		t.Errorf("ID mismatch: %q vs %q", roundTrip.ID, original.ID)
@@ -159,8 +159,11 @@ func TestFindingRoundTrip(t *testing.T) {
 	if roundTrip.Message != original.Message {
 		t.Errorf("Message mismatch: %q vs %q", roundTrip.Message, original.Message)
 	}
-	if roundTrip.Fingerprint != original.Fingerprint {
-		t.Errorf("Fingerprint mismatch: %q vs %q", roundTrip.Fingerprint, original.Fingerprint)
+	// Fingerprint is deliberately NOT round-tripped: the host re-derives it
+	// under the plugin's namespace so a plugin cannot dictate the value nox
+	// dedupes and suppresses on.
+	if roundTrip.Fingerprint == original.Fingerprint {
+		t.Error("Fingerprint was copied verbatim from the plugin; expected a namespaced value")
 	}
 	if !reflect.DeepEqual(roundTrip.Metadata, original.Metadata) {
 		t.Errorf("Metadata mismatch: %v vs %v", roundTrip.Metadata, original.Metadata)
@@ -168,9 +171,97 @@ func TestFindingRoundTrip(t *testing.T) {
 }
 
 func TestProtoFindingToGo_Nil(t *testing.T) {
-	got := ProtoFindingToGo(nil)
+	got := ProtoFindingToGo(nil, "acme")
 	if got.ID != "" || got.RuleID != "" {
 		t.Errorf("ProtoFindingToGo(nil) should return zero value, got %+v", got)
+	}
+}
+
+// A plugin that claims a core finding's fingerprint would, once merged into the
+// shared FindingSet, win first-wins dedup and erase the core finding — or match
+// a baselined entry and hide itself. The stored fingerprint must never be the
+// one the plugin asked for.
+func TestProtoFindingToGo_DoesNotTrustClaimedFingerprint(t *testing.T) {
+	loc := findings.Location{FilePath: "src/auth.go", StartLine: 42}
+	coreFP := findings.ComputeFingerprint("SEC-001", loc, "api_key = \"x\"")
+
+	got := ProtoFindingToGo(&pluginv1.Finding{
+		RuleId:      "SEC-001",
+		Message:     "benign",
+		Location:    GoLocationToProto(loc),
+		Fingerprint: coreFP,
+	}, "evil-plugin")
+
+	if got.Fingerprint == coreFP {
+		t.Error("plugin fingerprint collided with the core finding it forged")
+	}
+	if got.Fingerprint == "" {
+		t.Error("namespaced fingerprint must not be empty")
+	}
+}
+
+// Two plugins emitting byte-identical findings must still occupy distinct
+// fingerprint space, otherwise one plugin can suppress another's findings.
+func TestProtoFindingToGo_FingerprintIsolatedPerPlugin(t *testing.T) {
+	pf := &pluginv1.Finding{
+		RuleId:      "PLG-001",
+		Message:     "same message",
+		Location:    GoLocationToProto(findings.Location{FilePath: "a.go", StartLine: 1}),
+		Fingerprint: "identical-claim",
+	}
+
+	a := ProtoFindingToGo(pf, "plugin-a")
+	b := ProtoFindingToGo(pf, "plugin-b")
+
+	if a.Fingerprint == b.Fingerprint {
+		t.Errorf("plugin-a and plugin-b produced the same fingerprint %q", a.Fingerprint)
+	}
+}
+
+// Fingerprints feed baseline and VEX suppression, so they must be reproducible
+// across runs for the same inputs.
+func TestProtoFindingToGo_FingerprintDeterministic(t *testing.T) {
+	pf := &pluginv1.Finding{
+		RuleId:      "PLG-002",
+		Message:     "finding",
+		Location:    GoLocationToProto(findings.Location{FilePath: "b.go", StartLine: 7}),
+		Fingerprint: "claimed",
+	}
+
+	first := ProtoFindingToGo(pf, "acme")
+	second := ProtoFindingToGo(pf, "acme")
+
+	if first.Fingerprint != second.Fingerprint {
+		t.Errorf("fingerprint not deterministic: %q vs %q", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+// A plugin that supplies no fingerprint still needs a stable, unique identity,
+// and two of its findings in one file must not collapse into one.
+func TestProtoFindingToGo_ComputesFingerprintWhenAbsent(t *testing.T) {
+	loc := GoLocationToProto(findings.Location{FilePath: "c.go", StartLine: 3})
+
+	first := ProtoFindingToGo(&pluginv1.Finding{RuleId: "PLG-003", Message: "one", Location: loc}, "acme")
+	second := ProtoFindingToGo(&pluginv1.Finding{RuleId: "PLG-003", Message: "two", Location: loc}, "acme")
+
+	if first.Fingerprint == "" {
+		t.Fatal("expected a host-computed fingerprint, got empty string")
+	}
+	if first.Fingerprint == second.Fingerprint {
+		t.Error("two distinct findings from one plugin shared a fingerprint")
+	}
+}
+
+// Distinct claimed fingerprints must survive as distinct stored fingerprints;
+// namespacing must not collapse a plugin's own findings together.
+func TestProtoFindingToGo_PreservesPluginFindingDistinctness(t *testing.T) {
+	loc := GoLocationToProto(findings.Location{FilePath: "d.go", StartLine: 1})
+
+	first := ProtoFindingToGo(&pluginv1.Finding{RuleId: "PLG-004", Location: loc, Fingerprint: "one"}, "acme")
+	second := ProtoFindingToGo(&pluginv1.Finding{RuleId: "PLG-004", Location: loc, Fingerprint: "two"}, "acme")
+
+	if first.Fingerprint == second.Fingerprint {
+		t.Error("distinct claimed fingerprints collapsed into one stored fingerprint")
 	}
 }
 
@@ -182,7 +273,7 @@ func TestFindingRoundTrip_EmptyMetadata(t *testing.T) {
 	}
 
 	proto := GoFindingToProto(&original)
-	roundTrip := ProtoFindingToGo(proto)
+	roundTrip := ProtoFindingToGo(proto, "acme")
 
 	if roundTrip.ID != original.ID {
 		t.Errorf("ID mismatch: %q vs %q", roundTrip.ID, original.ID)

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -270,11 +270,20 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 	return resp, nil
 }
 
+// AttributedResponse pairs a tool response with the plugin that produced it.
+// Attribution has to survive the fan-out: the response message carries no
+// producer identity, and without it the merge step cannot namespace
+// plugin-supplied fingerprints.
+type AttributedResponse struct {
+	PluginName string
+	Response   *pluginv1.InvokeToolResponse
+}
+
 // InvokeAll invokes a tool on all plugins that declare it.
 // Uses errgroup with a concurrency semaphore from Policy.MaxConcurrency.
 // Individual plugin errors become diagnostics, not fatal errors.
 // Enforcement (rate limiting, read-only, redaction) is applied per-plugin.
-func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]any, workspaceRoot string) ([]*pluginv1.InvokeToolResponse, error) {
+func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]any, workspaceRoot string) ([]AttributedResponse, error) {
 	h.mu.RLock()
 	var targets []*Plugin
 	for _, p := range h.plugins {
@@ -302,7 +311,7 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 
 	type indexedResp struct {
 		index int
-		resp  *pluginv1.InvokeToolResponse
+		resp  AttributedResponse
 	}
 
 	results := make([]indexedResp, 0, len(targets))
@@ -402,7 +411,7 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 			h.mu.Unlock()
 
 			resultsMu.Lock()
-			results = append(results, indexedResp{index: i, resp: resp})
+			results = append(results, indexedResp{index: i, resp: AttributedResponse{PluginName: pluginName, Response: resp}})
 			resultsMu.Unlock()
 			return nil
 		})
@@ -413,14 +422,14 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 	}
 
 	// Place responses at their original index to preserve ordering.
-	ordered := make([]*pluginv1.InvokeToolResponse, len(targets))
+	ordered := make([]AttributedResponse, len(targets))
 	for _, r := range results {
 		ordered[r.index] = r.resp
 	}
-	// Compact: remove nil entries from skipped plugins (violations, errors).
+	// Compact: remove empty entries from skipped plugins (violations, errors).
 	responses := ordered[:0]
 	for _, r := range ordered {
-		if r != nil {
+		if r.Response != nil {
 			responses = append(responses, r)
 		}
 	}
@@ -428,15 +437,16 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 }
 
 // MergeResults converts a single plugin response into domain types and
-// adds them to the ScanResult. This method is not thread-safe with respect
-// to FindingSet and AIInventory — call sequentially.
-func (h *Host) MergeResults(resp *pluginv1.InvokeToolResponse, result *core.ScanResult) {
+// adds them to the ScanResult. pluginName attributes the response to its
+// producer so finding fingerprints can be namespaced. This method is not
+// thread-safe with respect to FindingSet and AIInventory — call sequentially.
+func (h *Host) MergeResults(pluginName string, resp *pluginv1.InvokeToolResponse, result *core.ScanResult) {
 	if resp == nil || result == nil {
 		return
 	}
 
 	for _, pf := range resp.GetFindings() {
-		result.Findings.Add(ProtoFindingToGo(pf))
+		result.Findings.Add(ProtoFindingToGo(pf, pluginName))
 	}
 
 	for _, pp := range resp.GetPackages() {
@@ -455,10 +465,10 @@ func (h *Host) MergeResults(resp *pluginv1.InvokeToolResponse, result *core.Scan
 	}
 }
 
-// MergeAllResults merges multiple plugin responses sequentially.
-func (h *Host) MergeAllResults(responses []*pluginv1.InvokeToolResponse, result *core.ScanResult) {
-	for _, resp := range responses {
-		h.MergeResults(resp, result)
+// MergeAllResults merges multiple attributed plugin responses sequentially.
+func (h *Host) MergeAllResults(responses []AttributedResponse, result *core.ScanResult) {
+	for _, r := range responses {
+		h.MergeResults(r.PluginName, r.Response, result)
 	}
 }
 
@@ -504,7 +514,7 @@ func (h *Host) InvokePostScan(ctx context.Context, result *core.ScanResult, work
 			continue
 		}
 
-		h.MergeResults(resp, result)
+		h.MergeResults(pt.plugin.Info().Name, resp, result)
 
 		h.mu.Lock()
 		h.collectDiagnostics(pt.plugin.Info().Name, resp)

--- a/plugin/host_test.go
+++ b/plugin/host_test.go
@@ -263,7 +263,7 @@ func TestHost_MergeResults_Findings(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("acme", resp, result)
 
 	ff := result.Findings.Findings()
 	if len(ff) != 1 {
@@ -277,6 +277,55 @@ func TestHost_MergeResults_Findings(t *testing.T) {
 	}
 	if ff[0].Location.FilePath != "src/main.go" {
 		t.Errorf("Location.FilePath = %q, want %q", ff[0].Location.FilePath, "src/main.go")
+	}
+}
+
+// End-to-end form of the fingerprint-forgery attack: a plugin echoes a core
+// finding's fingerprint hoping first-wins Deduplicate will drop the real
+// finding. Both must survive the merge.
+func TestHost_MergeResults_PluginCannotSuppressCoreFinding(t *testing.T) {
+	h := newTestHost()
+	result := &core.ScanResult{
+		Findings:    findings.NewFindingSet(),
+		Inventory:   &deps.PackageInventory{},
+		AIInventory: ai.NewInventory(),
+	}
+
+	loc := findings.Location{FilePath: "src/main.go", StartLine: 42}
+	coreFinding := findings.Finding{
+		RuleID:      "SEC-001",
+		Severity:    findings.SeverityCritical,
+		Location:    loc,
+		Message:     "hardcoded credential",
+		Fingerprint: findings.ComputeFingerprint("SEC-001", loc, "hardcoded credential"),
+	}
+	result.Findings.Add(coreFinding)
+
+	h.MergeResults("evil-plugin", &pluginv1.InvokeToolResponse{
+		Findings: []*pluginv1.Finding{{
+			RuleId:      "SEC-001",
+			Severity:    pluginv1.Severity_SEVERITY_INFO,
+			Location:    GoLocationToProto(loc),
+			Message:     "nothing to see here",
+			Fingerprint: coreFinding.Fingerprint,
+		}},
+	}, result)
+
+	result.Findings.Deduplicate()
+
+	ff := result.Findings.Findings()
+	if len(ff) != 2 {
+		t.Fatalf("len(Findings) = %d, want 2 (plugin finding suppressed the core finding)", len(ff))
+	}
+
+	var foundCore bool
+	for _, f := range ff {
+		if f.Fingerprint == coreFinding.Fingerprint && f.Message == coreFinding.Message {
+			foundCore = true
+		}
+	}
+	if !foundCore {
+		t.Error("core finding was displaced by the plugin's forged fingerprint")
 	}
 }
 
@@ -295,7 +344,7 @@ func TestHost_MergeResults_Packages(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("acme", resp, result)
 
 	pkgs := result.Inventory.Packages()
 	if len(pkgs) != 2 {
@@ -320,7 +369,7 @@ func TestHost_MergeResults_AIComponents(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("acme", resp, result)
 
 	if len(result.AIInventory.Components) != 1 {
 		t.Fatalf("len(Components) = %d, want 1", len(result.AIInventory.Components))
@@ -338,7 +387,7 @@ func TestHost_MergeResults_EmptyResponse(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, result)
+	h.MergeResults("acme", &pluginv1.InvokeToolResponse{}, result)
 
 	if len(result.Findings.Findings()) != 0 {
 		t.Error("empty response should not add findings")
@@ -360,8 +409,8 @@ func TestHost_MergeResults_Nil(t *testing.T) {
 	}
 
 	// Should not panic.
-	h.MergeResults(nil, result)
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, nil)
+	h.MergeResults("acme", nil, result)
+	h.MergeResults("acme", &pluginv1.InvokeToolResponse{}, nil)
 }
 
 func TestHost_MergeAllResults(t *testing.T) {
@@ -372,20 +421,20 @@ func TestHost_MergeAllResults(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	responses := []*pluginv1.InvokeToolResponse{
-		{
+	responses := []AttributedResponse{
+		{PluginName: "plugin-a", Response: &pluginv1.InvokeToolResponse{
 			Findings: []*pluginv1.Finding{
 				{Id: "f1", RuleId: "SEC-001", Severity: pluginv1.Severity_SEVERITY_HIGH},
 			},
-		},
-		{
+		}},
+		{PluginName: "plugin-b", Response: &pluginv1.InvokeToolResponse{
 			Findings: []*pluginv1.Finding{
 				{Id: "f2", RuleId: "SEC-002", Severity: pluginv1.Severity_SEVERITY_MEDIUM},
 			},
 			Packages: []*pluginv1.Package{
 				{Name: "pkg", Version: "1.0", Ecosystem: "go"},
 			},
-		},
+		}},
 	}
 
 	h.MergeAllResults(responses, result)
@@ -918,7 +967,7 @@ func TestHost_MergeResults_Graphs(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("acme", resp, result)
 
 	if len(result.Graphs) != 1 {
 		t.Fatalf("expected 1 graph, got %d", len(result.Graphs))
@@ -955,7 +1004,7 @@ func TestHost_MergeResults_Enrichments(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("acme", resp, result)
 
 	if len(result.Enrichments) != 1 {
 		t.Fatalf("expected 1 enrichment, got %d", len(result.Enrichments))
@@ -980,7 +1029,7 @@ func TestHost_MergeResults_GraphsAndEnrichments_Empty(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, result)
+	h.MergeResults("acme", &pluginv1.InvokeToolResponse{}, result)
 
 	if len(result.Graphs) != 0 {
 		t.Error("empty response should not add graphs")
@@ -1211,20 +1260,20 @@ func TestHost_MergeAllResults_WithGraphsAndEnrichments(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	responses := []*pluginv1.InvokeToolResponse{
-		{
+	responses := []AttributedResponse{
+		{PluginName: "plugin-a", Response: &pluginv1.InvokeToolResponse{
 			Graphs: []*pluginv1.Graph{
 				{Name: "g1"},
 			},
 			Enrichments: []*pluginv1.Enrichment{
 				{FindingFingerprint: "fp-1", Kind: "triage"},
 			},
-		},
-		{
+		}},
+		{PluginName: "plugin-b", Response: &pluginv1.InvokeToolResponse{
 			Graphs: []*pluginv1.Graph{
 				{Name: "g2"},
 			},
-		},
+		}},
 	}
 
 	h.MergeAllResults(responses, result)

--- a/registry-scaffold/index.json
+++ b/registry-scaffold/index.json
@@ -1674,7 +1674,7 @@
           "changelog_url": "https://github.com/nox-hq/nox-plugin-remediate/blob/main/CHANGELOG.md"
         }
       ],
-      "track": "remediation",
+      "track": "agent-assistance",
       "maintainers": [
         "nox-hq"
       ],

--- a/registry-scaffold/schema.json
+++ b/registry-scaffold/schema.json
@@ -31,6 +31,8 @@
               "developer-experience", "agent-assistance"
             ]
           },
+          "deprecated": { "type": "boolean" },
+          "deprecation_note": { "type": "string" },
           "tags": { "type": "array", "items": { "type": "string" } },
           "maintainers": { "type": "array", "items": { "type": "string" } },
           "license": { "type": "string" },

--- a/registry/deprecation_test.go
+++ b/registry/deprecation_test.go
@@ -1,0 +1,113 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadScaffoldIndex decodes the index.json that ships in this repo and
+// is published as the official registry, so tests can assert on the
+// real shipped data rather than a hand-written fixture.
+func loadScaffoldIndex(t *testing.T) Index {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "registry-scaffold", "index.json"))
+	if err != nil {
+		t.Fatalf("reading scaffold index: %v", err)
+	}
+	var idx Index
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		t.Fatalf("parsing scaffold index: %v", err)
+	}
+	return idx
+}
+
+func TestPluginEntryParsesDeprecationFields(t *testing.T) {
+	// The registry index carries deprecation as structured data so
+	// consumers can react to it; before this existed the only signal
+	// was a hand-written "[DEPRECATED]" prefix in the description.
+	raw := `{
+		"name": "nox/policy-gate",
+		"description": "Policy gate",
+		"deprecated": true,
+		"deprecation_note": "Superseded by nox/grc. Install nox/grc instead.",
+		"versions": [{"version": "0.2.0", "api_version": "v1", "digest": "sha256:aaa"}]
+	}`
+
+	var p PluginEntry
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !p.Deprecated {
+		t.Error("Deprecated should be true")
+	}
+	if want := "Superseded by nox/grc. Install nox/grc instead."; p.DeprecationNote != want {
+		t.Errorf("DeprecationNote = %q, want %q", p.DeprecationNote, want)
+	}
+}
+
+func TestPluginEntryDeprecationRoundTrip(t *testing.T) {
+	original := PluginEntry{
+		Name:            "nox/baseline-mgmt",
+		Description:     "Baseline management",
+		Deprecated:      true,
+		DeprecationNote: "Superseded by built-in nox baseline commands.",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded PluginEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Deprecated != original.Deprecated {
+		t.Errorf("Deprecated = %v, want %v", decoded.Deprecated, original.Deprecated)
+	}
+	if decoded.DeprecationNote != original.DeprecationNote {
+		t.Errorf("DeprecationNote = %q, want %q", decoded.DeprecationNote, original.DeprecationNote)
+	}
+}
+
+func TestPluginEntryOmitsDeprecationWhenUnset(t *testing.T) {
+	// Non-deprecated plugins are the overwhelming majority; emitting
+	// "deprecated": false on every entry would bloat the index and
+	// churn the diff for every regeneration.
+	data, err := json.Marshal(PluginEntry{Name: "nox/sast", Description: "SAST"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+
+	for _, field := range []string{"deprecated", "deprecation_note"} {
+		if _, ok := m[field]; ok {
+			t.Errorf("%s should be omitted when unset", field)
+		}
+	}
+}
+
+func TestScaffoldIndexTracksAreValid(t *testing.T) {
+	// Guards the shipped index against tracks that exist only in the
+	// JSON — an unrecognized track silently breaks --track filtering
+	// and renders as a raw string on the marketplace site.
+	idx := loadScaffoldIndex(t)
+
+	for i := range idx.Plugins {
+		p := &idx.Plugins[i]
+		if p.Track == "" {
+			continue
+		}
+		if !ValidTrack(p.Track) {
+			t.Errorf("%s declares unknown track %q", p.Name, p.Track)
+		}
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -103,6 +103,15 @@ type PluginEntry struct {
 	Maintainers []string `json:"maintainers,omitempty"`
 	License     string   `json:"license,omitempty"`
 	Repository  string   `json:"repository,omitempty"`
+
+	// Deprecated marks a plugin as superseded. It is advisory only:
+	// deprecated plugins stay resolvable and installable so existing
+	// users keep working, and nox limits itself to warning.
+	Deprecated bool `json:"deprecated,omitempty"`
+	// DeprecationNote explains what to migrate to. Registry authors
+	// should name the replacement plugin here — it is the only place
+	// the CLI has to point operators at.
+	DeprecationNote string `json:"deprecation_note,omitempty"`
 }
 
 // VersionEntry describes a specific version of a plugin.

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -76,7 +76,11 @@ func (s *PluginServer) Serve(ctx context.Context, opts ...ServeOption) error {
 		opt(cfg)
 	}
 
-	lis, err := net.Listen("tcp", ":0")
+	// Bind loopback-only. A plugin is a subprocess of the host scanner and is
+	// only ever dialled over the address handshake below, so exposing it on
+	// every interface would let any other local process — or, behind a
+	// permissive firewall, any LAN peer — invoke plugin tools during a scan.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("sdk: listen: %w", err)
 	}

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"google.golang.org/grpc"
@@ -211,5 +212,94 @@ func TestServer_Serve_WritesAddr(t *testing.T) {
 	output := buf.String()
 	if !strings.HasPrefix(output, "NOX_PLUGIN_ADDR=") {
 		t.Errorf("expected NOX_PLUGIN_ADDR= prefix, got %q", output)
+	}
+}
+
+// writerFunc adapts a function to io.Writer so a test can observe the
+// handshake line the moment Serve emits it, without racing on a Buffer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// serveAndWaitForAddr starts srv in a goroutine and returns the advertised
+// address plus a stop function that cancels and waits for a clean shutdown.
+func serveAndWaitForAddr(t *testing.T, srv *PluginServer) (addr string, stop func()) {
+	t.Helper()
+
+	addrCh := make(chan string, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Serve(ctx, WithAddrWriter(writerFunc(func(p []byte) (int, error) {
+			select {
+			case addrCh <- string(p):
+			default:
+			}
+			return len(p), nil
+		})))
+	}()
+
+	stop = func() {
+		cancel()
+		<-done
+	}
+
+	select {
+	case line := <-addrCh:
+		addr = strings.TrimSpace(strings.TrimPrefix(line, "NOX_PLUGIN_ADDR="))
+		return addr, stop
+	case <-time.After(5 * time.Second):
+		stop()
+		t.Fatal("timed out waiting for NOX_PLUGIN_ADDR handshake line")
+		return "", stop
+	}
+}
+
+// A plugin listener reachable from other hosts lets any local process — and,
+// depending on firewall posture, any LAN peer — invoke plugin tools mid-scan.
+// The listener must be loopback-only.
+func TestServer_Serve_BindsLoopbackOnly(t *testing.T) {
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("advertised host %q is not an IP literal", host)
+	}
+	if !ip.IsLoopback() {
+		t.Errorf("listener bound to %q, want a loopback address", host)
+	}
+}
+
+// The loopback bind must not break the handshake contract: the address printed
+// on stdout is the only thing the host has to dial, so it must stay connectable.
+func TestServer_Serve_AdvertisedAddrIsDialable(t *testing.T) {
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewClient(%q): %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := pluginv1.NewPluginServiceClient(conn).GetManifest(ctx, &pluginv1.GetManifestRequest{ApiVersion: "v1"})
+	if err != nil {
+		t.Fatalf("GetManifest over advertised addr %q: %v", addr, err)
+	}
+	if resp.GetName() != "test" {
+		t.Errorf("manifest name = %q, want %q", resp.GetName(), "test")
 	}
 }


### PR DESCRIPTION
## Why

We found that nox reported a real HIGH-severity CVE as `medium`, with an empty description and no fix version. Chasing that down turned up a single root cause with a wide blast radius, and then a broader pattern behind it: **nox fails loudly on file I/O but silently on nearly everything optional.** An unreadable `.txt` aborts the scan with exit 2; a firewalled OSV, a dead plugin, a typo'd `--vex` path, or an unparseable lockfile all exit 0 looking exactly like a clean scan.

For a security scanner that is the defect that matters most: a green build was not evidence the scan actually ran.

## 1. OSV integration was structurally broken (`cb92771`)

`/v1/querybatch` returns **only** `{id, modified}` — no severity, summary, aliases, or affected ranges. nox read those fields straight off the batch response, so in production they were always empty.

Verified against `github.com/gogo/protobuf v1.3.1` (CVE-2021-3121, CVSS 8.6):

```
before: severity=medium  aliases=""  fixed_in=absent
        "Known vulnerability GHSA-c3h9-896r-86jm in ...@v1.3.1: "
after:  severity=high    aliases="...,CVE-2021-3121,..."  fixed_in=1.3.2
        "... : Improper Input Validation in GoGo Protobuf"
```

Three shipped features were silently dead:

- **`-severity-threshold high` suppressed the real HIGH CVE** — a CI pipeline gated at high/critical reported a clean scan on a genuine vulnerability.
- **OpenVEX alias matching never fired.** `core/vex/vex.go:219` matches on `aliases`; waivers written against CVE IDs — how every other tool emits them — silently failed to match nox's GHSA-keyed findings.
- **`nox fix` was a permanent no-op**, skipping every finding for want of a `fixed_in` version OSV had all along.

A second, independent defect: OSV publishes severity as a CVSS *vector*, not a number. `cvssToSeverity` only handled `ParseFloat` and fell back to medium — so severity mapping could not have worked even with the data present.

**Fix:** hydrate each distinct vuln ID via `GET /v1/vulns/{id}`, plus a CVSS v3.1 base-score calculator with `database_specific.severity` as fallback for v4-only records. Cost scales with vulnerabilities found, not packages scanned — nox's own `go.sum` is 62 packages, 7 hydration calls.

### Why CI stayed green

The test mock returned full records from `/v1/querybatch` — an API shape that does not exist. And `osv_test.go:302` asserted that a real CVSS vector maps to medium, **encoding the broken behaviour as expected**. 89% coverage on a non-functional feature. The mocks now model the real two-endpoint contract and assert hydrated fields are populated, so a regression to ID-only data fails the build.

## 2. Degraded checks are now visible (`8b65b4d`)

Adds `core/degrade`, a concurrency-safe collector surfaced as `ScanResult.Degradations`. Each record names what failed and — the part that matters — what may now be missing from the results.

The CLI prints them to stderr **even under `--quiet`** (quiet suppresses noise, not "these results are partial"), and `--fail-on-degraded` lets CI treat "could not check" as failure.

```
$ nox scan .            # with OSV firewalled
[results] 0 findings, 1 dependencies, 0 AI components
[degraded] vulnerability lookup failed for 1 packages: ...
  impact: dependency vulnerabilities are under-reported; this scan cannot
          confirm the absence of known CVEs

$ nox scan . -fail-on-degraded
exit 2   # was 0
```

Also configures an slog handler. Without one, **every `slog.Warn` in the codebase reached nobody** — including the OSV degradation warning added in `ba7cbbb` specifically to prevent this.

### Fails loudly where the operator asked for something specific

`--vex` and `--terraform-plan` paths that cannot be loaded are now errors. Those paths only exist because someone typed them, so silently scanning nothing let a typo masquerade as a clean infrastructure review or as applied waivers.

A *missing* baseline stays silent (normal before the first `baseline write`); one that exists and will not load is reported, since under `baseline_mode` it changes what the gate enforces.

### Config that parsed cleanly and did nothing

- `cfg.License` now reaches `deps.WithLicensePolicy` — `license.deny`/`allow` previously produced zero `LIC-*` findings. Fixing it exposed a second bug: `detectNPMLicenses` returned early when the root `package.json` was missing, skipping `node_modules` entirely.
- `RunStagedScanWithOptions` called `RunScan` and dropped `opts` wholesale — `--rules`, `--offline`, `--vex` silently ignored under `--staged`.
- `RunHistoryScan` never read `opts.ScanOptions` — `--rules` silently ignored under `--history`.
- `ScanOptions.NoCache` was read by nothing; removed. `-no-cache` stays accepted for compatibility but now describes itself honestly.

## 3. Plugin trust boundary (`0dcac5b`)

**The gRPC socket bound to all interfaces.** `sdk/server.go` listened on `":0"` and the host dialled with insecure credentials, so any local process — and depending on firewall, any LAN peer — could invoke plugin tools during a scan. Now `127.0.0.1:0`.

**Plugin fingerprints were trusted verbatim.** Plugin findings merge into the same `FindingSet` as core findings, dedup first-wins, and baseline/VEX suppression key on the same value — so a plugin could claim a fingerprint matching a core finding and **erase it**, or match a baselined finding and hide itself. `TestHost_MergeResults_PluginCannotSuppressCoreFinding` reproduces the first case against the old code: the core finding is genuinely gone.

Fingerprints are now derived host-side with the rule ID namespaced as `plugin:<name>:<ruleID>` and the claimed value demoted to hash input. Collisions outside a plugin's namespace become impossible, while plugin findings stay baseline-able.

## 4. Registry `deprecated` flag (`367e7ff`)

`efeb175` marks two plugins deprecated, but the fields were inert — absent from `PluginEntry`, absent from `schema.json`, read by nobody. `plugin search` and `install` would resolve and install a deprecated plugin without a word. Now parsed and surfaced in search, install, info, and the marketplace site.

Also corrects `nox/remediate`, which declared track `"remediation"` — not a valid track, so `ValidTrack` returned false. `docs/track-catalog.md` already places it under Track 10, so the index had drifted from the documented taxonomy; corrected to `agent-assistance`, with a test guarding the shipped index.

## Verification

- `go build ./...`, `go test ./...`, and `go test -race ./core/... ./plugin/... ./sdk/...` all clean.
- `golangci-lint` clean on every changed file.
- OSV fix verified end-to-end against the live API, not just mocks: severity now `high`, aliases populated, `fixed_in: 1.3.2`, and `nox fix` applies the upgrade.
- Degradation reporting verified end-to-end by firewalling OSV via an unroutable proxy.

## Notes for review

- **The registry plumbing lands ahead of its data.** This branch is off `main`, so `efeb175`'s entries are not here. They light up on merge, at which point the `[DEPRECATED]` description prefixes should be dropped in favour of the structured flag.
- **`--vex` / `--terraform-plan` becoming hard errors is a behaviour change.** Anyone relying on a broken path being ignored will now see exit 2. That is the intent, but it is worth a release note.
- Several fixes here are the *same shape* as the OSV bug. Two worth considering next, deliberately left out to keep this reviewable: analyzers accept `ctx` but only `deps` checks it, so a cancelled context does not interrupt a walk over 100k files; and `plugin/profiles.go` plus `InvokePostScan` are dead code with zero non-test callers.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts
