### PR TITLE
fix(core): validate policy gate keywords; stop dedup dropping distinct findings

### DIFF
--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -209,10 +209,21 @@ func (fs *FindingSet) Deduplicate() {
 	unique := make([]Finding, 0, len(fs.items))
 	for i := range fs.items {
 		finding := fs.items[i]
-		if _, exists := seen[finding.Fingerprint]; exists {
+		// Key on fingerprint AND location, not fingerprint alone.
+		//
+		// The V2 fingerprint is deliberately line-independent so a baseline
+		// survives code moving up or down a file. But an analyzer that builds
+		// findings directly (weakcrypto, variants, slop) and leaves Add to
+		// derive the fingerprint from a static Message produces the SAME
+		// fingerprint for two genuinely distinct findings in one file — two
+		// MD5 calls at lines 10 and 50. Keying dedup on fingerprint alone then
+		// silently dropped the second, real finding. Two findings at different
+		// positions are never duplicates; a true duplicate shares position too.
+		key := fmt.Sprintf("%s|%d|%d", finding.Fingerprint, finding.Location.StartLine, finding.Location.StartColumn)
+		if _, exists := seen[key]; exists {
 			continue
 		}
-		seen[finding.Fingerprint] = struct{}{}
+		seen[key] = struct{}{}
 		unique = append(unique, finding)
 	}
 	fs.items = unique

--- a/core/findings/findings_test.go
+++ b/core/findings/findings_test.go
@@ -1151,3 +1151,44 @@ func TestDowngradeByRulePatternsAndPath_Idempotent(t *testing.T) {
 func ContextRuleScopeFixture() []string {
 	return []string{"AI-*", "MCP-*", "AGENT-*", "IAC-*", "TAINT-*", "SLOP-*", "VARIANT-*"}
 }
+
+// TestDeduplicate_KeepsDistinctFindingsAtDifferentLines is the regression test
+// for a silent finding loss.
+//
+// The V2 fingerprint is line-independent by design (baseline stability), so an
+// analyzer that builds findings directly and lets Add derive the fingerprint
+// from a static message gives two genuinely distinct findings in one file the
+// same fingerprint. Deduplicate keyed on fingerprint alone then dropped the
+// second — a real second MD5 call, a real second hardcoded secret, never
+// reported.
+func TestDeduplicate_KeepsDistinctFindingsAtDifferentLines(t *testing.T) {
+	fs := NewFindingSet()
+	// Same rule, same file, same message — differing only in line, exactly the
+	// shape a direct-construction analyzer produces for two occurrences.
+	fs.Add(Finding{RuleID: "CRYPTO-001", Message: "Use of MD5",
+		Location: Location{FilePath: "hash.go", StartLine: 10}})
+	fs.Add(Finding{RuleID: "CRYPTO-001", Message: "Use of MD5",
+		Location: Location{FilePath: "hash.go", StartLine: 50}})
+
+	fs.Deduplicate()
+
+	if got := len(fs.Findings()); got != 2 {
+		t.Errorf("expected both distinct findings to survive dedup, got %d", got)
+	}
+}
+
+// TestDeduplicate_RemovesTrueDuplicates confirms the fix did not disable dedup:
+// two findings identical in rule, location AND fingerprint are still collapsed.
+func TestDeduplicate_RemovesTrueDuplicates(t *testing.T) {
+	fs := NewFindingSet()
+	f := Finding{RuleID: "CRYPTO-001", Message: "Use of MD5",
+		Location: Location{FilePath: "hash.go", StartLine: 10}}
+	fs.Add(f)
+	fs.Add(f)
+
+	fs.Deduplicate()
+
+	if got := len(fs.Findings()); got != 1 {
+		t.Errorf("expected a true duplicate to be removed, got %d findings", got)
+	}
+}

--- a/core/policy/policy.go
+++ b/core/policy/policy.go
@@ -33,6 +33,40 @@ type Config struct {
 	Budget map[findings.Severity]int `yaml:"budget"`
 }
 
+// Validate rejects a policy configuration whose gate keywords are not
+// recognized values.
+//
+// This exists because an unrecognized fail_on silently DISABLES the gate rather
+// than failing loudly: meetsThreshold returns false for a severity it does not
+// know, so every finding is treated as un-gated and a scan with critical
+// findings exits 0. A capitalized "High", a trailing space, or a typo therefore
+// turns the primary CI gate off with no signal — strictly worse than having no
+// policy at all, because it looks configured. The severity comparison is
+// case-sensitive and lowercase-only, so the value must match exactly.
+func (c Config) Validate() error {
+	if c.FailOn != "" {
+		if _, ok := severityRank[c.FailOn]; !ok {
+			return fmt.Errorf("policy.fail_on: %q is not a valid severity (want one of critical, high, medium, low, info)", c.FailOn)
+		}
+	}
+	if c.WarnOn != "" {
+		if _, ok := severityRank[c.WarnOn]; !ok {
+			return fmt.Errorf("policy.warn_on: %q is not a valid severity (want one of critical, high, medium, low, info)", c.WarnOn)
+		}
+	}
+	switch c.BaselineMode {
+	case "", BaselineModeStrict, BaselineModeWarn, BaselineModeOff:
+	default:
+		return fmt.Errorf("policy.baseline_mode: %q is not valid (want one of strict, warn, off)", c.BaselineMode)
+	}
+	for sev := range c.Budget {
+		if _, ok := severityRank[sev]; !ok {
+			return fmt.Errorf("policy.budget: %q is not a valid severity key (want one of critical, high, medium, low, info)", sev)
+		}
+	}
+	return nil
+}
+
 // Result holds the outcome of a policy evaluation.
 type Result struct {
 	Pass      bool

--- a/core/policy/validate_test.go
+++ b/core/policy/validate_test.go
@@ -1,0 +1,75 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// TestConfig_Validate covers the gate-disabling bug: an unrecognized fail_on
+// value made meetsThreshold return false for every severity, so a scan with
+// critical findings passed. Validation must reject these at load time.
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	valid := []Config{
+		{},
+		{FailOn: "critical"},
+		{FailOn: "high", WarnOn: "low"},
+		{BaselineMode: BaselineModeStrict},
+		{Budget: map[findings.Severity]int{"high": 2}},
+	}
+	for _, c := range valid {
+		if err := c.Validate(); err != nil {
+			t.Errorf("expected %+v to be valid, got %v", c, err)
+		}
+	}
+
+	invalid := []struct {
+		cfg  Config
+		want string
+	}{
+		{Config{FailOn: "High"}, "fail_on"},      // capitalized
+		{Config{FailOn: "HIGH"}, "fail_on"},      // uppercase
+		{Config{FailOn: "critical "}, "fail_on"}, // trailing space
+		{Config{FailOn: "criticl"}, "fail_on"},   // typo
+		{Config{FailOn: "error"}, "fail_on"},     // wrong vocabulary
+		{Config{WarnOn: "Medium"}, "warn_on"},    // capitalized warn
+		{Config{BaselineMode: "strictt"}, "baseline_mode"},
+		{Config{Budget: map[findings.Severity]int{"High": 1}}, "budget"},
+	}
+	for _, tc := range invalid {
+		err := tc.cfg.Validate()
+		if err == nil {
+			t.Errorf("expected %+v to be rejected, got nil", tc.cfg)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("expected error to mention %q, got %v", tc.want, err)
+		}
+	}
+}
+
+// TestEvaluate_InvalidThresholdWouldBypass documents WHY validation matters: it
+// pins the dangerous runtime behaviour that Validate() now prevents from ever
+// being reached. An invalid threshold silently passes a critical finding.
+func TestEvaluate_InvalidThresholdWouldBypass(t *testing.T) {
+	t.Parallel()
+
+	crit := []findings.Finding{{Severity: findings.SeverityCritical, Status: findings.StatusNew}}
+
+	// The exact string an operator would typo. Evaluate does not validate — the
+	// load-time guard does — so this still demonstrates the bypass a caller
+	// would hit if they skipped Validate.
+	bypass := Evaluate(Config{FailOn: "High"}, crit)
+	if bypass.ExitCode == 0 {
+		t.Log("confirmed: an unvalidated invalid fail_on passes a critical finding (exit 0) — this is why Validate must run at load")
+	}
+
+	// The valid lowercase form gates correctly.
+	gated := Evaluate(Config{FailOn: "high"}, crit)
+	if gated.ExitCode != 1 {
+		t.Errorf("valid fail_on=high should gate a critical finding, got exit %d", gated.ExitCode)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -184,6 +184,18 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
+	// Fail loudly on an invalid policy gate keyword. An unrecognized fail_on
+	// silently disables the gate — a capitalized "High" or a typo turns CI
+	// green on critical findings — so reject it at load rather than at exit.
+	if err := (policy.Config{
+		FailOn:       findings.Severity(cfg.Policy.FailOn),
+		WarnOn:       findings.Severity(cfg.Policy.WarnOn),
+		BaselineMode: policy.BaselineMode(cfg.Policy.BaselineMode),
+		Budget:       policyBudget(cfg.Policy.Budget),
+	}).Validate(); err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
 	// Stage 1: Discover artifacts.
 	artifacts, err := discoverArtifacts(target, cfg, opts)
 	if err != nil {
@@ -791,20 +803,26 @@ func evaluatePolicy(cfg *ScanConfig, allFindings *findings.FindingSet) *policy.R
 	if cfg.Policy.FailOn == "" && cfg.Policy.BaselineMode == "" && len(cfg.Policy.Budget) == 0 {
 		return nil
 	}
-	var budget map[findings.Severity]int
-	if len(cfg.Policy.Budget) > 0 {
-		budget = make(map[findings.Severity]int, len(cfg.Policy.Budget))
-		for sev, n := range cfg.Policy.Budget {
-			budget[findings.Severity(sev)] = n
-		}
-	}
 	policyCfg := policy.Config{
 		FailOn:       findings.Severity(cfg.Policy.FailOn),
 		WarnOn:       findings.Severity(cfg.Policy.WarnOn),
 		BaselineMode: policy.BaselineMode(cfg.Policy.BaselineMode),
-		Budget:       budget,
+		Budget:       policyBudget(cfg.Policy.Budget),
 	}
 	return policy.Evaluate(policyCfg, allFindings.Findings())
+}
+
+// policyBudget converts the string-keyed budget from config into the
+// severity-keyed map the policy package expects.
+func policyBudget(in map[string]int) map[findings.Severity]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[findings.Severity]int, len(in))
+	for sev, n := range in {
+		out[findings.Severity(sev)] = n
+	}
+	return out
 }
 
 // analyzerTask runs one analyzer against the discovered artifacts. Wrapping


### PR DESCRIPTION
First batch from a comprehensive adversarial audit of the core. Two spine defects, both in the "reports success while a real finding is not counted" class, both verified end-to-end.

**Invalid `fail_on` silently disabled the CI gate.** `meetsThreshold` returns false for any unrecognized severity, so `fail_on: High` (capitalized), a trailing space, or a typo treated every finding as un-gated and exited 0 on critical findings — strictly worse than no policy, because it looks configured. Now rejected at config load, failing loudly like SAST depth already does. Verified: `fail_on: High` → exit 2 (was 0 on a critical secret); `fail_on: high` still gates at 1.

**Deduplicate dropped genuinely distinct findings.** The V2 fingerprint is line-independent by design (baseline stability), so direct-construction analyzers (CRYPTO-001, variants, slop) with a static message give two distinct findings in one file the same fingerprint; dedup keyed on fingerprint alone discarded the second. Now keys on fingerprint AND location — two MD5 calls at different lines report as two, was one — while baseline matching keeps the line-independent fingerprint.

Both covered by red-to-green tests. Build/test/-race/lint clean.

More batches from the same audit will follow. https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts