### PR TITLE
fix(deps): parse requirements.txt strict < and > bounds correctly

### DIFF
--- a/core/analyzers/deps/deps_test.go
+++ b/core/analyzers/deps/deps_test.go
@@ -165,6 +165,84 @@ Pillow[jpeg]==9.5.0
 	}
 }
 
+// TestParseRequirementsTxt_StrictBounds guards against a regression where
+// requirements.txt lines using bare "<" or ">" specifiers (valid PEP 508)
+// were dropped or corrupted. Two failure modes existed:
+//   - a strict-only bound (e.g. "Django<4") was dropped entirely because
+//     "<" and ">" were not in the operator set;
+//   - a compound line (e.g. "urllib3<1.27,>=1.21.1") was split on whichever
+//     operator appeared first in the operator LIST rather than the one at the
+//     leftmost position in the string, corrupting the package name (e.g.
+//     "urllib3<1.27,").
+//
+// Exercised through the real exported parser (ParseLockfile).
+func TestParseRequirementsTxt_StrictBounds(t *testing.T) {
+	analyzer := NewAnalyzer(WithOSVDisabled())
+
+	content := []byte("Django<4\nurllib3<1.27,>=1.21.1\nrequests>2.0\nflask==2.0.0\n")
+
+	pkgs, err := analyzer.ParseLockfile("/project/requirements.txt", content)
+	if err != nil {
+		t.Fatalf("ParseLockfile returned error: %v", err)
+	}
+
+	sort.Slice(pkgs, func(i, j int) bool {
+		return pkgs[i].Name < pkgs[j].Name
+	})
+
+	expected := []Package{
+		{Name: "Django", Version: "4", Ecosystem: "pypi"},
+		{Name: "flask", Version: "2.0.0", Ecosystem: "pypi"},
+		{Name: "requests", Version: "2.0", Ecosystem: "pypi"},
+		{Name: "urllib3", Version: "1.27", Ecosystem: "pypi"},
+	}
+
+	if len(pkgs) != len(expected) {
+		t.Fatalf("expected %d packages, got %d: %+v", len(expected), len(pkgs), pkgs)
+	}
+	for i, exp := range expected {
+		if pkgs[i] != exp {
+			t.Errorf("package[%d]: got %+v, want %+v", i, pkgs[i], exp)
+		}
+	}
+}
+
+// TestParseRequirementsTxt_OperatorSelection covers individual specifier
+// shapes: bare ">" / "<" alone, a compound "<...,>=..." (leftmost operator
+// wins), and confirms every previously-supported operator still parses.
+func TestParseRequirementsTxt_OperatorSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantPkg string
+		wantVer string
+	}{
+		{name: "strict greater alone", line: "pkg>1.0", wantPkg: "pkg", wantVer: "1.0"},
+		{name: "strict less alone", line: "pkg<2.0", wantPkg: "pkg", wantVer: "2.0"},
+		{name: "compound less then gte", line: "pkg<2,>=1", wantPkg: "pkg", wantVer: "2"},
+		{name: "exact", line: "pkg==1.2.3", wantPkg: "pkg", wantVer: "1.2.3"},
+		{name: "gte", line: "pkg>=1.2.3", wantPkg: "pkg", wantVer: "1.2.3"},
+		{name: "lte", line: "pkg<=1.2.3", wantPkg: "pkg", wantVer: "1.2.3"},
+		{name: "compatible", line: "pkg~=1.2.3", wantPkg: "pkg", wantVer: "1.2.3"},
+		{name: "not equal", line: "pkg!=1.2.3", wantPkg: "pkg", wantVer: "1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgs, err := parseRequirementsTxt([]byte(tt.line + "\n"))
+			if err != nil {
+				t.Fatalf("parseRequirementsTxt returned error: %v", err)
+			}
+			if len(pkgs) != 1 {
+				t.Fatalf("expected 1 package, got %d: %+v", len(pkgs), pkgs)
+			}
+			if pkgs[0].Name != tt.wantPkg || pkgs[0].Version != tt.wantVer {
+				t.Errorf("got %+v, want name=%q version=%q", pkgs[0], tt.wantPkg, tt.wantVer)
+			}
+		})
+	}
+}
+
 func TestParseRequirementsTxt_EmptyInput(t *testing.T) {
 	pkgs, err := parseRequirementsTxt([]byte("# only comments\n\n"))
 	if err != nil {

--- a/core/analyzers/deps/parsers.go
+++ b/core/analyzers/deps/parsers.go
@@ -441,14 +441,16 @@ func extractNpmPackageName(path string) string {
 
 // parseRequirementsTxt extracts pinned packages from a Python requirements.txt
 // file. It supports the == operator for exact pinning and also extracts the
-// version from >=, <=, ~=, and != specifiers (taking the version after the
-// operator). Lines without a version specifier are skipped.
+// version from >=, <=, ~=, !=, < and > specifiers (taking the version after the
+// leftmost operator). Lines without a version specifier are skipped.
 func parseRequirementsTxt(content []byte) ([]Package, error) {
 	var pkgs []Package
 
-	// Version specifier operators ordered from longest to shortest so that
-	// two-character operators match before single-character ones.
-	operators := []string{"==", ">=", "<=", "~=", "!="}
+	// All PEP 508 comparison operators, including the bare strict bounds
+	// "<" and ">". The two-character operators are listed before the
+	// single-character ones so that on an equal index (e.g. ">=" and ">"
+	// both start at the same position) the longer operator is preferred.
+	operators := []string{"==", ">=", "<=", "~=", "!=", "<", ">"}
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	for scanner.Scan() {
@@ -477,24 +479,38 @@ func parseRequirementsTxt(content []byte) ([]Package, error) {
 			}
 		}
 
-		// Try each operator to split name and version.
-		var name, version string
-		found := false
+		// Select the operator at the leftmost position in the line, not the
+		// first operator in the list. Compound specifiers such as
+		// "urllib3<1.27,>=1.21.1" must split on the "<" that precedes the
+		// name/version boundary; splitting on ">=" (which appears earlier in
+		// the operator list but later in the string) would corrupt the name.
+		// On an index tie the longer operator wins because two-character
+		// operators are ordered ahead of their single-character prefixes.
+		bestIdx := -1
+		var bestOp string
 		for _, op := range operators {
 			idx := strings.Index(line, op)
 			if idx == -1 {
 				continue
 			}
-			name = strings.TrimSpace(line[:idx])
+			if bestIdx == -1 || idx < bestIdx {
+				bestIdx = idx
+				bestOp = op
+			}
+		}
+
+		var name, version string
+		found := false
+		if bestIdx != -1 {
+			name = strings.TrimSpace(line[:bestIdx])
 			// Take only the first version (before any comma for
 			// compound specifiers like >=1.0,<2.0).
-			ver := strings.TrimSpace(line[idx+len(op):])
+			ver := strings.TrimSpace(line[bestIdx+len(bestOp):])
 			if comma := strings.Index(ver, ","); comma != -1 {
 				ver = strings.TrimSpace(ver[:comma])
 			}
 			version = ver
 			found = true
-			break
 		}
 
 		if !found || name == "" || version == "" {


### PR DESCRIPTION
## Problem

`parseRequirementsTxt` (core/analyzers/deps/parsers.go) missed dependencies — and therefore their CVEs — when a `requirements.txt` used the bare `<` or `>` PEP 508 specifiers, which are valid and common.

Two failure modes:

1. **Dropped package** — the operator set was `{"==", ">=", "<=", "~=", "!="}`; bare `<` and `>` were absent, so a strict-only bound like `Django<4` matched no operator and was skipped entirely.
2. **Corrupted name** — the parser selected the operator by *list order* rather than *leftmost position in the string*. A compound line like `urllib3<1.27,>=1.21.1` split on `>=` (earlier in the list, later in the string) instead of the leading `<`, producing the package name `urllib3<1.27,`, which matches no OSV record.

Confirmed repro through the exported `ParseLockfile`: input `Django<4 / urllib3<1.27,>=1.21.1 / requests>2.0 / flask==2.0.0` yielded only `flask` and a corrupted `urllib3`; `Django` and `requests` vanished.

## Fix

- Add `<` and `>` to the operator set.
- Select the operator with the smallest index in the line, preferring the longer operator on an index tie (`>=` over `>`).

This resolves both the dropped package and the name corruption. All four packages now parse with correct names and versions.

## Tests

- `TestParseRequirementsTxt_StrictBounds` — the four-line repro via the real `ParseLockfile`, asserting all 4 packages with correct names/versions. Confirmed failing before the fix (2 packages, one corrupted), passing after.
- `TestParseRequirementsTxt_OperatorSelection` — table-driven: `>`/`<` alone, `<...,>=...` compound (leftmost wins), and every previously-supported operator (`==`, `>=`, `<=`, `~=`, `!=`) still parses.
- Existing tests unchanged (none encoded the bug).

## Verification

- `go build ./...` clean
- `go test ./...` clean
- `golangci-lint run ./core/analyzers/deps/...` — 0 issues
- `go run ./cli bench --precision testdata/precision-suite` — OVERALL 1.000/1.000

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts