### PR TITLE
fix(plugin): redact structured plugin fields and the full GitHub token family

### DIFF
--- a/plugin/redaction.go
+++ b/plugin/redaction.go
@@ -21,7 +21,12 @@ func NewRedactor() *Redactor {
 		patterns: []*regexp.Regexp{
 			regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
 			regexp.MustCompile(`(?i)aws_secret_access_key\s*[=:]\s*[A-Za-z0-9/+=]{40}`),
-			regexp.MustCompile(`gh[ps]_[A-Za-z0-9_]{36,}`),
+			// GitHub token family. The old `gh[ps]_` covered only personal (ghp_)
+			// and server (ghs_) tokens and leaked OAuth (gho_), user-to-server
+			// (ghu_), and refresh (ghr_) tokens, plus fine-grained PATs
+			// (github_pat_), through the primary free-text redaction path.
+			regexp.MustCompile(`gh[opsur]_[A-Za-z0-9_]{36,}`),
+			regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`),
 			regexp.MustCompile(`-{5}BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-{5}`),
 			regexp.MustCompile(`(?i)(api[_-]?key|apikey|api[_-]?secret)\s*[=:]\s*['"][A-Za-z0-9]{16,}['"]`),
 		},
@@ -41,12 +46,18 @@ func (r *Redactor) RedactResponse(resp *pluginv1.InvokeToolResponse) (*pluginv1.
 
 	// Redact findings.
 	for _, f := range resp.GetFindings() {
+		// Location.FilePath is a free-text string the plugin fully controls; a
+		// secret embedded there (e.g. a URL with credentials) reaches
+		// findings.json and SARIF, so it must be scanned like any message field.
+		loc, locRedacted := r.redactLocation(f.GetLocation())
+		anyRedacted = anyRedacted || locRedacted
+
 		nf := &pluginv1.Finding{
 			Id:          f.GetId(),
 			RuleId:      f.GetRuleId(),
 			Severity:    f.GetSeverity(),
 			Confidence:  f.GetConfidence(),
-			Location:    f.GetLocation(),
+			Location:    loc,
 			Fingerprint: f.GetFingerprint(),
 		}
 
@@ -69,12 +80,19 @@ func (r *Redactor) RedactResponse(resp *pluginv1.InvokeToolResponse) (*pluginv1.
 	// Copy packages as-is (structured identifiers, not free text).
 	out.Packages = resp.GetPackages()
 
-	// Redact AI components.
+	// Redact AI components. Name/Type/Path are plugin-controlled strings copied
+	// straight into ai.inventory.json (Path/Name) — a secret routed through any
+	// of them would otherwise bypass redaction entirely.
 	for _, ac := range resp.GetAiComponents() {
+		acName, rn := r.redactString(ac.GetName())
+		acType, rt := r.redactString(ac.GetType())
+		acPath, rp := r.redactString(ac.GetPath())
+		anyRedacted = anyRedacted || rn || rt || rp
+
 		nac := &pluginv1.AIComponent{
-			Name: ac.GetName(),
-			Type: ac.GetType(),
-			Path: ac.GetPath(),
+			Name: acName,
+			Type: acType,
+			Path: acPath,
 		}
 
 		if ac.GetDetails() != nil {
@@ -89,11 +107,14 @@ func (r *Redactor) RedactResponse(resp *pluginv1.InvokeToolResponse) (*pluginv1.
 		out.AiComponents = append(out.AiComponents, nac)
 	}
 
-	// Redact diagnostics.
+	// Redact diagnostics. Source is a plugin-controlled label; redact it too.
 	for _, d := range resp.GetDiagnostics() {
+		src, srcRedacted := r.redactString(d.GetSource())
+		anyRedacted = anyRedacted || srcRedacted
+
 		nd := &pluginv1.Diagnostic{
 			Severity: d.GetSeverity(),
-			Source:   d.GetSource(),
+			Source:   src,
 		}
 
 		msg, redacted := r.redactString(d.GetMessage())
@@ -150,10 +171,12 @@ func (r *Redactor) RedactResponse(resp *pluginv1.InvokeToolResponse) (*pluginv1.
 		anyRedacted = anyRedacted || redacted
 
 		for _, n := range g.GetNodes() {
+			nfp, fpRed := r.redactString(n.GetFilePath())
+			anyRedacted = anyRedacted || fpRed
 			nn := &pluginv1.GraphNode{
 				Id:       n.GetId(),
 				Kind:     n.GetKind(),
-				FilePath: n.GetFilePath(),
+				FilePath: nfp,
 			}
 			label, red := r.redactString(n.GetLabel())
 			nn.Label = label
@@ -181,6 +204,22 @@ func (r *Redactor) RedactResponse(resp *pluginv1.InvokeToolResponse) (*pluginv1.
 	}
 
 	return out, anyRedacted
+}
+
+// redactLocation returns a copy of loc with its plugin-controlled FilePath
+// scanned for secrets, preserving the line/column fields. nil in ⇒ nil out.
+func (r *Redactor) redactLocation(loc *pluginv1.Location) (*pluginv1.Location, bool) {
+	if loc == nil {
+		return nil, false
+	}
+	fp, redacted := r.redactString(loc.GetFilePath())
+	return &pluginv1.Location{
+		FilePath:    fp,
+		StartLine:   loc.GetStartLine(),
+		EndLine:     loc.GetEndLine(),
+		StartColumn: loc.GetStartColumn(),
+		EndColumn:   loc.GetEndColumn(),
+	}, redacted
 }
 
 // redactMap redacts every value in a string map, preserving nil so an absent

--- a/plugin/redaction_hardening_test.go
+++ b/plugin/redaction_hardening_test.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+)
+
+// The redactor must cover the whole GitHub token family, not just ghp_/ghs_.
+// gho_ (OAuth), ghu_ (user-to-server), ghr_ (refresh) and github_pat_
+// (fine-grained PAT) are equally sensitive and travel the same free-text path.
+func TestRedact_GitHubTokenFamily(t *testing.T) {
+	r := NewRedactor()
+	tokens := map[string]string{
+		"ghp": "ghp_" + strings.Repeat("A", 36),
+		"ghs": "ghs_" + strings.Repeat("B", 36),
+		"gho": "gho_" + strings.Repeat("C", 36),
+		"ghu": "ghu_" + strings.Repeat("D", 36),
+		"ghr": "ghr_" + strings.Repeat("E", 36),
+		"pat": "github_pat_" + strings.Repeat("F", 22),
+	}
+	for name, tok := range tokens {
+		t.Run(name, func(t *testing.T) {
+			resp := &pluginv1.InvokeToolResponse{
+				Findings: []*pluginv1.Finding{{Message: "token leaked: " + tok}},
+			}
+			out, redacted := r.RedactResponse(resp)
+			if !redacted {
+				t.Fatalf("%s token was not redacted", name)
+			}
+			if strings.Contains(out.GetFindings()[0].GetMessage(), tok) {
+				t.Errorf("%s token leaked through: %q", name, out.GetFindings()[0].GetMessage())
+			}
+		})
+	}
+}
+
+// Secrets must not slip through plugin-controlled structured string fields.
+// A plugin fully controls Location.FilePath, AIComponent.Name/Type/Path,
+// Diagnostic.Source, and GraphNode.FilePath, all of which are copied into
+// on-disk artifacts (SARIF, findings.json, ai.inventory.json).
+func TestRedact_StructuredFields(t *testing.T) {
+	r := NewRedactor()
+	secret := "ghp_" + strings.Repeat("Z", 36)
+
+	resp := &pluginv1.InvokeToolResponse{
+		Findings: []*pluginv1.Finding{{
+			Location: &pluginv1.Location{FilePath: "https://user:" + secret + "@host/x", StartLine: 42, EndColumn: 9},
+		}},
+		AiComponents: []*pluginv1.AIComponent{{
+			Name: "n-" + secret, Type: "t-" + secret, Path: "p-" + secret,
+		}},
+		Diagnostics: []*pluginv1.Diagnostic{{Source: "src-" + secret}},
+		Graphs: []*pluginv1.Graph{{
+			Nodes: []*pluginv1.GraphNode{{Id: "n1", FilePath: "g-" + secret}},
+		}},
+	}
+
+	out, redacted := r.RedactResponse(resp)
+	if !redacted {
+		t.Fatal("expected redaction across structured fields")
+	}
+
+	fields := map[string]string{
+		"Location.FilePath":  out.GetFindings()[0].GetLocation().GetFilePath(),
+		"AIComponent.Name":   out.GetAiComponents()[0].GetName(),
+		"AIComponent.Type":   out.GetAiComponents()[0].GetType(),
+		"AIComponent.Path":   out.GetAiComponents()[0].GetPath(),
+		"Diagnostic.Source":  out.GetDiagnostics()[0].GetSource(),
+		"GraphNode.FilePath": out.GetGraphs()[0].GetNodes()[0].GetFilePath(),
+	}
+	for name, v := range fields {
+		if strings.Contains(v, secret) {
+			t.Errorf("%s leaked the secret: %q", name, v)
+		}
+	}
+
+	// Location's non-secret positional fields must survive redaction.
+	loc := out.GetFindings()[0].GetLocation()
+	if loc.GetStartLine() != 42 || loc.GetEndColumn() != 9 {
+		t.Errorf("location positional fields dropped: startLine=%d endColumn=%d", loc.GetStartLine(), loc.GetEndColumn())
+	}
+}


### PR DESCRIPTION
## Problem

Two secret-leak gaps in the plugin output redactor:

**1. Structured fields bypassed redaction entirely.** `RedactResponse` only scanned free-text fields (messages, metadata, enrichment title/body, graph labels). It copied `Finding.Location.FilePath`, `AIComponent.Name/Type/Path`, `Diagnostic.Source`, and `GraphNode.FilePath` **verbatim**. A malicious/compromised plugin fully controls those fields, and `convert.go` maps them straight into `findings.json` / SARIF / `ai.inventory.json` — so a secret routed through e.g. `AIComponent.Path` bypassed redaction, defeating the "redaction strips secrets from plugin I/O" guarantee for a whole class of output.

**2. GitHub token pattern was incomplete.** `gh[ps]_…` covered only personal (`ghp_`) and server (`ghs_`) tokens — it missed `gho_` (OAuth), `ghu_` (user-to-server), `ghr_` (refresh), and `github_pat_` (fine-grained PAT), all of which leaked through even the primary free-text path this subsystem exists to protect.

## Fix

- Scan all plugin-controlled structured string fields — a new `redactLocation` preserves the line/column fields while redacting `FilePath`; `AIComponent.Name/Type/Path`, `Diagnostic.Source`, and `GraphNode.FilePath` are folded into the redaction pass.
- Broaden the token pattern to `gh[opsur]_…` plus a dedicated `github_pat_…` pattern.

## Tests

- Every token prefix (`ghp/ghs/gho/ghu/ghr/github_pat`) is redacted from a finding message.
- A secret placed in each structured field is redacted, while `Location`'s positional fields survive.

Full suite green, `-race` clean, lint clean.

Found by a fresh adversarial audit of the hardened main; 3 of 4 PRs.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts