### PR TITLE
fix(core): emit valid SARIF/SBOM; stop --tracked-only inverting its scope

### DIFF
--- a/core/badge/badge.go
+++ b/core/badge/badge.go
@@ -4,8 +4,10 @@
 package badge
 
 import (
+	"encoding/xml"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/nox-hq/nox/core/findings"
 )
@@ -228,11 +230,25 @@ func SeverityBadges(ff []findings.Finding, label string) map[findings.Severity]*
 	return results
 }
 
+// escapeXML escapes text for safe inclusion in an SVG/XML attribute or element.
+func escapeXML(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
 // GenerateSVG produces an SVG badge string for the given label, value, and color.
 func GenerateSVG(label, value, color string) string {
+	// Widths are measured on the raw text (visual glyph count), but the text is
+	// XML-escaped before it goes into the SVG. A label containing '&', '<', '>'
+	// or '"' — a user-supplied --label — would otherwise produce malformed XML
+	// or allow markup injection into the badge.
 	labelW := textWidth(label) + 10
 	valueW := textWidth(value) + 10
 	totalW := labelW + valueW
+
+	label = escapeXML(label)
+	value = escapeXML(value)
 
 	// Text positions are in tenths of a pixel (SVG uses scale(.1)).
 	labelX := labelW * 10 / 2

--- a/core/report/sarif/sarif.go
+++ b/core/report/sarif/sarif.go
@@ -9,8 +9,10 @@ package sarif
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/nox-hq/nox/core/compliance"
 	"github.com/nox-hq/nox/core/findings"
@@ -103,6 +105,11 @@ type Result struct {
 	Message      Message           `json:"message"`
 	Locations    []Location        `json:"locations"`
 	Fingerprints map[string]string `json:"fingerprints"`
+	// Properties carries the finding's Metadata — the reachability class, the
+	// vuln class, and the original-severity downgrade audit trail. Without it a
+	// finding downgraded from critical to low showed only "low" in SARIF with
+	// no record of the override. Omitted when the finding has no metadata.
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 // Location wraps a physical location within a source artifact.
@@ -113,7 +120,10 @@ type Location struct {
 // PhysicalLocation identifies a file and region within that file.
 type PhysicalLocation struct {
 	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
-	Region           Region           `json:"region"`
+	// Region is a pointer so a file-level finding (no line) omits it. An empty
+	// "region": {} object is rejected by strict SARIF validators, which require
+	// a region to carry at least one property.
+	Region *Region `json:"region,omitempty"`
 }
 
 // ArtifactLocation is a URI reference to a source file.
@@ -175,27 +185,26 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			idx = 0
 		}
 
+		phys := PhysicalLocation{
+			ArtifactLocation: ArtifactLocation{URI: encodeURI(f.Location.FilePath)},
+		}
+		if f.Location.StartLine > 0 {
+			phys.Region = &Region{
+				StartLine:   f.Location.StartLine,
+				StartColumn: f.Location.StartColumn,
+				EndLine:     f.Location.EndLine,
+				EndColumn:   f.Location.EndColumn,
+			}
+		}
+
 		result := Result{
-			RuleID:    f.RuleID,
-			RuleIndex: idx,
-			Level:     severityToLevel(f.Severity),
-			Message:   Message{Text: f.Message},
-			Locations: []Location{
-				{
-					PhysicalLocation: PhysicalLocation{
-						ArtifactLocation: ArtifactLocation{URI: f.Location.FilePath},
-						Region: Region{
-							StartLine:   f.Location.StartLine,
-							StartColumn: f.Location.StartColumn,
-							EndLine:     f.Location.EndLine,
-							EndColumn:   f.Location.EndColumn,
-						},
-					},
-				},
-			},
-			Fingerprints: map[string]string{
-				"nox/v1": f.Fingerprint,
-			},
+			RuleID:       f.RuleID,
+			RuleIndex:    idx,
+			Level:        severityToLevel(f.Severity),
+			Message:      Message{Text: f.Message},
+			Locations:    []Location{{PhysicalLocation: phys}},
+			Fingerprints: map[string]string{"nox/v1": f.Fingerprint},
+			Properties:   sarifProperties(f),
 		}
 		results = append(results, result)
 	}
@@ -255,11 +264,59 @@ func severityToLevel(s findings.Severity) string {
 // its index within that array. When the reporter has a RuleSet, the catalog is
 // populated from it. Otherwise the catalog is derived from the unique rule IDs
 // found in the given findings slice.
+// encodeURI turns a scanned file path into a valid SARIF artifact URI. Paths
+// may contain spaces, '#', '?' and other characters that are invalid in a raw
+// URI reference; a bare '#' in particular truncates the path at the fragment.
+// Backslashes from Windows runners are normalised to forward slashes first so
+// the result is a portable relative URI.
+func encodeURI(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
+	u := url.URL{Path: path}
+	return u.String()
+}
+
+// sarifProperties projects a finding's metadata into a SARIF property bag,
+// returning nil when there is nothing to carry so the field is omitted.
+func sarifProperties(f findings.Finding) map[string]any {
+	if len(f.Metadata) == 0 {
+		return nil
+	}
+	props := make(map[string]any, len(f.Metadata))
+	for k, v := range f.Metadata {
+		props[k] = v
+	}
+	return props
+}
+
 func (r *Reporter) buildRuleCatalog(items []findings.Finding) (catalog []ReportingDescriptor, index map[string]int) {
 	if r.Rules != nil {
-		return r.buildCatalogFromRuleSet()
+		catalog, index = r.buildCatalogFromRuleSet()
+	} else {
+		return r.buildCatalogFromFindings(items)
 	}
-	return r.buildCatalogFromFindings(items)
+
+	// Reconcile against the findings actually present. A finding whose rule is
+	// not in the RuleSet — every plugin finding (taint, reachability) and any
+	// analyzer rule missing from the catalog — would otherwise get RuleIndex 0,
+	// a dangling ruleId pointing at whatever rule sorts first. GitHub Code
+	// Scanning validates this and rejects the whole upload silently. Synthesise
+	// a minimal descriptor for each missing rule ID so the reference resolves.
+	for i := range items {
+		id := items[i].RuleID
+		if _, ok := index[id]; ok || id == "" {
+			continue
+		}
+		index[id] = len(catalog)
+		catalog = append(catalog, ReportingDescriptor{
+			ID:               id,
+			Name:             id,
+			ShortDescription: Message{Text: items[i].Message},
+			DefaultConfiguration: Configuration{
+				Level: severityToLevel(items[i].Severity),
+			},
+		})
+	}
+	return catalog, index
 }
 
 // buildCatalogFromRuleSet creates catalog entries for every rule in the

--- a/core/report/sarif/validity_test.go
+++ b/core/report/sarif/validity_test.go
@@ -1,0 +1,116 @@
+package sarif
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// TestSARIF_NoDanglingRuleReference is the regression test for a silent
+// GitHub Code Scanning rejection. Plugin findings carry rule IDs absent from
+// the RuleSet, and the catalog was built from the RuleSet alone, so those
+// results got RuleIndex 0 — a ruleId that resolves to nothing and a ruleIndex
+// pointing at whatever sorts first. GitHub validates this and rejects the whole
+// upload. Every result's ruleIndex must point at the descriptor whose id equals
+// its ruleId.
+func TestSARIF_NoDanglingRuleReference(t *testing.T) {
+	t.Parallel()
+
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{ID: "AAA-001", Severity: "high", Description: "builtin"})
+	rep := NewReporter("test", rs)
+
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "TAINT-003", Severity: "high", Message: "plugin flow",
+		Location: findings.Location{FilePath: "a.py", StartLine: 5}})
+	fs.Add(findings.Finding{RuleID: "AAA-001", Severity: "high", Message: "builtin",
+		Location: findings.Location{FilePath: "b.go", StartLine: 3}})
+
+	doc := generateDoc(t, rep, fs)
+	run := doc["runs"].([]any)[0].(map[string]any)
+	catalog := run["tool"].(map[string]any)["driver"].(map[string]any)["rules"].([]any)
+
+	for _, res := range run["results"].([]any) {
+		m := res.(map[string]any)
+		id := m["ruleId"].(string)
+		ri := int(m["ruleIndex"].(float64))
+		if ri < 0 || ri >= len(catalog) {
+			t.Fatalf("ruleIndex %d out of range for %q", ri, id)
+		}
+		if got := catalog[ri].(map[string]any)["id"].(string); got != id {
+			t.Errorf("result ruleId=%q but ruleIndex points at %q — dangling reference", id, got)
+		}
+	}
+}
+
+// TestSARIF_URIsAreEncoded guards artifact URI validity: a raw space or '#' in
+// a path produces an invalid URI reference (a '#' truncates the path at the
+// fragment). Verified with a path that contains both.
+func TestSARIF_URIsAreEncoded(t *testing.T) {
+	t.Parallel()
+
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{ID: "A-1", Severity: "high", Description: "d"})
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "A-1", Severity: "high", Message: "m",
+		Location: findings.Location{FilePath: "src/my code/a#b.py", StartLine: 1}})
+
+	out := generateBytes(t, NewReporter("t", rs), fs)
+	if strings.Contains(out, `"uri": "src/my code/a#b.py"`) || strings.Contains(out, "a#b.py") {
+		t.Error("artifact URI was emitted unencoded")
+	}
+}
+
+// TestSARIF_FileLevelFindingOmitsRegion guards against an empty "region": {}
+// object, which strict SARIF validators reject.
+func TestSARIF_FileLevelFindingOmitsRegion(t *testing.T) {
+	t.Parallel()
+
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{ID: "A-1", Severity: "high", Description: "d"})
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "A-1", Severity: "high", Message: "m",
+		Location: findings.Location{FilePath: "cfg.yaml"}}) // no line
+
+	if strings.Contains(generateBytes(t, NewReporter("t", rs), fs), `"region":{}`) {
+		t.Error("emitted an empty region object for a file-level finding")
+	}
+}
+
+// TestSARIF_MetadataSurvives guards the downgrade audit trail, which was dropped
+// entirely from SARIF — a critical→low downgrade showed only "low" with no record.
+func TestSARIF_MetadataSurvives(t *testing.T) {
+	t.Parallel()
+
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{ID: "A-1", Severity: "low", Description: "d"})
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "A-1", Severity: "low", Message: "m",
+		Location: findings.Location{FilePath: "a.go", StartLine: 1},
+		Metadata: map[string]string{"original_severity": "critical"}})
+
+	if !strings.Contains(generateBytes(t, NewReporter("t", rs), fs), "original_severity") {
+		t.Error("Finding.Metadata dropped from SARIF output")
+	}
+}
+
+func generateBytes(t *testing.T, r *Reporter, fs *findings.FindingSet) string {
+	t.Helper()
+	out, err := r.Generate(fs)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	return string(out)
+}
+
+func generateDoc(t *testing.T, r *Reporter, fs *findings.FindingSet) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(generateBytes(t, r, fs)), &doc); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	return doc
+}

--- a/core/report/sbom/sbom.go
+++ b/core/report/sbom/sbom.go
@@ -4,6 +4,7 @@
 package sbom
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -138,9 +139,7 @@ func (r *CycloneDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, 
 			PURL:    buildPURL(ip.pkg),
 		}
 		if ip.pkg.License != "" {
-			comp.Licenses = []CDXLicenseWrapper{
-				{License: CDXLicense{ID: ip.pkg.License}},
-			}
+			comp.Licenses = []CDXLicenseWrapper{{License: cdxLicenseFor(ip.pkg.License)}}
 		}
 		components = append(components, comp)
 	}
@@ -188,7 +187,7 @@ func (r *CycloneDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, 
 	doc := CDXReport{
 		BOMFormat:    "CycloneDX",
 		SpecVersion:  "1.5",
-		SerialNumber: "urn:uuid:nox-scan",
+		SerialNumber: deterministicSerialURN(components),
 		Version:      1,
 		Metadata: CDXMetadata{
 			Timestamp: report.GeneratedAt(),
@@ -417,4 +416,49 @@ func buildPURL(p deps.Package) string {
 		return fmt.Sprintf("pkg:%s/%s/%s@%s", purlType, parts[0], parts[1], p.Version)
 	}
 	return fmt.Sprintf("pkg:%s/%s@%s", purlType, p.Name, p.Version)
+}
+
+// deterministicSerialURN returns a valid RFC-4122 UUID URN derived from the
+// component set. CycloneDX constrains serialNumber to the UUID URN grammar, so
+// the previous constant "urn:uuid:nox-scan" failed schema validation on every
+// document. Deriving it from a content hash keeps nox's reproducible-output
+// guarantee — identical input yields an identical serial — while remaining a
+// well-formed, per-scan-unique UUID.
+func deterministicSerialURN(components []CDXComponent) string {
+	h := sha256.New()
+	for i := range components {
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\n", components[i].Name, components[i].Version, components[i].PURL)
+	}
+	sum := h.Sum(nil)
+	// Format 16 bytes as a UUID, stamping the version (4) and variant (RFC 4122)
+	// nibbles so the result is a syntactically valid UUID.
+	var u [16]byte
+	copy(u[:], sum)
+	u[6] = (u[6] & 0x0f) | 0x40
+	u[8] = (u[8] & 0x3f) | 0x80
+	return fmt.Sprintf("urn:uuid:%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
+}
+
+// spdxLicenseIDs is the set of SPDX identifiers common in real dependency
+// metadata. CycloneDX validates license.id against the SPDX enumeration, so an
+// arbitrary string there (e.g. "Apache 2.0" with a space, or proprietary text)
+// fails the schema. Anything not confirmed here goes into license.name, which
+// accepts free text — always schema-valid, if less precise.
+var spdxLicenseIDs = map[string]bool{
+	"MIT": true, "Apache-2.0": true, "BSD-2-Clause": true, "BSD-3-Clause": true,
+	"ISC": true, "MPL-2.0": true, "LGPL-2.1": true, "LGPL-2.1-only": true,
+	"LGPL-3.0": true, "LGPL-3.0-only": true, "GPL-2.0": true, "GPL-2.0-only": true,
+	"GPL-3.0": true, "GPL-3.0-only": true, "GPL-3.0-or-later": true,
+	"AGPL-3.0": true, "AGPL-3.0-only": true, "Unlicense": true, "0BSD": true,
+	"CC0-1.0": true, "CC-BY-4.0": true, "BSL-1.0": true, "Zlib": true,
+	"Artistic-2.0": true, "EPL-2.0": true, "WTFPL": true, "Python-2.0": true,
+}
+
+// cdxLicenseFor routes a license string to license.id (valid SPDX IDs only) or
+// license.name (everything else), keeping the CycloneDX document schema-valid.
+func cdxLicenseFor(license string) CDXLicense {
+	if spdxLicenseIDs[license] {
+		return CDXLicense{ID: license}
+	}
+	return CDXLicense{Name: license}
 }

--- a/core/report/sbom/validity_test.go
+++ b/core/report/sbom/validity_test.go
@@ -1,0 +1,80 @@
+package sbom
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/deps"
+)
+
+var uuidURN = regexp.MustCompile(`^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// TestCDX_SerialNumberIsValidUUID guards the schema failure that made every
+// CycloneDX document invalid: serialNumber was the constant "urn:uuid:nox-scan",
+// which does not match the required UUID URN grammar.
+func TestCDX_SerialNumberIsValidUUID(t *testing.T) {
+	t.Parallel()
+
+	inv := &deps.PackageInventory{}
+	inv.Add(deps.Package{Name: "x", Version: "1.0.0", Ecosystem: "npm"})
+
+	doc := cdxDoc(t, inv)
+	if serial := doc["serialNumber"].(string); !uuidURN.MatchString(serial) {
+		t.Errorf("serialNumber %q is not a valid UUID URN", serial)
+	}
+}
+
+// TestCDX_SerialNumberIsDeterministic keeps the fix compatible with nox's
+// reproducible-output guarantee: identical input yields an identical serial.
+func TestCDX_SerialNumberIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	inv := &deps.PackageInventory{}
+	inv.Add(deps.Package{Name: "x", Version: "1.0.0", Ecosystem: "npm"})
+	if cdxDoc(t, inv)["serialNumber"] != cdxDoc(t, inv)["serialNumber"] {
+		t.Error("serialNumber differs across identical scans")
+	}
+}
+
+// TestCDX_NonSPDXLicenseGoesToName guards the schema failure where an arbitrary
+// license string was placed in license.id, which CycloneDX validates against
+// the SPDX enumeration.
+func TestCDX_NonSPDXLicenseGoesToName(t *testing.T) {
+	t.Parallel()
+
+	inv := &deps.PackageInventory{}
+	inv.Add(deps.Package{Name: "spdx", Version: "1", Ecosystem: "npm", License: "MIT"})
+	inv.Add(deps.Package{Name: "free", Version: "1", Ecosystem: "npm", License: "Apache 2.0"})
+
+	for _, c := range cdxDoc(t, inv)["components"].([]any) {
+		comp := c.(map[string]any)
+		lic := comp["licenses"].([]any)[0].(map[string]any)["license"].(map[string]any)
+		switch comp["name"] {
+		case "spdx":
+			if lic["id"] != "MIT" {
+				t.Errorf("valid SPDX id should be in license.id, got %v", lic)
+			}
+		case "free":
+			if _, has := lic["id"]; has {
+				t.Errorf("non-SPDX %q must not be in license.id: %v", "Apache 2.0", lic)
+			}
+			if lic["name"] != "Apache 2.0" {
+				t.Errorf("non-SPDX license should be in license.name, got %v", lic)
+			}
+		}
+	}
+}
+
+func cdxDoc(t *testing.T, inv *deps.PackageInventory) map[string]any {
+	t.Helper()
+	out, err := (&CycloneDXReporter{}).Generate(inv)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	return doc
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -574,14 +574,23 @@ func discoverArtifacts(target string, cfg *ScanConfig, opts ScanOptions) ([]disc
 
 	// --tracked-only: restrict the walk to git-tracked files by seeding the
 	// allow-list with `git ls-files`. Untracked working-tree files and
-	// submodule contents (gitlinks, not listed) are excluded. Best-effort:
-	// outside a git repo this errors and the full walk proceeds.
+	// submodule contents (gitlinks, not listed) are excluded.
+	//
+	// A git failure here is a hard error, not a fallback. The previous
+	// best-effort skip left the allow-list empty, which the walker treats as
+	// "no restriction" — so --tracked-only silently INVERTED to scanning the
+	// entire working tree, including the untracked and generated files the flag
+	// exists to keep out. An operator using it to bound a CI or pre-commit scan
+	// got the opposite of what they asked for, with no signal. As with --vex and
+	// --terraform-plan, an explicit request that cannot be honoured must fail.
 	if opts.TrackedOnly {
-		if tracked, err := git.TrackedFiles(target); err == nil {
-			walker.IncludePaths = make(map[string]bool, len(tracked))
-			for _, f := range tracked {
-				walker.IncludePaths[f] = true
-			}
+		tracked, err := git.TrackedFiles(target)
+		if err != nil {
+			return nil, fmt.Errorf("--tracked-only requires a git repository: %w", err)
+		}
+		walker.IncludePaths = make(map[string]bool, len(tracked))
+		for _, f := range tracked {
+			walker.IncludePaths[f] = true
 		}
 	}
 

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2469,3 +2469,29 @@ func TestRefineFindings_ContextDowngrade_Disabled(t *testing.T) {
 		t.Error("disabled downgrade must not stamp original_severity")
 	}
 }
+
+// TestScan_TrackedOnlyOutsideRepoIsError guards a silent scope inversion.
+//
+// --tracked-only seeds the walker's allow-list from `git ls-files`. On a git
+// failure the previous code skipped that block, leaving the allow-list empty —
+// which the walker reads as "no restriction", so --tracked-only silently
+// scanned the ENTIRE working tree including the untracked and generated files
+// the flag exists to exclude. An operator got the opposite of what they asked
+// for. It is now a hard error, matching --vex / --terraform-plan.
+func TestScan_TrackedOnlyOutsideRepoIsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir() // a temp dir is not a git repository
+	if err := os.WriteFile(filepath.Join(dir, "untracked.py"),
+		[]byte("x = 1\n"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	_, err := RunScanWithOptions(dir, ScanOptions{TrackedOnly: true, Offline: true})
+	if err == nil {
+		t.Fatal("expected an error for --tracked-only outside a git repository, got nil")
+	}
+	if !strings.Contains(err.Error(), "tracked-only") {
+		t.Errorf("expected the error to name --tracked-only, got: %v", err)
+	}
+}


### PR DESCRIPTION
Third batch from the core audit — the output boundary, where a security tool fails silently because a malformed artifact is rejected by the consumer, not by nox.

- **SARIF referenced rules absent from its own catalog.** Plugin findings (taint, reachability) carry rule IDs the RuleSet-only catalog didn't contain → `ruleIndex` 0, dangling `ruleId`. **GitHub Code Scanning validates this and silently rejects the whole upload** — so any project running a plugin and uploading SARIF uploaded nothing. Catalog now reconciled against the findings.
- **CycloneDX `serialNumber` was `urn:uuid:nox-scan`** — fails the required UUID URN grammar, so every SBOM was schema-invalid. Now a well-formed UUID derived from the component set: valid, unique, and deterministic for identical input.
- **CycloneDX `license.id` took arbitrary strings** (validated against SPDX enum) → schema failure on e.g. `Apache 2.0`. Confirmed SPDX IDs go in `id`, free text in `name`.
- **`--tracked-only` silently inverted to scan-everything** on any git error — scanning the untracked/generated files it exists to exclude, with no signal. Now a hard error, matching `--vex`/`--terraform-plan`.
- **SARIF dropped `Finding.Metadata`** (reachability, the critical→low downgrade audit trail) and emitted empty `region: {}`. Both fixed.
- Badge SVG label/value now XML-escaped.

SARIF and SBOM outputs are structurally validated by new regression tests; each fix confirmed against the invalid pre-fix output. Build/test/-race/lint clean.

Batches #255, #256 precede this. https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts