### PR TITLE
fix(plugin): fail closed on unrecognized plugin risk_class

### DIFF
--- a/plugin/safety.go
+++ b/plugin/safety.go
@@ -191,9 +191,22 @@ func validateSafety(safety *pluginv1.SafetyRequirements, policy *Policy) []Polic
 		}
 	}
 
-	// Check risk class.
+	// Check risk class. The gate must FAIL CLOSED: an empty value is the
+	// legitimate "unset -> default" case and is allowed, but any non-empty value
+	// the host does not recognise is a violation. Comparing an unknown class by
+	// ordinal used to admit it (riskClassLevel returns -1 for unknowns and
+	// "-1 > 0" is false), letting "RUNTIME", "exec", "active " (trailing space)
+	// etc. slip past a passive ceiling. An unrecognised class is now rejected
+	// outright rather than compared.
 	if rc := safety.GetRiskClass(); rc != "" {
-		if riskClassLevel(RiskClass(rc)) > riskClassLevel(policy.MaxRiskClass) {
+		rcLevel := riskClassLevel(RiskClass(rc))
+		switch {
+		case rcLevel < 0:
+			violations = append(violations, PolicyViolation{
+				Field:   "risk_class",
+				Message: fmt.Sprintf("unrecognized risk class %q; expected one of %q, %q, %q", rc, RiskClassPassive, RiskClassActive, RiskClassRuntime),
+			})
+		case rcLevel > riskClassLevel(policy.MaxRiskClass):
 			violations = append(violations, PolicyViolation{
 				Field:   "risk_class",
 				Message: fmt.Sprintf("plugin requires %q but policy allows at most %q", rc, policy.MaxRiskClass),

--- a/plugin/safety_failclosed_test.go
+++ b/plugin/safety_failclosed_test.go
@@ -1,0 +1,91 @@
+package plugin
+
+import (
+	"testing"
+
+	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
+)
+
+// TestValidateManifest_RiskClassFailClosed asserts the policy gate FAILS CLOSED:
+// a risk_class the host does not recognise must be rejected, not admitted.
+//
+// Regression guard for the fail-open defect where riskClassLevel returned -1 for
+// unrecognised values and `-1 > 0` is false, so "RUNTIME", "exec", "active "
+// (trailing space) etc. slipped past a passive ceiling.
+func TestValidateManifest_RiskClassFailClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		maxPolicy RiskClass
+		wantViolN int
+	}{
+		// Canonical value that genuinely exceeds the ceiling: blocked.
+		{name: "canonical runtime exceeds passive", requested: "runtime", maxPolicy: RiskClassPassive, wantViolN: 1},
+		// Non-canonical values that must ALSO be blocked (fail closed).
+		{name: "uppercase RUNTIME", requested: "RUNTIME", maxPolicy: RiskClassPassive, wantViolN: 1},
+		{name: "uppercase ACTIVE", requested: "ACTIVE", maxPolicy: RiskClassPassive, wantViolN: 1},
+		{name: "exec alias", requested: "exec", maxPolicy: RiskClassPassive, wantViolN: 1},
+		{name: "root alias", requested: "root", maxPolicy: RiskClassPassive, wantViolN: 1},
+		{name: "dangerous alias", requested: "dangerous", maxPolicy: RiskClassPassive, wantViolN: 1},
+		{name: "trailing space active", requested: "active ", maxPolicy: RiskClassPassive, wantViolN: 1},
+		// Unknown value even under a permissive ceiling: still rejected, because the
+		// host cannot reason about a class it does not know.
+		{name: "unknown under runtime ceiling", requested: "banana", maxPolicy: RiskClassRuntime, wantViolN: 1},
+		// Empty stays a legitimate "unset -> default" case: not a violation.
+		{name: "empty passes", requested: "", maxPolicy: RiskClassPassive, wantViolN: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := &pluginv1.GetManifestResponse{
+				Safety: &pluginv1.SafetyRequirements{RiskClass: tt.requested},
+			}
+			policy := DefaultPolicy()
+			policy.MaxRiskClass = tt.maxPolicy
+
+			violations := ValidateManifest(manifest, &policy)
+			if len(violations) != tt.wantViolN {
+				t.Errorf("ValidateManifest risk_class=%q max=%q: got %d violations, want %d: %v",
+					tt.requested, tt.maxPolicy, len(violations), tt.wantViolN, violations)
+			}
+		})
+	}
+}
+
+// TestValidateToolInvocation_RiskClassFailClosed exercises the same fail-closed
+// requirement on the per-tool invocation path, which is the check that actually
+// constrains what runs at call time.
+func TestValidateToolInvocation_RiskClassFailClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		wantViolN int
+	}{
+		{name: "canonical runtime blocked", requested: "runtime", wantViolN: 1},
+		{name: "uppercase RUNTIME blocked", requested: "RUNTIME", wantViolN: 1},
+		{name: "exec alias blocked", requested: "exec", wantViolN: 1},
+		{name: "trailing space blocked", requested: "active ", wantViolN: 1},
+		{name: "empty allowed", requested: "", wantViolN: 0},
+		{name: "passive allowed", requested: "passive", wantViolN: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := &pluginv1.GetManifestResponse{
+				Capabilities: []*pluginv1.Capability{{
+					Tools: []*pluginv1.ToolDef{{
+						Name:   "analyze",
+						Safety: &pluginv1.SafetyRequirements{RiskClass: tt.requested},
+					}},
+				}},
+			}
+			policy := DefaultPolicy() // passive ceiling
+
+			violations := ValidateToolInvocation(manifest, "analyze", &policy)
+			if len(violations) != tt.wantViolN {
+				t.Errorf("ValidateToolInvocation risk_class=%q: got %d violations, want %d: %v",
+					tt.requested, len(violations), tt.wantViolN, violations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The plugin policy gate **failed open** on non-canonical `risk_class` values.

`validateSafety` compared risk classes by ordinal via `riskClassLevel(rc) > riskClassLevel(policy.MaxRiskClass)`. `riskClassLevel` returns `-1` for any unrecognized value, and `-1 > 0` (passive ceiling) is `false`, so the check passed. A plugin declaring `risk_class` `"RUNTIME"`, `"exec"`, `"root"`, `"dangerous"`, or even `"active "` (trailing space) slipped past the `MaxRiskClass` ceiling at both:

- registration — `ValidateManifest`, and
- per-tool invocation — `ValidateToolInvocation` / `authorizeTool`.

Severity: MED (policy gate fails open).

## Fix

`validateSafety` now treats any **non-empty** `risk_class` the host does not recognise (`riskClassLevel < 0`) as a violation and rejects it, instead of admitting it through an unbounded ordinal comparison. The gate **fails closed**.

Empty `risk_class` is preserved as the legitimate "unset → default" case (guarded by `rc != ""`), matching the existing `TestValidateManifest_RiskClass` "empty risk class passes" case. No existing safety test encoded the fail-open behaviour, so none needed weakening.

## Tests (red → green)

New `plugin/safety_failclosed_test.go` covers both the manifest and per-tool paths. Under a passive policy:

- canonical `"runtime"` → blocked (1 violation) — was already correct
- `"RUNTIME"`, `"ACTIVE"`, `"exec"`, `"root"`, `"dangerous"`, `"active "`, unknown `"banana"` (even under a runtime ceiling) → **now blocked** (previously admitted with 0 violations — the bug)
- `""` (empty) and `"passive"` → allowed

Verified red before the fix (non-canonical cases returned 0 violations), green after.

## Verification

- `go build ./...` clean
- `go test ./...` clean (one pre-existing flaky `registry/trust` cosign-version test unrelated to this change; passes on rerun)
- `golangci-lint run ./plugin/...` → 0 issues
- `go run ./cli bench --precision testdata/precision-suite` → OVERALL precision/recall **1.000 / 1.000**

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts