### PR TITLE
fix: close the silent-failure gaps v1.11.0 left open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-19
+
+A post-release review found that three of 1.11.0's own promises did not hold.
+Each had full unit-test coverage of the function involved while the defect sat
+at the call site — the same shape as the bug 1.11.0 was written to fix.
+
+### Fixed
+
+- **Critical dependency advisories reported as `medium`, again.** The CVSS-v4
+  severity fallback added in 1.11.0 never received data: advisory hydration
+  copied summary, aliases and CVSS entries but not the source database's
+  severity label, and `/v1/querybatch` supplies none of those fields. A
+  `CRITICAL` advisory scored `medium`, so critical/high gates did not fire on
+  it. Severity mapping also returned on the first CVSS entry it *saw* rather
+  than the first it could *score*, letting an unscorable CVSS v2 vector
+  override an accurate label.
+
+- **`--fail-on-degraded` could not fire for plugin failures**, despite naming
+  them in its help text. A required plugin that was not installed was silently
+  skipped, so a CI job listing a security plugin, failing to install it, and
+  running with the flag exited 0 with a clean report.
+
+- **yarn, pnpm and poetry projects scanned clean while nothing was read.**
+  1.11.0 exempted unparsed lockfiles from degradation reporting to stop
+  `go.sum` warning on every Go repository; that exemption silently covered
+  three lockfiles nox cannot parse and has no substitute for. Only genuine
+  redundancy is exempt now. A new invariant test fails the build if a lockfile
+  is added to discovery without either a parser or a recorded, reported gap.
+
+- **A suppression with an unparseable expiry became a permanent waiver.**
+  `# nox:ignore SEC-001 -- expires:2026-13-01` (month 13) was accepted, the
+  expiry text stripped from the displayed reason, and the finding hidden
+  forever. The waiver is now not applied, the finding is reported, and the bad
+  date is named. This one is long-standing and failed toward hiding findings.
+
+- **`--fail-on-degraded` discarded every report.** It exited before report
+  generation, so a pipeline that tripped the flag lost `findings.json`, the
+  SARIF and the SBOM — including the findings it had collected. Reports are
+  now written first, and the degraded exit outranks the policy exit code.
+
+- **Silent supply-chain and CVE-variant data failures.** Typosquatting and
+  known-malicious-package detection returned nothing when their embedded
+  datasets failed to load; a whole-database parse failure disabled every
+  `VARIANT-*` rule. All are reported now.
+
+- **Dockerfile read and parse failures** are reported, in the same analyzer
+  that already reported lockfile failures.
+
+### Added
+
+- `findings.json` records incomplete checks under `meta.degradations`. The
+  consumers that most need them — CI jobs, dashboards, MCP clients — never see
+  stderr, and for them an empty findings list was indistinguishable from a scan
+  that never looked.
+
+### Known gaps
+
+`yarn.lock`, `poetry.lock` and `pnpm-lock.yaml` are still not parsed. They are
+now reported as blind spots on every scan that encounters them rather than
+passing silently; parsers are the fix and are not in this release.
+
+
 ## [1.11.0] - 2026-07-19
 
 ### BREAKING CHANGES
@@ -934,7 +996,8 @@ secrets-pattern noise inside npm bundles.
 - Interspersed flags and positional args handled correctly.
 - Timeout added to `nox explain` to prevent indefinite hangs.
 
-[Unreleased]: https://github.com/nox-hq/nox/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/nox-hq/nox/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/nox-hq/nox/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/nox-hq/nox/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/nox-hq/nox/compare/v1.9.2...v1.10.0
 [0.6.0]: https://github.com/nox-hq/nox/compare/v0.5.0...v0.6.0

--- a/cli/main.go
+++ b/cli/main.go
@@ -109,6 +109,26 @@ func isTopLevelStringFlag(name string) bool {
 	return false
 }
 
+// degradationsForReport converts scan degradations into their report form so
+// they can be recorded in findings.json. Consumers that only read the artifact
+// — CI jobs, dashboards, MCP clients — never see the stderr warnings, and for
+// them an empty findings list would otherwise be indistinguishable from a scan
+// that could not run.
+func degradationsForReport(ds []nox.Degradation) []report.Degradation {
+	if len(ds) == 0 {
+		return nil
+	}
+	out := make([]report.Degradation, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, report.Degradation{
+			Kind:   string(d.Kind),
+			Detail: d.Detail,
+			Impact: d.Impact,
+		})
+	}
+	return out
+}
+
 // run executes the CLI and returns the exit code.
 // 0 = clean (no findings), 1 = findings detected, 2 = error.
 func run(args []string) int {
@@ -503,12 +523,14 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	// Report incomplete checks even under --quiet, and on stderr. A scan that
 	// could not run part of itself must never look like a clean scan: quiet
 	// mode suppresses noise, not a warning that the results are partial.
+	//
+	// The --fail-on-degraded exit is deliberately NOT taken here: returning
+	// before report generation threw away findings.json, the SARIF and the
+	// SBOM, so a pipeline that tripped the flag lost the findings it did
+	// collect and had nothing to upload. The exit is applied after reports are
+	// written; see below.
 	for _, d := range result.Degradations {
 		fmt.Fprintf(os.Stderr, "[degraded] %s\n  impact: %s\n", d.Detail, d.Impact)
-	}
-	if len(result.Degradations) > 0 && failOnDegraded {
-		fmt.Fprintf(os.Stderr, "error: %d check(s) did not complete and --fail-on-degraded is set\n", len(result.Degradations))
-		return 2
 	}
 
 	// Generate reports.
@@ -525,6 +547,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			r.Offline = offlineFlag
 			r.Prioritize = sortFlag == "priority"
 			r.SASTLanguages = result.SASTProfile
+			r.Degradations = degradationsForReport(result.Degradations)
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2
@@ -604,6 +627,15 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	if !quiet {
 		printNextStepTips(activeFindings, outputDir)
 		fmt.Println("[done]")
+	}
+
+	// An incomplete scan outranks the findings verdict: a policy gate that
+	// passed on partial results has not actually been satisfied. Applied here,
+	// after reports are written, so CI still gets its artifacts.
+	if len(result.Degradations) > 0 && failOnDegraded {
+		fmt.Fprintf(os.Stderr, "error: %d check(s) did not complete and --fail-on-degraded is set\n",
+			len(result.Degradations))
+		return 2
 	}
 
 	// If policy is configured, use its exit code.

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/degrade"
 	"github.com/nox-hq/nox/plugin"
 	"github.com/nox-hq/nox/registry"
 )
@@ -36,18 +37,35 @@ type installedPlugin struct {
 // An empty track — a sideloaded plugin, or one installed before tracks were
 // recorded — is passed through as-is, which the host resolves to the strict
 // default policy.
-func installedPluginBinaries(required []string) ([]installedPlugin, error) {
+func installedPluginBinaries(required []string) ([]installedPlugin, []core.Degradation, error) {
 	st, err := LoadState(DefaultStatePath())
 	if err != nil {
-		return nil, fmt.Errorf("loading plugin state: %w", err)
+		return nil, nil, fmt.Errorf("loading plugin state: %w", err)
 	}
+
 	var binaries []installedPlugin
+	var missing []core.Degradation
+
 	for _, name := range required {
+		// A plugin the project REQUIRED and did not get is reported, not
+		// skipped. Silently continuing here meant a CI job listing a security
+		// plugin, failing to install it, and exiting 0 with a clean report —
+		// even under --fail-on-degraded, whose help text promises otherwise.
 		ip := st.FindPlugin(name)
 		if ip == nil {
+			missing = append(missing, core.Degradation{
+				Kind:   degrade.Plugin,
+				Detail: fmt.Sprintf("required plugin %q is not installed", name),
+				Impact: "findings this plugin would have produced are missing from this scan",
+			})
 			continue
 		}
 		if _, statErr := os.Stat(ip.BinaryPath); statErr != nil {
+			missing = append(missing, core.Degradation{
+				Kind:   degrade.Plugin,
+				Detail: fmt.Sprintf("required plugin %q has no usable binary at %s: %v", name, ip.BinaryPath, statErr),
+				Impact: "findings this plugin would have produced are missing from this scan",
+			})
 			continue
 		}
 		binaries = append(binaries, installedPlugin{
@@ -55,7 +73,7 @@ func installedPluginBinaries(required []string) ([]installedPlugin, error) {
 			track: registry.Track(ip.Track),
 		})
 	}
-	return binaries, nil
+	return binaries, missing, nil
 }
 
 // runPostScanPlugins invokes the post-scan (scan-context) tools of every
@@ -69,7 +87,7 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 		return nil
 	}
 
-	binaries, err := installedPluginBinaries(required)
+	binaries, _, err := installedPluginBinaries(required)
 	if err != nil {
 		return err
 	}
@@ -122,7 +140,7 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 		return nil, nil
 	}
 
-	binaries, err := installedPluginBinaries(required)
+	binaries, missing, err := installedPluginBinaries(required)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +153,17 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 		overrides = cfg.PluginPolicy.Overrides()
 		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
 	}
-	return runPluginBinaries(ctx, target, binaries, &policy, &overrides, ignoreTrackProfiles)
+	out, err := runPluginBinaries(ctx, target, binaries, &policy, &overrides, ignoreTrackProfiles)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil && len(missing) > 0 {
+		out = &core.PluginScanOutput{}
+	}
+	if out != nil {
+		out.Degradations = append(out.Degradations, missing...)
+	}
+	return out, nil
 }
 
 // runPluginBinaries registers the given plugin binaries with a host, runs

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/degrade"
 )
 
 // The heavy path (registering a real plugin binary, gRPC invocation, proto
@@ -31,15 +33,33 @@ func TestRunPluginBinaries_NoBinaries_NoOp(t *testing.T) {
 	}
 }
 
-func TestRunScanPlugins_UninstalledRequired_Skipped(t *testing.T) {
-	// A required plugin that isn't in the install state resolves to zero
-	// binaries, so the run is a no-op rather than an error.
+func TestRunScanPlugins_UninstalledRequired_IsReported(t *testing.T) {
+	// A required plugin that isn't installed must not abort the scan — but it
+	// must not vanish either.
+	//
+	// This previously asserted a nil output, i.e. that the plugin was silently
+	// skipped. That is what let a CI job list a security plugin, fail to
+	// install it, and exit 0 with a clean report even under
+	// --fail-on-degraded. Skipping is right; staying quiet about it is not.
 	out, err := runScanPlugins(context.Background(), t.TempDir(), []string{"nox/definitely-not-installed"})
 	if err != nil {
-		t.Fatalf("uninstalled required plugin should be skipped, got error: %v", err)
+		t.Fatalf("uninstalled required plugin should not abort the scan, got error: %v", err)
 	}
-	if out != nil {
-		t.Fatalf("expected nil output, got %+v", out)
+	if out == nil {
+		t.Fatal("expected a degradation for the uninstalled plugin, got nil output")
+	}
+	if len(out.Findings) != 0 {
+		t.Errorf("expected no findings from an uninstalled plugin, got %d", len(out.Findings))
+	}
+
+	var reported bool
+	for _, d := range out.Degradations {
+		if d.Kind == degrade.Plugin && strings.Contains(d.Detail, "definitely-not-installed") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("the uninstalled required plugin was not reported: %+v", out.Degradations)
 	}
 }
 

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -24,6 +24,39 @@ import (
 	"github.com/nox-hq/nox/core/rules"
 )
 
+// redundantLockfiles names files that carry no dependency information nox
+// cannot already get from a file it does parse. Only these are exempt from
+// degradation reporting when they go unparsed.
+//
+// go.sum is the sole member: it hashes the whole module graph, while go.mod
+// carries the versions Minimal Version Selection actually chose, so parsing
+// go.mod loses nothing. Do not add a lockfile here merely because nox lacks a
+// parser for it — that is exactly the blind spot this list exists to avoid
+// hiding.
+var redundantLockfiles = map[string]bool{
+	"go.sum": true,
+}
+
+// knownUnparsed names lockfiles nox classifies but cannot yet parse.
+//
+// Unlike redundantLockfiles, these ARE blind spots: a project using one gets no
+// dependency inventory and no vulnerability matching for it. They are listed
+// only so the gap is a recorded, testable decision rather than an accident —
+// each still produces a degradation at scan time, so operators are told. Adding
+// a parser and removing the entry is the fix; the entry is not the fix.
+var knownUnparsed = map[string]string{
+	"yarn.lock":      "no parser yet — yarn v1 and berry use different formats",
+	"poetry.lock":    "no parser yet — TOML with a distinct schema from pyproject",
+	"pnpm-lock.yaml": "no parser yet — YAML with a version-dependent schema",
+}
+
+// isRedundantLockfile reports whether an unparsed lockfile is safe to ignore
+// silently. Only genuine redundancy qualifies — a missing parser does not,
+// because the operator needs to know their dependencies went unscanned.
+func isRedundantLockfile(path string) bool {
+	return redundantLockfiles[filepath.Base(path)]
+}
+
 // ErrUnsupportedLockfile marks a file whose name matches no known lockfile
 // parser. It is deliberately distinguishable from a parse failure: the former
 // means nox never intended to read the file, the latter means it tried and
@@ -338,15 +371,22 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			pkgs, err = a.ParseLockfile(art.AbsPath, content)
 		}
 		if err != nil {
-			// A file type we deliberately do not parse (go.sum, yarn.lock) is
-			// not a degradation — nothing was expected of it, and reporting it
-			// would train operators to ignore the degradation output entirely.
-			// A file we DO claim to parse but could not is the real signal:
-			// every package it declares is now absent from CVE matching.
-			if !errors.Is(err, ErrUnsupportedLockfile) {
+			// Two different situations reach here, and conflating them is how
+			// yarn, pnpm, poetry and gradle projects came to get a silently
+			// empty dependency scan.
+			//
+			// A file whose contents are redundant with one we DO parse (go.sum
+			// against go.mod) is genuinely nothing to report; saying so on every
+			// Go repository would train operators to ignore this channel.
+			//
+			// Anything else — a lockfile nox recognises well enough to classify
+			// but has no parser for, or one that failed to parse — is a real
+			// blind spot. Every dependency it declares is absent from
+			// vulnerability matching, and the operator has no way to know.
+			if !isRedundantLockfile(art.Path) {
 				a.degradations.Add(degrade.Lockfile,
-					fmt.Sprintf("%s could not be parsed: %v", art.Path, err),
-					"dependencies declared in this file were not scanned for vulnerabilities")
+					fmt.Sprintf("%s was not parsed: %v", art.Path, err),
+					"dependencies declared in this file were NOT scanned for vulnerabilities")
 			}
 			continue
 		}
@@ -366,13 +406,22 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			continue
 		}
 
+		// Same class of blind spot as an unparsed lockfile: without the base
+		// image nox has no container inventory and no base-image findings for
+		// this file, and reported success either way.
 		content, err := os.ReadFile(art.AbsPath)
 		if err != nil {
-			continue // best-effort: skip unreadable files
+			a.degradations.Add(degrade.Lockfile,
+				fmt.Sprintf("%s could not be read: %v", art.Path, err),
+				"base images declared in this Dockerfile were NOT inventoried or scanned")
+			continue
 		}
 
 		images, err := ParseDockerfile(content)
 		if err != nil {
+			a.degradations.Add(degrade.Lockfile,
+				fmt.Sprintf("%s could not be parsed: %v", art.Path, err),
+				"base images declared in this Dockerfile were NOT inventoried or scanned")
 			continue
 		}
 
@@ -451,6 +500,15 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	// offline using embedded data.
 	{
 		pkgs := inventory.Packages()
+		// Report any embedded dataset that failed to load. Both checks below
+		// silently return "not malicious" / "not a typosquat" when their data
+		// is missing, so without this a supply-chain scan that never loaded its
+		// attack data is indistinguishable from one that found nothing.
+		for _, failure := range dataLoadFailures() {
+			a.degradations.Add(degrade.VulnData, failure,
+				"malicious-package and typosquatting detection did not run against this dataset")
+		}
+
 		for i, pkg := range pkgs {
 			lockfilePath := ""
 			if i < len(sources) {

--- a/core/analyzers/deps/deps_test.go
+++ b/core/analyzers/deps/deps_test.go
@@ -777,3 +777,62 @@ func TestNewAnalyzer(t *testing.T) {
 		t.Errorf("expected OSVBaseURL %q, got %q", "https://api.osv.dev", a.OSVBaseURL)
 	}
 }
+
+// TestEveryClassifiedLockfileIsHandled enforces the invariant that produced
+// the yarn/pnpm/poetry blind spot: discovery classified those files as
+// lockfiles, the analyzer had no parser for them, and the gap was invisible.
+//
+// Every name discovery treats as a lockfile must either have a parser, or be
+// explicitly listed as redundant with one that does. A new entry on one side
+// and not the other fails here rather than shipping a silently empty scan for
+// that ecosystem.
+func TestEveryClassifiedLockfileIsHandled(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range discovery.LockfileNames() {
+		if _, parsed := supportedLockfiles[name]; parsed {
+			continue
+		}
+		if redundantLockfiles[name] {
+			continue
+		}
+		if _, known := knownUnparsed[name]; known {
+			continue
+		}
+		t.Errorf("%s is classified as a lockfile but is neither parsed, nor redundant, nor a "+
+			"recorded gap: projects using it would scan clean while nothing was read. Add a "+
+			"parser, or record it in knownUnparsed so the blind spot is deliberate and reported.", name)
+	}
+}
+
+// TestKnownUnparsedLockfilesAreReported ensures a recorded gap is a REPORTED
+// gap. An entry in knownUnparsed documents that nox cannot read the file; it
+// must never become a second silent-exemption list, so each one is checked to
+// be absent from the silently-ignored set.
+func TestKnownUnparsedLockfilesAreReported(t *testing.T) {
+	t.Parallel()
+
+	for name := range knownUnparsed {
+		if redundantLockfiles[name] {
+			t.Errorf("%s is recorded as an unparsed blind spot but is also exempt from "+
+				"degradation reporting; operators would never learn it went unscanned", name)
+		}
+	}
+}
+
+// TestRedundantLockfilesAreActuallyClassified keeps the exemption list honest —
+// an entry naming a file discovery never classifies is dead weight that hides
+// nothing and misleads the next reader.
+func TestRedundantLockfilesAreActuallyClassified(t *testing.T) {
+	t.Parallel()
+
+	classified := make(map[string]bool)
+	for _, name := range discovery.LockfileNames() {
+		classified[name] = true
+	}
+	for name := range redundantLockfiles {
+		if !classified[name] {
+			t.Errorf("%s is listed as a redundant lockfile but discovery does not classify it", name)
+		}
+	}
+}

--- a/core/analyzers/deps/malicious.go
+++ b/core/analyzers/deps/malicious.go
@@ -9,12 +9,30 @@ package deps
 import (
 	"embed"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 )
 
 //go:embed data/popular_npm.txt data/popular_pypi.txt data/known_malicious.json
 var dataFS embed.FS
+
+// dataLoadErrs records embedded-dataset load failures.
+//
+// These datasets drive typosquatting and known-malicious-package detection. If
+// one fails to load, the corresponding check returns no findings and the scan
+// reports success — for a supply-chain scanner, the worst possible silent
+// failure: the check that exists to catch active attacks says "clean" when it
+// never loaded its data. Writes happen inside sync.Once, reads after it.
+var dataLoadErrs []string
+
+// dataLoadFailures returns the embedded-dataset load failures seen so far.
+// Callers must have triggered the relevant sync.Once first.
+func dataLoadFailures() []string {
+	out := make([]string, len(dataLoadErrs))
+	copy(out, dataLoadErrs)
+	return out
+}
 
 // popularPackages holds lazy-loaded popular package names per ecosystem.
 var (
@@ -46,6 +64,8 @@ func loadPopular() {
 	for eco, path := range files {
 		data, err := dataFS.ReadFile(path)
 		if err != nil {
+			dataLoadErrs = append(dataLoadErrs,
+				fmt.Sprintf("popular-package list for %s (%s) could not be read: %v", eco, path, err))
 			continue
 		}
 		var names []string
@@ -70,11 +90,15 @@ func loadMalicious() {
 
 	data, err := dataFS.ReadFile("data/known_malicious.json")
 	if err != nil {
+		dataLoadErrs = append(dataLoadErrs,
+			fmt.Sprintf("known-malicious package list could not be read: %v", err))
 		return
 	}
 
 	var raw map[string][]string
 	if err := json.Unmarshal(data, &raw); err != nil {
+		dataLoadErrs = append(dataLoadErrs,
+			fmt.Sprintf("known-malicious package list could not be parsed: %v", err))
 		return
 	}
 

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -337,6 +337,9 @@ func applyVulnDetails(vulns []osvVuln, details map[string]osvVuln) {
 		if len(detail.Affected) > 0 {
 			vulns[i].Affected = detail.Affected
 		}
+		if detail.DatabaseSpecific.Severity != "" {
+			vulns[i].DatabaseSpecific = detail.DatabaseSpecific
+		}
 	}
 }
 
@@ -397,14 +400,27 @@ func decodeBatchResponse(resp *http.Response) ([]osvBatchResult, error) {
 // increasingly common case — silently collapsed to medium regardless of how
 // severe it actually was. SeverityMedium now means a genuine "unknown".
 func mapOSVSeverity(sev []osvSeverity, dbSpecific osvDatabaseSpecific) findings.Severity {
+	// A computable CVSS base score is the most precise signal, so it wins when
+	// one is available. Note the score must be PARSED, not merely present: a
+	// CVSS v2 vector matches the type check but cannot be scored, and returning
+	// on it discarded an accurate database label in favour of cvssToSeverity's
+	// medium default.
 	for _, s := range sev {
-		if s.Type == "CVSS_V3" || s.Type == "CVSS_V2" {
-			return cvssToSeverity(s.Score)
+		if s.Type != "CVSS_V3" && s.Type != "CVSS_V2" {
+			continue
+		}
+		if score, ok := cvssBaseScore(s.Score); ok {
+			return scoreToSeverity(score)
 		}
 	}
+
+	// No score we could compute — fall back to the source database's coarse
+	// label. This is the only severity signal for CVSS v4-only advisories.
 	if s, ok := severityFromLabel(dbSpecific.Severity); ok {
 		return s
 	}
+
+	// Genuinely unknown.
 	return findings.SeverityMedium
 }
 
@@ -425,25 +441,28 @@ func severityFromLabel(label string) (findings.Severity, bool) {
 	}
 }
 
-// cvssToSeverity converts a CVSS vector string or numeric score to a Severity.
-// It extracts the base score from either a bare number ("9.8") or a CVSS
-// vector string by looking for a trailing numeric value.
-func cvssToSeverity(score string) findings.Severity {
-	// Try parsing as a plain float first (e.g. "9.8").
-	f, err := strconv.ParseFloat(score, 64)
-	if err != nil {
-		// OSV publishes CVSS as a vector string, e.g.
-		// "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H". The base score is not
-		// embedded in it, but it is fully determined by it, so compute it.
-		if base, ok := cvssV3BaseScore(score); ok {
-			f = base
-		} else {
-			// Unrecognised format (e.g. a CVSS v2 or v4 vector): stay
-			// conservative rather than guessing.
-			return findings.SeverityMedium
-		}
+// cvssBaseScore returns the CVSS base score for an OSV severity value, which
+// is published either as a bare number ("9.8") or as a vector string.
+//
+// The bool reports whether a score could be DERIVED, which callers must
+// distinguish from a low score. CVSS v2 and v4 vectors match OSV's type field
+// but use scoring algorithms this does not implement; conflating "cannot
+// compute" with "scored medium" discarded accurate severity labels.
+func cvssBaseScore(score string) (float64, bool) {
+	// A bare number, as some databases publish.
+	if f, err := strconv.ParseFloat(score, 64); err == nil {
+		return f, true
 	}
 
+	// OSV publishes CVSS as a vector string, e.g.
+	// "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H". The base score is not
+	// embedded in it, but it is fully determined by it, so compute it.
+	return cvssV3BaseScore(score)
+}
+
+// scoreToSeverity buckets a CVSS base score using the standard qualitative
+// severity rating scale.
+func scoreToSeverity(f float64) findings.Severity {
 	switch {
 	case f >= 9.0:
 		return findings.SeverityCritical
@@ -456,6 +475,16 @@ func cvssToSeverity(score string) findings.Severity {
 	default:
 		return findings.SeverityInfo
 	}
+}
+
+// cvssToSeverity converts a CVSS vector string or numeric score to a Severity,
+// falling back to medium when no score can be derived.
+func cvssToSeverity(score string) findings.Severity {
+	f, ok := cvssBaseScore(score)
+	if !ok {
+		return findings.SeverityMedium
+	}
+	return scoreToSeverity(f)
 }
 
 // upgradeCommand returns the canonical one-liner an operator can run to

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -322,7 +322,12 @@ func TestMapOSVSeverity(t *testing.T) {
 		{
 			// v2 vectors use a different formula and are not computed; keep the
 			// conservative default rather than guessing.
-			name:     "CVSS v2 vector string falls back to medium",
+			// A v2 vector cannot be scored and there is no label to fall back
+			// to, so medium here means "unknown" — not "this is a medium
+			// vulnerability". The companion case in
+			// TestMapOSVSeverity_FallsBackToLabel covers what happens when a
+			// label IS available, which is where this previously went wrong.
+			name:     "unscorable CVSS v2 vector with no label is unknown",
 			input:    []osvSeverity{{Type: "CVSS_V2", Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"}},
 			expected: findings.SeverityMedium,
 		},
@@ -333,6 +338,66 @@ func TestMapOSVSeverity(t *testing.T) {
 			result := mapOSVSeverity(tt.input, osvDatabaseSpecific{})
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestMapOSVSeverity_FallsBackToLabel covers the precedence between a CVSS
+// entry and the source database's coarse label.
+//
+// The rule is "most precise signal wins", and the trap is that presence of a
+// CVSS entry is not the same as being able to score it. Returning on any
+// CVSS_V2/V3 entry meant an unscorable vector beat an accurate label, so
+// advisories that plainly said CRITICAL were reported as medium.
+func TestMapOSVSeverity_FallsBackToLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		sev      []osvSeverity
+		label    string
+		expected findings.Severity
+	}{
+		{
+			name:     "unscorable v2 vector yields to the label",
+			sev:      []osvSeverity{{Type: "CVSS_V2", Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"}},
+			label:    "CRITICAL",
+			expected: findings.SeverityCritical,
+		},
+		{
+			name:     "v4-only advisory uses the label",
+			sev:      []osvSeverity{{Type: "CVSS_V4", Score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"}},
+			label:    "HIGH",
+			expected: findings.SeverityHigh,
+		},
+		{
+			name:     "a scorable v3 vector beats the label",
+			sev:      []osvSeverity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+			label:    "LOW",
+			expected: findings.SeverityCritical,
+		},
+		{
+			name:     "github MODERATE means medium",
+			label:    "MODERATE",
+			expected: findings.SeverityMedium,
+		},
+		{
+			name:     "unrecognised label is unknown",
+			label:    "SPICY",
+			expected: findings.SeverityMedium,
+		},
+		{
+			name:     "no signal at all is unknown",
+			expected: findings.SeverityMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapOSVSeverity(tt.sev, osvDatabaseSpecific{Severity: tt.label})
+			if got != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, got)
 			}
 		})
 	}

--- a/core/analyzers/deps/osv_wire_test.go
+++ b/core/analyzers/deps/osv_wire_test.go
@@ -1,0 +1,242 @@
+package deps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// These tests exercise the OSV WIRE PATH end to end: lockfile in, finding
+// severity out, across a server that behaves the way api.osv.dev actually
+// behaves.
+//
+// They exist because two severity bugs have now shipped with full unit-test
+// coverage of the functions involved. Both times the defect was at a call site
+// — data fetched from the network and then dropped before it reached the
+// mapping function — while every test handed that function a struct built by
+// hand. Asserting on mapOSVSeverity cannot catch that class of bug by
+// construction. Asserting on the severity of the emitted finding can.
+
+// fakeOSV serves the real two-endpoint OSV contract.
+//
+// The fidelity that matters: /v1/querybatch returns ONLY {id, modified}. Every
+// other field — summary, severity, aliases, affected, database_specific —
+// exists solely on the /v1/vulns/{id} response. A mock that returns full
+// records from querybatch tests an API that does not exist, and will report
+// success while the hydration path is broken.
+func fakeOSV(t *testing.T, vulnsFor map[string][]string, advisories map[string]string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id, ok := strings.CutPrefix(r.URL.Path, "/v1/vulns/"); ok {
+			body, found := advisories[id]
+			if !found {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+
+		if r.URL.Path != "/v1/querybatch" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		var req osvBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decoding batch request: %v", err)
+			return
+		}
+
+		results := make([]osvBatchResult, len(req.Queries))
+		for i, q := range req.Queries {
+			for _, id := range vulnsFor[q.Package.Name] {
+				// ID and nothing else, exactly as the real endpoint answers.
+				results[i].Vulns = append(results[i].Vulns, osvVuln{ID: id})
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(osvBatchResponse{Results: results}); err != nil {
+			t.Errorf("encoding batch response: %v", err)
+		}
+	}))
+}
+
+// scanOneNPMPackage runs the analyzer over a lockfile declaring a single npm
+// package and returns the findings, so tests can assert on what an operator
+// would actually see.
+func scanOneNPMPackage(t *testing.T, srv *httptest.Server, name, version string) []findings.Finding {
+	t.Helper()
+
+	dir := t.TempDir()
+	lock := fmt.Sprintf(`{"packages":{"node_modules/%s":{"version":%q}}}`, name, version)
+	lockPath := filepath.Join(dir, "package-lock.json")
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatalf("writing lockfile: %v", err)
+	}
+
+	analyzer := NewAnalyzer(WithOSVBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	_, fs, err := analyzer.ScanArtifacts(context.Background(), []discovery.Artifact{{
+		Path:    "package-lock.json",
+		AbsPath: lockPath,
+		Type:    discovery.Lockfile,
+		Size:    int64(len(lock)),
+	}})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	return fs.Findings()
+}
+
+func vulnSeverity(t *testing.T, items []findings.Finding) findings.Severity {
+	t.Helper()
+
+	for i := range items {
+		if items[i].RuleID == "VULN-001" {
+			return items[i].Severity
+		}
+	}
+	t.Fatal("no VULN-001 finding was emitted")
+	return ""
+}
+
+// TestOSVWire_CVSSv4OnlyAdvisoryKeepsItsSeverity is the regression test for the
+// bug this release fixes: applyVulnDetails hydrated summary and severity but
+// dropped database_specific, so the label fallback added for CVSS v4 advisories
+// never received data and every such advisory reported medium.
+func TestOSVWire_CVSSv4OnlyAdvisoryKeepsItsSeverity(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOSV(t,
+		map[string][]string{"leftpad": {"GHSA-v4-only"}},
+		map[string]string{
+			"GHSA-v4-only": `{
+				"id": "GHSA-v4-only",
+				"summary": "Remote code execution",
+				"severity": [{"type":"CVSS_V4","score":"CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"}],
+				"database_specific": {"severity": "CRITICAL"}
+			}`,
+		})
+	defer srv.Close()
+
+	got := vulnSeverity(t, scanOneNPMPackage(t, srv, "leftpad", "1.0.0"))
+	if got != findings.SeverityCritical {
+		t.Errorf("a CRITICAL advisory was reported as %s; a critical/high gate would not fire on it", got)
+	}
+}
+
+// TestOSVWire_UnparseableCVSSFallsBackToLabel covers the second half of the
+// bug. mapOSVSeverity returned on the first CVSS_V2/V3 entry it saw, so an
+// advisory carrying a v2 vector (which the scorer cannot parse) collapsed to
+// medium even when the source database stated the severity plainly.
+func TestOSVWire_UnparseableCVSSFallsBackToLabel(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOSV(t,
+		map[string][]string{"leftpad": {"GHSA-v2-vector"}},
+		map[string]string{
+			"GHSA-v2-vector": `{
+				"id": "GHSA-v2-vector",
+				"summary": "Authentication bypass",
+				"severity": [{"type":"CVSS_V2","score":"AV:N/AC:L/Au:N/C:P/I:P/A:P"}],
+				"database_specific": {"severity": "HIGH"}
+			}`,
+		})
+	defer srv.Close()
+
+	got := vulnSeverity(t, scanOneNPMPackage(t, srv, "leftpad", "1.0.0"))
+	if got != findings.SeverityHigh {
+		t.Errorf("expected the HIGH label to be honoured when the CVSS vector is unparseable, got %s", got)
+	}
+}
+
+// TestOSVWire_ParsableVectorBeatsLabel guards the other direction: the coarse
+// label is a fallback, not an override. A computable CVSS score is more precise
+// and must win.
+func TestOSVWire_ParsableVectorBeatsLabel(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOSV(t,
+		map[string][]string{"leftpad": {"GHSA-v3-vector"}},
+		map[string]string{
+			"GHSA-v3-vector": `{
+				"id": "GHSA-v3-vector",
+				"summary": "Remote code execution",
+				"severity": [{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+				"database_specific": {"severity": "LOW"}
+			}`,
+		})
+	defer srv.Close()
+
+	got := vulnSeverity(t, scanOneNPMPackage(t, srv, "leftpad", "1.0.0"))
+	if got != findings.SeverityCritical {
+		t.Errorf("expected the computed 9.8 vector to win over the LOW label, got %s", got)
+	}
+}
+
+// TestOSVWire_HydratesEveryOperatorFacingField pins the full set of fields that
+// must survive hydration. Each has already been shipped broken once: the batch
+// endpoint supplies none of them, so any field omitted from applyVulnDetails is
+// silently empty in production while unit tests that build the struct by hand
+// keep passing.
+func TestOSVWire_HydratesEveryOperatorFacingField(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOSV(t,
+		map[string][]string{"leftpad": {"GHSA-complete"}},
+		map[string]string{
+			"GHSA-complete": `{
+				"id": "GHSA-complete",
+				"summary": "Prototype pollution",
+				"details": "Long form description.",
+				"aliases": ["CVE-2024-0001"],
+				"severity": [{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+				"database_specific": {"severity": "CRITICAL"},
+				"affected": [{
+					"package": {"name":"leftpad","ecosystem":"npm"},
+					"ranges": [{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"1.2.3"}]}]
+				}]
+			}`,
+		})
+	defer srv.Close()
+
+	items := scanOneNPMPackage(t, srv, "leftpad", "1.0.0")
+
+	var f *findings.Finding
+	for i := range items {
+		if items[i].RuleID == "VULN-001" {
+			f = &items[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("no VULN-001 finding was emitted")
+	}
+
+	if !strings.Contains(f.Message, "Prototype pollution") {
+		t.Errorf("summary did not survive hydration: %q", f.Message)
+	}
+	if !strings.Contains(f.Metadata["aliases"], "CVE-2024-0001") {
+		t.Errorf("aliases did not survive hydration: %q — VEX waivers keyed on CVE IDs will not match",
+			f.Metadata["aliases"])
+	}
+	if f.Metadata["fixed_in"] != "1.2.3" {
+		t.Errorf("fixed_in did not survive hydration: %q — nox fix has nothing to act on",
+			f.Metadata["fixed_in"])
+	}
+	if f.Severity != findings.SeverityCritical {
+		t.Errorf("severity did not survive hydration: %s", f.Severity)
+	}
+}

--- a/core/analyzers/variants/variants.go
+++ b/core/analyzers/variants/variants.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,14 +48,33 @@ type signature struct {
 // Analyzer matches embedded CVE-variant signatures against source/config files.
 type Analyzer struct {
 	sigs []signature
+
+	// loadErr is set when the embedded signature database could not be parsed
+	// at all, leaving the analyzer with no signatures. Exposed via LoadErr so
+	// the pipeline can report that CVE-variant detection did not run, rather
+	// than emitting zero findings and calling it clean.
+	loadErr error
 }
+
+// LoadErr reports a whole-database load failure, or nil when the signature
+// database parsed. A non-nil value means no VARIANT-* rule can match.
+func (a *Analyzer) LoadErr() error { return a.loadErr }
 
 // NewAnalyzer returns a variants analyzer with the embedded signatures compiled.
 // Signatures that fail to compile are skipped so one bad entry can't disable
 // the analyzer.
+//
+// LoadErr reports whole-database failure, which is a different matter from a
+// bad entry: an unparseable signatures file leaves the analyzer with nothing
+// to match, so every VARIANT-* detection is off while the scan reports success.
+// Because the data is compiled in, that failure would ship to every user at
+// once and look like a quiet week for CVE variants.
 func NewAnalyzer() *Analyzer {
 	var sigs []signature
-	_ = json.Unmarshal(signaturesJSON, &sigs)
+	var loadErr error
+	if err := json.Unmarshal(signaturesJSON, &sigs); err != nil {
+		loadErr = fmt.Errorf("variant signature database could not be parsed: %w", err)
+	}
 	compiled := sigs[:0]
 	for i := range sigs {
 		re, err := regexp.Compile(sigs[i].Pattern)
@@ -69,7 +89,7 @@ func NewAnalyzer() *Analyzer {
 		}
 		compiled = append(compiled, sigs[i])
 	}
-	return &Analyzer{sigs: compiled}
+	return &Analyzer{sigs: compiled, loadErr: loadErr}
 }
 
 // Signatures returns the compiled CVE-variant signatures (for the `variants`

--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -1,10 +1,15 @@
 package core
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nox-hq/nox/core/degrade"
+	"github.com/nox-hq/nox/core/findings"
 )
 
 // These tests cover the degradation-reporting and fail-loud behaviour added to
@@ -218,12 +223,11 @@ func hasDegradationKind(result *ScanResult, kind string) bool {
 	return false
 }
 
-// TestScan_UnsupportedLockfileIsNotADegradation guards the signal-to-noise
-// property. go.sum and yarn.lock are deliberately not parsed, so reporting them
-// as degraded would fire on almost every Go repository — and a warning that
-// fires on healthy scans is one operators learn to ignore, which defeats the
-// entire point of the channel. It also wrongly tripped --fail-on-degraded.
-func TestScan_UnsupportedLockfileIsNotADegradation(t *testing.T) {
+// TestScan_RedundantLockfileIsNotADegradation guards signal-to-noise. go.sum
+// carries nothing go.mod does not, and nox parses go.mod — so reporting it
+// would fire on essentially every Go repository, and a warning that fires on
+// healthy scans is one operators learn to ignore.
+func TestScan_RedundantLockfileIsNotADegradation(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -237,6 +241,188 @@ func TestScan_UnsupportedLockfileIsNotADegradation(t *testing.T) {
 		t.Fatalf("scan failed: %v", err)
 	}
 	if hasDegradationKind(result, "lockfile_parse") {
-		t.Errorf("a deliberately unparsed file was reported as degraded: %+v", result.Degradations)
+		t.Errorf("go.sum is redundant with go.mod and must be silent: %+v", result.Degradations)
 	}
+}
+
+// TestScan_UnparsedEcosystemIsReported is the regression test for a blind spot
+// this project shipped: yarn, pnpm, poetry and gradle lockfiles are recognised
+// well enough to be classified, but nox has no parser for any of them. They
+// were lumped in with go.sum as "deliberately not parsed", so those projects
+// got zero dependencies, zero vulnerability findings, and no warning at all.
+//
+// Being unable to parse a lockfile is defensible. Not saying so is not.
+func TestScan_UnparsedEcosystemIsReported(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ file, content string }{
+		{"yarn.lock", "# yarn lockfile v1\nlodash@4.17.20:\n  version \"4.17.20\"\n"},
+		{"pnpm-lock.yaml", "lockfileVersion: '6.0'\n"},
+		{"poetry.lock", "[[package]]\nname = \"django\"\nversion = \"4.2.1\"\n"},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("writing %s: %v", tc.file, err)
+			}
+
+			result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+			if err != nil {
+				t.Fatalf("scan failed: %v", err)
+			}
+			if !hasDegradationKind(result, "lockfile_parse") {
+				t.Errorf("%s produced no dependencies and no degradation — a silent blind spot", tc.file)
+			}
+		})
+	}
+}
+
+// TestScan_MalformedSuppressionExpiryDoesNotWaive is the regression test for a
+// waiver that silently became permanent.
+//
+// The parser discarded the date-parse error while still stripping the expires:
+// text from the reason, so `expires:2026-13-01` (month 13) produced a
+// suppression with no expiry at all. The operator saw their directive accepted
+// and the finding disappear, forever. It failed toward HIDING findings, which
+// is the worst direction for a scanner.
+//
+// This asserts the operator-visible outcome — is the finding reported — rather
+// than the parser's internals, because the bug lived in what the caller did
+// with the parse result.
+func TestScan_MalformedSuppressionExpiryDoesNotWaive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A file that reliably produces a finding, waived with an invalid date.
+	content := "# nox:ignore SEC-652 -- expires:2026-13-01\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "conf.py"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	var active bool
+	for _, f := range result.Findings.Findings() {
+		if f.RuleID == "SEC-652" && (f.Status == "" || f.Status == findings.StatusNew) {
+			active = true
+		}
+	}
+	if !active {
+		t.Error("a waiver with an unparseable expiry suppressed the finding; it must not be applied")
+	}
+	if !hasDegradationKind(result, "suppression") {
+		t.Errorf("the unparseable expiry was not reported to the operator: %+v", result.Degradations)
+	}
+}
+
+// TestScan_ValidExpiredSuppressionStillReports guards the neighbouring
+// behaviour so the fix above cannot be satisfied by breaking expiry entirely.
+func TestScan_ValidExpiredSuppressionStillReports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := "# nox:ignore SEC-652 -- expires:2020-01-01\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "conf.py"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	// An expired waiver is a normal, correctly-parsed state — not a degradation.
+	if hasDegradationKind(result, "suppression") {
+		t.Errorf("a valid expired waiver should not be reported as degraded: %+v", result.Degradations)
+	}
+}
+
+// TestScan_ValidUnexpiredSuppressionStillWaives ensures the fix did not break
+// the feature it protects.
+func TestScan_ValidUnexpiredSuppressionStillWaives(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := "# nox:ignore SEC-652 -- expires:2099-01-01\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "conf.py"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	for _, f := range result.Findings.Findings() {
+		if f.RuleID == "SEC-652" && (f.Status == "" || f.Status == findings.StatusNew) {
+			t.Error("a valid unexpired waiver failed to suppress its finding")
+		}
+	}
+}
+
+// TestScan_FailedPluginIsReported covers the guarantee --fail-on-degraded
+// advertises in its own help text ("OSV lookup, plugin, lockfile parse").
+//
+// degrade.Plugin was declared and never emitted, so a required security plugin
+// that failed to run produced a clean scan and a passing gate — the precise
+// failure the degradation channel exists to prevent, inside the release that
+// shipped it.
+func TestScan_FailedPluginIsReported(t *testing.T) {
+	dir := t.TempDir()
+	cfg := "plugins:\n  required:\n    - acme/scanner\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	original := ScanPluginHook
+	t.Cleanup(func() { ScanPluginHook = original })
+
+	t.Run("hook error", func(t *testing.T) {
+		ScanPluginHook = func(_ context.Context, _ string, _ []string) (*PluginScanOutput, error) {
+			return nil, errors.New("plugin host failed to start")
+		}
+		result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+		if err != nil {
+			t.Fatalf("a plugin failure must not abort the scan: %v", err)
+		}
+		if !hasDegradationKind(result, "plugin") {
+			t.Errorf("a failed plugin was not reported: %+v", result.Degradations)
+		}
+	})
+
+	t.Run("plugin reported as not contributing", func(t *testing.T) {
+		// The commoner case: the hook succeeds having run what it could, and
+		// reports the required plugins it could not run. No error is returned,
+		// so an error-only channel would miss it entirely.
+		ScanPluginHook = func(_ context.Context, _ string, _ []string) (*PluginScanOutput, error) {
+			return &PluginScanOutput{Degradations: []Degradation{{
+				Kind:   degrade.Plugin,
+				Detail: `required plugin "acme/scanner" is not installed`,
+				Impact: "findings this plugin would have produced are missing from this scan",
+			}}}, nil
+		}
+		result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+		if err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		if !hasDegradationKind(result, "plugin") {
+			t.Errorf("an uninstalled required plugin was not reported: %+v", result.Degradations)
+		}
+	})
+
+	t.Run("healthy plugin stays silent", func(t *testing.T) {
+		ScanPluginHook = func(_ context.Context, _ string, _ []string) (*PluginScanOutput, error) {
+			return &PluginScanOutput{}, nil
+		}
+		result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+		if err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		if hasDegradationKind(result, "plugin") {
+			t.Errorf("a plugin that ran cleanly must not be reported: %+v", result.Degradations)
+		}
+	})
 }

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -81,6 +81,23 @@ func (r *ClassifierRegistry) Classify(path string, info os.FileInfo) ArtifactTyp
 // DefaultClassifier classifies files by extension and well-known names.
 type DefaultClassifier struct{}
 
+// LockfileNames returns the set of filenames that discovery classifies as
+// dependency lockfiles.
+//
+// Exported so the dependency analyzer can assert that every classified
+// lockfile is either parsed or explicitly known to be redundant. Adding a name
+// here without a parser creates a silent blind spot — a project of that
+// ecosystem scans clean while nothing was read — which is exactly what
+// happened to yarn, pnpm and poetry.
+func LockfileNames() []string {
+	out := make([]string, 0, len(lockfileNames))
+	for name := range lockfileNames {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // lockfileNames contains exact file names that identify lockfiles.
 var lockfileNames = map[string]bool{
 	"package-lock.json": true,

--- a/core/plugin_hook.go
+++ b/core/plugin_hook.go
@@ -14,6 +14,15 @@ type PluginScanOutput struct {
 	Findings    []findings.Finding
 	Enrichments []findings.Enrichment
 	Graphs      []graph.Graph
+
+	// Degradations reports plugins that were required but did not contribute —
+	// not installed, binary missing, failed to register.
+	//
+	// These are not hook errors: the hook succeeds, having run whatever
+	// plugins it could. Without a channel for them, a required security plugin
+	// that was never installed produced a clean scan and a passing gate, which
+	// is the exact failure the degradation mechanism exists to prevent.
+	Degradations []Degradation
 }
 
 // ScanPluginHook runs the analysis plugins listed in a project's .nox.yaml

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -54,6 +54,24 @@ type Meta struct {
 	// re-deriving defaults from config. Omitted from JSON when empty (a scan
 	// run without a profile, e.g. history scans).
 	SASTLanguages map[string]string `json:"sast_languages,omitempty"`
+	// Degradations records checks that did not complete — a failed OSV lookup,
+	// a required plugin that never ran, an unparsed lockfile.
+	//
+	// It belongs in the artifact and not only on stderr, because the consumers
+	// that most need it never see stderr: a CI job reading findings.json, a
+	// dashboard, an MCP client. Without it, an empty findings list is
+	// indistinguishable from a scan that never looked. Omitted when the scan
+	// was complete.
+	Degradations []Degradation `json:"degradations,omitempty"`
+}
+
+// Degradation is a single incomplete check, as recorded in the artifact.
+type Degradation struct {
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
+	// Impact states what may be missing from the results, in the operator's
+	// terms. It is the field that answers "should I trust this report?".
+	Impact string `json:"impact"`
 }
 
 // JSONReport is the top-level structure serialized to JSON. It pairs report
@@ -77,6 +95,10 @@ type JSONReporter struct {
 	// recorded verbatim in the report Meta. Set it from ScanResult.SASTProfile
 	// before Generate to make the depth strategy auditable in the artifact.
 	SASTLanguages map[string]string
+	// Degradations are the scan's incomplete checks. Set from
+	// ScanResult.Degradations before Generate so a consumer reading only the
+	// artifact can tell a clean scan from one that could not run.
+	Degradations []Degradation
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -111,6 +133,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			ToolVersion:   r.ToolVersion,
 			Offline:       r.Offline,
 			SASTLanguages: r.SASTLanguages,
+			Degradations:  r.Degradations,
 		},
 		Findings: f,
 	}

--- a/core/scan.go
+++ b/core/scan.go
@@ -236,6 +236,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	slopAnalyzer := slop.NewAnalyzer()
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
+	// A signature database that fails to parse leaves every VARIANT-* rule
+	// unable to match. The scan would otherwise report zero variant findings
+	// and look clean.
+	if err := variantsAnalyzer.LoadErr(); err != nil {
+		degradations.Add(degrade.VulnData,
+			fmt.Sprintf("CVE-variant signatures could not be loaded: %v", err),
+			"no VARIANT-* detection ran; known CVE variants in this codebase would not be reported")
+	}
 	taintflowAnalyzer := taintflow.NewAnalyzer()
 	agentflowAnalyzer := agentflow.NewAnalyzer()
 	provenanceAnalyzer := provenance.NewAnalyzer()
@@ -473,6 +481,12 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		out, hookErr := ScanPluginHook(ctx, target, cfg.Plugins.Required)
 		if hookErr != nil {
 			slog.WarnContext(ctx, "analysis plugins failed; continuing with built-in findings only", "error", hookErr)
+			// A required detector that fails silently is the worst outcome for
+			// a security scanner: the build stays green precisely because the
+			// check that would have failed it never ran.
+			degradations.Add(degrade.Plugin,
+				fmt.Sprintf("required analysis plugins %v did not run: %v", cfg.Plugins.Required, hookErr),
+				"findings these plugins would have produced are missing from this scan")
 		}
 		if out != nil {
 			for i := range out.Findings {
@@ -480,6 +494,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			}
 			pluginEnrichments = out.Enrichments
 			pluginGraphs = out.Graphs
+			for _, d := range out.Degradations {
+				degradations.Add(d.Kind, d.Detail, d.Impact)
+			}
 		}
 	}
 
@@ -491,6 +508,13 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		postResult := &ScanResult{Findings: allFindings, Inventory: inventory, AIInventory: aiInventory}
 		if hookErr := PostScanPluginHook(ctx, postResult, target, cfg.Plugins.Required); hookErr != nil {
 			slog.WarnContext(ctx, "post-scan plugins failed; continuing with findings so far", "error", hookErr)
+			// Post-scan plugins annotate rather than detect — reachability
+			// classification, most importantly. Their failure leaves findings
+			// present but stripped of the signal operators triage on, which
+			// looks like a normal scan.
+			degradations.Add(degrade.Plugin,
+				fmt.Sprintf("post-scan plugins %v did not run: %v", cfg.Plugins.Required, hookErr),
+				"findings are missing enrichment such as reachability classification; triage priority is unreliable")
 		}
 		pluginEnrichments = append(pluginEnrichments, postResult.Enrichments...)
 	}
@@ -1077,6 +1101,19 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 		}
 
 		suppressions := suppress.ScanForSuppressions(content, filePath)
+
+		// A waiver whose expiry date will not parse is not applied — see
+		// Suppression.InvalidExpiry. Say so, or the operator sees an
+		// unexplained finding they believe they waived.
+		for i := range suppressions {
+			if suppressions[i].InvalidExpiry == "" {
+				continue
+			}
+			deg.Add(degrade.Suppression,
+				fmt.Sprintf("%s:%d has an unparseable expiry date %q (expected YYYY-MM-DD)",
+					filePath, suppressions[i].Line, suppressions[i].InvalidExpiry),
+				"this waiver was NOT applied and its findings are reported; fix the date to restore it")
+		}
 		if len(suppressions) == 0 {
 			continue
 		}

--- a/core/suppress/suppress.go
+++ b/core/suppress/suppress.go
@@ -28,6 +28,17 @@ type Suppression struct {
 	Line     int // the line the suppression applies to
 	Reason   string
 	Expires  *time.Time
+
+	// InvalidExpiry holds the date text of an expires: directive that could
+	// not be parsed. It is set instead of Expires, never alongside it.
+	//
+	// A malformed expiry must never be treated as "no expiry". The parse
+	// failure used to be discarded while the expires: text was still stripped
+	// from the reason, so a typo like expires:2026-13-01 silently produced a
+	// PERMANENT waiver that looked accepted. Suppressions carrying this field
+	// do not match, so the finding is reported — failing toward showing
+	// findings rather than hiding them — and the caller reports it.
+	InvalidExpiry string
 }
 
 // suppressionRE matches nox:ignore / nox:disable directives in any
@@ -90,9 +101,12 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 
 		// Parse expiration from reason.
 		var expires *time.Time
+		var invalidExpiry string
 		if em := expiresRE.FindStringSubmatch(reason); em != nil {
 			if t, err := time.Parse("2006-01-02", em[1]); err == nil {
 				expires = &t
+			} else {
+				invalidExpiry = em[1]
 			}
 			reason = strings.TrimSpace(expiresRE.ReplaceAllString(reason, ""))
 		}
@@ -107,11 +121,12 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 		}
 
 		result = append(result, Suppression{
-			RuleIDs:  ruleIDs,
-			FilePath: filePath,
-			Line:     targetLine,
-			Reason:   reason,
-			Expires:  expires,
+			RuleIDs:       ruleIDs,
+			FilePath:      filePath,
+			Line:          targetLine,
+			Reason:        reason,
+			Expires:       expires,
+			InvalidExpiry: invalidExpiry,
 		})
 	}
 
@@ -122,6 +137,12 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 // and line, considering expiration.
 func (s Suppression) MatchesFinding(ruleID string, line int, now time.Time) bool {
 	if s.Line != line {
+		return false
+	}
+	// An expiry the operator wrote but nox could not parse is not an absent
+	// expiry. Refuse to suppress rather than silently making the waiver
+	// permanent.
+	if s.InvalidExpiry != "" {
 		return false
 	}
 	if s.Expires != nil && now.After(*s.Expires) {


### PR DESCRIPTION
A post-release review of v1.11.0 found that **three of its own promises did not hold**. Each had full unit-test coverage of the function involved while the defect sat at the call site — the same shape as the bug v1.11.0 was written to fix.

## The three broken promises

**1. Critical advisories still reported as `medium`.** The CVSS-v4 severity fallback shipped in v1.11.0 never received data. `applyVulnDetails` copied summary, details, severity, aliases and affected — but not `database_specific`. Since `/v1/querybatch` returns only `{id, modified}`, that field is populated *exclusively* by hydration, so the fallback got the zero value on every scan:

```
Summary    = "Critical RCE"   (hydrated OK)
Severity   = 1 entry          (hydrated OK)
DBSpecific = ""               <-- DROPPED
nox severity = medium          (advisory is CRITICAL)
```

Compounding it, `mapOSVSeverity` returned on the first CVSS entry it *saw* rather than the first it could *score*, so an unscorable v2 vector beat an accurate label. `cvssBaseScore` now separates "cannot compute" from "computed low".

**2. `--fail-on-degraded` could not fire for plugin failures**, despite naming them in its help text. `degrade.Plugin` had zero producers, and `installedPluginBinaries` silently skipped required-but-missing plugins. A CI job listing a security plugin, failing to install it, and running with the flag exited 0 with a clean report. `PluginScanOutput` gained a `Degradations` field because this is *not* a hook error — the hook succeeds having run what it could, so an error-only channel could never carry it.

**3. yarn, pnpm and poetry projects scanned clean while nothing was read.** v1.11.0's `ErrUnsupportedLockfile` exemption was added to stop `go.sum` warning on every Go repo; it silently covered three lockfiles nox cannot parse and has no substitute for. Only genuine redundancy is exempt now, and `TestEveryClassifiedLockfileIsHandled` makes the invariant enforceable — a lockfile added to discovery without a parser now fails the build instead of shipping an empty scan for that ecosystem.

## Also fixed

- **A suppression with an unparseable expiry became a permanent waiver.** `expires:2026-13-01` (month 13) was accepted, the expiry text stripped from the reason, and the finding hidden forever. Long-standing, and it failed *toward hiding findings*. Now the waiver is not applied, the finding is reported, and the bad date is named.
- **`--fail-on-degraded` discarded every report** — it exited before report generation, losing `findings.json`, SARIF and SBOM including the findings it had collected.
- **Degradations in `findings.json` `meta`** — CI, dashboards and MCP clients never see stderr.
- **Silent supply-chain and CVE-variant data failures** — typosquatting and known-malicious detection returned nothing when their embedded data failed to load; a whole-database parse failure disabled every `VARIANT-*` rule.
- **Dockerfile read/parse failures**, in the same analyzer that already reported lockfile failures twenty lines above.

## On the tests

Two tests that asserted the broken behaviour are **corrected, not deleted**: `TestRunScanPlugins_UninstalledRequired_Skipped` required the silent skip, and a CVSS v2 case blessed an unscorable vector collapsing to medium.

The new tests assert **operator-visible outcomes** — the severity of the emitted finding, whether the finding is reported, the process exit code — rather than the functions involved. `osv_wire_test.go` drives a mock built to the real two-endpoint OSV contract (batch returns `{id, modified}`; everything else comes from `/v1/vulns/{id}`), because a mock that returns full records from querybatch tests an API that does not exist. Asserting on `mapOSVSeverity` could not have caught any of this, which is why it did not.

Verified end-to-end against the built binary, including that healthy scans stay silent:

```
yarn project      → [degraded] yarn.lock was not parsed
typo'd expiry     → 1 finding reported + [degraded] unparseable expiry date
go.sum only       → (silent, as intended)
missing plugin    → [degraded] + exit 2 under --fail-on-degraded, reports still written
```

## Known gaps, stated plainly

`yarn.lock`, `poetry.lock` and `pnpm-lock.yaml` are still **not parsed**. They are now reported as blind spots rather than passing silently; writing the parsers is the fix and is a feature, not a patch.

Deliberately **not** in this release, since both change plugin behaviour and need their own review: `InvokePostScan` bypassing all enforcement (0 enforcement references vs 8 in `InvokeTool`, reachable today via `nox-plugin-remediate`'s non-read-only `apply_code`), and the plugin fingerprint delimiter being injectable. Both are in the review notes.

`go build ./...`, `go test ./...`, `-race`, and `golangci-lint` all clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts
