### PR TITLE
fix(report): deterministic SBOM ordering, valid SPDX license, reproducible HTML

### DIFF
--- a/core/report/html/html.go
+++ b/core/report/html/html.go
@@ -9,9 +9,9 @@ import (
 	"html/template"
 	"os"
 	"sort"
-	"time"
 
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/report"
 )
 
 // Reporter generates standalone HTML reports from scan findings.
@@ -119,7 +119,10 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 
 	data := reportData{
 		ToolVersion: r.ToolVersion,
-		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		// Use report.GeneratedAt() so the embedded timestamp honors
+		// SOURCE_DATE_EPOCH like the JSON and SBOM emitters, keeping the HTML
+		// artifact byte-reproducible across runs.
+		GeneratedAt: report.GeneratedAt(),
 		Counts:      counts,
 		Findings:    rows,
 		SevPercents: percents,

--- a/core/report/html/html_test.go
+++ b/core/report/html/html_test.go
@@ -161,6 +161,31 @@ func TestGenerateSuppressedNotIncluded(t *testing.T) {
 	}
 }
 
+// TestGenerateHonorsSourceDateEpoch guards nox's reproducible-output guarantee
+// for the HTML artifact (DEFECT 3): the embedded timestamp must come from
+// report.GeneratedAt(), which honors SOURCE_DATE_EPOCH like the JSON and SBOM
+// emitters, not wall-clock time.Now(). Without this the HTML report is never
+// byte-reproducible across runs.
+func TestGenerateHonorsSourceDateEpoch(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+
+	r := NewReporter("test")
+	fs := findings.NewFindingSet()
+
+	data, err := r.Generate(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1700000000 == 2023-11-14T22:13:20Z.
+	const frozen = "2023-11-14T22:13:20Z"
+	html := string(data)
+	if !strings.Contains(html, frozen) {
+		t.Errorf("HTML report does not embed frozen SOURCE_DATE_EPOCH timestamp %q", frozen)
+	}
+}
+
 func TestWriteToFile(t *testing.T) {
 	t.Parallel()
 	r := NewReporter("test")

--- a/core/report/sbom/sbom.go
+++ b/core/report/sbom/sbom.go
@@ -160,7 +160,16 @@ func (r *CycloneDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, 
 			}
 		}
 		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].vuln.ID < entries[j].vuln.ID
+			// Sort by vuln.ID first, then by the package's original index as a
+			// deterministic tie-breaker. Entries are collected by ranging a map
+			// (randomized order in Go), so when one CVE affects several packages
+			// its entries share an equal vuln.ID; without this tie-breaker their
+			// relative order would vary run to run, breaking nox's byte-identical
+			// output guarantee.
+			if entries[i].vuln.ID != entries[j].vuln.ID {
+				return entries[i].vuln.ID < entries[j].vuln.ID
+			}
+			return entries[i].origIdx < entries[j].origIdx
 		})
 
 		for _, e := range entries {
@@ -307,8 +316,14 @@ func (r *SPDXReporter) Generate(inventory *deps.PackageInventory) ([]byte, error
 		spdxID := fmt.Sprintf("SPDXRef-Package-%d", i)
 		purl := buildPURL(ip.pkg)
 
+		// SPDX 2.3 requires licenseDeclared to be a valid SPDX license
+		// expression, NOASSERTION, or NONE. Free-text like "Apache 2.0" (with a
+		// space) or "see LICENSE file" would produce a spec-invalid document, so
+		// only emit the license when it is a recognized SPDX identifier and fall
+		// back to NOASSERTION otherwise. This mirrors the CycloneDX path's use of
+		// the spdxLicenseIDs whitelist.
 		declaredLicense := "NOASSERTION"
-		if ip.pkg.License != "" {
+		if spdxLicenseIDs[ip.pkg.License] {
 			declaredLicense = ip.pkg.License
 		}
 

--- a/core/report/sbom/sbom_test.go
+++ b/core/report/sbom/sbom_test.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -734,6 +735,93 @@ func TestSPDX_DeclaredLicense(t *testing.T) {
 // ---------------------------------------------------------------------------
 // CycloneDX & SPDX: WriteToFile error path
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// CycloneDX: determinism when one CVE affects multiple packages (DEFECT 1)
+// ---------------------------------------------------------------------------
+
+// TestCycloneDX_SharedCVEDeterministic guards nox's hard determinism guarantee:
+// identical input must yield byte-identical output. When a single CVE affects
+// two packages, the vulnerability entries share an equal vuln.ID, so a sort keyed
+// only on vuln.ID leaves their relative order to Go's randomized map iteration.
+// Generating repeatedly must produce the exact same bytes every time.
+func TestCycloneDX_SharedCVEDeterministic(t *testing.T) {
+	t.Parallel()
+
+	build := func() *deps.PackageInventory {
+		inv := &deps.PackageInventory{}
+		inv.Add(deps.Package{Name: "express", Version: "4.17.1", Ecosystem: "npm"})
+		inv.Add(deps.Package{Name: "lodash", Version: "4.17.20", Ecosystem: "npm"})
+		// The same CVE affects both packages — equal vuln.ID, different refs.
+		shared := deps.Vulnerability{ID: "CVE-2021-0001", Summary: "Shared issue", Severity: "high"}
+		inv.SetVulnerabilities(0, []deps.Vulnerability{shared})
+		inv.SetVulnerabilities(1, []deps.Vulnerability{shared})
+		return inv
+	}
+
+	r := NewCycloneDXReporter("0.1.0")
+	want, err := r.Generate(build())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		got, err := r.Generate(build())
+		if err != nil {
+			t.Fatalf("generate run %d: %v", i, err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatalf("run %d: output not byte-identical to first run\nfirst:\n%s\ngot:\n%s", i, want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SPDX: licenseDeclared must be a valid SPDX expression (DEFECT 2)
+// ---------------------------------------------------------------------------
+
+// TestSPDX_DeclaredLicenseIsSPDXValid guards SPDX 2.3 conformance: licenseDeclared
+// must be a valid SPDX license expression, NOASSERTION, or NONE — never raw
+// free-text. Unrecognized strings must collapse to NOASSERTION; a valid SPDX id
+// must be preserved verbatim.
+func TestSPDX_DeclaredLicenseIsSPDXValid(t *testing.T) {
+	t.Parallel()
+
+	inv := &deps.PackageInventory{}
+	inv.Add(deps.Package{Name: "valid", Version: "1", Ecosystem: "npm", License: "MIT"})
+	inv.Add(deps.Package{Name: "spaced", Version: "1", Ecosystem: "npm", License: "Apache 2.0"})
+	inv.Add(deps.Package{Name: "freetext", Version: "1", Ecosystem: "npm", License: "see LICENSE file"})
+
+	r := NewSPDXReporter("0.1.0")
+	data, err := r.Generate(inv)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var doc SPDXDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+
+	byName := map[string]string{}
+	for _, p := range doc.Packages {
+		byName[p.Name] = p.DeclaredLicense
+	}
+
+	if byName["valid"] != "MIT" {
+		t.Errorf("valid SPDX id should be preserved, got %q", byName["valid"])
+	}
+	if byName["spaced"] == "Apache 2.0" {
+		t.Errorf("raw non-SPDX license %q leaked into licenseDeclared", byName["spaced"])
+	}
+	if byName["spaced"] != "NOASSERTION" {
+		t.Errorf("expected NOASSERTION for %q, got %q", "Apache 2.0", byName["spaced"])
+	}
+	if byName["freetext"] == "see LICENSE file" {
+		t.Errorf("raw free-text license %q leaked into licenseDeclared", byName["freetext"])
+	}
+	if byName["freetext"] != "NOASSERTION" {
+		t.Errorf("expected NOASSERTION for free-text, got %q", byName["freetext"])
+	}
+}
 
 func TestCycloneDX_WriteToFile_ErrorOnInvalidPath(t *testing.T) {
 	r := NewCycloneDXReporter("0.1.0")


### PR DESCRIPTION
## Summary

Fixes three confirmed defects in nox's report emitters (`core/report/`), each covered by a red→green test.

### DEFECT 1 (HIGH) — CycloneDX SBOM non-deterministic when one CVE affects multiple packages
`CycloneDXReporter.Generate` built vulnerability entries by ranging a `map[int][]Vulnerability` (randomized Go map order) and sorted them only by `vuln.ID`. When a single CVE affects two packages, the entries share an equal `vuln.ID`, so their relative order was left to map-iteration randomness — the output was not byte-identical across runs, violating nox's hard determinism guarantee. Added a deterministic tie-breaker on the package's original index.

### DEFECT 2 (MED) — SPDX `licenseDeclared` emitted raw non-SPDX strings
`SPDXReporter.Generate` copied the raw package license verbatim. SPDX 2.3 requires `licenseDeclared` to be a valid SPDX license expression, `NOASSERTION`, or `NONE`, so free-text like `"Apache 2.0"` (space) or `"see LICENSE file"` produced spec-invalid documents. Now emits the license only when it is a recognized SPDX identifier (reusing the existing `spdxLicenseIDs` whitelist that the CycloneDX path already uses), else `NOASSERTION`.

### DEFECT 3 (MED) — HTML report ignored `SOURCE_DATE_EPOCH`
`html.go` used `time.Now().UTC()` instead of `report.GeneratedAt()`, so the HTML artifact was never reproducible. Now uses `report.GeneratedAt()`, honoring `SOURCE_DATE_EPOCH` like the JSON and SBOM emitters.

## Tests (red → green)
- `TestCycloneDX_SharedCVEDeterministic` — two packages share one CVE; `Generate` is called 100× and every run must be byte-identical.
- `TestSPDX_DeclaredLicenseIsSPDXValid` — `"Apache 2.0"` and `"see LICENSE file"` collapse to `NOASSERTION`; a valid SPDX id (`MIT`) is preserved.
- `TestGenerateHonorsSourceDateEpoch` — with `SOURCE_DATE_EPOCH` set, the embedded timestamp is the frozen epoch, not wall-clock.

Each test was confirmed failing against the unpatched code, then passing after the fix. No existing tests were weakened.

## Verification
- `go build ./...` clean
- `go test ./core/report/...` clean; full suite clean
- `golangci-lint run ./core/report/...` — 0 issues
- `go run ./cli bench --precision testdata/precision-suite` — OVERALL 1.000 / 1.000

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts