### PR TITLE
fix(discovery): classify source under prompts/ and agents/ as Source, not AIComponent

### DIFF
--- a/core/discovery/ai_dir_source_test.go
+++ b/core/discovery/ai_dir_source_test.go
@@ -1,0 +1,41 @@
+package discovery
+
+import "testing"
+
+// Source files living under a prompts/ or agents/ directory must classify as
+// Source, not AIComponent. The taint, SAST, agentflow, slop, and variants
+// analyzers all skip any artifact whose Type is not Source, so misclassifying
+// this code silently drops it from injection/taint analysis — the worst place
+// for a false negative, since prompt- and agent-driving code is the highest-risk
+// code in the tree. Genuine AI-component artifacts (prompts, configs, agent
+// docs) under the same directories must still classify as AIComponent.
+func TestClassify_SourceUnderAIDirsIsSource(t *testing.T) {
+	c := &DefaultClassifier{}
+
+	source := []string{
+		"internal/prompts/vuln.go",
+		"pkg/prompts/builder.py",
+		"src/agents/handler.ts",
+		"app/agents/server.go",
+		"lib/prompts/render.rb",
+	}
+	for _, p := range source {
+		if got := c.Classify(p, nil); got != Source {
+			t.Errorf("Classify(%q) = %q, want Source (must be reachable by taint/SAST)", p, got)
+		}
+	}
+
+	aiComponent := []string{
+		"prompts/summarize.prompt", // *.prompt
+		"prompts/agent.md",         // markdown prompt doc, not source
+		"agents/policy.yaml",       // config, not source
+		"mcp.json",                 // mcp config
+		"config/server.mcp.json",   // *.mcp.json
+		"agents/system.prompt.md",  // *.prompt.md
+	}
+	for _, p := range aiComponent {
+		if got := c.Classify(p, nil); got != AIComponent {
+			t.Errorf("Classify(%q) = %q, want AIComponent (must stay in AI inventory)", p, got)
+		}
+	}
+}

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -272,7 +272,18 @@ func isAIComponent(name, normalised string) bool {
 	if strings.HasSuffix(name, ".prompt.md") {
 		return true
 	}
-	if containsSegment(normalised, "prompts") || containsSegment(normalised, "agents") {
+	// The prompts/ and agents/ directory heuristic is a weak, path-only signal.
+	// It must NOT claim files that are recognised source code: a .go/.ts/.py
+	// living under a prompts/ or agents/ directory is exactly the LLM-prompt and
+	// agent-driving code that most needs SAST, taint, and agentflow analysis —
+	// all of which skip any artifact whose Type is not Source, so misclassifying
+	// it as AIComponent silently drops it from those scans. The specific AI
+	// signals above (mcp.json, *.prompt, and the agent-config names below) stay
+	// authoritative; only this broad segment test yields to source. Such files
+	// are still enriched by the AI analyzer when their content carries AI SDK
+	// markers (see ai.ScanArtifacts's isSourceFile && isLikelyAIContent path).
+	if !sourceExtensions[filepath.Ext(name)] && !sourceNames[name] &&
+		(containsSegment(normalised, "prompts") || containsSegment(normalised, "agents")) {
 		return true
 	}
 	if isAgentConfig(name, normalised) {

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -71,9 +71,11 @@ func TestDefaultClassifier_AIComponent(t *testing.T) {
 		{"system.prompt", AIComponent},
 		{"system.prompt.md", AIComponent},
 		{"prompts/security.txt", AIComponent},
-		{"agents/scanner.go", AIComponent},
+		// Recognised source under prompts/ or agents/ is Source, not AIComponent,
+		// so taint/SAST/agentflow actually scan it. Non-source (.txt) stays AI.
+		{"agents/scanner.go", Source},
 		{"deep/nested/prompts/foo.txt", AIComponent},
-		{"deep/nested/agents/bar.py", AIComponent},
+		{"deep/nested/agents/bar.py", Source},
 	}
 
 	for _, tc := range cases {
@@ -849,7 +851,7 @@ func TestWalker_ClassifiesFileTypes(t *testing.T) {
 		"src/handler.ts":       Source,
 		"src/utils.py":         Source,
 		"prompts/security.txt": AIComponent,
-		"agents/scanner.go":    AIComponent,
+		"agents/scanner.go":    Source, // source under agents/ must reach taint/SAST
 		"README.md":            Unknown,
 		"build/app.dockerfile": Container,
 		"mcp.json":             AIComponent,


### PR DESCRIPTION
## Problem

`isAIComponent` claimed **any** file whose path contained a `prompts` or `agents` directory segment as an AI component, regardless of file type. The taint, SAST, agentflow, slop, and variants analyzers all early-skip any artifact whose `Type != Source`, so every real source file (`.go`/`.ts`/`.py`/…) under such a directory got **zero** injection/taint/CVE analysis.

That's a silent false negative landing exactly on the **LLM-prompt and agent-driving code that most needs it** — in an AI-security scanner.

**Repro (confirmed):** the same command-injection sample under `internal/handlers/vuln.go` fires TAINT; under `internal/prompts/vuln.go` it fires nothing.

## Fix

The directory-segment test is a weak, path-only signal. It now **yields to recognised source**: skipped when the extension is a known source extension or the name is a known source name. The strong, specific AI signals (`mcp.json`, `*.mcp.json`, `*.prompt`, `*.prompt.md`, agent-config names) stay authoritative, so genuine AI artifacts under those directories still classify as `AIComponent`.

**No loss on the AI side:** the AI analyzer already scans non-`AIComponent` source files carrying AI SDK markers (`ai.ScanArtifacts`, `isSourceFile && isLikelyAIContent`), so a prompt-building `.py` is still enriched for model/prompt/tool inventory while *also* becoming reachable by taint and SAST.

## Tests

Two existing table tests **encoded the bug** (`agents/scanner.go`, `deep/nested/agents/bar.py` asserted `AIComponent`) — corrected to `Source`. Non-source entries (`.txt`) under the same dirs correctly stay `AIComponent`. New test pins both directions.

Full suite 51/51, precision suite 1.000/1.000, lint clean.

Found by a fresh adversarial audit of the hardened main; 2 of 4 PRs.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts