### PR TITLE
fix(plugin): enforce trust policy on update and required-install paths

### DIFF
--- a/cli/install_cmd.go
+++ b/cli/install_cmd.go
@@ -176,7 +176,11 @@ func installOne(name, constraint string, st *State) error {
 	}
 
 	client := newRegistryClient(st)
-	store := newOCIStore()
+	// Enforce the operator's trust policy here too: this path drives .nox.yaml
+	// plugins.required installs (including scan-time auto-install), so a
+	// fail-open store would auto-install an unverified plugin during a scan.
+	policyName := resolveTrustPolicy("", false, false, false)
+	store := newOCIStoreWithPolicy(policyName)
 	ctx := context.Background()
 
 	ve, err := client.Resolve(ctx, name, constraint)
@@ -190,6 +194,11 @@ func installOne(name, constraint string, st *State) error {
 	artifact, err := store.Fetch(ctx, name, ve)
 	if err != nil {
 		return fmt.Errorf("fetching: %w", err)
+	}
+
+	// Fail closed: never auto-install an artifact that violates the trust policy.
+	if msgs, fatal := trustViolationsBlock(artifact.VerifyResult, policyName, false); fatal {
+		return fmt.Errorf("blocked by trust policy %q: %s", policyName, strings.Join(msgs, "; "))
 	}
 
 	now := time.Now()

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -81,6 +81,26 @@ func newOCIStoreWithPolicy(policyName string) *oci.Store {
 	)
 }
 
+// trustViolationsBlock is the single trust-policy gate shared by the install
+// and update paths. Store.Fetch is fail-open by contract: it records policy
+// violations in VerifyResult but still returns a runnable BinaryPath, delegating
+// enforcement to the caller. Having each caller re-implement that check is how
+// `nox plugin update` came to silently install artifacts `nox plugin install`
+// would refuse — so both now route through here.
+//
+// It returns the violation messages to surface and whether they are fatal under
+// the policy (never fatal for a permissive policy or an explicit
+// --allow-unverified). No violations ⇒ (nil, false).
+func trustViolationsBlock(vr trust.VerifyResult, policyName string, allowUnverified bool) (msgs []string, fatal bool) {
+	if len(vr.Violations) == 0 {
+		return nil, false
+	}
+	for _, v := range vr.Violations {
+		msgs = append(msgs, v.Message)
+	}
+	return msgs, !allowUnverified && policyName != "permissive"
+}
+
 // policyFromName resolves a config / flag string into a trust.Policy.
 // Empty / unknown names map to the default policy (TrustCommunity
 // minimum) — every published plugin in the official registry now
@@ -400,14 +420,13 @@ func runPluginInstall(args []string) int {
 	}
 	fmt.Println()
 
-	if len(artifact.VerifyResult.Violations) > 0 {
-		fatal := !allowUnverified && policyName != "permissive"
-		for _, v := range artifact.VerifyResult.Violations {
+	if msgs, fatal := trustViolationsBlock(artifact.VerifyResult, policyName, allowUnverified); len(msgs) > 0 {
+		for _, m := range msgs {
 			label := "warning"
 			if fatal {
 				label = "error"
 			}
-			fmt.Fprintf(os.Stderr, "  %s: %s\n", label, v.Message)
+			fmt.Fprintf(os.Stderr, "  %s: %s\n", label, m)
 		}
 		if fatal {
 			fmt.Fprintf(os.Stderr, "Install blocked by trust policy %q. Override with --allow-unverified or set plugins.trust_policy: permissive in .nox.yaml.\n", policyName)
@@ -469,7 +488,14 @@ func runPluginUpdate(args []string) int {
 	}
 
 	client := newRegistryClient(st)
-	store := newOCIStore()
+	// Update must enforce the same trust policy as install. It previously used
+	// the permissive-by-construction default store and never inspected
+	// VerifyResult, so a higher version published in a configured registry — or
+	// a MITM'd/stale unsigned index — was installed unverified. Resolve the
+	// operator's policy (.nox.yaml plugins.trust_policy, else "default") and
+	// build a policy-aware store so violations are both produced and gated.
+	policyName := resolveTrustPolicy("", false, false, false)
+	store := newOCIStoreWithPolicy(policyName)
 	ctx := context.Background()
 
 	updated := 0
@@ -494,6 +520,16 @@ func runPluginUpdate(args []string) int {
 		artifact, err := store.Fetch(ctx, name, ve)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: cannot fetch %s@%s: %v\n", name, ve.Version, err)
+			continue
+		}
+
+		// Fail closed: a new version that violates the trust policy is skipped,
+		// not silently installed. The currently-installed version stays in place.
+		if msgs, fatal := trustViolationsBlock(artifact.VerifyResult, policyName, false); fatal {
+			for _, m := range msgs {
+				fmt.Fprintf(os.Stderr, "warning: not updating %s@%s: %s\n", name, ve.Version, m)
+			}
+			fmt.Fprintf(os.Stderr, "Skipped %s: new version blocked by trust policy %q (run `nox plugin install %s@%s --allow-unverified` to override).\n", name, policyName, name, ve.Version)
 			continue
 		}
 

--- a/cli/plugin_update_trust_test.go
+++ b/cli/plugin_update_trust_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/registry/trust"
+)
+
+// trustViolationsBlock is the single gate both `nox plugin install` and
+// `nox plugin update` use to enforce the trust policy on a fetched artifact.
+// Store.Fetch is fail-open (returns a runnable binary even for a policy-failing
+// artifact), so this predicate is the actual enforcement; the update path
+// silently skipped it before, installing unverified plugins. The matrix below
+// pins the decision so the two paths cannot diverge again.
+func TestTrustViolationsBlock(t *testing.T) {
+	twoViolations := trust.VerifyResult{Violations: []trust.Violation{
+		{Field: "trust_level", Message: `trust level "unverified" is below minimum "community"`},
+		{Field: "signature", Message: "no signature present"},
+	}}
+	none := trust.VerifyResult{}
+
+	cases := []struct {
+		name            string
+		vr              trust.VerifyResult
+		policy          string
+		allowUnverified bool
+		wantFatal       bool
+		wantMsgs        int
+	}{
+		{"clean artifact passes", none, "default", false, false, 0},
+		{"violations blocked under default", twoViolations, "default", false, true, 2},
+		{"violations blocked under enterprise", twoViolations, "enterprise", false, true, 2},
+		{"permissive policy never fatal", twoViolations, "permissive", false, false, 2},
+		{"allow-unverified overrides", twoViolations, "default", true, false, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs, fatal := trustViolationsBlock(tc.vr, tc.policy, tc.allowUnverified)
+			if fatal != tc.wantFatal {
+				t.Errorf("fatal = %v, want %v", fatal, tc.wantFatal)
+			}
+			if len(msgs) != tc.wantMsgs {
+				t.Errorf("len(msgs) = %d, want %d", len(msgs), tc.wantMsgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Store.Fetch` is **fail-open** by contract — it records trust-policy violations in `VerifyResult` but still returns a runnable `BinaryPath`, leaving enforcement to the caller. Only `runPluginInstall` honored that. Two other callers did not:

- **`runPluginUpdate`** used the permissive default store and never inspected `VerifyResult`, so a higher version published in a configured registry — or a MITM'd / **stale unsigned index** — was installed **unverified**, its `BinaryPath` recorded for later execution. `nox plugin update` would install what `nox plugin install` refuses.
- **`installOne`** (the `.nox.yaml` `plugins.required` path, including **scan-time auto-install**) had the same gap — a required plugin could be auto-installed unverified during a scan.

An attacker able to influence a configured registry could get a plugin that the install gate rejects onto disk and, later, executed.

## Root cause

Duplicated trust enforcement that diverged — install had the check, the other two paths didn't.

## Fix

Extract one shared gate, `trustViolationsBlock`, that **all three** paths call. The update and required-install paths now resolve the operator's policy (`.nox.yaml` `plugins.trust_policy`, else `default`), build a **policy-aware store**, and **fail closed** on violations — update skips the new version (keeping the installed one), required-install returns an error. `install` behavior is unchanged (same logic, extracted).

## Test

The shared gate is pinned across the policy matrix — clean artifact passes; violations fatal under `default`/`enterprise`; `permissive` and `--allow-unverified` never fatal — so the three paths cannot silently diverge again.

Build clean, `cli` tests pass, lint clean.

Found by a fresh adversarial audit of the hardened main; 1 of 4 PRs. Related: #264, #265.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts