### PR TITLE
fix(plugin): re-verify plugin binary integrity at scan time

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -122,7 +122,7 @@ func bootstrapBundledPlugins() {
 			if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
 				continue
 			}
-			st.AddPlugin(&InstalledPlugin{
+			bundledIP := &InstalledPlugin{
 				Name:        canonicalName(name),
 				Version:     "bundled",
 				BinaryPath:  path,
@@ -130,7 +130,9 @@ func bootstrapBundledPlugins() {
 				RiskClass:   "passive",
 				InstalledAt: time.Now().UTC(),
 				UpdatedAt:   time.Now().UTC(),
-			})
+			}
+			bundledIP.RecordBinaryDigest()
+			st.AddPlugin(bundledIP)
 			changed = true
 			notices = append(notices, fmt.Sprintf(
 				"registered bundled plugin %s -> %s (disable: export NOX_NO_BUNDLED_PLUGINS=1)",

--- a/cli/install_cmd.go
+++ b/cli/install_cmd.go
@@ -193,7 +193,7 @@ func installOne(name, constraint string, st *State) error {
 	}
 
 	now := time.Now()
-	st.AddPlugin(&InstalledPlugin{
+	ip := &InstalledPlugin{
 		Name:        name,
 		Version:     ve.Version,
 		Digest:      artifact.Digest,
@@ -203,7 +203,9 @@ func installOne(name, constraint string, st *State) error {
 		Track:       string(trackForPlugin(ctx, client, name)),
 		InstalledAt: now,
 		UpdatedAt:   now,
-	})
+	}
+	ip.RecordBinaryDigest()
+	st.AddPlugin(ip)
 	return nil
 }
 

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -416,7 +416,7 @@ func runPluginInstall(args []string) int {
 	}
 
 	now := time.Now()
-	st.AddPlugin(&InstalledPlugin{
+	ip := &InstalledPlugin{
 		Name:        name,
 		Version:     ve.Version,
 		Digest:      artifact.Digest,
@@ -426,7 +426,9 @@ func runPluginInstall(args []string) int {
 		Track:       string(trackForPlugin(ctx, client, name)),
 		InstalledAt: now,
 		UpdatedAt:   now,
-	})
+	}
+	ip.RecordBinaryDigest()
+	st.AddPlugin(ip)
 
 	if err := SaveState(statePath, st); err != nil {
 		fmt.Fprintf(os.Stderr, "error: saving state: %v\n", err)
@@ -496,7 +498,7 @@ func runPluginUpdate(args []string) int {
 		}
 
 		now := time.Now()
-		st.AddPlugin(&InstalledPlugin{
+		newIP := &InstalledPlugin{
 			Name:        name,
 			Version:     ve.Version,
 			Digest:      artifact.Digest,
@@ -506,7 +508,9 @@ func runPluginUpdate(args []string) int {
 			Track:       string(trackForPlugin(ctx, client, name)),
 			InstalledAt: ip.InstalledAt,
 			UpdatedAt:   now,
-		})
+		}
+		newIP.RecordBinaryDigest()
+		st.AddPlugin(newIP)
 		updated++
 		fmt.Printf("Updated %s: %s -> %s\n", name, ip.Version, ve.Version)
 	}
@@ -741,14 +745,19 @@ func installLocalPlugin(name, path string) int {
 	}
 
 	now := time.Now()
-	st.AddPlugin(&InstalledPlugin{
+	localIP := &InstalledPlugin{
 		Name:        name,
 		Version:     "local",
 		BinaryPath:  abs,
 		TrustLevel:  "local",
 		InstalledAt: now,
 		UpdatedAt:   now,
-	})
+	}
+	// Record the digest even for local plugins: it does not imply marketplace
+	// trust (TrustLevel stays "local"), but it still lets the scan path detect
+	// if this binary is swapped out from under an installed reference.
+	localIP.RecordBinaryDigest()
+	st.AddPlugin(localIP)
 	if err := SaveState(statePath, st); err != nil {
 		fmt.Fprintf(os.Stderr, "error: saving state: %v\n", err)
 		return 2

--- a/cli/plugin_integrity_test.go
+++ b/cli/plugin_integrity_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/degrade"
+	"github.com/nox-hq/nox/registry/trust"
+)
+
+// RecordBinaryDigest must measure the actual bytes of the executable so the
+// scan path has a value to re-check against.
+func TestRecordBinaryDigest(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "plugin-bin")
+	content := []byte("#!/bin/sh\necho hi\n")
+	if err := os.WriteFile(bin, content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ip := &InstalledPlugin{Name: "x", BinaryPath: bin}
+	ip.RecordBinaryDigest()
+
+	want := trust.ComputeDigest(content).String()
+	if ip.BinaryDigest != want {
+		t.Fatalf("BinaryDigest = %q, want %q", ip.BinaryDigest, want)
+	}
+
+	// No path ⇒ nothing recorded, no panic.
+	empty := &InstalledPlugin{Name: "y"}
+	empty.RecordBinaryDigest()
+	if empty.BinaryDigest != "" {
+		t.Fatalf("expected empty digest for empty path, got %q", empty.BinaryDigest)
+	}
+}
+
+// writePluginState installs a single plugin into a temp NOX_HOME and returns the
+// binary path so a test can tamper with it.
+func writePluginState(t *testing.T, ip *InstalledPlugin) {
+	t.Helper()
+	if err := SaveState(DefaultStatePath(), &State{Plugins: []InstalledPlugin{*ip}}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+}
+
+// The integrity gate is the security property: a plugin whose binary matches its
+// recorded digest runs; one whose binary changed since install is refused and
+// surfaced as a degradation, never silently executed as still-trusted.
+func TestInstalledPluginBinaries_IntegrityGate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("NOX_HOME", dir)
+
+	bin := filepath.Join(dir, "plugin-bin")
+	original := []byte("original trusted binary\n")
+	if err := os.WriteFile(bin, original, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recorded := trust.ComputeDigest(original).String()
+
+	t.Run("matching digest runs", func(t *testing.T) {
+		writePluginState(t, &InstalledPlugin{Name: "p", BinaryPath: bin, BinaryDigest: recorded})
+		bins, missing, err := installedPluginBinaries([]string{"p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bins) != 1 {
+			t.Fatalf("expected the plugin to run; got %d binaries, missing=%+v", len(bins), missing)
+		}
+		for _, d := range missing {
+			if strings.Contains(d.Detail, "integrity") {
+				t.Fatalf("unexpected integrity degradation on a matching binary: %s", d.Detail)
+			}
+		}
+	})
+
+	t.Run("tampered binary is refused", func(t *testing.T) {
+		writePluginState(t, &InstalledPlugin{Name: "p", BinaryPath: bin, BinaryDigest: recorded})
+		// Overwrite the binary after install — the contained-plugin self-modify case.
+		if err := os.WriteFile(bin, []byte("modified malicious binary\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		bins, missing, err := installedPluginBinaries([]string{"p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bins) != 0 {
+			t.Fatalf("tampered plugin must not run; got %d binaries", len(bins))
+		}
+		var found bool
+		for _, d := range missing {
+			if d.Kind == degrade.Plugin && strings.Contains(d.Detail, "integrity") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected an integrity degradation; got %+v", missing)
+		}
+	})
+
+	t.Run("empty recorded digest is not enforced", func(t *testing.T) {
+		// Restore a valid binary, install with NO recorded digest (pre-existing
+		// install). It must still run — the change is backward compatible.
+		if err := os.WriteFile(bin, original, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writePluginState(t, &InstalledPlugin{Name: "p", BinaryPath: bin, BinaryDigest: ""})
+		bins, missing, err := installedPluginBinaries([]string{"p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bins) != 1 {
+			t.Fatalf("plugin without a recorded digest must still run; got %d, missing=%+v", len(bins), missing)
+		}
+	})
+}

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -68,6 +68,28 @@ func installedPluginBinaries(required []string) ([]installedPlugin, []core.Degra
 			})
 			continue
 		}
+
+		// Integrity gate: the binary the host is about to exec must match the
+		// digest measured when the plugin was installed and verified. state.json
+		// is writable by anything running as the user — including a plugin
+		// subprocess, the very principal the sandbox is meant to contain — so a
+		// plugin that runs once and then overwrites its own binary would
+		// otherwise be re-launched as a still-"trusted" plugin. Refusing on
+		// mismatch means tampering can only stop a plugin, never escalate it.
+		// Only enforced when a digest was recorded (installs predating the field,
+		// and any where the hash could not be read, fall through unchanged).
+		if ip.BinaryDigest != "" {
+			got, digErr := fileDigest(ip.BinaryPath)
+			if digErr != nil || got != ip.BinaryDigest {
+				missing = append(missing, core.Degradation{
+					Kind:   degrade.Plugin,
+					Detail: fmt.Sprintf("required plugin %q failed its integrity check: the binary at %s does not match the digest recorded at install", name, ip.BinaryPath),
+					Impact: "the plugin was not run because its binary changed since install; reinstall it with `nox plugin install` if the change is expected",
+				})
+				continue
+			}
+		}
+
 		binaries = append(binaries, installedPlugin{
 			path:  ip.BinaryPath,
 			track: registry.Track(ip.Track),

--- a/cli/state.go
+++ b/cli/state.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nox-hq/nox/registry"
+	"github.com/nox-hq/nox/registry/trust"
 )
 
 // InstalledPlugin records metadata for a locally installed plugin.
@@ -26,9 +27,50 @@ type InstalledPlugin struct {
 	// sandbox. Empty for sideloaded (--local) plugins and for installs
 	// predating this field, both of which fall back to the strict default
 	// policy.
-	Track       string    `json:"track,omitempty"`
+	Track string `json:"track,omitempty"`
+
+	// BinaryDigest is the SHA-256 of the plugin executable itself, measured at
+	// install time. It is distinct from Digest: Digest is the signed *artifact*
+	// blob, which for a tar.gz plugin is the tarball, not the extracted
+	// executable — so it cannot be re-checked against the file the host execs.
+	// BinaryDigest measures exactly that file. The scan path re-checks it before
+	// launch and refuses to run a plugin whose binary changed since install,
+	// closing the gap where a plugin, having run once, overwrites its own
+	// on-disk binary to execute modified code as a still-"trusted" plugin on the
+	// next scan. Empty for installs predating this field and when the hash could
+	// not be read; the scan path then skips the check (unchanged behavior).
+	BinaryDigest string `json:"binary_digest,omitempty"`
+
 	InstalledAt time.Time `json:"installed_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// fileDigest returns the "sha256:<hex>" digest of the file at path.
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // path is an installed plugin binary recorded by nox
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	d, err := trust.ComputeDigestReader(f)
+	if err != nil {
+		return "", err
+	}
+	return d.String(), nil
+}
+
+// RecordBinaryDigest measures the executable at p.BinaryPath and stores it in
+// BinaryDigest. It must be called at install time, when the binary is
+// known-good. A hash failure leaves the field empty rather than aborting the
+// install: the scan path then falls back to no integrity check, which is no
+// worse than the pre-existing behavior.
+func (p *InstalledPlugin) RecordBinaryDigest() {
+	if p.BinaryPath == "" {
+		return
+	}
+	if d, err := fileDigest(p.BinaryPath); err == nil {
+		p.BinaryDigest = d
+	}
 }
 
 // State persists registry sources and installed plugins across CLI invocations.


### PR DESCRIPTION
## Problem

The scan path trusted `~/.nox/state.json` wholesale. `installedPluginBinaries` loaded a plugin's `BinaryPath` and `Track`, did nothing but `os.Stat` the file, and launched it — with **no re-check that the binary is the one verified at install**. Verification runs only at install time; `state.json` then serves as the de-facto trust root.

But `state.json` and the plugin binary are writable by anything running as the user — **including a plugin subprocess, the exact principal the sandbox is meant to contain**. A plugin that ran once could overwrite its own on-disk binary and be re-launched as a still-"trusted" plugin, executing modified code under its granted profile.

### Why the obvious fixes don't apply
- The recorded `Digest` is the signed **artifact blob** digest — for a tar.gz plugin that's the tarball, not the extracted executable, so it can't be compared against the file the host execs.
- Trust is **cosign-keyless** (verified over the network at install), so the signature can't be re-verified offline at scan time without breaking offline-first.

## Fix

Measure the **executable's own SHA-256 at install** (new `BinaryDigest` field, recorded at all five install sites: marketplace install, update, `--local`, bundled, and the scan-time auto-install path) and re-check it before launch. On mismatch the plugin is **not run** and a visible `degrade.Plugin` degradation is emitted (caught by `--fail-on-degraded`).

- **Zero false positives** — fires only when the binary actually changed.
- **Backward compatible** — only enforced when a digest was recorded; installs predating the field keep working.

### Invariant

Tampering with plugin state can now only **stop** a plugin from running, never **escalate** one.

### Honest scope

This does not defend against a fully privileged same-user attacker who rewrites both the binary *and* its recorded digest — undefendable offline without an online trust root. That remains the domain of the install-time cosign gate and `nox plugin install --require-verified`.

## Tests

- `RecordBinaryDigest` measures the real bytes.
- Scan gate: a matching binary **runs**, a tampered one is **refused with an integrity degradation**, and a digest-less (pre-existing) install stays **unenforced** — exercised end-to-end through a real `state.json` round-trip under a temp `NOX_HOME`.

Full suite 51/51, `-race` clean on `cli`, lint clean.

Second of the two plugin trust-boundary fixes (first: #264, gRPC channel auth).

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts