### PR TITLE
fix: make core scan reliable — visible degradation, plugin trust boundary, cancellation

### DIFF
--- a/cli/install_cmd.go
+++ b/cli/install_cmd.go
@@ -200,6 +200,7 @@ func installOne(name, constraint string, st *State) error {
 		BinaryPath:  artifact.BinaryPath,
 		TrustLevel:  artifact.VerifyResult.Level.String(),
 		RiskClass:   ve.RiskClass,
+		Track:       string(trackForPlugin(ctx, client, name)),
 		InstalledAt: now,
 		UpdatedAt:   now,
 	})

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,19 @@ var (
 )
 
 func main() {
+	// Route slog to stderr at warn level. Nothing configured a handler before,
+	// so every slog.Warn the pipeline emits about degraded checks — including
+	// the OSV degradation warning added specifically to prevent silent failure
+	// — was reaching nobody. NOX_LOG_LEVEL surfaces the rest.
+	level := slog.LevelWarn
+	if lvl := os.Getenv("NOX_LOG_LEVEL"); lvl != "" {
+		var parsed slog.Level
+		if err := parsed.UnmarshalText([]byte(lvl)); err == nil {
+			level = parsed
+		}
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
 	os.Exit(run(os.Args[1:]))
 }
 
@@ -289,11 +303,15 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		noAutoInstallFlg      bool
 		failOnUnwaivedFlg     bool
 		offlineFlag           bool
+		failOnDegraded        bool
 		sortFlag              string
 	)
 	scanFS.BoolVar(&historyFlag, "history", false, "scan git history for secrets in past commits")
 	scanFS.IntVar(&historyDepthFlag, "history-depth", 0, "max number of commits to scan (0 = unlimited)")
-	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "disable incremental scan cache")
+	// Accepted for compatibility with existing scripts, but the scan pipeline
+	// consults no incremental cache — every run is already a full re-scan. The
+	// flag previously set ScanOptions.NoCache, which nothing read.
+	scanFS.BoolVar(&noCacheFlag, "no-cache", false, "no-op: scans are never cached (accepted for compatibility)")
 	scanFS.StringVar(&changedSinceFlag, "changed-since", "", "scan only files changed since the given git ref")
 	var baselineFlag string
 	scanFS.StringVar(&baselineFlag, "baseline", "", "path to the baseline file whose fingerprints mark known findings as suppressed (default: auto-discover .nox/baseline.json, or .nox.yaml policy.baseline_path)")
@@ -301,6 +319,10 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.BoolVar(&trackedOnlyFlag, "tracked-only", false, "scan only git-tracked files (git ls-files); exclude untracked working-tree files and submodule contents")
 	scanFS.BoolVar(&noAutoInstallFlg, "no-auto-install", false, "skip auto-installing plugins listed in .nox.yaml plugins.required")
 	scanFS.BoolVar(&failOnUnwaivedFlg, "fail-on-unwaived", false, "with --vex: only exit non-zero on findings NOT covered by an OpenVEX waiver")
+	// For CI that must treat "could not check" as failure rather than success —
+	// e.g. a runner where OSV is firewalled, or a required plugin is missing.
+	// Without this, an incomplete scan exits 0 exactly like a clean one.
+	scanFS.BoolVar(&failOnDegraded, "fail-on-degraded", false, "exit non-zero if any check could not complete (OSV lookup, plugin, lockfile parse)")
 	scanFS.BoolVar(&offlineFlag, "offline", false, "guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry)")
 	scanFS.StringVar(&sortFlag, "sort", "deterministic", "findings.json order: 'deterministic' (rule/path/line) or 'priority' (severity, then reachability, then confidence — most actionable first)")
 	var fingerprintVersionFlag string
@@ -402,7 +424,6 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			Offline:            offlineFlag,
 			VEXPath:            vexFlag,
 			TerraformPlanPath:  tfPlanFlag,
-			NoCache:            noCacheFlag,
 			ChangedSince:       changedSinceFlag,
 			NoRespectGitignore: noRespectGitignoreFlg,
 			TrackedOnly:        trackedOnlyFlag,
@@ -477,6 +498,17 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		if offlineFlag {
 			fmt.Println("[offline] zero-network guarantee: no OSV, no API, no token, no telemetry (recorded in findings.json meta)")
 		}
+	}
+
+	// Report incomplete checks even under --quiet, and on stderr. A scan that
+	// could not run part of itself must never look like a clean scan: quiet
+	// mode suppresses noise, not a warning that the results are partial.
+	for _, d := range result.Degradations {
+		fmt.Fprintf(os.Stderr, "[degraded] %s\n  impact: %s\n", d.Detail, d.Impact)
+	}
+	if len(result.Degradations) > 0 && failOnDegraded {
+		fmt.Fprintf(os.Stderr, "error: %d check(s) did not complete and --fail-on-degraded is set\n", len(result.Degradations))
+		return 2
 	}
 
 	// Generate reports.

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -184,10 +184,36 @@ func runPluginSearch(args []string) int {
 		if track == "" {
 			track = "-"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, track, p.Description, latest)
+		desc := p.Description
+		if p.Deprecated {
+			desc = "[DEPRECATED] " + desc
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, track, desc, latest)
 	}
 	_ = w.Flush()
+
+	// Migration notices go to stderr so the table on stdout stays pipeable.
+	for i := range results {
+		warnIfDeprecated(&results[i])
+	}
 	return 0
+}
+
+// warnIfDeprecated prints a migration notice for a retired plugin.
+//
+// The registry carried "deprecated" and "deprecation_note" for two releases
+// before anything read them, so search and install happily kept recommending
+// retired plugins. The warning is advisory and never blocks: existing installs
+// must keep working.
+func warnIfDeprecated(p *registry.PluginEntry) {
+	if p == nil || !p.Deprecated {
+		return
+	}
+	if p.DeprecationNote != "" {
+		fmt.Fprintf(os.Stderr, "warning: %s is deprecated — %s\n", p.Name, p.DeprecationNote)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: %s is deprecated and no longer maintained\n", p.Name)
 }
 
 // runPluginInfo shows detailed information about a plugin.
@@ -234,6 +260,13 @@ func runPluginInfo(args []string) int {
 
 	fmt.Printf("Name:        %s\n", found.Name)
 	fmt.Printf("Description: %s\n", found.Description)
+	if found.Deprecated {
+		note := found.DeprecationNote
+		if note == "" {
+			note = "no longer maintained"
+		}
+		fmt.Printf("Status:      DEPRECATED — %s\n", note)
+	}
 	if found.Track != "" {
 		fmt.Printf("Track:       %s\n", found.Track)
 	}
@@ -335,6 +368,17 @@ func runPluginInstall(args []string) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: resolving %s@%s: %v\n", name, constraint, err)
 		return 2
+	}
+
+	// Warn before downloading, but do not block: retired plugins must stay
+	// installable so existing pipelines keep working.
+	if entries, searchErr := client.Search(ctx, name); searchErr == nil {
+		for i := range entries {
+			if entries[i].Name == name {
+				warnIfDeprecated(&entries[i])
+				break
+			}
+		}
 	}
 
 	// If already installed at the resolved version, skip.

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -423,6 +423,7 @@ func runPluginInstall(args []string) int {
 		BinaryPath:  artifact.BinaryPath,
 		TrustLevel:  trustLevel,
 		RiskClass:   ve.RiskClass,
+		Track:       string(trackForPlugin(ctx, client, name)),
 		InstalledAt: now,
 		UpdatedAt:   now,
 	})
@@ -502,6 +503,7 @@ func runPluginUpdate(args []string) int {
 			BinaryPath:  artifact.BinaryPath,
 			TrustLevel:  artifact.VerifyResult.Level.String(),
 			RiskClass:   ve.RiskClass,
+			Track:       string(trackForPlugin(ctx, client, name)),
 			InstalledAt: ip.InstalledAt,
 			UpdatedAt:   now,
 		})

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/plugin"
+	"github.com/nox-hq/nox/registry"
 )
 
 // init registers the analysis-plugin runner with the core scan pipeline.
@@ -19,15 +20,28 @@ func init() {
 	core.PostScanPluginHook = runPostScanPlugins
 }
 
+// installedPlugin pairs a plugin binary with the registry track it was
+// installed under. The track selects the safety profile the host enforces, so
+// it travels with the path rather than being looked up again later.
+type installedPlugin struct {
+	path  string
+	track registry.Track
+}
+
 // installedPluginBinaries resolves each required plugin name to its installed
-// binary path. Missing or not-yet-installed plugins are skipped (scan-time
-// auto-install may have been disabled or failed) rather than aborting the scan.
-func installedPluginBinaries(required []string) ([]string, error) {
+// binary path and recorded track. Missing or not-yet-installed plugins are
+// skipped (scan-time auto-install may have been disabled or failed) rather than
+// aborting the scan.
+//
+// An empty track — a sideloaded plugin, or one installed before tracks were
+// recorded — is passed through as-is, which the host resolves to the strict
+// default policy.
+func installedPluginBinaries(required []string) ([]installedPlugin, error) {
 	st, err := LoadState(DefaultStatePath())
 	if err != nil {
 		return nil, fmt.Errorf("loading plugin state: %w", err)
 	}
-	var binaries []string
+	var binaries []installedPlugin
 	for _, name := range required {
 		ip := st.FindPlugin(name)
 		if ip == nil {
@@ -36,7 +50,10 @@ func installedPluginBinaries(required []string) ([]string, error) {
 		if _, statErr := os.Stat(ip.BinaryPath); statErr != nil {
 			continue
 		}
-		binaries = append(binaries, ip.BinaryPath)
+		binaries = append(binaries, installedPlugin{
+			path:  ip.BinaryPath,
+			track: registry.Track(ip.Track),
+		})
 	}
 	return binaries, nil
 }
@@ -66,15 +83,23 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 	}
 
 	policy := plugin.DefaultPolicy()
+	var overrides plugin.Policy
+	ignoreTrackProfiles := false
 	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
 		policy = cfg.PluginPolicy.ToPolicy()
+		overrides = cfg.PluginPolicy.Overrides()
+		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
 	}
 
-	host := plugin.NewHost(plugin.WithPolicy(&policy))
+	host := plugin.NewHost(
+		plugin.WithPolicy(&policy),
+		plugin.WithPolicyOverrides(&overrides),
+		plugin.WithIgnoreTrackProfiles(ignoreTrackProfiles),
+	)
 	defer func() { _ = host.Close() }()
 	for _, bin := range binaries {
-		if regErr := host.RegisterBinary(ctx, bin, nil); regErr != nil {
-			return fmt.Errorf("registering plugin %q: %w", bin, regErr)
+		if regErr := host.RegisterBinaryWithTrack(ctx, bin.path, nil, bin.track); regErr != nil {
+			return fmt.Errorf("registering plugin %q: %w", bin.path, regErr)
 		}
 	}
 
@@ -103,10 +128,14 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 	}
 
 	policy := plugin.DefaultPolicy()
+	var overrides plugin.Policy
+	ignoreTrackProfiles := false
 	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
 		policy = cfg.PluginPolicy.ToPolicy()
+		overrides = cfg.PluginPolicy.Overrides()
+		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
 	}
-	return runPluginBinaries(ctx, target, binaries, &policy)
+	return runPluginBinaries(ctx, target, binaries, &policy, &overrides, ignoreTrackProfiles)
 }
 
 // runPluginBinaries registers the given plugin binaries with a host, runs
@@ -114,7 +143,7 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 // findings/enrichments/graphs. It is separated from runScanPlugins so it can
 // be exercised against a freshly-built plugin binary without touching the
 // installed-plugin state.
-func runPluginBinaries(ctx context.Context, target string, binaries []string, policy *plugin.Policy) (*core.PluginScanOutput, error) {
+func runPluginBinaries(ctx context.Context, target string, binaries []installedPlugin, policy, overrides *plugin.Policy, ignoreTrackProfiles bool) (*core.PluginScanOutput, error) {
 	if len(binaries) == 0 {
 		return nil, nil
 	}
@@ -132,12 +161,20 @@ func runPluginBinaries(ctx context.Context, target string, binaries []string, po
 		absTarget = target
 	}
 
-	host := plugin.NewHost(plugin.WithPolicy(policy))
+	if overrides == nil {
+		overrides = &plugin.Policy{}
+	}
+
+	host := plugin.NewHost(
+		plugin.WithPolicy(policy),
+		plugin.WithPolicyOverrides(overrides),
+		plugin.WithIgnoreTrackProfiles(ignoreTrackProfiles),
+	)
 	defer func() { _ = host.Close() }()
 
 	for _, bin := range binaries {
-		if regErr := host.RegisterBinary(ctx, bin, nil); regErr != nil {
-			return nil, fmt.Errorf("registering plugin %q: %w", bin, regErr)
+		if regErr := host.RegisterBinaryWithTrack(ctx, bin.path, nil, bin.track); regErr != nil {
+			return nil, fmt.Errorf("registering plugin %q: %w", bin.path, regErr)
 		}
 	}
 

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -151,17 +151,17 @@ func runPluginBinaries(ctx context.Context, target string, binaries []string, po
 	}
 
 	out := &core.PluginScanOutput{}
-	for _, resp := range responses {
-		if resp == nil {
+	for _, r := range responses {
+		if r.Response == nil {
 			continue
 		}
-		for _, pf := range resp.GetFindings() {
-			out.Findings = append(out.Findings, plugin.ProtoFindingToGo(pf))
+		for _, pf := range r.Response.GetFindings() {
+			out.Findings = append(out.Findings, plugin.ProtoFindingToGo(pf, r.PluginName))
 		}
-		for _, pe := range resp.GetEnrichments() {
+		for _, pe := range r.Response.GetEnrichments() {
 			out.Enrichments = append(out.Enrichments, plugin.ProtoEnrichmentToGo(pe))
 		}
-		for _, pg := range resp.GetGraphs() {
+		for _, pg := range r.Response.GetGraphs() {
 			out.Graphs = append(out.Graphs, plugin.ProtoGraphToGo(pg))
 		}
 	}

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -22,7 +22,7 @@ func TestRunScanPlugins_NoRequired_NoOp(t *testing.T) {
 }
 
 func TestRunPluginBinaries_NoBinaries_NoOp(t *testing.T) {
-	out, err := runPluginBinaries(context.Background(), t.TempDir(), nil, nil)
+	out, err := runPluginBinaries(context.Background(), t.TempDir(), nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cli/state.go
+++ b/cli/state.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,12 +12,21 @@ import (
 
 // InstalledPlugin records metadata for a locally installed plugin.
 type InstalledPlugin struct {
-	Name        string    `json:"name"`
-	Version     string    `json:"version"`
-	Digest      string    `json:"digest"`
-	BinaryPath  string    `json:"binary_path"`
-	TrustLevel  string    `json:"trust_level"`
-	RiskClass   string    `json:"risk_class"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	Digest     string `json:"digest"`
+	BinaryPath string `json:"binary_path"`
+	TrustLevel string `json:"trust_level"`
+	RiskClass  string `json:"risk_class"`
+
+	// Track is the registry track this plugin was published under, captured at
+	// install time. It selects the safety profile enforced at scan time, so it
+	// is deliberately recorded from the registry entry and never read from the
+	// plugin itself — a self-declared track would let a plugin choose its own
+	// sandbox. Empty for sideloaded (--local) plugins and for installs
+	// predating this field, both of which fall back to the strict default
+	// policy.
+	Track       string    `json:"track,omitempty"`
 	InstalledAt time.Time `json:"installed_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }
@@ -121,4 +131,24 @@ func noxHome() string {
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".nox")
+}
+
+// trackForPlugin looks up the registry track a plugin is published under.
+//
+// The track selects which safety profile the host enforces, so it must come
+// from the registry — the operator-configured source of truth — and never from
+// the plugin's own manifest, which carries no track field for exactly this
+// reason. A lookup failure returns an empty track, which the host treats as
+// "provenance unknown" and falls back to the strict default policy.
+func trackForPlugin(ctx context.Context, client *registry.Client, name string) registry.Track {
+	entries, err := client.Search(ctx, name)
+	if err != nil {
+		return ""
+	}
+	for i := range entries {
+		if entries[i].Name == name {
+			return entries[i].Track
+		}
+	}
+	return ""
 }

--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -124,6 +124,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	inv := NewInventory()
 
 	for _, artifact := range artifacts {
+		// Honour cancellation between artifacts — see the note in the secrets
+		// analyzer: nothing else in this loop consults ctx.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+
 		content, err := os.ReadFile(artifact.AbsPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("reading artifact %s: %w", artifact.Path, err)

--- a/core/analyzers/cancellation_test.go
+++ b/core/analyzers/cancellation_test.go
@@ -1,0 +1,117 @@
+// Package analyzers_test verifies that every analyzer honours context
+// cancellation between artifacts.
+//
+// All four analyzers accepted a context and then ignored it: only the deps
+// analyzer ever consulted ctx, so a cancelled scan kept reading files until the
+// walk finished. On a large tree that meant cancellation was effectively
+// ignored, while the pipeline's doc comment claimed the context was propagated
+// to every analyzer.
+package analyzers_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/ai"
+	"github.com/nox-hq/nox/core/analyzers/data"
+	"github.com/nox-hq/nox/core/analyzers/iac"
+	"github.com/nox-hq/nox/core/analyzers/secrets"
+	"github.com/nox-hq/nox/core/discovery"
+)
+
+// buildArtifacts writes n small files and returns artifacts describing them.
+// Several files are needed because cancellation is checked between artifacts.
+func buildArtifacts(t *testing.T, n int) []discovery.Artifact {
+	t.Helper()
+
+	dir := t.TempDir()
+	artifacts := make([]discovery.Artifact, 0, n)
+	for i := range n {
+		name := filepath.Join(dir, "file.tf")
+		if i > 0 {
+			name = filepath.Join(dir, "file"+string(rune('a'+i))+".tf")
+		}
+		content := []byte("resource \"aws_s3_bucket\" \"b\" {}\n")
+		if err := os.WriteFile(name, content, 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+		artifacts = append(artifacts, discovery.Artifact{
+			Path:    filepath.Base(name),
+			AbsPath: name,
+			Size:    int64(len(content)),
+		})
+	}
+	return artifacts
+}
+
+func TestAnalyzers_HonourCancellation(t *testing.T) {
+	t.Parallel()
+
+	artifacts := buildArtifacts(t, 8)
+
+	// Already-cancelled context: every analyzer must give up rather than
+	// working through the artifact list.
+	tests := []struct {
+		name string
+		scan func(ctx context.Context) error
+	}{
+		{"secrets", func(ctx context.Context) error {
+			_, err := secrets.NewAnalyzer().ScanArtifacts(ctx, artifacts)
+			return err
+		}},
+		{"data", func(ctx context.Context) error {
+			_, err := data.NewAnalyzer().ScanArtifacts(ctx, artifacts)
+			return err
+		}},
+		{"iac", func(ctx context.Context) error {
+			_, err := iac.NewAnalyzer().ScanArtifacts(ctx, artifacts)
+			return err
+		}},
+		{"ai", func(ctx context.Context) error {
+			_, _, err := ai.NewAnalyzer().ScanArtifacts(ctx, artifacts)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			if err := tt.scan(ctx); err == nil {
+				t.Error("expected a cancellation error, got nil — the analyzer ignores ctx")
+			} else if !errorIsCancelled(err) {
+				t.Errorf("expected context.Canceled, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAnalyzers_RunToCompletionWithLiveContext(t *testing.T) {
+	t.Parallel()
+
+	// The cancellation check must not break the normal path.
+	artifacts := buildArtifacts(t, 3)
+	ctx := context.Background()
+
+	if _, err := secrets.NewAnalyzer().ScanArtifacts(ctx, artifacts); err != nil {
+		t.Errorf("secrets: %v", err)
+	}
+	if _, err := data.NewAnalyzer().ScanArtifacts(ctx, artifacts); err != nil {
+		t.Errorf("data: %v", err)
+	}
+	if _, err := iac.NewAnalyzer().ScanArtifacts(ctx, artifacts); err != nil {
+		t.Errorf("iac: %v", err)
+	}
+	if _, _, err := ai.NewAnalyzer().ScanArtifacts(ctx, artifacts); err != nil {
+		t.Errorf("ai: %v", err)
+	}
+}
+
+func errorIsCancelled(err error) bool {
+	return err == context.Canceled || err.Error() == context.Canceled.Error()
+}

--- a/core/analyzers/data/data.go
+++ b/core/analyzers/data/data.go
@@ -50,6 +50,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	fs := findings.NewFindingSet()
 
 	for _, artifact := range artifacts {
+		// Honour cancellation between artifacts — see the note in the secrets
+		// analyzer: nothing else in this loop consults ctx.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		content, err := os.ReadFile(artifact.AbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading artifact %s: %w", artifact.Path, err)

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -9,6 +9,7 @@ package deps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -17,10 +18,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
 )
+
+// ErrUnsupportedLockfile marks a file whose name matches no known lockfile
+// parser. It is deliberately distinguishable from a parse failure: the former
+// means nox never intended to read the file, the latter means it tried and
+// failed, which leaves a real blind spot worth reporting.
+var ErrUnsupportedLockfile = errors.New("unsupported lockfile type")
 
 // Package represents a single dependency extracted from a lockfile.
 type Package struct {
@@ -160,6 +168,18 @@ type Analyzer struct {
 	httpClient    *http.Client
 	osvEnabled    bool
 	licensePolicy *LicensePolicy
+
+	// degradations collects the checks this analyzer could not complete. It is
+	// optional: a nil collector discards records, so library callers that do
+	// not supply one behave exactly as before.
+	degradations *degrade.Degradations
+}
+
+// WithDegradations gives the analyzer a collector to report incomplete checks
+// to. Without one, a failed OSV lookup or an unparseable lockfile is
+// indistinguishable from a clean result.
+func WithDegradations(d *degrade.Degradations) AnalyzerOption {
+	return func(a *Analyzer) { a.degradations = d }
 }
 
 // NewAnalyzer returns an Analyzer with the default OSV API endpoint.
@@ -274,7 +294,7 @@ func (a *Analyzer) ParseLockfile(path string, content []byte) ([]Package, error)
 	base := filepath.Base(path)
 	parser, ok := supportedLockfiles[base]
 	if !ok {
-		return nil, fmt.Errorf("unsupported lockfile type: %s", base)
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedLockfile, base)
 	}
 	return parser(content)
 }
@@ -318,8 +338,16 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			pkgs, err = a.ParseLockfile(art.AbsPath, content)
 		}
 		if err != nil {
-			// Skip lockfiles we cannot parse (e.g. yarn.lock)
-			// rather than failing the entire scan.
+			// A file type we deliberately do not parse (go.sum, yarn.lock) is
+			// not a degradation — nothing was expected of it, and reporting it
+			// would train operators to ignore the degradation output entirely.
+			// A file we DO claim to parse but could not is the real signal:
+			// every package it declares is now absent from CVE matching.
+			if !errors.Is(err, ErrUnsupportedLockfile) {
+				a.degradations.Add(degrade.Lockfile,
+					fmt.Sprintf("%s could not be parsed: %v", art.Path, err),
+					"dependencies declared in this file were not scanned for vulnerabilities")
+			}
 			continue
 		}
 
@@ -483,7 +511,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancel()
 
-			vulnMap, err := queryOSV(ctx, a.httpClient, a.OSVBaseURL, pkgs)
+			vulnMap, err := queryOSV(ctx, a.httpClient, a.OSVBaseURL, pkgs, a.degradations)
 			if err != nil {
 				return nil, nil, fmt.Errorf("querying OSV: %w", err)
 			}
@@ -505,7 +533,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				var domainVulns []Vulnerability
 
 				for _, ov := range osvVulns {
-					sev := mapOSVSeverity(ov.Severity)
+					sev := mapOSVSeverity(ov.Severity, ov.DatabaseSpecific)
 					domainVulns = append(domainVulns, Vulnerability{
 						ID:       ov.ID,
 						Summary:  ov.Summary,

--- a/core/analyzers/deps/license.go
+++ b/core/analyzers/deps/license.go
@@ -149,24 +149,24 @@ func matchesLicenseList(license string, list []string) bool {
 // name to license string.
 func detectNPMLicenses(basePath string) map[string]string {
 	result := make(map[string]string)
+
+	// Read the root manifest's own license if present. A missing or malformed
+	// root package.json must not stop us: the dependency licences actually
+	// evaluated live in node_modules, and returning early here meant a project
+	// without a readable root manifest got no license findings whatsoever.
 	path := filepath.Join(basePath, "package.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return result
-	}
-
-	var pkg struct {
-		Name    string          `json:"name"`
-		License json.RawMessage `json:"license"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return result
-	}
-
-	// The license field can be a string or an object {type: "MIT"}.
-	license := extractJSONLicense(pkg.License)
-	if license != "" && pkg.Name != "" {
-		result[pkg.Name] = license
+	if data, err := os.ReadFile(path); err == nil {
+		var pkg struct {
+			Name    string          `json:"name"`
+			License json.RawMessage `json:"license"`
+		}
+		if err := json.Unmarshal(data, &pkg); err == nil {
+			// The license field can be a string or an object {type: "MIT"}.
+			license := extractJSONLicense(pkg.License)
+			if license != "" && pkg.Name != "" {
+				result[pkg.Name] = license
+			}
+		}
 	}
 
 	// Read license info from node_modules package.json files.

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/findings"
 )
 
@@ -52,6 +53,16 @@ type osvVuln struct {
 	Aliases  []string      `json:"aliases"`
 	Details  string        `json:"details"`
 	Affected []osvAffected `json:"affected"`
+
+	// DatabaseSpecific carries source-database annotations. GitHub advisories
+	// publish a coarse severity label here, which is the only severity signal
+	// available for records that carry a CVSS v4 vector and nothing else.
+	DatabaseSpecific osvDatabaseSpecific `json:"database_specific"`
+}
+
+// osvDatabaseSpecific holds the subset of source-specific annotations we read.
+type osvDatabaseSpecific struct {
+	Severity string `json:"severity"`
 }
 
 // osvSeverity holds a CVSS or other severity score.
@@ -126,7 +137,7 @@ func fixedVersion(vuln *osvVuln, pkgName, ecosystem string) string {
 //
 // On network errors the function returns an empty map (graceful degradation)
 // rather than failing the scan, honouring Nox's offline-first design.
-func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []Package) (map[int][]osvVuln, error) {
+func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []Package, deg *degrade.Degradations) (map[int][]osvVuln, error) {
 	result := make(map[int][]osvVuln)
 
 	// Only query packages whose ecosystem OSV.dev actually understands. Other
@@ -185,6 +196,9 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 			// result is indistinguishable from "no vulnerabilities found".
 			slog.WarnContext(ctx, "OSV query failed; dependency vulnerabilities may be under-reported",
 				"error", err, "queries", len(queries))
+			deg.Add(degrade.OSV,
+				fmt.Sprintf("vulnerability lookup failed for %d packages: %v", len(queries), err),
+				"dependency vulnerabilities are under-reported; this scan cannot confirm the absence of known CVEs")
 			return result, nil
 		}
 
@@ -195,6 +209,9 @@ func queryOSV(ctx context.Context, client *http.Client, baseURL string, pkgs []P
 			// clean scan when the lookup actually failed.
 			slog.WarnContext(ctx, "OSV query returned an error; dependency vulnerabilities may be under-reported",
 				"error", decodeErr, "queries", len(queries))
+			deg.Add(degrade.OSV,
+				fmt.Sprintf("vulnerability lookup failed for %d packages: %v", len(queries), decodeErr),
+				"dependency vulnerabilities are under-reported; this scan cannot confirm the absence of known CVEs")
 			return result, nil
 		}
 
@@ -345,6 +362,15 @@ func fetchVulnDetail(ctx context.Context, client *http.Client, baseURL, id strin
 	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return osvVuln{}, err
 	}
+
+	// Confirm we got back the record we asked for. Any JSON object decodes into
+	// osvVuln without error, so an intercepting proxy or captive portal
+	// answering 200 with unrelated JSON would otherwise yield a well-formed but
+	// entirely empty advisory — silently blanking a real finding's severity and
+	// fix version, which is exactly the failure hydration exists to prevent.
+	if v.ID != id {
+		return osvVuln{}, fmt.Errorf("OSV vuln lookup for %s returned mismatched record %q", id, v.ID)
+	}
 	return v, nil
 }
 
@@ -362,15 +388,41 @@ func decodeBatchResponse(resp *http.Response) ([]osvBatchResult, error) {
 }
 
 // mapOSVSeverity converts OSV severity entries to a nox Severity.
-// It looks for a CVSS_V3 score first, then falls back to CVSS_V2.
-// If no score is found, it returns SeverityMedium as a conservative default.
-func mapOSVSeverity(sev []osvSeverity) findings.Severity {
+// It looks for a CVSS_V3 score first, then falls back to CVSS_V2, then to the
+// source database's coarse severity label.
+//
+// The label matters because CVSS v4 vectors score by a different and
+// substantially more complex algorithm that cvssToSeverity does not attempt.
+// Without the fallback, an advisory publishing only a v4 vector — an
+// increasingly common case — silently collapsed to medium regardless of how
+// severe it actually was. SeverityMedium now means a genuine "unknown".
+func mapOSVSeverity(sev []osvSeverity, dbSpecific osvDatabaseSpecific) findings.Severity {
 	for _, s := range sev {
 		if s.Type == "CVSS_V3" || s.Type == "CVSS_V2" {
 			return cvssToSeverity(s.Score)
 		}
 	}
+	if s, ok := severityFromLabel(dbSpecific.Severity); ok {
+		return s
+	}
 	return findings.SeverityMedium
+}
+
+// severityFromLabel maps a coarse textual severity label to a nox Severity.
+// GitHub advisories say "MODERATE" where most other sources say "MEDIUM".
+func severityFromLabel(label string) (findings.Severity, bool) {
+	switch strings.ToUpper(strings.TrimSpace(label)) {
+	case "CRITICAL":
+		return findings.SeverityCritical, true
+	case "HIGH":
+		return findings.SeverityHigh, true
+	case "MODERATE", "MEDIUM":
+		return findings.SeverityMedium, true
+	case "LOW":
+		return findings.SeverityLow, true
+	default:
+		return "", false
+	}
 }
 
 // cvssToSeverity converts a CVSS vector string or numeric score to a Severity.

--- a/core/analyzers/deps/osv_hydrate_test.go
+++ b/core/analyzers/deps/osv_hydrate_test.go
@@ -39,7 +39,7 @@ func TestHydrateVulnDetails_FillsSeverityAndSummary(t *testing.T) {
 	if got.Summary != "Remote code execution in example" {
 		t.Errorf("summary not hydrated: %q", got.Summary)
 	}
-	if sev := mapOSVSeverity(got.Severity); sev != findings.SeverityCritical {
+	if sev := mapOSVSeverity(got.Severity, osvDatabaseSpecific{}); sev != findings.SeverityCritical {
 		t.Errorf("severity = %v, want critical (CVSS 9.8)", sev)
 	}
 	if len(got.Affected) != 1 {

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -99,7 +99,7 @@ func TestQueryOSV_BatchQuery(t *testing.T) {
 		{Name: "lodash", Version: "4.17.20", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestQueryOSV_LargeBatch(t *testing.T) {
 		pkgs[i] = Package{Name: "pkg", Version: "1.0.0", Ecosystem: "npm"}
 	}
 
-	_, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	_, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestQueryOSV_NetworkError(t *testing.T) {
 		{Name: "express", Version: "4.17.1", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestQueryOSV_EmptyResponse(t *testing.T) {
 		{Name: "lodash", Version: "4.17.21", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestQueryOSV_Non200Status(t *testing.T) {
 		{Name: "express", Version: "4.17.1", Ecosystem: "npm"},
 	}
 
-	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	result, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestMapOSVSeverity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := mapOSVSeverity(tt.input)
+			result := mapOSVSeverity(tt.input, osvDatabaseSpecific{})
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
@@ -846,7 +846,7 @@ func TestQueryOSV_SkipsUnknownEcosystem(t *testing.T) {
 		{Name: "esbuild", Version: "0.27.7", Ecosystem: "npm"},
 	}
 
-	got, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs)
+	got, err := queryOSV(context.Background(), srv.Client(), srv.URL, pkgs, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}
@@ -881,7 +881,7 @@ func TestQueryOSV_WarnsOnNon200(t *testing.T) {
 	defer slog.SetDefault(prev)
 
 	got, err := queryOSV(context.Background(), srv.Client(), srv.URL,
-		[]Package{{Name: "lodash", Version: "4.17.0", Ecosystem: "npm"}})
+		[]Package{{Name: "lodash", Version: "4.17.0", Ecosystem: "npm"}}, nil)
 	if err != nil {
 		t.Fatalf("queryOSV returned error: %v", err)
 	}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -54,6 +54,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 	var collected []findings.Finding
 	for _, artifact := range artifacts {
+		// Honour cancellation between artifacts — see the note in the secrets
+		// analyzer: nothing else in this loop consults ctx.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		content, err := os.ReadFile(artifact.AbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading artifact %s: %w", artifact.Path, err)

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -123,6 +123,14 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	fs := findings.NewFindingSet()
 
 	for _, artifact := range artifacts {
+		// Honour cancellation between artifacts. A scan over a large tree can
+		// run for a long time; without this the analyzer would keep reading
+		// files after the caller's context was cancelled or its deadline
+		// passed, since nothing inside the loop touches ctx.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		// Skip lock files, checksums, minified bundles and tool state dirs
 		// wholesale: their content-addressed hashes match both the entropy
 		// rules and the provider-key regexes, producing thousands of false

--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -1,0 +1,242 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover the degradation-reporting and fail-loud behaviour added to
+// close a class of bug where nox reported a clean scan without having run the
+// check. Each one previously passed silently with exit 0.
+
+func TestRefine_MalformedVEXIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	vexPath := filepath.Join(dir, "broken.vex.json")
+	if err := os.WriteFile(vexPath, []byte("{ this is not valid json"), 0o644); err != nil {
+		t.Fatalf("writing vex: %v", err)
+	}
+
+	// An operator who passes --vex expects those waivers to be applied. Before
+	// this change the load error was discarded, so a typo'd or corrupt document
+	// silently applied no waivers at all.
+	_, err := RunScanWithOptions(dir, ScanOptions{VEXPath: vexPath, Offline: true})
+	if err == nil {
+		t.Fatal("expected an error for a malformed VEX document, got nil")
+	}
+	if !strings.Contains(err.Error(), "VEX") {
+		t.Errorf("expected the error to name VEX, got: %v", err)
+	}
+}
+
+func TestRefine_MissingVEXFileIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	_, err := RunScanWithOptions(dir, ScanOptions{
+		VEXPath: filepath.Join(dir, "does-not-exist.json"),
+		Offline: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing VEX document, got nil")
+	}
+}
+
+func TestRefine_MissingTerraformPlanIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Silently scanning nothing would let a typo'd plan path masquerade as a
+	// clean infrastructure review.
+	_, err := RunScanWithOptions(dir, ScanOptions{
+		TerraformPlanPath: filepath.Join(dir, "no-such-plan.json"),
+		Offline:           true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a missing terraform plan, got nil")
+	}
+	if !strings.Contains(err.Error(), "terraform") {
+		t.Errorf("expected the error to name the terraform plan, got: %v", err)
+	}
+}
+
+func TestRefine_MalformedTerraformPlanIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(planPath, []byte("not json at all"), 0o644); err != nil {
+		t.Fatalf("writing plan: %v", err)
+	}
+
+	_, err := RunScanWithOptions(dir, ScanOptions{TerraformPlanPath: planPath, Offline: true})
+	if err == nil {
+		t.Fatal("expected an error for a malformed terraform plan, got nil")
+	}
+}
+
+func TestScan_CorruptBaselineIsReportedAsDegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A file the secrets analyzer will flag, so there is something to classify.
+	if err := os.WriteFile(filepath.Join(dir, "cfg.env"),
+		[]byte("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY\n"), 0o644); err != nil {
+		t.Fatalf("writing target file: %v", err)
+	}
+
+	cfg := "policy:\n  baseline_path: .nox-baseline.json\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox-baseline.json"),
+		[]byte("{ corrupt"), 0o644); err != nil {
+		t.Fatalf("writing baseline: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	// A corrupt baseline must not fail the scan — but under baseline_mode it
+	// changes what the gate enforces, so it cannot pass unnoticed either.
+	if !hasDegradationKind(result, "baseline") {
+		t.Errorf("expected a baseline degradation, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_AbsentBaselineIsNotADegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Having no baseline is the normal state before the first
+	// `nox baseline write`. Reporting it would train operators to ignore
+	// degradation output entirely.
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if hasDegradationKind(result, "baseline") {
+		t.Errorf("absent baseline should be silent, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_UnparseableLockfileIsReportedAsDegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Valid filename so it is classified as a lockfile, invalid content so the
+	// parse fails. Every dependency it declares is now absent from CVE matching.
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"),
+		[]byte("{ not valid json at all"), 0o644); err != nil {
+		t.Fatalf("writing lockfile: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	if !hasDegradationKind(result, "lockfile_parse") {
+		t.Errorf("expected a lockfile degradation, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_CleanScanReportsNoDegradations(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# hello\n"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if len(result.Degradations) != 0 {
+		t.Errorf("expected no degradations on a clean offline scan, got %+v", result.Degradations)
+	}
+}
+
+func TestScan_LicensePolicyIsWiredThrough(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A dependency in the inventory (from the lockfile) whose license the
+	// policy denies (from its node_modules manifest). Before this change
+	// license.deny parsed cleanly and then produced no findings whatsoever.
+	lock := `{"packages":{"node_modules/leftpad":{"version":"1.0.0"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(lock), 0o644); err != nil {
+		t.Fatalf("writing lockfile: %v", err)
+	}
+	modDir := filepath.Join(dir, "node_modules", "leftpad")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatalf("creating node_modules: %v", err)
+	}
+	manifest := `{"name":"leftpad","version":"1.0.0","license":"GPL-3.0"}`
+	if err := os.WriteFile(filepath.Join(modDir, "package.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+
+	cfg := "license:\n  deny:\n    - GPL-3.0\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var found bool
+	for _, f := range result.Findings.Findings() {
+		if strings.HasPrefix(f.RuleID, "LIC-") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a LIC-* finding from the configured license policy; license config is not wired through")
+	}
+}
+
+func hasDegradationKind(result *ScanResult, kind string) bool {
+	for _, d := range result.Degradations {
+		if string(d.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestScan_UnsupportedLockfileIsNotADegradation guards the signal-to-noise
+// property. go.sum and yarn.lock are deliberately not parsed, so reporting them
+// as degraded would fire on almost every Go repository — and a warning that
+// fires on healthy scans is one operators learn to ignore, which defeats the
+// entire point of the channel. It also wrongly tripped --fail-on-degraded.
+func TestScan_UnsupportedLockfileIsNotADegradation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"),
+		[]byte("github.com/x/y v1.0.0 h1:abc=\n"), 0o644); err != nil {
+		t.Fatalf("writing go.sum: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if hasDegradationKind(result, "lockfile_parse") {
+		t.Errorf("a deliberately unparsed file was reported as degraded: %+v", result.Degradations)
+	}
+}

--- a/core/degrade/degrade.go
+++ b/core/degrade/degrade.go
@@ -1,0 +1,117 @@
+package degrade
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Kind classifies why part of a scan could not run.
+type Kind string
+
+const (
+	// OSV means a vulnerability lookup against OSV.dev failed, so
+	// dependency vulnerabilities are under-reported.
+	OSV Kind = "osv_lookup"
+
+	// Lockfile means a lockfile was found but could not be parsed,
+	// so its packages are absent from the inventory and from vulnerability
+	// matching.
+	Lockfile Kind = "lockfile_parse"
+
+	// VulnData means an embedded vulnerability dataset (known
+	// malicious packages, popular-package lists) failed to load, silently
+	// disabling the detections built on it.
+	VulnData Kind = "vuln_data_load"
+
+	// Plugin means an analysis plugin failed to run, so any findings
+	// it would have produced are missing.
+	Plugin Kind = "plugin"
+
+	// Baseline means a baseline file existed but could not be read,
+	// so new-vs-known classification is not being applied.
+	Baseline Kind = "baseline"
+
+	// Suppression means a file could not be re-read to apply inline
+	// suppression comments, so its findings are reported unsuppressed.
+	Suppression Kind = "suppression"
+)
+
+// Degradation records that some part of the scan did not run to completion.
+//
+// This type exists because a security scanner's most dangerous failure mode is
+// not crashing — it is reporting "no findings" when it never actually looked.
+// Nox degrades gracefully in many places by design (an OSV outage should not
+// fail a build), but graceful degradation is only safe if it is *visible*.
+// Every site that swallows an error to keep the scan running records a
+// Degradation here so the operator, and CI, can tell the difference between
+// "clean" and "did not check".
+type Degradation struct {
+	// Kind classifies the failure so callers can filter programmatically.
+	Kind Kind
+
+	// Detail is a human-readable explanation naming the affected subject
+	// (a file path, package count, plugin name).
+	Detail string
+
+	// Impact states, in the operator's terms, what may now be missing from
+	// the results. This is the field that answers "should I trust this scan?".
+	Impact string
+}
+
+// String renders a degradation as a single diagnostic line.
+func (d Degradation) String() string {
+	return fmt.Sprintf("%s: %s (%s)", d.Kind, d.Detail, d.Impact)
+}
+
+// Degradations is a concurrency-safe collector for Degradation records.
+//
+// Analyzers run in parallel, so the collector is shared across goroutines. The
+// zero value is ready to use; a nil *Degradations silently discards records so
+// that callers which do not care (tests, library users) need not construct one.
+type Degradations struct {
+	mu    sync.Mutex
+	items []Degradation
+}
+
+// Add records a degradation. It is safe to call concurrently, and safe to call
+// on a nil receiver.
+func (d *Degradations) Add(kind Kind, detail, impact string) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.items = append(d.items, Degradation{Kind: kind, Detail: detail, Impact: impact})
+}
+
+// Items returns the collected degradations in a deterministic order: by kind,
+// then detail. Analyzers run concurrently, so insertion order varies between
+// runs — sorting keeps scan output reproducible, which nox guarantees.
+func (d *Degradations) Items() []Degradation {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	out := make([]Degradation, len(d.items))
+	copy(out, d.items)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Detail < out[j].Detail
+	})
+	return out
+}
+
+// Len reports how many degradations were recorded.
+func (d *Degradations) Len() int {
+	if d == nil {
+		return 0
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.items)
+}

--- a/core/degrade/degrade_test.go
+++ b/core/degrade/degrade_test.go
@@ -1,0 +1,108 @@
+package degrade
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestDegradations_NilReceiverIsSafe(t *testing.T) {
+	t.Parallel()
+
+	// Library callers that do not want degradation reporting pass nil. That
+	// must not panic, or every optional call site would need a guard.
+	var d *Degradations
+	d.Add(OSV, "detail", "impact")
+
+	if got := d.Len(); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+	if got := d.Items(); got != nil {
+		t.Errorf("expected nil items, got %v", got)
+	}
+}
+
+func TestDegradations_ItemsAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Analyzers run in parallel, so insertion order varies run to run. Nox
+	// guarantees identical output for identical input, so Items must sort.
+	build := func(order []Kind) []Degradation {
+		d := &Degradations{}
+		for _, k := range order {
+			d.Add(k, string(k)+"-detail", "impact")
+		}
+		return d.Items()
+	}
+
+	forward := build([]Kind{OSV, Lockfile, Plugin, Baseline})
+	reverse := build([]Kind{Baseline, Plugin, Lockfile, OSV})
+
+	if len(forward) != len(reverse) {
+		t.Fatalf("length mismatch: %d vs %d", len(forward), len(reverse))
+	}
+	for i := range forward {
+		if forward[i] != reverse[i] {
+			t.Errorf("index %d differs: %+v vs %+v", i, forward[i], reverse[i])
+		}
+	}
+}
+
+func TestDegradations_SortsByKindThenDetail(t *testing.T) {
+	t.Parallel()
+
+	d := &Degradations{}
+	d.Add(OSV, "zzz", "impact")
+	d.Add(Lockfile, "bbb", "impact")
+	d.Add(OSV, "aaa", "impact")
+
+	items := d.Items()
+	want := []struct{ kind, detail string }{
+		{string(Lockfile), "bbb"},
+		{string(OSV), "aaa"},
+		{string(OSV), "zzz"},
+	}
+	if len(items) != len(want) {
+		t.Fatalf("expected %d items, got %d", len(want), len(items))
+	}
+	for i, w := range want {
+		if string(items[i].Kind) != w.kind || items[i].Detail != w.detail {
+			t.Errorf("index %d: expected %s/%s, got %s/%s", i, w.kind, w.detail, items[i].Kind, items[i].Detail)
+		}
+	}
+}
+
+func TestDegradations_ConcurrentAdd(t *testing.T) {
+	t.Parallel()
+
+	// The collector is shared across the parallel analyzer errgroup, so it
+	// must tolerate concurrent writes. Run with -race to make this meaningful.
+	d := &Degradations{}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.Add(OSV, "concurrent", "impact")
+		}()
+	}
+	wg.Wait()
+
+	if got := d.Len(); got != 50 {
+		t.Errorf("expected 50 degradations, got %d", got)
+	}
+}
+
+func TestDegradation_StringIncludesImpact(t *testing.T) {
+	t.Parallel()
+
+	// The impact text is the part that tells an operator whether to trust the
+	// scan, so it must not be dropped from the rendered form.
+	d := Degradation{Kind: OSV, Detail: "lookup failed", Impact: "CVEs under-reported"}
+	got := d.String()
+	for _, want := range []string{"osv_lookup", "lookup failed", "CVEs under-reported"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -159,6 +159,11 @@ func RunScanWithOptions(target string, opts ScanOptions) (*ScanResult, error) {
 // every analyzer (including OSV network lookups) and bounds parallel analyzer
 // execution.
 //
+// Analyzers check ctx between artifacts, so cancellation takes effect within
+// one file rather than at the end of the walk. Discovery itself is not
+// interruptible: a cancelled scan still completes the directory traversal it
+// had already begun.
+//
 //nolint:gocritic // ScanOptions is a public API surface; passing by value keeps callers ergonomic.
 func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*ScanResult, error) {
 	if err := ctx.Err(); err != nil {

--- a/core/scan.go
+++ b/core/scan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/variants"
 	"github.com/nox-hq/nox/core/analyzers/weakcrypto"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/git"
@@ -68,7 +69,17 @@ type ScanResult struct {
 	// "what depth did this scan give each language?" and is copied into the
 	// report meta so the decision is visible in the artifact, not just in config.
 	SASTProfile map[string]string
+
+	// Degradations lists the parts of the scan that could not run. An empty
+	// slice means every configured check completed; a non-empty one means the
+	// findings are incomplete and "no findings" must not be read as "clean".
+	Degradations []Degradation
 }
+
+// Degradation re-exports degrade.Degradation so callers holding a ScanResult
+// need not import the leaf package. It lives in its own package because
+// analyzers report degradations too, and they cannot import core.
+type Degradation = degrade.Degradation
 
 // ScanOptions holds optional parameters for RunScanWithOptions. The zero
 // value means no additional options are applied.
@@ -102,9 +113,6 @@ type ScanOptions struct {
 	// Sequential forces analyzers to run sequentially instead of in parallel.
 	// Useful for debugging analyzer interactions.
 	Sequential bool
-
-	// NoCache disables the incremental scan cache, forcing a full re-scan.
-	NoCache bool
 
 	// ChangedSince limits the scan to files changed since the given git ref.
 	// Only files in the diff between the ref and HEAD are analyzed.
@@ -201,9 +209,23 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	dataAnalyzer := data.NewAnalyzer()
 	iacAnalyzer := iac.NewAnalyzer()
 	aiAnalyzer := ai.NewAnalyzer()
-	var depsOpts []deps.AnalyzerOption
+	// degradations collects checks that could not complete. Analyzers write to
+	// it concurrently; it is surfaced on ScanResult so "no findings" can be
+	// distinguished from "did not look".
+	degradations := &degrade.Degradations{}
+
+	depsOpts := []deps.AnalyzerOption{deps.WithDegradations(degradations)}
 	if opts.Offline || opts.DisableOSV || cfg.Scan.OSV.Disabled {
 		depsOpts = append(depsOpts, deps.WithOSVDisabled())
+	}
+	// Wire the project's license policy through. Without this, license.deny /
+	// license.allow in .nox.yaml parsed cleanly and then produced no LIC-*
+	// findings at all — configured policy that silently did nothing.
+	if len(cfg.License.Deny) > 0 || len(cfg.License.Allow) > 0 {
+		depsOpts = append(depsOpts, deps.WithLicensePolicy(deps.LicensePolicy{
+			Deny:  cfg.License.Deny,
+			Allow: cfg.License.Allow,
+		}))
 	}
 	depsAnalyzer := deps.NewAnalyzer(depsOpts...)
 	slopAnalyzer := slop.NewAnalyzer()
@@ -471,7 +493,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// Stage 3: Refine findings — apply rule config, generated/noise filters,
 	// conditional severity, dedup, inline suppressions, terraform plan,
 	// baseline matching, and VEX.
-	refineFindings(allFindings, cfg, opts, target)
+	if err := refineFindings(allFindings, cfg, opts, target, degradations); err != nil {
+		return nil, err
+	}
 
 	// Stage 4: Evaluate policy gates.
 	policyResult := evaluatePolicy(cfg, allFindings)
@@ -484,6 +508,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		AIInventory:  aiInventory,
 		PolicyResult: policyResult,
 		Rules:        allRules,
+		Degradations: degradations.Items(),
 		SASTProfile:  cfg.Scan.SAST.ResolvedProfile(),
 	}, nil
 }
@@ -594,7 +619,7 @@ func singleFileArtifacts(path string, cfg *ScanConfig) ([]discovery.Artifact, er
 // conditional severity, dedup + deterministic sort, inline suppressions,
 // optional terraform-plan findings, baseline matching, and VEX. It is stage 3
 // of the scan pipeline.
-func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts ScanOptions, target string) {
+func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts ScanOptions, target string, deg *degrade.Degradations) error {
 	// Config rule disabling and severity overrides.
 	if len(cfg.Scan.Rules.Disable) > 0 {
 		allFindings.RemoveByRuleIDs(cfg.Scan.Rules.Disable)
@@ -672,16 +697,22 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	allFindings.Deduplicate()
 	allFindings.SortDeterministic()
 
-	applySuppressions(allFindings, target)
+	applySuppressions(allFindings, target, deg)
 
-	// Scan a terraform plan if provided.
+	// Scan a terraform plan if provided. A plan path is only ever set because
+	// the operator asked for it, so a plan that cannot be read or parsed is an
+	// error: silently scanning nothing while reporting success would let a
+	// typo'd path masquerade as a clean infrastructure review.
 	if opts.TerraformPlanPath != "" {
 		tfPlanPath := opts.TerraformPlanPath
 		if !filepath.IsAbs(tfPlanPath) {
 			tfPlanPath = filepath.Join(target, tfPlanPath)
 		}
 		tfFindings, tfErr := iac.ScanTerraformPlan(tfPlanPath)
-		if tfErr == nil && tfFindings != nil {
+		if tfErr != nil {
+			return fmt.Errorf("scanning terraform plan %s: %w", opts.TerraformPlanPath, tfErr)
+		}
+		if tfFindings != nil {
 			tfItems := tfFindings.Findings()
 			for i := range tfItems {
 				allFindings.Add(tfItems[i])
@@ -701,21 +732,28 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	} else if !filepath.IsAbs(baselinePath) {
 		baselinePath = filepath.Join(target, baselinePath)
 	}
-	applyBaseline(allFindings, baselinePath)
+	applyBaseline(allFindings, baselinePath, deg)
 
 	// VEX document.
 	vexPath := opts.VEXPath
 	if vexPath == "" {
 		vexPath = cfg.Policy.VEXPath
 	}
+	// As with the terraform plan, the path is explicit — from a flag or from
+	// .nox.yaml — so failing to load it is an error rather than a silent no-op
+	// that would leave every waiver unapplied.
 	if vexPath != "" {
 		if !filepath.IsAbs(vexPath) {
 			vexPath = filepath.Join(target, vexPath)
 		}
-		if vexDoc, vexErr := vex.LoadVEX(vexPath); vexErr == nil {
-			vex.ApplyVEX(allFindings, vexDoc)
+		vexDoc, vexErr := vex.LoadVEX(vexPath)
+		if vexErr != nil {
+			return fmt.Errorf("loading VEX document %s: %w", vexPath, vexErr)
 		}
+		vex.ApplyVEX(allFindings, vexDoc)
 	}
+
+	return nil
 }
 
 // evaluatePolicy runs the configured fail-on / baseline policy gate over the
@@ -857,7 +895,17 @@ func RunStagedScanWithOptions(repoRoot string, opts ScanOptions) (*ScanResult, e
 	// Run the standard scan against the temp directory. Paths in findings
 	// will be relative to tmpDir, which mirrors the repository-relative
 	// structure, so no remapping is needed.
-	result, err := RunScan(tmpDir)
+	// opts is threaded through deliberately: this previously called
+	// RunScan(tmpDir) and dropped every option, so --rules, --offline, --vex and
+	// friends were silently ignored whenever --staged was used.
+	//
+	// ChangedSince is cleared because the temp directory is not a git
+	// repository — a staged scan already IS a changed-files scan, and leaving
+	// the ref set would make discovery fail.
+	stagedOpts := opts
+	stagedOpts.ChangedSince = ""
+
+	result, err := RunScanWithOptions(tmpDir, stagedOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -890,11 +938,32 @@ func RunHistoryScan(repoRoot string, opts *HistoryScanOptions) (*ScanResult, err
 	allRules := rules.NewRuleSet()
 
 	secretsAnalyzer := secrets.NewAnalyzer()
-	for _, r := range secretsAnalyzer.Rules().Rules() {
+	scanRules := secretsAnalyzer.Rules()
+	for _, r := range scanRules.Rules() {
 		allRules.Add(r)
 	}
 
-	engine := rules.NewEngine(secretsAnalyzer.Rules())
+	// Honour --rules here too. HistoryScanOptions carried a ScanOptions field
+	// that nothing ever read, so custom rules were silently dropped for
+	// --history scans — the flag appeared to work and quietly did nothing.
+	if path := opts.ScanOptions.CustomRulesPath; path != "" {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(repoRoot, path)
+		}
+		customRules, err := loadCustomRules(path)
+		if err != nil {
+			return nil, fmt.Errorf("loading custom rules: %w", err)
+		}
+		for _, r := range customRules.Rules() {
+			if scanRules.HasID(r.ID) {
+				return nil, fmt.Errorf("custom rule %s conflicts with a built-in rule ID", r.ID)
+			}
+			scanRules.Add(r)
+			allRules.Add(r)
+		}
+	}
+
+	engine := rules.NewEngine(scanRules)
 
 	walkOpts := git.WalkHistoryOptions{
 		MaxDepth: opts.MaxDepth,
@@ -977,7 +1046,7 @@ func ConfidenceMeetsThreshold(confidence, threshold findings.Confidence) bool {
 }
 
 // applySuppressions reads files that have findings and marks suppressed findings.
-func applySuppressions(fs *findings.FindingSet, target string) {
+func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degradations) {
 	// Group findings by file.
 	byFile := make(map[string][]int)
 	items := fs.Findings()
@@ -993,6 +1062,12 @@ func applySuppressions(fs *findings.FindingSet, target string) {
 
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
+			// Fails safe — findings stay reported rather than being wrongly
+			// suppressed — but the operator's nox:ignore comments in this file
+			// are not being honoured, which is surprising enough to surface.
+			deg.Add(degrade.Suppression,
+				fmt.Sprintf("%s could not be re-read to apply inline suppressions: %v", filePath, err),
+				"nox:ignore comments in this file were not applied; its findings may be reported despite being waived")
 			continue
 		}
 
@@ -1015,9 +1090,21 @@ func applySuppressions(fs *findings.FindingSet, target string) {
 }
 
 // applyBaseline loads a baseline file and marks matched findings.
-func applyBaseline(fs *findings.FindingSet, baselinePath string) {
+func applyBaseline(fs *findings.FindingSet, baselinePath string, deg *degrade.Degradations) {
 	bl, err := baseline.Load(baselinePath)
-	if err != nil || bl.Len() == 0 {
+	if err != nil {
+		// No baseline is the normal state before the first `nox baseline write`,
+		// so absence is silent. A baseline that exists but will not load is
+		// different: under baseline_mode it changes what the gate enforces, so
+		// it must not pass unnoticed.
+		if !os.IsNotExist(err) {
+			deg.Add(degrade.Baseline,
+				fmt.Sprintf("%s could not be loaded: %v", baselinePath, err),
+				"findings are not being classified against the baseline; known-vs-new status is unreliable")
+		}
+		return
+	}
+	if bl.Len() == 0 {
 		return
 	}
 

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2409,7 +2409,9 @@ func TestRefineFindings_ContextDowngrade_Default(t *testing.T) {
 	t.Parallel()
 
 	fs := refineContextDowngradeFixture()
-	refineFindings(fs, &ScanConfig{}, ScanOptions{}, t.TempDir())
+	if err := refineFindings(fs, &ScanConfig{}, ScanOptions{}, t.TempDir(), nil); err != nil {
+		t.Fatalf("refineFindings: %v", err)
+	}
 
 	// IAC-010 in docs/ downgrades high->medium and records provenance.
 	ex := findBy(fs, "IAC-010", "docs/main.tf")
@@ -2455,7 +2457,9 @@ func TestRefineFindings_ContextDowngrade_Disabled(t *testing.T) {
 	off := false
 	cfg := &ScanConfig{}
 	cfg.Scan.ContextDowngrade = &off
-	refineFindings(fs, cfg, ScanOptions{}, t.TempDir())
+	if err := refineFindings(fs, cfg, ScanOptions{}, t.TempDir(), nil); err != nil {
+		t.Fatalf("refineFindings: %v", err)
+	}
 
 	ex := findBy(fs, "IAC-010", "docs/main.tf")
 	if ex == nil || ex.Severity != findings.SeverityHigh {

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -171,17 +171,31 @@ sdk.WithMaxArtifactBytes(50 * 1024 * 1024)   // Maximum artifact size
 | supply-chain | passive | *.osv.dev, *.github.com | no |
 | agent-assistance | passive | LLM APIs | no |
 
-**These profiles are suggestions, not the enforced policy.** The host does not
-apply them automatically. The policy actually enforced at registration is
-`DefaultPolicy()` — max risk class `passive`, and **empty allowlists for
-network hosts, file paths and environment variables** — overridden only by the
-operator's `.nox.yaml` `plugin_policy` block.
+These profiles are **enforced**. The host resolves each plugin's policy as its
+track profile merged with the operator's `.nox.yaml` `plugin_policy` block,
+where operator settings win. A `dynamic-runtime` plugin therefore gets
+localhost access without the operator configuring anything, and a
+`core-analysis` plugin does not — even in the same scan, since policy is
+per-plugin rather than host-wide.
 
-The practical consequence for plugin authors: declaring any `network_hosts`,
-`file_paths` or `env_vars` in your manifest, or a risk class above `passive`,
-means your plugin is **rejected at registration** until the operator opts in.
-Being on the `dynamic-runtime` track does not grant localhost access on its
-own. Say so in your README, and give operators the block to paste:
+### Where the track comes from
+
+**The track is read from the registry entry your plugin was published under,
+captured at install time — never from your manifest.** The gRPC manifest
+carries no track field by design: a self-declared track would let a plugin
+choose its own sandbox, which is not a sandbox.
+
+The practical consequences:
+
+- A plugin installed with `--local` has no registry entry, so it has **no
+  track** and runs under the strict default policy: `passive` risk class, empty
+  allowlists. Declaring `network_hosts` in a sideloaded plugin means rejection
+  at registration. Test your plugin as installed from a registry, not only
+  sideloaded, or you will not exercise the policy it actually runs under.
+- Plugins installed before tracks were recorded also have no track and get the
+  strict default until reinstalled.
+
+If your plugin needs more than its track grants, the operator must opt in:
 
 ```yaml
 # .nox.yaml
@@ -190,8 +204,18 @@ plugin_policy:
   allowed_network_hosts: ["localhost", "127.0.0.1"]
 ```
 
-`ProfileForTrack` and `MergeWithUserPolicy` exist to help operators *derive*
-such a block for a track; they are not consulted by the host at runtime.
+Operators who want the pre-track behaviour — every plugin on the strict default
+regardless of track — set:
+
+```yaml
+plugin_policy:
+  ignore_track_profiles: true
+```
+
+This exists because the override semantics are one-directional: an operator can
+widen an allowlist but cannot empty one, since a zero-length list reads as "not
+configured". Without the flag there would be no way to revoke the localhost
+access the `dynamic-runtime` profile grants.
 
 ## Testing
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -161,7 +161,7 @@ sdk.WithMaxArtifactBytes(50 * 1024 * 1024)   // Maximum artifact size
 
 ### Track-Specific Profiles
 
-Each track has pre-built safety profiles. Use `plugin.ProfileForTrack(track)` to get defaults:
+`plugin.ProfileForTrack(track)` returns a suggested policy per track:
 
 | Track | Risk | Network | Confirmation |
 |-------|------|---------|-------------|
@@ -170,6 +170,28 @@ Each track has pre-built safety profiles. Use `plugin.ProfileForTrack(track)` to
 | ai-security | passive | none | no |
 | supply-chain | passive | *.osv.dev, *.github.com | no |
 | agent-assistance | passive | LLM APIs | no |
+
+**These profiles are suggestions, not the enforced policy.** The host does not
+apply them automatically. The policy actually enforced at registration is
+`DefaultPolicy()` — max risk class `passive`, and **empty allowlists for
+network hosts, file paths and environment variables** — overridden only by the
+operator's `.nox.yaml` `plugin_policy` block.
+
+The practical consequence for plugin authors: declaring any `network_hosts`,
+`file_paths` or `env_vars` in your manifest, or a risk class above `passive`,
+means your plugin is **rejected at registration** until the operator opts in.
+Being on the `dynamic-runtime` track does not grant localhost access on its
+own. Say so in your README, and give operators the block to paste:
+
+```yaml
+# .nox.yaml
+plugin_policy:
+  max_risk_class: active
+  allowed_network_hosts: ["localhost", "127.0.0.1"]
+```
+
+`ProfileForTrack` and `MergeWithUserPolicy` exist to help operators *derive*
+such a block for a track; they are not consulted by the host at runtime.
 
 ## Testing
 

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -26,6 +26,17 @@ type PolicyConfig struct {
 	ToolTimeoutSeconds    int      `yaml:"tool_timeout_seconds"`
 	RequestsPerMinute     int      `yaml:"requests_per_minute"`
 	BandwidthMBPerMinute  int      `yaml:"bandwidth_mb_per_minute"`
+
+	// IgnoreTrackProfiles forces every plugin onto DefaultPolicy() regardless
+	// of its registry track.
+	//
+	// This exists because the override semantics are one-directional: an
+	// operator can widen an allowlist but cannot empty one, since a zero-length
+	// list reads as "not configured". Without this flag there would be no way
+	// to revoke the localhost access the dynamic-runtime profile grants — an
+	// operator could only add to it. Setting this restores the pre-track
+	// behaviour: passive risk class, empty allowlists, opt-in only.
+	IgnoreTrackProfiles bool `yaml:"ignore_track_profiles"`
 }
 
 // LoadConfig reads a .nox.yaml configuration file. If the file does not
@@ -45,6 +56,46 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// Overrides returns a Policy holding ONLY the fields the operator explicitly
+// configured, leaving everything else at its zero value.
+//
+// This is deliberately different from ToPolicy, which starts from
+// DefaultPolicy() and overlays config on top. That resolved form cannot be
+// merged with a track profile: every DefaultPolicy-derived value looks like a
+// deliberate operator choice and would silently override the profile, so
+// applying a profile through it would be a no-op. Merging needs to know what
+// the operator actually wrote, which is what this returns.
+func (c *PolicyConfig) Overrides() Policy {
+	var p Policy
+
+	p.AllowedNetworkHosts = c.AllowedNetworkHosts
+	p.AllowedNetworkCIDRs = c.AllowedNetworkCIDRs
+	p.AllowedFilePaths = c.AllowedFilePaths
+	p.AllowedEnvVars = c.AllowedEnvVars
+	if c.MaxRiskClass != "" {
+		p.MaxRiskClass = RiskClass(c.MaxRiskClass)
+	}
+	p.AllowConfirmationReqd = c.AllowConfirmationReqd
+
+	if c.MaxArtifactMB > 0 {
+		p.MaxArtifactBytes = int64(c.MaxArtifactMB) * 1024 * 1024
+	}
+	if c.MaxConcurrency > 0 {
+		p.MaxConcurrency = c.MaxConcurrency
+	}
+	if c.ToolTimeoutSeconds > 0 {
+		p.ToolInvocationTimeout = time.Duration(c.ToolTimeoutSeconds) * time.Second
+	}
+	if c.RequestsPerMinute > 0 {
+		p.RequestsPerMinute = c.RequestsPerMinute
+	}
+	if c.BandwidthMBPerMinute > 0 {
+		p.BandwidthBytesPerMin = int64(c.BandwidthMBPerMinute) * 1024 * 1024
+	}
+
+	return p
 }
 
 // ToPolicy converts PolicyConfig to a runtime Policy, applying unit

--- a/plugin/convert.go
+++ b/plugin/convert.go
@@ -12,19 +12,23 @@ import (
 // --- Proto → Go conversion ---
 
 // ProtoFindingToGo converts a protobuf Finding to the domain Finding type.
-func ProtoFindingToGo(pf *pluginv1.Finding) findings.Finding {
+//
+// pluginName identifies the plugin that produced the finding; it namespaces the
+// fingerprint so a plugin cannot reach outside its own findings. See
+// pluginFingerprint.
+func ProtoFindingToGo(pf *pluginv1.Finding, pluginName string) findings.Finding {
 	if pf == nil {
 		return findings.Finding{}
 	}
 	f := findings.Finding{
-		ID:          pf.GetId(),
-		RuleID:      pf.GetRuleId(),
-		Severity:    ProtoSeverityToGo(pf.GetSeverity()),
-		Confidence:  ProtoConfidenceToGo(pf.GetConfidence()),
-		Location:    ProtoLocationToGo(pf.GetLocation()),
-		Message:     pf.GetMessage(),
-		Fingerprint: pf.GetFingerprint(),
+		ID:         pf.GetId(),
+		RuleID:     pf.GetRuleId(),
+		Severity:   ProtoSeverityToGo(pf.GetSeverity()),
+		Confidence: ProtoConfidenceToGo(pf.GetConfidence()),
+		Location:   ProtoLocationToGo(pf.GetLocation()),
+		Message:    pf.GetMessage(),
 	}
+	f.Fingerprint = pluginFingerprint(pluginName, pf.GetRuleId(), pf.GetFingerprint(), f)
 	if m := pf.GetMetadata(); len(m) > 0 {
 		f.Metadata = make(map[string]string, len(m))
 		for k, v := range m {
@@ -32,6 +36,31 @@ func ProtoFindingToGo(pf *pluginv1.Finding) findings.Finding {
 		}
 	}
 	return f
+}
+
+// pluginFingerprint derives the fingerprint stored for a plugin finding.
+//
+// A plugin's claimed fingerprint cannot be used as-is. Plugin findings merge
+// into the same FindingSet as core findings and are then deduplicated
+// first-wins, and baseline and VEX suppression key on the same value. A plugin
+// could therefore claim a fingerprint matching a core finding and erase it, or
+// claim one matching a baselined finding and hide itself.
+//
+// So the value is recomputed host-side using the core scheme — which keeps
+// determinism, path normalisation and fingerprint-version parity — with the
+// rule ID namespaced by plugin name. The plugin's claim is demoted to hash
+// input, tagged so a claimed fingerprint and a message can never alias. That
+// preserves the one legitimate use of the claim: deciding which of a plugin's
+// own findings are "the same" across runs, so they stay baseline-able.
+func pluginFingerprint(pluginName, ruleID, claimed string, f findings.Finding) string {
+	namespaced := "plugin:" + pluginName + ":" + ruleID
+
+	identity := "msg:" + f.Message
+	if claimed != "" {
+		identity = "fp:" + claimed
+	}
+
+	return findings.ComputeFingerprint(namespaced, f.Location, identity)
 }
 
 // ProtoLocationToGo converts a protobuf Location to the domain Location type.
@@ -432,4 +461,17 @@ func GoScanResultToProtoContext(r *core.ScanResult) *pluginv1.ScanContext {
 		}
 	}
 	return sc
+}
+
+// AttributedResponse pairs a plugin response with the name of the plugin that
+// produced it.
+//
+// The response message itself carries no producer identity, but the host needs
+// it at merge time to namespace fingerprints — see pluginFingerprint. Carrying
+// it alongside is simpler than widening the wire format, and keeps the
+// attribution authoritative: it comes from the host's own registry rather than
+// from anything the plugin says about itself.
+type AttributedResponse struct {
+	PluginName string
+	Response   *pluginv1.InvokeToolResponse
 }

--- a/plugin/convert_test.go
+++ b/plugin/convert_test.go
@@ -139,7 +139,7 @@ func TestFindingRoundTrip(t *testing.T) {
 	}
 
 	proto := GoFindingToProto(&original)
-	roundTrip := ProtoFindingToGo(proto)
+	roundTrip := ProtoFindingToGo(proto, "test-plugin")
 
 	if roundTrip.ID != original.ID {
 		t.Errorf("ID mismatch: %q vs %q", roundTrip.ID, original.ID)
@@ -159,8 +159,15 @@ func TestFindingRoundTrip(t *testing.T) {
 	if roundTrip.Message != original.Message {
 		t.Errorf("Message mismatch: %q vs %q", roundTrip.Message, original.Message)
 	}
-	if roundTrip.Fingerprint != original.Fingerprint {
-		t.Errorf("Fingerprint mismatch: %q vs %q", roundTrip.Fingerprint, original.Fingerprint)
+	// Fingerprint is deliberately NOT round-tripped. Non-preservation is the
+	// security property: a fingerprint arriving from a plugin is recomputed
+	// host-side and namespaced, so a plugin cannot collide with a core finding
+	// and suppress it via dedup, or match a baselined finding to hide itself.
+	if roundTrip.Fingerprint == original.Fingerprint {
+		t.Error("Fingerprint was preserved verbatim; it must be recomputed host-side")
+	}
+	if roundTrip.Fingerprint == "" {
+		t.Error("Fingerprint should be recomputed, not blanked")
 	}
 	if !reflect.DeepEqual(roundTrip.Metadata, original.Metadata) {
 		t.Errorf("Metadata mismatch: %v vs %v", roundTrip.Metadata, original.Metadata)
@@ -168,7 +175,7 @@ func TestFindingRoundTrip(t *testing.T) {
 }
 
 func TestProtoFindingToGo_Nil(t *testing.T) {
-	got := ProtoFindingToGo(nil)
+	got := ProtoFindingToGo(nil, "test-plugin")
 	if got.ID != "" || got.RuleID != "" {
 		t.Errorf("ProtoFindingToGo(nil) should return zero value, got %+v", got)
 	}
@@ -182,7 +189,7 @@ func TestFindingRoundTrip_EmptyMetadata(t *testing.T) {
 	}
 
 	proto := GoFindingToProto(&original)
-	roundTrip := ProtoFindingToGo(proto)
+	roundTrip := ProtoFindingToGo(proto, "test-plugin")
 
 	if roundTrip.ID != original.ID {
 		t.Errorf("ID mismatch: %q vs %q", roundTrip.ID, original.ID)
@@ -521,5 +528,100 @@ func TestGoEnrichmentToProto_Nil(t *testing.T) {
 	got := GoEnrichmentToProto(nil)
 	if got != nil {
 		t.Errorf("GoEnrichmentToProto(nil) should return nil, got %+v", got)
+	}
+}
+
+// --- fingerprint trust boundary ---
+
+// TestProtoFindingToGo_DoesNotTrustClaimedFingerprint pins the core property:
+// whatever a plugin claims, the stored value is derived host-side.
+func TestProtoFindingToGo_DoesNotTrustClaimedFingerprint(t *testing.T) {
+	t.Parallel()
+
+	claimed := "0000000000000000000000000000000000000000000000000000000000000000"
+	f := ProtoFindingToGo(&pluginv1.Finding{
+		RuleId:      "PLG-001",
+		Message:     "something",
+		Fingerprint: claimed,
+	}, "some-plugin")
+
+	if f.Fingerprint == claimed {
+		t.Fatal("the plugin's claimed fingerprint was stored verbatim")
+	}
+	if f.Fingerprint == "" {
+		t.Fatal("expected a recomputed fingerprint, got empty")
+	}
+}
+
+// TestProtoFindingToGo_FingerprintIsolatedPerPlugin shows two plugins cannot
+// collide even when they claim the identical fingerprint for identical content
+// — which is what made cross-plugin and plugin-vs-core suppression possible.
+func TestProtoFindingToGo_FingerprintIsolatedPerPlugin(t *testing.T) {
+	t.Parallel()
+
+	proto := &pluginv1.Finding{RuleId: "PLG-001", Message: "same", Fingerprint: "identical"}
+
+	a := ProtoFindingToGo(proto, "plugin-a")
+	b := ProtoFindingToGo(proto, "plugin-b")
+
+	if a.Fingerprint == b.Fingerprint {
+		t.Error("two plugins claiming the same fingerprint collided; namespacing is not applied")
+	}
+}
+
+// TestProtoFindingToGo_FingerprintDeterministic guards nox's reproducibility
+// guarantee: identical input must yield an identical fingerprint across runs.
+func TestProtoFindingToGo_FingerprintDeterministic(t *testing.T) {
+	t.Parallel()
+
+	proto := &pluginv1.Finding{
+		RuleId:      "PLG-001",
+		Message:     "stable",
+		Fingerprint: "claimed",
+		Location:    &pluginv1.Location{FilePath: "a/b.go", StartLine: 4},
+	}
+
+	first := ProtoFindingToGo(proto, "plugin-a")
+	second := ProtoFindingToGo(proto, "plugin-a")
+
+	if first.Fingerprint != second.Fingerprint {
+		t.Errorf("fingerprint is not deterministic: %q vs %q", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+// TestProtoFindingToGo_DistinctFindingsStayDistinct confirms namespacing does
+// not over-collapse: a plugin's own findings must remain individually
+// addressable, or they could not be baselined or waived separately.
+func TestProtoFindingToGo_DistinctFindingsStayDistinct(t *testing.T) {
+	t.Parallel()
+
+	one := ProtoFindingToGo(&pluginv1.Finding{
+		RuleId: "PLG-001", Message: "first", Fingerprint: "fp-1",
+	}, "plugin-a")
+	two := ProtoFindingToGo(&pluginv1.Finding{
+		RuleId: "PLG-001", Message: "second", Fingerprint: "fp-2",
+	}, "plugin-a")
+
+	if one.Fingerprint == two.Fingerprint {
+		t.Error("two distinct findings from one plugin share a fingerprint")
+	}
+}
+
+// TestProtoFindingToGo_ComputesFingerprintWhenAbsent covers the plugin that
+// supplies no fingerprint at all — it must still get a stable one, and it must
+// not alias with a plugin that claimed its message as a fingerprint.
+func TestProtoFindingToGo_ComputesFingerprintWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	absent := ProtoFindingToGo(&pluginv1.Finding{RuleId: "PLG-001", Message: "text"}, "plugin-a")
+	if absent.Fingerprint == "" {
+		t.Fatal("expected a computed fingerprint when the plugin supplied none")
+	}
+
+	claimedAsMessage := ProtoFindingToGo(&pluginv1.Finding{
+		RuleId: "PLG-001", Message: "text", Fingerprint: "text",
+	}, "plugin-a")
+	if absent.Fingerprint == claimedAsMessage.Fingerprint {
+		t.Error("a claimed fingerprint aliased with an absent one; the hash inputs are not tagged")
 	}
 }

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nox-hq/nox/core"
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+	"github.com/nox-hq/nox/registry"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -27,6 +28,39 @@ type Host struct {
 	telemetry   *telemetryCollector
 	mu          sync.RWMutex
 	logger      *slog.Logger
+
+	// overrides holds the operator's explicit .nox.yaml settings, kept
+	// separately from policy so they can be merged onto a track profile.
+	// policy remains the effective policy for plugins with no known track,
+	// and governs host-global concerns (concurrency, the InvokeAll deadline).
+	overrides           Policy
+	ignoreTrackProfiles bool
+}
+
+// WithPolicyOverrides supplies the operator's explicit .nox.yaml settings so
+// they can be merged onto each plugin's track profile.
+//
+// Without this the host has only a fully-resolved policy, in which every
+// DefaultPolicy-derived value is indistinguishable from a deliberate operator
+// choice — merging a track profile through it would be a no-op.
+func WithPolicyOverrides(o *Policy) HostOption {
+	return func(h *Host) { h.overrides = *o }
+}
+
+// WithIgnoreTrackProfiles forces every plugin onto DefaultPolicy() regardless
+// of track. See PolicyConfig.IgnoreTrackProfiles.
+func WithIgnoreTrackProfiles(ignore bool) HostOption {
+	return func(h *Host) { h.ignoreTrackProfiles = ignore }
+}
+
+// policyForTrack resolves the effective policy for a plugin of the given
+// track. An empty or unrecognised track yields the host's default policy,
+// which is the strict one — see EffectivePolicy for why that matters.
+func (h *Host) policyForTrack(track registry.Track) Policy {
+	if track == "" || h.ignoreTrackProfiles {
+		return h.policy
+	}
+	return EffectivePolicy(track, &h.overrides, h.ignoreTrackProfiles)
 }
 
 // HostOption is a functional option for configuring a Host.
@@ -88,6 +122,7 @@ func (h *Host) RegisterPlugin(ctx context.Context, conn *grpc.ClientConn) error 
 		return fmt.Errorf("plugin %q rejected: %s", info.Name, strings.Join(msgs, "; "))
 	}
 
+	p.setPolicy(h.policy)
 	p.rateLimiter = NewRateLimiter(h.policy.RequestsPerMinute, h.policy.BandwidthBytesPerMin)
 
 	h.mu.Lock()
@@ -100,9 +135,25 @@ func (h *Host) RegisterPlugin(ctx context.Context, conn *grpc.ClientConn) error 
 	return nil
 }
 
-// RegisterBinary spawns a plugin binary subprocess and registers it.
+// RegisterBinary spawns a plugin binary subprocess and registers it under the
+// host's default policy. Use RegisterBinaryWithTrack when the plugin's registry
+// track is known, so its track profile applies.
 func (h *Host) RegisterBinary(ctx context.Context, path string, args []string) error {
-	timeout := h.policy.ToolInvocationTimeout
+	return h.RegisterBinaryWithTrack(ctx, path, args, "")
+}
+
+// RegisterBinaryWithTrack spawns a plugin binary and registers it under the
+// policy for the given registry track, merged with the operator's overrides.
+//
+// SECURITY: track must come from the registry entry the plugin was installed
+// from. It is not, and must not be, anything the plugin asserts about itself —
+// see EffectivePolicy. Pass an empty track whenever provenance is uncertain
+// (sideloaded binaries, installs predating track recording); that selects the
+// strict default policy.
+func (h *Host) RegisterBinaryWithTrack(ctx context.Context, path string, args []string, track registry.Track) error {
+	policy := h.policyForTrack(track)
+
+	timeout := policy.ToolInvocationTimeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
@@ -124,7 +175,7 @@ func (h *Host) RegisterBinary(ctx context.Context, path string, args []string) e
 		ApiVersion:   info.APIVersion,
 		Capabilities: infoToProtoCapabilities(&info),
 		Safety:       info.Safety,
-	}, &h.policy)
+	}, &policy)
 
 	if len(violations) > 0 {
 		_ = p.Close()
@@ -135,14 +186,16 @@ func (h *Host) RegisterBinary(ctx context.Context, path string, args []string) e
 		return fmt.Errorf("plugin %q rejected: %s", info.Name, strings.Join(msgs, "; "))
 	}
 
-	p.rateLimiter = NewRateLimiter(h.policy.RequestsPerMinute, h.policy.BandwidthBytesPerMin)
+	p.setPolicy(policy)
+	p.rateLimiter = NewRateLimiter(policy.RequestsPerMinute, policy.BandwidthBytesPerMin)
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	h.plugins[info.Name] = p
 	h.buildToolIndex()
-	h.logger.Info("registered plugin binary", "name", info.Name, "path", path)
+	h.logger.Info("registered plugin binary",
+		"name", info.Name, "path", path, "track", string(track), "max_risk_class", string(policy.MaxRiskClass))
 
 	return nil
 }
@@ -170,6 +223,12 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 
 	pluginName := p.Info().Name
 
+	// Enforcement below reads the plugin's OWN effective policy, not the
+	// host's: plugins of different tracks run under different policies in the
+	// same host, so a dynamic-runtime plugin's localhost grant must not leak to
+	// a core-analysis one sharing the process.
+	policy := p.Policy()
+
 	// Per-tool safety enforcement.
 	//
 	// Registration only establishes that SOMETHING in this plugin is runnable
@@ -181,7 +240,7 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 	// This is what lets a plugin ship a passive tool alongside an active one
 	// without the active sibling gating the passive one.
 	if ti := p.getToolInfo(resolvedName); ti != nil && ti.Safety != nil {
-		if violations := validateSafety(ti.Safety, &h.policy); len(violations) > 0 {
+		if violations := validateSafety(ti.Safety, &policy); len(violations) > 0 {
 			msgs := make([]string, 0, len(violations))
 			for _, pv := range violations {
 				msgs = append(msgs, pv.Error())
@@ -208,7 +267,7 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 	// mutate the workspace" — not "passive": nox/llm-triage declares a read_only
 	// tool that ships source code to an external chat endpoint. Neither property
 	// implies the other, so a tool must satisfy both.
-	if h.policy.MaxRiskClass == RiskClassPassive {
+	if policy.MaxRiskClass == RiskClassPassive {
 		ti := p.getToolInfo(resolvedName)
 		if ti != nil && !ti.ReadOnly {
 			v := RuntimeViolation{
@@ -240,7 +299,7 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 		}
 	}
 
-	timeout := h.policy.ToolInvocationTimeout
+	timeout := policy.ToolInvocationTimeout
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
@@ -325,13 +384,25 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 		return nil, nil
 	}
 
+	// Bound the whole group by the LONGEST timeout any participating plugin is
+	// allowed, then bound each plugin individually by its own below. Using a
+	// single host-wide deadline would cut short a dynamic-runtime plugin whose
+	// track grants it five minutes just because a core-analysis plugin's track
+	// grants two.
 	timeout := h.policy.ToolInvocationTimeout
+	for _, p := range targets {
+		if t := p.Policy().ToolInvocationTimeout; t > timeout {
+			timeout = t
+		}
+	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 
+	// Concurrency is genuinely host-global: it bounds this process's fan-out,
+	// not any single plugin's entitlement.
 	concurrency := h.policy.MaxConcurrency
 	if concurrency <= 0 {
 		concurrency = 1
@@ -352,9 +423,10 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 	for i, p := range targets {
 		g.Go(func() error {
 			pluginName := p.Info().Name
+			policy := p.Policy()
 
-			// Read-only enforcement.
-			if h.policy.MaxRiskClass == RiskClassPassive {
+			// Read-only enforcement, against this plugin's own policy.
+			if policy.MaxRiskClass == RiskClassPassive {
 				ti := p.getToolInfo(toolName)
 				if ti != nil && !ti.ReadOnly {
 					v := RuntimeViolation{
@@ -386,7 +458,17 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 				}
 			}
 
-			resp, err := p.InvokeTool(gCtx, toolName, input, workspaceRoot)
+			// Bound this plugin by its own track's timeout, inside the group's
+			// longest-of-all deadline, so one plugin's larger allowance never
+			// extends another's.
+			invokeCtx := gCtx
+			if t := policy.ToolInvocationTimeout; t > 0 {
+				var cancel context.CancelFunc
+				invokeCtx, cancel = context.WithTimeout(gCtx, t)
+				defer cancel()
+			}
+
+			resp, err := p.InvokeTool(invokeCtx, toolName, input, workspaceRoot)
 			if err != nil {
 				h.mu.Lock()
 				h.diagnostics = append(h.diagnostics, Diagnostic{

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -311,7 +311,7 @@ func (h *Host) InvokeTool(ctx context.Context, toolName string, input map[string
 // Uses errgroup with a concurrency semaphore from Policy.MaxConcurrency.
 // Individual plugin errors become diagnostics, not fatal errors.
 // Enforcement (rate limiting, read-only, redaction) is applied per-plugin.
-func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]any, workspaceRoot string) ([]*pluginv1.InvokeToolResponse, error) {
+func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]any, workspaceRoot string) ([]AttributedResponse, error) {
 	h.mu.RLock()
 	var targets []*Plugin
 	for _, p := range h.plugins {
@@ -338,8 +338,9 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 	}
 
 	type indexedResp struct {
-		index int
-		resp  *pluginv1.InvokeToolResponse
+		index  int
+		plugin string
+		resp   *pluginv1.InvokeToolResponse
 	}
 
 	results := make([]indexedResp, 0, len(targets))
@@ -439,7 +440,7 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 			h.mu.Unlock()
 
 			resultsMu.Lock()
-			results = append(results, indexedResp{index: i, resp: resp})
+			results = append(results, indexedResp{index: i, plugin: p.Info().Name, resp: resp})
 			resultsMu.Unlock()
 			return nil
 		})
@@ -450,14 +451,14 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 	}
 
 	// Place responses at their original index to preserve ordering.
-	ordered := make([]*pluginv1.InvokeToolResponse, len(targets))
+	ordered := make([]AttributedResponse, len(targets))
 	for _, r := range results {
-		ordered[r.index] = r.resp
+		ordered[r.index] = AttributedResponse{PluginName: r.plugin, Response: r.resp}
 	}
 	// Compact: remove nil entries from skipped plugins (violations, errors).
 	responses := ordered[:0]
 	for _, r := range ordered {
-		if r != nil {
+		if r.Response != nil {
 			responses = append(responses, r)
 		}
 	}
@@ -467,13 +468,13 @@ func (h *Host) InvokeAll(ctx context.Context, toolName string, input map[string]
 // MergeResults converts a single plugin response into domain types and
 // adds them to the ScanResult. This method is not thread-safe with respect
 // to FindingSet and AIInventory — call sequentially.
-func (h *Host) MergeResults(resp *pluginv1.InvokeToolResponse, result *core.ScanResult) {
+func (h *Host) MergeResults(pluginName string, resp *pluginv1.InvokeToolResponse, result *core.ScanResult) {
 	if resp == nil || result == nil {
 		return
 	}
 
 	for _, pf := range resp.GetFindings() {
-		result.Findings.Add(ProtoFindingToGo(pf))
+		result.Findings.Add(ProtoFindingToGo(pf, pluginName))
 	}
 
 	for _, pp := range resp.GetPackages() {
@@ -493,9 +494,9 @@ func (h *Host) MergeResults(resp *pluginv1.InvokeToolResponse, result *core.Scan
 }
 
 // MergeAllResults merges multiple plugin responses sequentially.
-func (h *Host) MergeAllResults(responses []*pluginv1.InvokeToolResponse, result *core.ScanResult) {
-	for _, resp := range responses {
-		h.MergeResults(resp, result)
+func (h *Host) MergeAllResults(responses []AttributedResponse, result *core.ScanResult) {
+	for _, r := range responses {
+		h.MergeResults(r.PluginName, r.Response, result)
 	}
 }
 
@@ -541,7 +542,7 @@ func (h *Host) InvokePostScan(ctx context.Context, result *core.ScanResult, work
 			continue
 		}
 
-		h.MergeResults(resp, result)
+		h.MergeResults(pt.plugin.Info().Name, resp, result)
 
 		h.mu.Lock()
 		h.collectDiagnostics(pt.plugin.Info().Name, resp)

--- a/plugin/host_test.go
+++ b/plugin/host_test.go
@@ -263,7 +263,7 @@ func TestHost_MergeResults_Findings(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("test-plugin", resp, result)
 
 	ff := result.Findings.Findings()
 	if len(ff) != 1 {
@@ -295,7 +295,7 @@ func TestHost_MergeResults_Packages(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("test-plugin", resp, result)
 
 	pkgs := result.Inventory.Packages()
 	if len(pkgs) != 2 {
@@ -320,7 +320,7 @@ func TestHost_MergeResults_AIComponents(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("test-plugin", resp, result)
 
 	if len(result.AIInventory.Components) != 1 {
 		t.Fatalf("len(Components) = %d, want 1", len(result.AIInventory.Components))
@@ -338,7 +338,7 @@ func TestHost_MergeResults_EmptyResponse(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, result)
+	h.MergeResults("test-plugin", &pluginv1.InvokeToolResponse{}, result)
 
 	if len(result.Findings.Findings()) != 0 {
 		t.Error("empty response should not add findings")
@@ -360,8 +360,8 @@ func TestHost_MergeResults_Nil(t *testing.T) {
 	}
 
 	// Should not panic.
-	h.MergeResults(nil, result)
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, nil)
+	h.MergeResults("test-plugin", nil, result)
+	h.MergeResults("test-plugin", &pluginv1.InvokeToolResponse{}, nil)
 }
 
 func TestHost_MergeAllResults(t *testing.T) {
@@ -388,7 +388,7 @@ func TestHost_MergeAllResults(t *testing.T) {
 		},
 	}
 
-	h.MergeAllResults(responses, result)
+	h.MergeAllResults(attributed(responses), result)
 
 	if len(result.Findings.Findings()) != 2 {
 		t.Errorf("len(Findings) = %d, want 2", len(result.Findings.Findings()))
@@ -918,7 +918,7 @@ func TestHost_MergeResults_Graphs(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("test-plugin", resp, result)
 
 	if len(result.Graphs) != 1 {
 		t.Fatalf("expected 1 graph, got %d", len(result.Graphs))
@@ -955,7 +955,7 @@ func TestHost_MergeResults_Enrichments(t *testing.T) {
 		},
 	}
 
-	h.MergeResults(resp, result)
+	h.MergeResults("test-plugin", resp, result)
 
 	if len(result.Enrichments) != 1 {
 		t.Fatalf("expected 1 enrichment, got %d", len(result.Enrichments))
@@ -980,7 +980,7 @@ func TestHost_MergeResults_GraphsAndEnrichments_Empty(t *testing.T) {
 		AIInventory: ai.NewInventory(),
 	}
 
-	h.MergeResults(&pluginv1.InvokeToolResponse{}, result)
+	h.MergeResults("test-plugin", &pluginv1.InvokeToolResponse{}, result)
 
 	if len(result.Graphs) != 0 {
 		t.Error("empty response should not add graphs")
@@ -1227,12 +1227,77 @@ func TestHost_MergeAllResults_WithGraphsAndEnrichments(t *testing.T) {
 		},
 	}
 
-	h.MergeAllResults(responses, result)
+	h.MergeAllResults(attributed(responses), result)
 
 	if len(result.Graphs) != 2 {
 		t.Errorf("expected 2 graphs, got %d", len(result.Graphs))
 	}
 	if len(result.Enrichments) != 1 {
 		t.Errorf("expected 1 enrichment, got %d", len(result.Enrichments))
+	}
+}
+
+// attributed wraps bare responses for tests written before InvokeAll began
+// carrying the producing plugin's name alongside each response.
+func attributed(responses []*pluginv1.InvokeToolResponse) []AttributedResponse {
+	out := make([]AttributedResponse, 0, len(responses))
+	for _, r := range responses {
+		out = append(out, AttributedResponse{PluginName: "test-plugin", Response: r})
+	}
+	return out
+}
+
+// TestHost_MergeResults_PluginCannotSuppressCoreFinding reproduces the attack
+// end to end: a plugin claims a core finding's fingerprint, hoping Deduplicate
+// (first-wins) will drop the core finding in favour of its own. Before
+// fingerprints were recomputed host-side this erased the core finding
+// outright — the scan reported the plugin's benign entry and nothing else.
+func TestHost_MergeResults_PluginCannotSuppressCoreFinding(t *testing.T) {
+	h := NewHost()
+	result := &core.ScanResult{
+		Findings:    findings.NewFindingSet(),
+		Inventory:   &deps.PackageInventory{},
+		AIInventory: ai.NewInventory(),
+	}
+
+	coreFinding := findings.Finding{
+		RuleID:   "SEC-001",
+		Severity: findings.SeverityCritical,
+		Message:  "Hardcoded AWS key",
+		Location: findings.Location{FilePath: "app/config.go", StartLine: 12},
+	}
+	result.Findings.Add(coreFinding)
+
+	stored := result.Findings.Findings()[0].Fingerprint
+	if stored == "" {
+		t.Fatal("expected the core finding to have a fingerprint")
+	}
+
+	// The plugin claims the core finding's fingerprint verbatim.
+	h.MergeResults("evil-plugin", &pluginv1.InvokeToolResponse{
+		Findings: []*pluginv1.Finding{{
+			RuleId:      "PLG-001",
+			Severity:    pluginv1.Severity_SEVERITY_INFO,
+			Message:     "nothing to see here",
+			Fingerprint: stored,
+			Location:    &pluginv1.Location{FilePath: "app/config.go", StartLine: 12},
+		}},
+	}, result)
+
+	result.Findings.Deduplicate()
+
+	items := result.Findings.Findings()
+	if len(items) != 2 {
+		t.Fatalf("expected both findings to survive dedup, got %d", len(items))
+	}
+
+	var foundCore bool
+	for _, f := range items {
+		if f.RuleID == "SEC-001" && f.Severity == findings.SeverityCritical {
+			foundCore = true
+		}
+	}
+	if !foundCore {
+		t.Error("the core critical finding was suppressed by the plugin's claimed fingerprint")
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -87,6 +87,27 @@ type Plugin struct {
 	cmd         *exec.Cmd // nil if connected to an external process
 	rateLimiter *RateLimiter
 	mu          sync.Mutex
+
+	// policy is the effective policy for THIS plugin, resolved from its
+	// registry track merged with the operator's overrides. Plugins of
+	// different tracks run under different policies in the same host, so
+	// enforcement reads this rather than a single host-wide value.
+	policy Policy
+}
+
+// Policy returns the effective policy enforced against this plugin.
+func (p *Plugin) Policy() Policy {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.policy
+}
+
+// setPolicy assigns the effective policy. Called by the host during
+// registration, before the plugin can be invoked.
+func (p *Plugin) setPolicy(pol Policy) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.policy = pol
 }
 
 // NewPlugin creates a Plugin from an existing gRPC client connection.

--- a/plugin/profiles.go
+++ b/plugin/profiles.go
@@ -165,3 +165,32 @@ func MergeWithUserPolicy(profile, user *Policy) Policy {
 
 	return merged
 }
+
+// EffectivePolicy resolves the policy enforced against a single plugin.
+//
+// The track is the base: it decides what class of plugin this is and therefore
+// what it may reasonably need — a dynamic-runtime scanner has to reach
+// localhost, a core-analysis plugin never does. The operator's .nox.yaml then
+// overrides on top, so a project can always widen or tighten what its own
+// plugins get.
+//
+// SECURITY: track MUST come from the registry entry the plugin was installed
+// from, never from the plugin itself. The gRPC manifest deliberately carries no
+// track field — a self-declared track would let a plugin choose its own
+// sandbox, which is not a sandbox. Callers that cannot establish a trustworthy
+// track (a --local sideloaded binary, an install predating track recording)
+// must pass an empty track, which falls back to the strict DefaultPolicy.
+//
+// ignoreTrackProfiles forces that strict base regardless of track; see
+// PolicyConfig.IgnoreTrackProfiles for why an explicit opt-out is required
+// rather than expressible through overrides.
+func EffectivePolicy(track registry.Track, overrides *Policy, ignoreTrackProfiles bool) Policy {
+	base := DefaultPolicy()
+	if !ignoreTrackProfiles && registry.ValidTrack(track) {
+		base = ProfileForTrack(track)
+	}
+	if overrides == nil {
+		return base
+	}
+	return MergeWithUserPolicy(&base, overrides)
+}

--- a/plugin/profiles_test.go
+++ b/plugin/profiles_test.go
@@ -142,3 +142,46 @@ func TestMergeWithUserPolicyNetworkOverride(t *testing.T) {
 		t.Errorf("merged network hosts = %v, want [custom.registry.example.com]", merged.AllowedNetworkHosts)
 	}
 }
+
+// TestHost_DoesNotAutoApplyTrackProfiles pins the gap between ProfileForTrack
+// and what the host actually enforces.
+//
+// docs/plugin-authoring.md previously presented the per-track profiles as
+// though they were the effective policy, so a plugin author would reasonably
+// expect a dynamic-runtime plugin to get localhost network access. It does not:
+// the host enforces DefaultPolicy() — passive, with empty allowlists — unless
+// the operator's .nox.yaml opts in. Documenting an enforced control that does
+// not exist is the more dangerous half of this, so if the host ever starts
+// consulting track profiles, this test should fail and the documentation must
+// be corrected in the same change.
+func TestHost_DoesNotAutoApplyTrackProfiles(t *testing.T) {
+	t.Parallel()
+
+	h := NewHost()
+
+	got := h.policy
+	want := DefaultPolicy()
+
+	if got.MaxRiskClass != want.MaxRiskClass {
+		t.Errorf("MaxRiskClass = %v, want %v", got.MaxRiskClass, want.MaxRiskClass)
+	}
+	if len(got.AllowedNetworkHosts) != 0 {
+		t.Errorf("expected an empty network allowlist, got %v", got.AllowedNetworkHosts)
+	}
+	if len(got.AllowedFilePaths) != 0 {
+		t.Errorf("expected an empty file-path allowlist, got %v", got.AllowedFilePaths)
+	}
+	if len(got.AllowedEnvVars) != 0 {
+		t.Errorf("expected an empty env-var allowlist, got %v", got.AllowedEnvVars)
+	}
+
+	// The dynamic-runtime profile is materially more permissive. Confirm that
+	// difference is real, so the test above is meaningful rather than vacuous.
+	profile := ProfileForTrack(registry.TrackDynamicRuntime)
+	if len(profile.AllowedNetworkHosts) == 0 {
+		t.Fatal("expected the dynamic-runtime profile to allow localhost; test premise is stale")
+	}
+	if profile.MaxRiskClass == want.MaxRiskClass {
+		t.Fatal("expected the dynamic-runtime profile to differ in risk class; test premise is stale")
+	}
+}

--- a/plugin/profiles_test.go
+++ b/plugin/profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"github.com/nox-hq/nox/registry"
 )
 
@@ -143,45 +144,151 @@ func TestMergeWithUserPolicyNetworkOverride(t *testing.T) {
 	}
 }
 
-// TestHost_DoesNotAutoApplyTrackProfiles pins the gap between ProfileForTrack
-// and what the host actually enforces.
-//
-// docs/plugin-authoring.md previously presented the per-track profiles as
-// though they were the effective policy, so a plugin author would reasonably
-// expect a dynamic-runtime plugin to get localhost network access. It does not:
-// the host enforces DefaultPolicy() — passive, with empty allowlists — unless
-// the operator's .nox.yaml opts in. Documenting an enforced control that does
-// not exist is the more dangerous half of this, so if the host ever starts
-// consulting track profiles, this test should fail and the documentation must
-// be corrected in the same change.
-func TestHost_DoesNotAutoApplyTrackProfiles(t *testing.T) {
+// --- track profile enforcement ---
+
+// TestHost_AppliesTrackProfile confirms the profile actually reaches the
+// enforced policy. Track profiles existed for several releases while the host
+// enforced DefaultPolicy() regardless, so docs promised a sandbox shape that
+// was never applied.
+func TestHost_AppliesTrackProfile(t *testing.T) {
+	t.Parallel()
+
+	h := NewHost()
+	got := h.policyForTrack(registry.TrackDynamicRuntime)
+
+	if got.MaxRiskClass != RiskClassActive {
+		t.Errorf("MaxRiskClass = %q, want %q", got.MaxRiskClass, RiskClassActive)
+	}
+	if len(got.AllowedNetworkHosts) == 0 {
+		t.Error("expected the dynamic-runtime profile to permit localhost")
+	}
+}
+
+// TestHost_UnknownTrackFallsBackToStrict is the security-critical case: a
+// plugin whose provenance cannot be established must not get a profile.
+// Sideloaded (--local) binaries and installs predating track recording both
+// arrive with an empty track.
+func TestHost_UnknownTrackFallsBackToStrict(t *testing.T) {
 	t.Parallel()
 
 	h := NewHost()
 
-	got := h.policy
-	want := DefaultPolicy()
+	for _, track := range []registry.Track{"", "not-a-real-track", "dynamic-runtime-ish"} {
+		t.Run(string(track), func(t *testing.T) {
+			got := h.policyForTrack(track)
 
-	if got.MaxRiskClass != want.MaxRiskClass {
-		t.Errorf("MaxRiskClass = %v, want %v", got.MaxRiskClass, want.MaxRiskClass)
+			if got.MaxRiskClass != RiskClassPassive {
+				t.Errorf("MaxRiskClass = %q, want passive for an unverifiable track", got.MaxRiskClass)
+			}
+			if len(got.AllowedNetworkHosts) != 0 {
+				t.Errorf("an unverifiable track was granted network access: %v", got.AllowedNetworkHosts)
+			}
+		})
+	}
+}
+
+// TestHost_IgnoreTrackProfilesRestoresStrictBase covers the opt-out. It has to
+// exist because the override semantics are one-directional: an operator can
+// widen an allowlist but cannot empty one, so without this flag there is no way
+// to revoke the localhost access the dynamic-runtime profile grants.
+func TestHost_IgnoreTrackProfilesRestoresStrictBase(t *testing.T) {
+	t.Parallel()
+
+	h := NewHost(WithIgnoreTrackProfiles(true))
+	got := h.policyForTrack(registry.TrackDynamicRuntime)
+
+	if got.MaxRiskClass != RiskClassPassive {
+		t.Errorf("MaxRiskClass = %q, want passive when track profiles are ignored", got.MaxRiskClass)
 	}
 	if len(got.AllowedNetworkHosts) != 0 {
-		t.Errorf("expected an empty network allowlist, got %v", got.AllowedNetworkHosts)
+		t.Errorf("expected no network access when track profiles are ignored, got %v", got.AllowedNetworkHosts)
 	}
-	if len(got.AllowedFilePaths) != 0 {
-		t.Errorf("expected an empty file-path allowlist, got %v", got.AllowedFilePaths)
+}
+
+// TestEffectivePolicy_OperatorOverridesWin confirms a project can still tighten
+// or widen what its own plugins get; the track sets the base, not the ceiling.
+func TestEffectivePolicy_OperatorOverridesWin(t *testing.T) {
+	t.Parallel()
+
+	overrides := Policy{
+		MaxRiskClass:        RiskClassPassive,
+		AllowedNetworkHosts: []string{"proxy.internal"},
 	}
-	if len(got.AllowedEnvVars) != 0 {
-		t.Errorf("expected an empty env-var allowlist, got %v", got.AllowedEnvVars)
+	got := EffectivePolicy(registry.TrackDynamicRuntime, &overrides, false)
+
+	if got.MaxRiskClass != RiskClassPassive {
+		t.Errorf("operator's max_risk_class was not honoured: got %q", got.MaxRiskClass)
+	}
+	if len(got.AllowedNetworkHosts) != 1 || got.AllowedNetworkHosts[0] != "proxy.internal" {
+		t.Errorf("operator's network allowlist was not honoured: got %v", got.AllowedNetworkHosts)
+	}
+}
+
+// TestEffectivePolicy_ProfileAppliesWithoutOverrides pins the loosening this
+// change deliberately introduces, so it cannot happen by accident later.
+func TestEffectivePolicy_ProfileAppliesWithoutOverrides(t *testing.T) {
+	t.Parallel()
+
+	got := EffectivePolicy(registry.TrackDynamicRuntime, &Policy{}, false)
+
+	if got.MaxRiskClass != RiskClassActive {
+		t.Errorf("MaxRiskClass = %q, want active from the track profile", got.MaxRiskClass)
+	}
+	if len(got.AllowedNetworkHosts) == 0 {
+		t.Error("expected localhost access from the track profile")
+	}
+}
+
+// TestTrackProfile_GovernsManifestAcceptance exercises the decision that
+// actually matters: whether a plugin declaring network access is admitted.
+//
+// It runs the real ValidateManifest against the real resolved policies, so it
+// would catch a regression where policyForTrack returns the right values but
+// registration consults something else.
+func TestTrackProfile_GovernsManifestAcceptance(t *testing.T) {
+	t.Parallel()
+
+	// A plugin that needs localhost — the shape a dynamic-runtime scanner has.
+	manifest := &pluginv1.GetManifestResponse{
+		Name:       "runtime-scanner",
+		Version:    "1.0.0",
+		ApiVersion: HostAPIVersion,
+		Safety: &pluginv1.SafetyRequirements{
+			RiskClass:    "active",
+			NetworkHosts: []string{"localhost"},
+		},
 	}
 
-	// The dynamic-runtime profile is materially more permissive. Confirm that
-	// difference is real, so the test above is meaningful rather than vacuous.
-	profile := ProfileForTrack(registry.TrackDynamicRuntime)
-	if len(profile.AllowedNetworkHosts) == 0 {
-		t.Fatal("expected the dynamic-runtime profile to allow localhost; test premise is stale")
-	}
-	if profile.MaxRiskClass == want.MaxRiskClass {
-		t.Fatal("expected the dynamic-runtime profile to differ in risk class; test premise is stale")
-	}
+	h := NewHost()
+
+	t.Run("dynamic-runtime track admits it", func(t *testing.T) {
+		policy := h.policyForTrack(registry.TrackDynamicRuntime)
+		if v := ValidateManifest(manifest, &policy); len(v) > 0 {
+			t.Errorf("expected admission under the dynamic-runtime profile, rejected with: %v", v)
+		}
+	})
+
+	t.Run("core-analysis track rejects it", func(t *testing.T) {
+		// Same host, same process, different plugin: policy is per-plugin, so a
+		// dynamic-runtime plugin's grant must not leak to a passive track.
+		policy := h.policyForTrack(registry.TrackCoreAnalysis)
+		if v := ValidateManifest(manifest, &policy); len(v) == 0 {
+			t.Error("expected rejection under the core-analysis profile, but it was admitted")
+		}
+	})
+
+	t.Run("unknown track rejects it", func(t *testing.T) {
+		policy := h.policyForTrack("")
+		if v := ValidateManifest(manifest, &policy); len(v) == 0 {
+			t.Error("a plugin of unverifiable provenance was admitted with network access")
+		}
+	})
+
+	t.Run("ignore_track_profiles rejects it", func(t *testing.T) {
+		strict := NewHost(WithIgnoreTrackProfiles(true))
+		policy := strict.policyForTrack(registry.TrackDynamicRuntime)
+		if v := ValidateManifest(manifest, &policy); len(v) == 0 {
+			t.Error("the opt-out did not restore strict enforcement")
+		}
+	})
 }

--- a/registry/deprecation_test.go
+++ b/registry/deprecation_test.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPluginEntry_DeprecationRoundTrips guards the bug this fixes: the registry
+// index carried "deprecated" and "deprecation_note" for two releases while
+// PluginEntry had no such fields, so they decoded to nothing and every consumer
+// silently ignored them. A retired plugin kept being resolved and installed
+// with no warning.
+func TestPluginEntry_DeprecationRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"name": "nox/policy-gate",
+		"description": "Policy gating",
+		"versions": [],
+		"deprecated": true,
+		"deprecation_note": "superseded by core policy.fail_on"
+	}`
+
+	var p PluginEntry
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("unmarshalling entry: %v", err)
+	}
+
+	if !p.Deprecated {
+		t.Error("deprecated was not decoded; the index field is inert")
+	}
+	if p.DeprecationNote != "superseded by core policy.fail_on" {
+		t.Errorf("deprecation_note = %q, want the superseded-by text", p.DeprecationNote)
+	}
+
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshalling entry: %v", err)
+	}
+	var decoded PluginEntry
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("re-unmarshalling entry: %v", err)
+	}
+	if decoded.Deprecated != p.Deprecated || decoded.DeprecationNote != p.DeprecationNote {
+		t.Errorf("round-trip lost deprecation data: %+v", decoded)
+	}
+}
+
+// TestPluginEntry_DeprecationOmittedWhenUnset keeps non-deprecated entries
+// byte-identical to before, so adding the fields does not churn the index.
+func TestPluginEntry_DeprecationOmittedWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(PluginEntry{Name: "nox/example"})
+	if err != nil {
+		t.Fatalf("marshalling entry: %v", err)
+	}
+	for _, field := range []string{"deprecated", "deprecation_note"} {
+		if containsField(string(encoded), field) {
+			t.Errorf("expected %q to be omitted for a live plugin, got %s", field, encoded)
+		}
+	}
+}
+
+func containsField(encoded, field string) bool {
+	needle := `"` + field + `"`
+	for i := 0; i+len(needle) <= len(encoded); i++ {
+		if encoded[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -103,6 +103,15 @@ type PluginEntry struct {
 	Maintainers []string `json:"maintainers,omitempty"`
 	License     string   `json:"license,omitempty"`
 	Repository  string   `json:"repository,omitempty"`
+
+	// Deprecated marks a plugin that is no longer maintained. Existing installs
+	// keep working — resolution and install are unaffected — but users are told,
+	// so a retired plugin cannot go on being adopted silently.
+	Deprecated bool `json:"deprecated,omitempty"`
+
+	// DeprecationNote explains what supersedes the plugin. It is shown verbatim
+	// on search, info and install, so it should name the replacement.
+	DeprecationNote string `json:"deprecation_note,omitempty"`
 }
 
 // VersionEntry describes a specific version of a plugin.

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -76,7 +76,11 @@ func (s *PluginServer) Serve(ctx context.Context, opts ...ServeOption) error {
 		opt(cfg)
 	}
 
-	lis, err := net.Listen("tcp", ":0")
+	// Bind loopback-only. A plugin is a subprocess of the host scanner and is
+	// only ever dialled over the address handshake below, so exposing it on
+	// every interface would let any other local process — or, behind a
+	// permissive firewall, any LAN peer — invoke plugin tools during a scan.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("sdk: listen: %w", err)
 	}

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"google.golang.org/grpc"
@@ -211,5 +212,94 @@ func TestServer_Serve_WritesAddr(t *testing.T) {
 	output := buf.String()
 	if !strings.HasPrefix(output, "NOX_PLUGIN_ADDR=") {
 		t.Errorf("expected NOX_PLUGIN_ADDR= prefix, got %q", output)
+	}
+}
+
+// writerFunc adapts a function to io.Writer so a test can observe the
+// handshake line the moment Serve emits it, without racing on a Buffer.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// serveAndWaitForAddr starts srv in a goroutine and returns the advertised
+// address plus a stop function that cancels and waits for a clean shutdown.
+func serveAndWaitForAddr(t *testing.T, srv *PluginServer) (addr string, stop func()) {
+	t.Helper()
+
+	addrCh := make(chan string, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Serve(ctx, WithAddrWriter(writerFunc(func(p []byte) (int, error) {
+			select {
+			case addrCh <- string(p):
+			default:
+			}
+			return len(p), nil
+		})))
+	}()
+
+	stop = func() {
+		cancel()
+		<-done
+	}
+
+	select {
+	case line := <-addrCh:
+		addr = strings.TrimSpace(strings.TrimPrefix(line, "NOX_PLUGIN_ADDR="))
+		return addr, stop
+	case <-time.After(5 * time.Second):
+		stop()
+		t.Fatal("timed out waiting for NOX_PLUGIN_ADDR handshake line")
+		return "", stop
+	}
+}
+
+// A plugin listener reachable from other hosts lets any local process — and,
+// depending on firewall posture, any LAN peer — invoke plugin tools mid-scan.
+// The listener must be loopback-only.
+func TestServer_Serve_BindsLoopbackOnly(t *testing.T) {
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("advertised host %q is not an IP literal", host)
+	}
+	if !ip.IsLoopback() {
+		t.Errorf("listener bound to %q, want a loopback address", host)
+	}
+}
+
+// The loopback bind must not break the handshake contract: the address printed
+// on stdout is the only thing the host has to dial, so it must stay connectable.
+func TestServer_Serve_AdvertisedAddrIsDialable(t *testing.T) {
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewClient(%q): %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := pluginv1.NewPluginServiceClient(conn).GetManifest(ctx, &pluginv1.GetManifestRequest{ApiVersion: "v1"})
+	if err != nil {
+		t.Fatalf("GetManifest over advertised addr %q: %v", addr, err)
+	}
+	if resp.GetName() != "test" {
+		t.Errorf("manifest name = %q, want %q", resp.GetName(), "test")
 	}
 }


### PR DESCRIPTION
Supersedes #249, which was cut from a stale `main` and conflicted. #248 had already landed the OSV hydration and CVSS vector scoring that PR duplicated, and #245 moved the registry index out of this repo — so this branch is cut fresh from `main` with only the work that is still needed.

## The pattern

Chasing a severity bug turned up a systematic asymmetry: **nox fails loudly on file I/O but silently on nearly everything optional.** An unreadable `.txt` aborts the scan with exit 2. A firewalled OSV, a dead plugin, a typo'd `--vex` path, or an unparseable lockfile all exit 0, looking exactly like a clean scan.

For a security scanner that is the defect that matters most: a green build was not evidence the scan actually ran.

## 1. Degraded checks are visible (`7277e92`)

New `core/degrade` collector, surfaced as `ScanResult.Degradations`. Each record names what failed and — the part that matters — what may now be missing.

Printed to stderr **even under `--quiet`** (quiet suppresses noise, not "these results are partial"), with `--fail-on-degraded` so CI can treat "could not check" as failure.

```
$ nox scan .            # with OSV firewalled
[results] 0 findings, 1 dependencies, 0 AI components
[degraded] vulnerability lookup failed for 1 packages: ...
  impact: dependency vulnerabilities are under-reported; this scan cannot
          confirm the absence of known CVEs

$ nox scan . -fail-on-degraded
exit 2   # was 0
```

**Silence is preserved where nothing is wrong.** A warning that fires on healthy scans is one operators learn to ignore. My first cut reported `go.sum` as degraded — which fires on essentially every Go repository and wrongly tripped `--fail-on-degraded`. `ParseLockfile` now returns a distinguishable `ErrUnsupportedLockfile`, so only files nox *claims* to parse and then failed on are reported. There's a regression test for that specifically.

Also configures an slog handler. Without one, **every `slog.Warn` in the codebase reached nobody** — including the OSV degradation warning added specifically to prevent silent failure.

### Fails loudly where the operator asked for something specific

`--vex` and `--terraform-plan` that cannot be loaded are now errors. Those paths only exist because someone typed them, so silently scanning nothing let a typo masquerade as a clean infrastructure review or as applied waivers.

A *missing* baseline stays silent (normal before the first `baseline write`); one that exists and won't load is reported, since under `baseline_mode` it changes what the gate enforces.

### Config that parsed cleanly and did nothing

- `cfg.License` now reaches `deps.WithLicensePolicy` — `license.deny`/`allow` previously produced **zero** `LIC-*` findings. Fixing it exposed a second bug: `detectNPMLicenses` returned early when the root `package.json` was missing, skipping `node_modules` entirely.
- `RunStagedScanWithOptions` called `RunScan` and dropped `opts` wholesale — `--rules`, `--offline`, `--vex` silently ignored under `--staged`.
- `RunHistoryScan` never read `opts.ScanOptions` — `--rules` silently ignored under `--history`.
- `ScanOptions.NoCache` was read by nothing; removed. `-no-cache` stays accepted but now describes itself honestly.

Two OSV hardening deltas salvaged from #249, on top of #248's work: `fetchVulnDetail` now rejects a response whose ID isn't the one requested (any JSON decodes into `osvVuln`, so a proxy answering 200 with unrelated JSON produced a well-formed but empty advisory), and severity falls back to `database_specific.severity` for CVSS v4-only advisories, which previously collapsed to medium.

## 2. Plugin trust boundary (`3f6e484`)

**The gRPC socket bound to all interfaces.** `sdk/server.go` listened on `":0"` with insecure credentials, so any local process — and depending on firewall, any LAN peer — could invoke plugin tools during a scan. Now `127.0.0.1:0`, with tests for both loopback binding and that the advertised address still completes a real RPC.

**Plugin fingerprints were trusted verbatim.** Plugin findings merge into the same `FindingSet`, dedup first-wins, and baseline/VEX key on the same value — so a plugin could claim a core finding's fingerprint and **erase it**. `TestHost_MergeResults_PluginCannotSuppressCoreFinding` reproduces it against the old code: `expected both findings to survive dedup, got 1`.

Fingerprints are now derived host-side, namespaced `plugin:<name>:<ruleID>`, with the claimed value demoted to hash input — so plugin findings stay individually baseline-able but can't reach outside their namespace. `InvokeAll` returns `[]AttributedResponse` to carry the producing plugin's identity, taken from the host's registry rather than anything the plugin claims.

## 3. Context cancellation (`589a348`)

All four non-deps analyzers accepted a `context` and ignored it — only `deps` ever consulted it. A cancelled scan kept reading files until the walk finished, while `RunScanContext`'s doc comment claimed the context was propagated to every analyzer. Each now checks between artifacts; the doc comment is corrected to say discovery itself is still not interruptible.

### A documented security control that isn't enforced

Investigating the "dead code" in `plugin/profiles.go` turned up something worse than dead code. `docs/plugin-authoring.md` presented the per-track safety profiles as the effective policy — a plugin author would reasonably expect a `dynamic-runtime` plugin to get localhost network access. **It does not.** The host enforces `DefaultPolicy()`: passive risk class, empty allowlists, overridden only by the operator's `.nox.yaml`. So such a plugin is rejected at registration until the operator opts in.

Documenting a control that doesn't exist is worse in a security tool than not documenting it. The doc now says plainly that the profiles are suggestions, and gives authors the `.nox.yaml` block to hand their users. `TestHost_DoesNotAutoApplyTrackProfiles` pins the gap so the docs can't drift back out of sync.

**I deliberately did not wire the profiles into enforcement** — that would loosen the default posture (localhost network, active risk class) and is a decision that deserves its own review, not a fold-in to a reliability PR. The functions are kept rather than deleted: they're exported, referenced by the authoring guide, and useful for deriving that config block.

## 4. Registry `deprecated` flag (`e9ccaad`)

Carried in the index since `c91a9ad` but inert — `PluginEntry` had no such fields, so they decoded to nothing and `search`/`install` went on recommending retired plugins silently. Now parsed and surfaced in search, install (advisory, never blocking) and info. Both fields are `omitempty`, so live entries serialise byte-identically.

The index now lives in the extracted registry repo, so this is the consuming half only; the schema and marketplace site should be updated there.

## Verification

- `go build ./...`, `go test ./...`, and `go test -race` on core/plugin/sdk/registry all clean.
- `golangci-lint` clean across all 27 changed Go files.
- Degradation reporting verified end-to-end by firewalling OSV through an unroutable proxy, including confirming a healthy scan stays silent and exits 1 rather than 2.
- Every security and cancellation test confirmed red against the pre-fix code, not just green after.

## Notes for review

- **`--vex` / `--terraform-plan` becoming hard errors is a behaviour change.** Anyone relying on a broken path being ignored will now see exit 2. Intended, but it wants a release note.
- `MergeResults` and `InvokeAll` changed signature. Both are exported; `plugin` is importable, so this is technically breaking for any external consumer.
- `ScanOptions.NoCache` is removed from the public struct for the same reason.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts
