### PR TITLE
fix(rules): stop yaml-block span absorbing sibling sequence items

### DIFF
--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -485,6 +485,18 @@ func yamlBlockSpan(content []byte, pos int) []byte {
 	}
 	baseIndent := lineIndent(content, start)
 
+	// Whether the anchor line itself opens a sequence entry ("- ..."). This
+	// distinguishes the two same-indent cases below: a mapping-key anchor
+	// ("containers:") owns its equally-indented "-" children, but a sequence-entry
+	// anchor ("- name: app") is a sibling of the next equally-indented "-" and
+	// must stop before it.
+	anchorLineEnd := start
+	for anchorLineEnd < len(content) && content[anchorLineEnd] != '\n' {
+		anchorLineEnd++
+	}
+	anchorTrimmed := bytes.TrimSpace(content[start:anchorLineEnd])
+	anchorIsSeqItem := len(anchorTrimmed) > 0 && anchorTrimmed[0] == '-'
+
 	end := start
 	first := true
 	for end < len(content) {
@@ -498,12 +510,18 @@ func yamlBlockSpan(content []byte, pos int) []byte {
 				ind := lineIndent(content, end)
 				// A block sequence may be indented the SAME as its parent key
 				// (YAML allows `containers:` and its `- name:` items at equal
-				// indentation), so a same-indent line that is a sequence entry
-				// ("-") still belongs to the block. The block ends at the first
-				// line that is shallower, or at the same indent but a sibling
-				// mapping key rather than a sequence entry.
+				// indentation), so when the anchor is a mapping key a same-indent
+				// sequence entry ("-") still belongs to the block. But when the
+				// anchor is itself a sequence entry, the next same-indent "-" is a
+				// SIBLING list item, not a child, and must terminate the block —
+				// otherwise the anchor item would absorb its siblings' properties
+				// (a false negative). The block therefore ends at the first line
+				// that is shallower, or at the same indent when the line is a
+				// sibling: a mapping key, or a sequence entry when the anchor was
+				// one too.
 				isSeqItem := trimmed[0] == '-'
-				if ind < baseIndent || (ind == baseIndent && !isSeqItem) {
+				sameIndentSibling := !isSeqItem || anchorIsSeqItem
+				if ind < baseIndent || (ind == baseIndent && sameIndentSibling) {
 					break
 				}
 			}

--- a/core/rules/matcher_yamlblock_test.go
+++ b/core/rules/matcher_yamlblock_test.go
@@ -1,0 +1,112 @@
+package rules
+
+import "testing"
+
+// A pod spec whose FIRST container ("app") lacks a securityContext while a LATER
+// sibling ("sidecar") has one. Because both list items sit at the same
+// indentation, a yaml-block span anchored on the first "- name:" must NOT bleed
+// into the sibling and borrow its securityContext — doing so would clear the
+// insecure first container (a false negative).
+const podInsecureFirst = `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: app
+      image: app:latest
+    - name: sidecar
+      image: sidecar:latest
+      securityContext:
+        runAsNonRoot: true
+`
+
+// Mirror: the hardened container comes first, the insecure one second. The span
+// leak is forward-only (a block never absorbs preceding lines), so this case
+// already reports the insecure sibling. It guards against a fix that over-swings
+// and breaks the legitimate second-item detection.
+const podInsecureSecond = `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: app
+      image: app:latest
+      securityContext:
+        runAsNonRoot: true
+    - name: sidecar
+      image: sidecar:latest
+`
+
+// seqAnchorRule anchors on a YAML sequence entry ("- name:") and requires each
+// entry to carry a securityContext. This is the scenario the shipped rules do
+// not yet exercise (they anchor on mapping keys like "containers:"), which is
+// why the sibling-absorption bug is latent.
+func seqAnchorRule() *Rule {
+	return &Rule{
+		ID:              "TEST-SEQ-SECCTX",
+		AbsenceAnchor:   `(?i)- name:`,
+		AbsenceProperty: `(?i)securityContext`,
+		AbsenceSpan:     "yaml-block",
+	}
+}
+
+func TestAbsenceMatcher_YAMLBlock_SequenceSiblingNotAbsorbed(t *testing.T) {
+	m := NewAbsenceMatcher()
+
+	// Insecure container is FIRST, hardened sibling is SECOND. The first item's
+	// span must stop at the sibling "- name:" so its missing securityContext is
+	// reported. Before the fix this returns 0 (false negative).
+	got := m.Match([]byte(podInsecureFirst), seqAnchorRule())
+	if len(got) != 1 {
+		t.Fatalf("insecure-first: expected 1 finding on the unhardened container, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 5 {
+		t.Errorf("insecure-first: expected finding on line 5 (- name: app), got line %d", got[0].Line)
+	}
+}
+
+func TestAbsenceMatcher_YAMLBlock_SequenceSiblingMirrorStillFires(t *testing.T) {
+	m := NewAbsenceMatcher()
+
+	// Hardened container is FIRST, insecure sibling is SECOND. This already
+	// worked; it must keep working after the fix.
+	got := m.Match([]byte(podInsecureSecond), seqAnchorRule())
+	if len(got) != 1 {
+		t.Fatalf("insecure-second: expected 1 finding on the unhardened sibling, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 9 {
+		t.Errorf("insecure-second: expected finding on line 9 (- name: sidecar), got line %d", got[0].Line)
+	}
+}
+
+// TestAbsenceMatcher_YAMLBlock_MappingKeyAnchorAbsorbsSeqChildren guards the
+// mapping-key behavior the shipped rules depend on: an anchor on "containers:"
+// must still absorb its "- name:" sequence children (which sit at the same
+// indent) so a securityContext on any child clears the block.
+func TestAbsenceMatcher_YAMLBlock_MappingKeyAnchorAbsorbsSeqChildren(t *testing.T) {
+	m := NewAbsenceMatcher()
+	rule := &Rule{
+		ID:              "TEST-CONTAINERS-SECCTX",
+		AbsenceAnchor:   `(?i)containers:`,
+		AbsenceProperty: `(?i)securityContext`,
+		AbsenceSpan:     "yaml-block",
+	}
+
+	// securityContext lives on a child list item at the same indent as its
+	// siblings; the "containers:" span must reach it → no finding.
+	if got := m.Match([]byte(podInsecureSecond), rule); len(got) != 0 {
+		t.Fatalf("mapping-key anchor should absorb seq children and see securityContext, got %d findings: %+v", len(got), got)
+	}
+
+	// No securityContext anywhere under "containers:" → the block fires once.
+	noSecCtx := `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: app
+      image: app:latest
+    - name: sidecar
+      image: sidecar:latest
+`
+	if got := m.Match([]byte(noSecCtx), rule); len(got) != 1 {
+		t.Fatalf("mapping-key anchor with no securityContext should fire once, got %d: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Problem

`yamlBlockSpan` (core/rules/matcher.go), reached via `AbsenceMatcher.Match` for `absence_span: yaml-block`, terminated a block only at a shallower line or a same-indent **mapping key**. It treated every same-indent sequence entry (`- ...`) as a child of the block.

That is correct when the anchor is a **mapping key** (`containers:`) whose `-` items are genuinely its children. It is wrong when the anchor is itself a **sequence entry** (`- name: app`): the next same-indent `-` is a *sibling* list item, but the span kept absorbing it, so the anchor's block bled across the sibling and borrowed its properties.

### Effect (latent false negative)

For an absence rule anchored on a sequence entry (`- name:`) requiring `securityContext`, an insecure container that *precedes* a hardened sibling would "see" the sibling's `securityContext` and be wrongly cleared. No currently-shipped rule anchors on a sequence entry — IAC-135/137/138/139/140/145/147 all anchor on mapping keys like `containers:`/`securityContext:`, whose siblings are shallower and terminate correctly — so the defect was latent, not user-visible. Fixed before a future rule trips it.

## Fix

Detect whether the anchor line itself opens a sequence entry. When it does, a subsequent same-indent `-` terminates the block as a sibling instead of being absorbed as a child. Mapping-key anchors keep absorbing their equally-indented `-` children exactly as before.

Break condition at equal indent becomes "line is a sibling" = `!isSeqItem || anchorIsSeqItem`.

## Tests / verification

New matcher-level regression `core/rules/matcher_yamlblock_test.go`:
- insecure-first container now fires (was **0** before the fix — red→green)
- mirror insecure-second still fires (proves the leak was forward-only and the fix doesn't over-swing)
- mapping-key `containers:` anchor still absorbs its `- name:` seq children (guards shipped-rule behavior)

Regression gates held:
- `go run ./cli bench --precision testdata/precision-suite` → **OVERALL 1.000/1.000**
- `go test ./core/rules/... ./core/analyzers/iac/...` pass
- `go build ./...` and `golangci-lint run ./core/rules/...` clean (0 issues)

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts