### PR TITLE
chore(iac): drop dead SEC-430 key from GHA services downgrade set

### DIFF
--- a/core/analyzers/iac/gha_context.go
+++ b/core/analyzers/iac/gha_context.go
@@ -27,8 +27,10 @@ var servicesBlockRe = regexp.MustCompile(`(?m)^\s{2,}services:\s*$`)
 var ephemeralTestDBRules = map[string]bool{
 	"IAC-254": true,
 	"IAC-351": true,
+	// SEC-073 is the credential-aware DB connection-string rule. The bare
+	// scheme rule SEC-430 (postgres://) it superseded was retired in the
+	// secrets rebuild, so only SEC-073 remains here.
 	"SEC-073": true,
-	"SEC-430": true,
 }
 
 // permissionConsumers maps a workflow permission rule ID to a set of action


### PR DESCRIPTION
SEC-430 (a bare `postgres://` scheme rule) was retired in the secrets rebuild (#259). Its detection is fully subsumed by **SEC-073**, the credential-aware DB connection-string rule, which is already present in `ephemeralTestDBRules`. The leftover `"SEC-430": true` key could never match a finding after the rule was deleted.

**No coverage change**: an ephemeral test-DB connection string in a GitHub Actions `services:` block is still downgraded via SEC-073.

Verified: `go build ./...`, `go test ./core/analyzers/iac/`, and `golangci-lint run ./core/analyzers/iac/...` all clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts