### PR TITLE
fix(secrets): gate anchorless secret rules by proximity and shape

### DIFF
--- a/core/analyzers/secrets/degenerate_rules_test.go
+++ b/core/analyzers/secrets/degenerate_rules_test.go
@@ -70,9 +70,20 @@ func realisticSecret(pattern string) string {
 		alphabet = lowerNum
 	}
 
+	// A linear-congruential walk over the alphabet, seeded off the length so
+	// different rules get different tokens, with no short-period repetition —
+	// real credentials are near-maximal entropy, and a generator that repeats
+	// digraphs would fail the very shape filter the rule applies to genuine
+	// tokens.
 	var b strings.Builder
-	for i := 0; b.Len() < length; i++ {
-		b.WriteByte(alphabet[(i*7+i*i*3)%len(alphabet)])
+	x := length*2654435761 + 40503
+	for b.Len() < length {
+		x = x*1103515245 + 12345
+		idx := (x >> 16) % len(alphabet)
+		if idx < 0 {
+			idx += len(alphabet)
+		}
+		b.WriteByte(alphabet[idx])
 	}
 	return b.String()[:length]
 }
@@ -215,5 +226,70 @@ func TestDegenerateRules_RejectOrdinaryCode(t *testing.T) {
 	if noisy > 0 {
 		t.Errorf("%d false positives on ordinary code: every one is a high-severity "+
 			"finding an operator must triage", noisy)
+	}
+}
+
+// cleanConfigValues are non-credential values that legitimately sit right next
+// to a vendor keyword in real configuration: hostnames, job names, environment
+// names, phone/account numbers, placeholders. The context requirement alone
+// does not stop these — the keyword IS adjacent — so they are what the shape
+// filter has to reject.
+var cleanConfigValues = []string{
+	"nightly-integration-suite",    // job name (has hyphens)
+	"production-eu-west-1-cluster", // environment name
+	"MobileAnalyticsProduction",    // project identifier
+	"staging-canary-deployment",    // deployment name
+	"441234567890123456",           // phone / account number (digits only)
+	"0000000000000000000000000000", // zero placeholder
+	"xxxxxxxxxxxxxxxxxxxxxxxxxxxx", // redacted placeholder
+	"YOUR_API_KEY_HERE_REPLACE_ME", // template
+	"1234567890123456789012345678", // sequential
+	"ExampleConfigurationValue123", // camel identifier
+}
+
+// TestDegenerateRules_RejectRealisticConfig measures false positives on values
+// that appear DIRECTLY beside their vendor keyword — the case the context
+// requirement cannot catch, where the shape filter earns its keep.
+//
+// It records a hard upper bound rather than asserting zero: a small residual
+// survives on values whose shape is genuinely ambiguous with a lowercase
+// credential (a run-together hostname like "buildserverhostname01" has the same
+// character profile as a real lowercase API key). Removing the last few would
+// require a dictionary/word heuristic that — measured directly — also rejects
+// real high-entropy keys such as an AWS secret access key, trading noise for
+// false negatives. The bound catches a regression without pretending the
+// residual is gone.
+func TestDegenerateRules_RejectRealisticConfig(t *testing.T) {
+	t.Parallel()
+
+	defs := degenerateRules(t)
+	analyzer := NewAnalyzer()
+
+	const maxFalsePositives = 12 // current: 9, all on hostname-shaped values
+
+	var fps []string
+	for _, rule := range defs {
+		keyword := "secret"
+		if len(rule.Keywords) > 0 {
+			keyword = rule.Keywords[0]
+		}
+		for _, v := range cleanConfigValues {
+			content := fmt.Sprintf("%s_setting = %q\n", keyword, v)
+			matches, err := analyzer.ScanFile("config.py", []byte(content))
+			if err != nil {
+				t.Fatalf("%s: scan error: %v", rule.ID, err)
+			}
+			for i := range matches {
+				if matches[i].RuleID == rule.ID {
+					fps = append(fps, fmt.Sprintf("%s on %q", rule.ID, v))
+				}
+			}
+		}
+	}
+
+	t.Logf("false positives on realistic config: %d (bound %d)", len(fps), maxFalsePositives)
+	if len(fps) > maxFalsePositives {
+		t.Errorf("false positives rose to %d, above the %d bound:\n  %s",
+			len(fps), maxFalsePositives, strings.Join(fps, "\n  "))
 	}
 }

--- a/core/analyzers/secrets/degenerate_rules_test.go
+++ b/core/analyzers/secrets/degenerate_rules_test.go
@@ -1,0 +1,219 @@
+package secrets
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// A large family of vendor secret rules match nothing but a bare character
+// class and a length — `[a-zA-Z0-9]{32}` and similar — gated only by a keyword
+// appearing somewhere in the same FILE. On any file mentioning the vendor, every
+// run of characters of that length becomes a high-severity credential finding:
+// Go comments, JSON values, test names.
+//
+// Measured on nox's own source, one such rule (SEC-652, "Jenkins API Token",
+// `[a-zA-Z0-9]{20}` keyed on "jenkins") produced 34 high-severity false
+// positives, and two of them blocked this repository's own PR gate.
+//
+// The fix is the shape/entropy gate the codebase already applies to the same
+// pattern elsewhere. The risk of that fix is false NEGATIVES: a gate tuned too
+// tight stops detecting real credentials, which is far worse than noise. These
+// tests bound that risk from both sides.
+
+// degenerateRule reports whether a rule's pattern is a bare character class
+// plus a length quantifier, carrying no literal anchor text of its own.
+var degeneratePattern = regexp.MustCompile(`^(\\b)?\[[^\]]+\]\{\d+(,\d+)?\}(\\b)?$`)
+
+func degenerateRules(t *testing.T) []*rules.Rule {
+	t.Helper()
+
+	var out []*rules.Rule
+	for _, r := range builtinSecretRules() {
+		if degeneratePattern.MatchString(r.Pattern) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// realisticSecret builds a token that satisfies a rule's pattern and looks like
+// a credential a vendor would actually issue: mixed case, digits, high entropy,
+// no repetition. This is the input that MUST still be detected.
+func realisticSecret(pattern string) string {
+	// The alphabet a real token draws from, restricted to what the pattern
+	// permits. Order is shuffled deterministically to keep entropy high.
+	const mixed = "aZ3xQ7mK9pR2wL5vN8tB4yH6jD0sF1gC"
+	const lowerNum = "a3x7m9p2w5v8t4y6j0s1g"
+	const hexish = "a3f7b9e2c5d8a4f6b0e1c"
+
+	length := patternLength(pattern)
+	if length == 0 {
+		length = 32
+	}
+
+	// Draw only from characters the pattern actually permits, or the "secret"
+	// cannot match and the test reports a false negative that is really a flaw
+	// in its own fixture.
+	const upperNum = "A3XQ7MK9PR2WL5VN8TB4YH6JD0SF1GC"
+
+	alphabet := mixed
+	switch {
+	case strings.Contains(pattern, "a-f0-9") || strings.Contains(pattern, "0-9a-f"):
+		alphabet = hexish
+	case !strings.Contains(pattern, "a-z"):
+		alphabet = upperNum
+	case !strings.Contains(pattern, "A-Z"):
+		alphabet = lowerNum
+	}
+
+	var b strings.Builder
+	for i := 0; b.Len() < length; i++ {
+		b.WriteByte(alphabet[(i*7+i*i*3)%len(alphabet)])
+	}
+	return b.String()[:length]
+}
+
+// patternLength extracts the minimum length from a `{n}` or `{n,m}` quantifier.
+func patternLength(pattern string) int {
+	m := regexp.MustCompile(`\{(\d+)`).FindStringSubmatch(pattern)
+	if m == nil {
+		return 0
+	}
+	var n int
+	_, _ = fmt.Sscanf(m[1], "%d", &n)
+	return n
+}
+
+// TestDegenerateRules_StillDetectRealSecrets is the false-negative guard.
+//
+// Tightening these rules must not stop them finding actual credentials. For
+// every degenerate rule, a realistic high-entropy token of the right shape is
+// placed in a file containing the rule's keyword — the exact scenario the rule
+// exists for — and must still be reported.
+func TestDegenerateRules_StillDetectRealSecrets(t *testing.T) {
+	t.Parallel()
+
+	defs := degenerateRules(t)
+	if len(defs) == 0 {
+		t.Fatal("no degenerate rules matched; this test's pattern detection is stale")
+	}
+	t.Logf("checking %d rules with bare character-class patterns", len(defs))
+
+	analyzer := NewAnalyzer()
+
+	var missed, redundant []string
+	for _, rule := range defs {
+		secret := realisticSecret(rule.Pattern)
+		keyword := "secret"
+		if len(rule.Keywords) > 0 {
+			keyword = rule.Keywords[0]
+		}
+
+		content := fmt.Sprintf("%s_api_key = %q\n", keyword, secret)
+		matches, err := analyzer.ScanFile("config.py", []byte(content))
+		if err != nil {
+			t.Fatalf("%s: scan error: %v", rule.ID, err)
+		}
+
+		// The security property is that the credential is DETECTED — not that a
+		// particular rule ID detects it. Several of these anchorless rules
+		// duplicate a more specific rule for the same vendor (SEC-545 restates
+		// SEC-063 for PagerDuty), so asserting per-rule would report a false
+		// negative where the secret is in fact reported.
+		var detected, byOwnRule bool
+		for i := range matches {
+			detected = true
+			if matches[i].RuleID == rule.ID {
+				byOwnRule = true
+			}
+		}
+		if !detected {
+			missed = append(missed, fmt.Sprintf("%s (pattern %s, token %q)", rule.ID, rule.Pattern, secret))
+		} else if !byOwnRule {
+			redundant = append(redundant, rule.ID)
+		}
+	}
+
+	if len(missed) > 0 {
+		t.Errorf("%d of %d rules no longer detect a realistic secret — these are FALSE NEGATIVES, "+
+			"strictly worse than the noise being fixed:\n  %s",
+			len(missed), len(defs), strings.Join(missed, "\n  "))
+	}
+	if len(redundant) > 0 {
+		// Informational: the credential is still caught, by a more specific
+		// rule for the same vendor. Recorded because a rule that never fires on
+		// its own realistic input is dead weight worth retiring.
+		t.Logf("%d rules were shadowed by a more specific rule for the same vendor: %s",
+			len(redundant), strings.Join(redundant, ", "))
+	}
+}
+
+// TestDegenerateRules_RejectOrdinaryCode is the false-positive measurement.
+//
+// The same rules are fed the kind of content that produced 34 high-severity
+// findings on nox's own source: identifiers, prose comments, and structured
+// data values that happen to be long enough. None is a credential, and the
+// vendor keyword is far from every one of them.
+func TestDegenerateRules_RejectOrdinaryCode(t *testing.T) {
+	t.Parallel()
+
+	defs := degenerateRules(t)
+	analyzer := NewAnalyzer()
+
+	// Real lines from nox's source that were flagged, plus common shapes.
+	samples := []struct{ name, line string }{
+		{"go comment", "// NewClassifierRegistry creates an empty ClassifierRegistry."},
+		{"json value", `          "call": "HttpResponseRedirect",`},
+		{"identifier", "TestEveryClassifiedLockfileIsHandled"},
+		{"import path", `import "github.com/nox-hq/nox/core/analyzers/secrets"`},
+		{"prose", "// dirContainsAnyIncluded reports whether any path in the include-set is"},
+		{"camelCase chain", "resultBuilderConfigurationManagerFactory"},
+	}
+
+	var noisy int
+	total := len(defs) * len(samples)
+
+	for _, rule := range defs {
+		keyword := "secret"
+		if len(rule.Keywords) > 0 {
+			keyword = rule.Keywords[0]
+		}
+		for _, s := range samples {
+			// The keyword appears in the file but FAR from the match, which is
+			// the real false-positive shape. In nox's own discovery.go the word
+			// "Jenkinsfile" sits in a filename list around line 60 while the
+			// flagged comment is at line 306 — 246 lines away. A test that puts
+			// the keyword adjacent measures the case where the rule SHOULD
+			// fire, and would have reported this fix as ineffective.
+			var b strings.Builder
+			fmt.Fprintf(&b, "// this file mentions %s once, near the top\n", keyword)
+			for range 40 {
+				b.WriteString("// filler line with no credential material\n")
+			}
+			b.WriteString(s.line + "\n")
+			content := b.String()
+			matches, err := analyzer.ScanFile("code.go", []byte(content))
+			if err != nil {
+				t.Fatalf("%s: scan error: %v", rule.ID, err)
+			}
+			for i := range matches {
+				if matches[i].RuleID == rule.ID {
+					noisy++
+					if noisy <= 5 {
+						t.Logf("FP: %s on %s — %q", rule.ID, s.name, matches[i].Message)
+					}
+				}
+			}
+		}
+	}
+
+	t.Logf("false positives: %d across %d rule/sample combinations", noisy, total)
+	if noisy > 0 {
+		t.Errorf("%d false positives on ordinary code: every one is a high-severity "+
+			"finding an operator must triage", noisy)
+	}
+}

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -3766,8 +3766,16 @@ func builtinSecretRules() []*rules.Rule {
 		// recall, unlike an entropy cutoff: real tokens and code identifiers
 		// occupy the same entropy range, so no threshold separates them.
 		var requireContext []string
-		if isAnchorlessPattern(d.pattern) && len(d.keywords) > 0 {
-			requireContext = d.keywords
+		if isAnchorlessPattern(d.pattern) {
+			if len(d.keywords) > 0 {
+				requireContext = d.keywords
+			}
+			// Layered with the context requirement: proximity establishes that
+			// the value is in the right place, shape establishes that it looks
+			// like a credential at all. Neither alone is sufficient — a
+			// hostname sits right next to `jenkins_url`, and a real key can
+			// score lower entropy than a Go identifier.
+			md["secret_shape"] = "true"
 		}
 
 		out = append(out, &rules.Rule{

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"regexp"
 	"strconv"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -3750,23 +3751,56 @@ func builtinSecretRules() []*rules.Rule {
 				md["min_entropy"] = strconv.FormatFloat(d.minEntropy, 'f', -1, 64)
 			}
 		}
+
+		// A pattern that is nothing but a character class and a length carries
+		// no anchor of its own, so it matches any run of characters of that
+		// length. Keywords gate at file level only — a cheap pre-filter — which
+		// means one mention of the vendor anywhere in a file turns every
+		// identifier, comment word and JSON value of the right length into a
+		// high-severity credential finding. Measured on nox's own source, that
+		// produced 34 such findings from a single rule and blocked this
+		// repository's PR gate twice.
+		//
+		// Requiring the vendor name NEAR the match reflects how credentials
+		// are actually written (`jenkins_api_token = "..."`) and costs no
+		// recall, unlike an entropy cutoff: real tokens and code identifiers
+		// occupy the same entropy range, so no threshold separates them.
+		var requireContext []string
+		if isAnchorlessPattern(d.pattern) && len(d.keywords) > 0 {
+			requireContext = d.keywords
+		}
+
 		out = append(out, &rules.Rule{
-			ID:          d.id,
-			Version:     "1.0",
-			Description: d.description,
-			Severity:    d.severity,
-			Confidence:  d.confidence,
-			MatcherType: "regex",
-			Pattern:     d.pattern,
-			Keywords:    d.keywords,
-			Tags:        []string{"secrets"},
-			Metadata:    md,
-			Remediation: d.remediation,
-			References:  d.references,
+			ID:                     d.id,
+			Version:                "1.0",
+			Description:            d.description,
+			Severity:               d.severity,
+			Confidence:             d.confidence,
+			MatcherType:            "regex",
+			Pattern:                d.pattern,
+			Keywords:               d.keywords,
+			RequireContextKeywords: requireContext,
+			Tags:                   []string{"secrets"},
+			Metadata:               md,
+			Remediation:            d.remediation,
+			References:             d.references,
 		})
 	}
 	out = append(out, builtinEntropyRules()...)
 	return out
+}
+
+// anchorlessPattern matches a regex that is only a character class plus a
+// length quantifier, optionally word-bounded — `[a-zA-Z0-9]{32}`,
+// `\b[a-f0-9]{40}\b`. Such a pattern contains no literal text tying it to the
+// credential format it claims to detect, so it needs the vendor name nearby to
+// mean anything.
+var anchorlessPattern = regexp.MustCompile(`^(\\b)?\[[^\]]+\]\{\d+(,\d+)?\}(\\b)?$`)
+
+// isAnchorlessPattern reports whether a rule pattern relies entirely on shape
+// and length, with no literal anchor of its own.
+func isAnchorlessPattern(pattern string) bool {
+	return anchorlessPattern.MatchString(pattern)
 }
 
 // entropySourceFilePatterns restricts entropy rules to source-like files,

--- a/core/rules/engine.go
+++ b/core/rules/engine.go
@@ -68,7 +68,8 @@ func (e *Engine) ScanFile(path string, content []byte) ([]findings.Finding, erro
 		for _, mr := range results {
 			// Precision filters: drop matches in comments or defensive
 			// contexts when the rule opts in. Lines are computed lazily.
-			if rule.IgnoreInComments || len(rule.ExcludeContextKeywords) > 0 {
+			if rule.IgnoreInComments || len(rule.ExcludeContextKeywords) > 0 ||
+				len(rule.RequireContextKeywords) > 0 {
 				if lines == nil {
 					lines = splitLines(content)
 				}
@@ -77,6 +78,12 @@ func (e *Engine) ScanFile(path string, content []byte) ([]findings.Finding, erro
 				}
 				if len(rule.ExcludeContextKeywords) > 0 &&
 					contextHasKeyword(lines, mr.Line, contextWindow, rule.ExcludeContextKeywords) {
+					continue
+				}
+				// Positive context requirement: the vendor name must be near
+				// the match, not merely somewhere in the file.
+				if len(rule.RequireContextKeywords) > 0 &&
+					!contextHasKeyword(lines, mr.Line, contextWindow, rule.RequireContextKeywords) {
 					continue
 				}
 			}

--- a/core/rules/rules.go
+++ b/core/rules/rules.go
@@ -46,6 +46,22 @@ type Rule struct {
 	// defensive contexts — e.g. an SSRF metadata IP that sits in a block/deny
 	// list rather than in a live request.
 	ExcludeContextKeywords []string `yaml:"exclude_context_keywords"`
+	// RequireContextKeywords drops a match UNLESS one of these keywords appears
+	// on or near the matched line (windowed).
+	//
+	// This is the precision control for vendor rules whose pattern carries no
+	// literal anchor of its own — `[a-zA-Z0-9]{32}` and similar. Keywords alone
+	// gate at FILE level, which is only a cheap pre-filter: once any line in a
+	// file mentions the vendor, such a pattern matches every run of characters
+	// of that length anywhere in it, including comments and identifiers.
+	//
+	// Requiring the vendor name near the match reflects how credentials are
+	// actually written — the vendor name and the value sit on the same line —
+	// without resorting to an entropy threshold. Entropy cannot separate the
+	// two cases: measured on real data, a long Go test identifier scored 4.118
+	// while a genuine AWS access key scored 3.684, so any cutoff rejecting the
+	// identifier also rejects the key.
+	RequireContextKeywords []string `yaml:"require_context_keywords"`
 }
 
 // RuleSet is an ordered collection of rules with fast lookup by ID and tag.


### PR DESCRIPTION
The last outstanding item from the audit: **129 of 938 built-in secret rules match nothing but a character class and a length** — `[a-zA-Z0-9]{32}` and similar — with no literal text tying them to the credential format they claim to detect.

Keywords gate them at **file** level only, so one mention of a vendor anywhere in a file turned every run of characters of that length into a high-severity credential finding. On nox's own source, `SEC-652` ("Jenkins API Token") produced **34** findings on Go comments and JSON values, and two blocked this repo's own PR gate during v1.12.0.

## Two layers, because each catches what the other cannot

**Proximity** (commit 1): require the vendor keyword *near* the match, not merely somewhere in the file. This is the positive counterpart to the existing `ExcludeContextKeywords`.

**Shape** (commit 2): also apply the entropy/shape filter the codebase already uses for the same pattern elsewhere.

Neither alone is enough. A hostname sits right beside `jenkins_url`, so proximity can't filter it. And entropy can't stand alone either — measured directly, `TestEveryClassifiedLockfileIsHandled` scores 4.118 while a real AWS key scores 3.684, so any threshold that rejects the identifier also rejects the key.

## Measured effect

Self-scan, like-for-like at `--severity-threshold high`:

| | before | after |
|---|---|---|
| active findings | 74 | **41** |
| `SEC-*` | 45 | **12** |
| `SEC-652` | 34 | **0** |

False positives on realistic config where the keyword is adjacent (hostnames, job names, phone numbers, placeholders), across all 129 rules:

| | FPs |
|---|---|
| proximity only | 88 |
| proximity + shape | **9** |

**Recall holds throughout:** precision suite stays 1.000/1.000 with zero noise, and a test confirms all 129 rules still detect a credential-grade token of their own shape.

## Where I deliberately stopped

The 9 residual all fire on one shape — a run-together hostname like `buildserverhostname01`, which has the same lowercase-alphanumeric profile as a genuine lowercase API key. The only discriminator that removes them, longest letter-run, **also flags a real AWS secret access key** (run of 23). For a security tool that trades noise for false negatives, which is the wrong direction, so they're bounded by a test rather than chased with a risky heuristic.

## Measurement honesty

Three of my own measurements were wrong before they were right, each recorded in the commits: the "129" count first reproduced as 14 (a `\b?` regex bug matched only already-gated rules); the FP test first read 188-before-188-after because it put the keyword on the adjacent line, which is where the rule *should* fire; and the shadowed-rule count was inflated by a token generator with short-period repetition that failed the shape filter real credentials pass.

`go build ./...`, `go test ./...`, `-race`, `golangci-lint` all clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts