### PR TITLE
fix(deps): normalize purl types so Go and Ruby SBOM components reach OSV

### DIFF
--- a/core/analyzers/deps/sbom_input.go
+++ b/core/analyzers/deps/sbom_input.go
@@ -137,5 +137,23 @@ func ecosystemFromPurl(purl string) string {
 	if len(parts) < 2 || parts[0] == "" {
 		return "unknown"
 	}
-	return parts[0]
+	return normalizePurlType(parts[0])
+}
+
+// normalizePurlType maps a Package-URL type to nox's internal ecosystem name.
+// The two differ for Go and Ruby: purl uses "golang"/"gem" where nox (and the
+// OSV mapping in osvEcosystem) use "go"/"rubygems". Returning the raw purl type
+// meant every Go and Ruby component parsed from a CycloneDX/SPDX SBOM was
+// dropped from the OSV batch — a silent clean bill of health for those whole
+// ecosystems. Types that already coincide (npm, pypi, cargo, maven, nuget) pass
+// through unchanged.
+func normalizePurlType(t string) string {
+	switch t {
+	case "golang":
+		return "go"
+	case "gem":
+		return "rubygems"
+	default:
+		return t
+	}
 }

--- a/core/analyzers/deps/sbom_input_test.go
+++ b/core/analyzers/deps/sbom_input_test.go
@@ -104,7 +104,10 @@ func TestEcosystemFromPurl(t *testing.T) {
 		{"pkg:npm/express@4.18.2", "npm"},
 		{"pkg:maven/org.apache/commons@3.0", "maven"},
 		{"pkg:pypi/requests@2.31.0", "pypi"},
-		{"pkg:golang/github.com/foo/bar@1.0", "golang"},
+		// purl types differ from nox's ecosystem names for Go and Ruby; they
+		// must be normalized or OSV never queries these components.
+		{"pkg:golang/github.com/foo/bar@1.0", "go"},
+		{"pkg:gem/rails@7.0.0", "rubygems"},
 		{"", "unknown"},
 		{"invalid", "unknown"},
 	}
@@ -210,5 +213,24 @@ func TestParseSPDXInput_Success(t *testing.T) {
 	}
 	if pkgs[0].Name != "lodash" || pkgs[0].Version != "4.17.21" || pkgs[0].Ecosystem != "npm" {
 		t.Fatalf("unexpected package: %+v", pkgs[0])
+	}
+}
+
+// TestPurlEcosystemReachesOSV is the security assertion behind the
+// normalization: a Go or Ruby component parsed from an SBOM must map to an
+// ecosystem OSV.dev recognizes, or osvEcosystem returns false and the component
+// is silently dropped from the vulnerability batch — a clean bill of health for
+// the whole ecosystem. Before normalization, "golang"/"gem" failed this.
+func TestPurlEcosystemReachesOSV(t *testing.T) {
+	for _, purl := range []string{
+		"pkg:golang/github.com/foo/bar@1.0",
+		"pkg:gem/rails@7.0.0",
+		"pkg:npm/express@4.18.2",
+		"pkg:pypi/requests@2.31.0",
+	} {
+		eco := ecosystemFromPurl(purl)
+		if _, ok := osvEcosystem(eco); !ok {
+			t.Errorf("%s -> ecosystem %q not OSV-queryable; component would be dropped from scanning", purl, eco)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

CycloneDX (`bom.json`) and SPDX (`sbom.json`) are first-class scan inputs. `ecosystemFromPurl` returned the raw purl **type**, but purl types differ from nox's internal ecosystem names for two ecosystems: purl uses `golang` and `gem` where nox (and `osvEcosystem`) use `go` and `rubygems`.

`osvEcosystem` returns `ok=false` for the raw purl names, so **every Go and Ruby component parsed from an SBOM was filtered out of the OSV batch** — no query, no finding, no degradation. An operator feeding an SBOM got a silent clean bill of health for their entire Go and Ruby dependency surface.

**Repro (confirmed):** a CycloneDX SBOM with `golang`, `gem`, and `npm` components, scanned against a mock OSV returning a critical vuln for anything queried — only `npm` was ever queried; the Go and Ruby packages were never asked about.

## Fix

Normalize the purl type to nox's ecosystem name (`golang`→`go`, `gem`→`rubygems`; `npm`/`pypi`/`cargo`/`maven`/`nuget` already coincide and pass through).

## Tests

An existing test **enshrined the wrong value** (`"golang"`) — corrected. A new assertion pins the security property directly: the normalized ecosystem for a Go/Ruby purl must be OSV-queryable (`osvEcosystem` returns true), so the component is no longer silently dropped.

Full suite green, lint clean.

Found by a fresh adversarial audit of the hardened main; 4 of 4 PRs.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts