### PR TITLE
fix(plugin): authenticate host↔plugin gRPC channel with a per-launch token

### DIFF
--- a/plugin/auth_test.go
+++ b/plugin/auth_test.go
@@ -1,0 +1,109 @@
+package plugin
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// The client interceptor must attach the per-launch token to every outgoing
+// RPC. A capturing invoker stands in for the real gRPC call.
+func TestTokenUnaryInterceptor_AttachesToken(t *testing.T) {
+	const token = "cafebabecafebabe"
+	var got []string
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			t.Fatal("no outgoing metadata attached")
+		}
+		got = md.Get(pluginTokenMetaKey)
+		return nil
+	}
+
+	err := tokenUnaryInterceptor(token)(context.Background(), "/svc/Method", nil, nil, nil, invoker)
+	if err != nil {
+		t.Fatalf("interceptor returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != token {
+		t.Fatalf("attached token = %v, want [%q]", got, token)
+	}
+}
+
+// Each launch must get a distinct, well-formed 256-bit token; a predictable or
+// reused token would let a foreign process forge it.
+func TestNewLaunchToken_UniqueAndWellFormed(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 100 {
+		tok, err := newLaunchToken()
+		if err != nil {
+			t.Fatalf("newLaunchToken: %v", err)
+		}
+		if len(tok) != 64 {
+			t.Fatalf("token length = %d, want 64 hex chars", len(tok))
+		}
+		if seen[tok] {
+			t.Fatalf("duplicate token generated: %q", tok)
+		}
+		seen[tok] = true
+	}
+}
+
+// End-to-end: StartBinary spawns a real SDK-based plugin, which enforces the
+// token. A successful handshake and tool invocation prove the host passes the
+// token via the environment and attaches it on every RPC, and that the SDK
+// server accepts exactly that token — the two halves interoperate.
+func TestStartBinary_TokenRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a plugin binary; skipped under -short")
+	}
+
+	bin := filepath.Join(t.TempDir(), "authplugin")
+	build := exec.Command("go", "build", "-o", bin, "./testdata/authplugin")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building test plugin: %v\n%s", err, out)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	p, err := StartBinary(ctx, bin, nil, 10*time.Second)
+	if err != nil {
+		t.Fatalf("StartBinary: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	if err := p.Handshake(ctx, HostAPIVersion); err != nil {
+		t.Fatalf("Handshake through authenticated channel: %v", err)
+	}
+
+	resp, err := p.InvokeTool(ctx, "scan", map[string]any{"workspace_root": t.TempDir()}, t.TempDir())
+	if err != nil {
+		t.Fatalf("InvokeTool through authenticated channel: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("InvokeTool returned nil response")
+	}
+}
+
+// Guard: the host and SDK must agree on the env var and metadata key, or the
+// token would be attached under one name and checked under another — silently
+// disabling the control. This pins the wire contract from the host side; the
+// SDK side pins the same literals in sdk/auth_test.go.
+func TestTokenWireContract(t *testing.T) {
+	if pluginTokenEnv != "NOX_PLUGIN_TOKEN" {
+		t.Errorf("pluginTokenEnv = %q, want NOX_PLUGIN_TOKEN", pluginTokenEnv)
+	}
+	if pluginTokenMetaKey != "x-nox-plugin-token" {
+		t.Errorf("pluginTokenMetaKey = %q, want x-nox-plugin-token", pluginTokenMetaKey)
+	}
+	// Metadata keys are case-insensitive but must be lowercase in the map.
+	if strings.ToLower(pluginTokenMetaKey) != pluginTokenMetaKey {
+		t.Errorf("metadata key must be lowercase: %q", pluginTokenMetaKey)
+	}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,9 +3,12 @@ package plugin
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -14,11 +17,44 @@ import (
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // HostAPIVersion is the protocol version the host advertises during handshake.
 const HostAPIVersion = "v1"
+
+// pluginTokenEnv is the environment variable through which the host hands a
+// per-launch shared secret to the plugin subprocess it spawns. A plugin binds
+// an unauthenticated loopback gRPC port (see sdk.Serve); the token lets the
+// plugin authenticate the one caller allowed to drive it — the host that
+// launched it — and reject every other local process or LAN peer that connects
+// to the port during a scan.
+const pluginTokenEnv = "NOX_PLUGIN_TOKEN"
+
+// pluginTokenMetaKey is the gRPC metadata key carrying the per-launch token on
+// every RPC. It must match the key the SDK server checks.
+const pluginTokenMetaKey = "x-nox-plugin-token"
+
+// newLaunchToken returns a fresh 256-bit hex token. A crypto/rand failure is
+// returned to the caller rather than swallowed: the host must not fall back to
+// an unauthenticated channel.
+func newLaunchToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// tokenUnaryInterceptor attaches the per-launch token to every outgoing RPC so
+// the plugin can authenticate the caller as the host that spawned it.
+func tokenUnaryInterceptor(token string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, pluginTokenMetaKey, token)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
 
 // State represents the lifecycle state of a plugin connection.
 type State int
@@ -125,7 +161,21 @@ func NewPlugin(conn *grpc.ClientConn) *Plugin {
 // NOX_PLUGIN_ADDR=host:port line from its stdout, and establishes
 // a gRPC connection. The returned Plugin is in StateInit.
 func StartBinary(ctx context.Context, path string, args []string, timeout time.Duration) (*Plugin, error) {
+	// Per-launch shared secret authenticating this host to the plugin it spawns.
+	// Generated before the process starts so it can be passed in the child's
+	// environment; a crypto/rand failure aborts the launch rather than falling
+	// back to an unauthenticated channel.
+	token, err := newLaunchToken()
+	if err != nil {
+		return nil, fmt.Errorf("generating plugin auth token: %w", err)
+	}
+
 	cmd := exec.CommandContext(ctx, path, args...)
+	// Inherit the host environment and add the auth token. A foreign process
+	// that later connects to the plugin's loopback port cannot read this child's
+	// environment (on a correctly configured OS it is owner-only), so it cannot
+	// present the token and is rejected by the plugin's server interceptor.
+	cmd.Env = append(os.Environ(), pluginTokenEnv+"="+token)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdout pipe: %w", err)
@@ -143,7 +193,10 @@ func StartBinary(ctx context.Context, path string, args []string, timeout time.D
 		return nil, fmt.Errorf("waiting for plugin address: %w", err)
 	}
 
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(tokenUnaryInterceptor(token)),
+	)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		return nil, fmt.Errorf("dialing plugin at %s: %w", addr, err)

--- a/plugin/testdata/authplugin/main.go
+++ b/plugin/testdata/authplugin/main.go
@@ -1,0 +1,30 @@
+// Command authplugin is a minimal SDK-based plugin used by the plugin
+// package's end-to-end auth test. It exposes a single read-only "scan" tool and
+// relies entirely on sdk.Serve for the NOX_PLUGIN_ADDR handshake and the
+// per-launch token enforcement, so the test exercises the real host↔SDK path.
+package main
+
+import (
+	"context"
+	"os"
+
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+	"github.com/nox-hq/nox/sdk"
+)
+
+func main() {
+	manifest := sdk.NewManifest("nox/authtest", "1.0.0").
+		Capability("scan", "auth test capability").
+		Tool("scan", "no-op scan tool", true).
+		Done().
+		Build()
+
+	srv := sdk.NewPluginServer(manifest).
+		HandleTool("scan", func(_ context.Context, _ sdk.ToolRequest) (*pluginv1.InvokeToolResponse, error) {
+			return sdk.NewResponse().Build(), nil
+		})
+
+	if err := srv.Serve(context.Background()); err != nil {
+		os.Exit(1)
+	}
+}

--- a/sdk/auth_test.go
+++ b/sdk/auth_test.go
@@ -1,0 +1,80 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// dialGetManifest connects to addr over an insecure loopback channel and calls
+// GetManifest, optionally attaching outgoing metadata. It models exactly what a
+// foreign local process could do: reach the plugin's port and try to drive it.
+func dialGetManifest(t *testing.T, addr string, md metadata.MD) error {
+	t.Helper()
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial %s: %v", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if md != nil {
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+	_, err = pluginv1.NewPluginServiceClient(conn).GetManifest(ctx, &pluginv1.GetManifestRequest{ApiVersion: "v1"})
+	return err
+}
+
+// When the host sets NOX_PLUGIN_TOKEN, the plugin's gRPC server must accept only
+// callers presenting the matching token and reject everyone else. This is the
+// control that closes the unauthenticated loopback port to any other local
+// process (or LAN peer) for the lifetime of a scan.
+func TestServe_TokenAuth_RejectsUnauthenticatedCallers(t *testing.T) {
+	const token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	t.Setenv(pluginTokenEnv, token)
+
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	// No token — the foreign-process case — is rejected.
+	if err := dialGetManifest(t, addr, nil); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("no-token call: got code %v (%v), want Unauthenticated", status.Code(err), err)
+	}
+
+	// A guessed/wrong token is rejected.
+	wrong := metadata.Pairs(pluginTokenMetaKey, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	if err := dialGetManifest(t, addr, wrong); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("wrong-token call: got code %v (%v), want Unauthenticated", status.Code(err), err)
+	}
+
+	// The correct token — what the host attaches — is accepted.
+	right := metadata.Pairs(pluginTokenMetaKey, token)
+	if err := dialGetManifest(t, addr, right); err != nil {
+		t.Fatalf("correct-token call: got %v, want success", err)
+	}
+}
+
+// A plugin started without a token in its environment (standalone during
+// development, or by a host predating this control) keeps its prior behavior and
+// does not require authentication — so the change is backward compatible.
+func TestServe_NoToken_NoEnforcement(t *testing.T) {
+	// Empty value ⇒ Serve installs no interceptor, matching an unset variable.
+	t.Setenv(pluginTokenEnv, "")
+
+	srv := NewPluginServer(NewManifest("test", "1.0.0").Build())
+	addr, stop := serveAndWaitForAddr(t, srv)
+	defer stop()
+
+	if err := dialGetManifest(t, addr, nil); err != nil {
+		t.Fatalf("no-token-env call: got %v, want success (no enforcement)", err)
+	}
+}

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net"
@@ -12,8 +13,38 @@ import (
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// pluginTokenEnv is the environment variable through which the host passes a
+// per-launch shared secret. When set, every RPC must present the matching token
+// or it is rejected — this is what closes the loopback port to callers other
+// than the host that spawned this plugin. The key and value must match the
+// host's (see plugin.StartBinary).
+const pluginTokenEnv = "NOX_PLUGIN_TOKEN"
+
+// pluginTokenMetaKey is the gRPC metadata key carrying the per-launch token.
+const pluginTokenMetaKey = "x-nox-plugin-token"
+
+// tokenAuthInterceptor rejects any unary RPC whose metadata does not carry the
+// expected per-launch token. Comparison is constant-time. It is only installed
+// when the host provided a token, so a plugin run standalone (e.g. by its author
+// during development) is unaffected; the real host always sets one.
+func tokenAuthInterceptor(token string) grpc.UnaryServerInterceptor {
+	want := []byte(token)
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing plugin auth token")
+		}
+		vals := md.Get(pluginTokenMetaKey)
+		if len(vals) != 1 || subtle.ConstantTimeCompare([]byte(vals[0]), want) != 1 {
+			return nil, status.Error(codes.Unauthenticated, "invalid plugin auth token")
+		}
+		return handler(ctx, req)
+	}
+}
 
 // PluginServer wraps a gRPC server implementing the PluginService with
 // the NOX_PLUGIN_ADDR stdout handshake protocol and signal handling.
@@ -85,7 +116,15 @@ func (s *PluginServer) Serve(ctx context.Context, opts ...ServeOption) error {
 		return fmt.Errorf("sdk: listen: %w", err)
 	}
 
-	grpcServer := grpc.NewServer()
+	// Require the host's per-launch token on every RPC when one was provided.
+	// The host (plugin.StartBinary) always sets it, so in normal operation the
+	// loopback port only answers the host that spawned this plugin.
+	var serverOpts []grpc.ServerOption
+	if token := os.Getenv(pluginTokenEnv); token != "" {
+		serverOpts = append(serverOpts, grpc.UnaryInterceptor(tokenAuthInterceptor(token)))
+	}
+
+	grpcServer := grpc.NewServer(serverOpts...)
 	pluginv1.RegisterPluginServiceServer(grpcServer, s)
 
 	// Print the address for the host to connect to.


### PR DESCRIPTION
## Problem

A plugin subprocess binds an **unauthenticated** gRPC server on a loopback TCP port (`sdk.Serve`: `net.Listen("tcp", "127.0.0.1:0")` + `grpc.NewServer()` with no credentials/interceptor) and advertises its address on stdout. The host dialled it with `insecure.NewCredentials()`, and the only handshake was an API-version string.

**Consequence:** for the entire lifetime of a scan, any other local process — or, behind a permissive firewall, any LAN peer — could connect to that port and call `InvokeTool`, driving the plugin's tools within its filesystem/exec profile. A classic local confused-deputy gap. The SDK already flagged the loopback exposure in a comment but never authenticated the channel.

## Fix

Per-launch shared-secret authentication:

- **Host** (`plugin.StartBinary`): generates a fresh 256-bit token with `crypto/rand`, passes it to the subprocess via `NOX_PLUGIN_TOKEN`, and attaches it on every RPC via a client unary interceptor. A `crypto/rand` failure aborts the launch rather than falling back to an unauthenticated channel.
- **SDK** (`sdk.Serve`): when `NOX_PLUGIN_TOKEN` is set, installs a server interceptor that constant-time-compares the token (`crypto/subtle`) on every call and returns `codes.Unauthenticated` otherwise.

A foreign process can't read another process's environment on a correctly configured OS, so it can't present the token; a LAN peer never sees the env at all.

## Scope / compatibility

- Enforcement is **gated on the token being present**, so a plugin run standalone during development still works.
- `StartBinary` is the **only** subprocess-over-loopback path. `RegisterPlugin` (caller-owned conn) and the conformance harness (in-process `bufconn`) expose no port and are untouched.

## Tests

- SDK server **rejects** no-token and wrong-token calls (the foreign-process case) and **accepts** the correct token; stays open when no token is set (backward-compat).
- Host interceptor attaches the token; `newLaunchToken` is unique/well-formed; wire-contract guard pins the env var + metadata key on both sides.
- **End-to-end**: a real SDK-built plugin binary spawned via `StartBinary` completes handshake + tool invocation over the authenticated channel.

Full suite 51/51, `-race` clean on `plugin`/`sdk`, lint clean.

This is the first of two plugin trust-boundary fixes; the second (scan-time re-verification of plugin provenance instead of trusting `~/.nox/state.json`) follows separately.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts