### PR TITLE
fix(registry): cap tar.gz extraction to defend against decompression bombs

### DIFF
--- a/registry/oci/extract.go
+++ b/registry/oci/extract.go
@@ -24,6 +24,22 @@ const (
 // ErrPathTraversal indicates a tar entry attempted to escape the destination directory.
 var ErrPathTraversal = errors.New("tar entry contains path traversal")
 
+const (
+	// defaultMaxExtractSize caps the total uncompressed bytes written across all
+	// entries during extraction. download() bounds the compressed blob at 500 MB,
+	// but gzip's ~1000x worst-case ratio means an archive within that limit could
+	// still expand to hundreds of GB and exhaust disk (a decompression bomb).
+	// 2 GB comfortably fits any legitimate plugin (binaries + libraries + assets)
+	// while capping the worst case to a bounded, recoverable amount of disk.
+	defaultMaxExtractSize int64 = 2 * 1024 * 1024 * 1024 // 2 GB
+
+	// defaultMaxExtractEntries caps the number of tar entries processed. This
+	// bounds a "many tiny files" bomb, where per-entry filesystem overhead
+	// (inodes, directory writes) dominates over the raw byte budget. A real
+	// plugin has far fewer entries than this.
+	defaultMaxExtractEntries = 100000
+)
+
 // gzipMagic is the two-byte magic number for gzip files.
 var gzipMagic = []byte{0x1f, 0x8b}
 
@@ -49,7 +65,20 @@ func DetectFormat(path string) (ArtifactFormat, error) {
 // ExtractTarGz extracts a gzip-compressed tar archive to dstDir using atomic
 // extraction (extract to temp dir, then rename). Returns the list of extracted
 // file paths relative to dstDir.
+//
+// Extraction is bounded: the total uncompressed size and the number of entries
+// are capped (see defaultMaxExtractSize / defaultMaxExtractEntries) to defend
+// against decompression bombs. ErrSizeExceeded is returned when either cap is
+// hit, and no partial output is left behind (the temp dir is removed).
 func ExtractTarGz(srcPath, dstDir string) ([]string, error) {
+	return extractTarGz(srcPath, dstDir, defaultMaxExtractSize, defaultMaxExtractEntries)
+}
+
+// extractTarGz is the bounded implementation of ExtractTarGz. maxBytes caps the
+// cumulative uncompressed bytes written; maxEntries caps the number of tar
+// entries. It is a separate function (rather than reading package constants
+// directly) so tests can exercise the limits with small, fast archives.
+func extractTarGz(srcPath, dstDir string, maxBytes int64, maxEntries int) ([]string, error) {
 	// Extract to a temporary directory next to dstDir, then rename atomically.
 	parentDir := filepath.Dir(dstDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
@@ -82,6 +111,11 @@ func ExtractTarGz(srcPath, dstDir string) ([]string, error) {
 	tr := tar.NewReader(gz)
 	var extracted []string
 
+	// remaining is the running uncompressed-byte budget shared across all
+	// entries; entryCount enforces the per-archive entry cap.
+	remaining := maxBytes
+	entryCount := 0
+
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -89,6 +123,11 @@ func ExtractTarGz(srcPath, dstDir string) ([]string, error) {
 		}
 		if err != nil {
 			return nil, fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		entryCount++
+		if entryCount > maxEntries {
+			return nil, fmt.Errorf("%w: archive has more than %d entries", ErrSizeExceeded, maxEntries)
 		}
 
 		if err := validateTarEntry(hdr, tmpDir); err != nil {
@@ -107,9 +146,17 @@ func ExtractTarGz(srcPath, dstDir string) ([]string, error) {
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return nil, fmt.Errorf("creating parent for %s: %w", hdr.Name, err)
 			}
-			if err := extractFile(target, tr, hdr.FileInfo().Mode()); err != nil {
+			// Bound this entry to the remaining budget. extractFile reads at most
+			// remaining+1 bytes so we can distinguish "exactly at the limit"
+			// (allowed) from "over the limit" (rejected) exactly.
+			n, err := extractFile(target, tr, hdr.FileInfo().Mode(), remaining)
+			if err != nil {
 				return nil, fmt.Errorf("extracting %s: %w", hdr.Name, err)
 			}
+			if n > remaining {
+				return nil, fmt.Errorf("%w: uncompressed size exceeds %d bytes", ErrSizeExceeded, maxBytes)
+			}
+			remaining -= n
 			extracted = append(extracted, filepath.Clean(hdr.Name))
 
 		case tar.TypeSymlink:
@@ -173,23 +220,29 @@ func validateTarEntry(hdr *tar.Header, dstDir string) error {
 	return nil
 }
 
-// extractFile writes a tar entry to disk atomically.
-func extractFile(target string, r io.Reader, mode os.FileMode) error {
+// extractFile writes a tar entry to disk atomically, reading at most limit+1
+// bytes from r. It returns the number of bytes written. Reading one byte past
+// the limit lets the caller detect an over-budget entry exactly (n > limit)
+// while an entry sized exactly at the limit still succeeds. Because at most
+// limit+1 bytes are ever written before the caller aborts and removes the temp
+// dir, a decompression bomb cannot write unbounded output to disk.
+func extractFile(target string, r io.Reader, mode os.FileMode, limit int64) (int64, error) {
 	tmp := target + ".tmp"
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode&0o777|0o644)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	if _, err := io.Copy(f, r); err != nil {
+	n, err := io.Copy(f, io.LimitReader(r, limit+1))
+	if err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
-		return err
+		return n, err
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
-		return err
+		return n, err
 	}
 
-	return os.Rename(tmp, target)
+	return n, os.Rename(tmp, target)
 }

--- a/registry/oci/extract_test.go
+++ b/registry/oci/extract_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -493,6 +494,232 @@ func TestExtractTarGzFilePermissions(t *testing.T) {
 	// The extractFile function applies mode&0o777|0o644, so 0o755 should be preserved.
 	if info.Mode()&0o111 == 0 {
 		t.Error("script.sh should have executable bits set")
+	}
+}
+
+// createTestTarGzZeros writes a tar.gz containing a single regular-file entry
+// of `size` zero bytes. Zeros are highly compressible, so the resulting archive
+// is tiny while the uncompressed payload is `size` — the shape of a
+// decompression bomb.
+func createTestTarGzZeros(t *testing.T, dstPath, name string, size int64) {
+	t.Helper()
+
+	f, err := os.Create(dstPath)
+	if err != nil {
+		t.Fatalf("creating tar.gz: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0o644,
+		Size:     size,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatalf("writing tar header: %v", err)
+	}
+	if _, err := io.CopyN(tw, zeroReader{}, size); err != nil {
+		t.Fatalf("writing tar content: %v", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
+}
+
+// zeroReader is an infinite source of zero bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestExtractTarGzDecompressionBomb verifies that an archive whose uncompressed
+// payload far exceeds the budget is rejected with ErrSizeExceeded, and that the
+// full expanded output is not written to disk.
+func TestExtractTarGzDecompressionBomb(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "bomb.tar.gz")
+	extractDir := filepath.Join(tmpDir, "extracted")
+
+	// 8 MiB of zeros, but a 64 KiB budget: ~128x over the cap.
+	const payload = 8 * 1024 * 1024
+	const maxBytes = 64 * 1024
+	createTestTarGzZeros(t, archivePath, "bomb.bin", payload)
+
+	// The compressed archive is tiny (zeros compress ~1000x); confirm it would
+	// pass the 500 MB download cap yet expand far beyond the extract budget.
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("stat archive: %v", err)
+	}
+	if info.Size() >= maxBytes {
+		t.Fatalf("test archive %d bytes is not smaller than the budget; not a bomb", info.Size())
+	}
+
+	_, err = extractTarGz(archivePath, extractDir, maxBytes, defaultMaxExtractEntries)
+	if !errors.Is(err, ErrSizeExceeded) {
+		t.Fatalf("error = %v, want ErrSizeExceeded", err)
+	}
+
+	// The atomic rename never happens on failure, so the destination must not
+	// exist. This is what fails on the unbounded (buggy) code, which writes all
+	// 8 MiB and renames it into place.
+	if _, statErr := os.Stat(extractDir); !os.IsNotExist(statErr) {
+		t.Errorf("extract dir exists after bomb rejection: %v", statErr)
+	}
+
+	// Nothing near the full payload should remain anywhere under tmpDir (the
+	// archive itself is tiny). Bound it well under the payload to prove the
+	// bomb was not written unbounded.
+	total, err := dirSize(tmpDir)
+	if err != nil {
+		t.Fatalf("measuring tmpDir: %v", err)
+	}
+	if leftover := total - info.Size(); leftover > 2*maxBytes {
+		t.Errorf("leftover extracted bytes = %d, want <= %d (bomb written unbounded)", leftover, 2*maxBytes)
+	}
+}
+
+// TestExtractTarGzSizeBoundaryExact verifies the LimitReader boundary is exact:
+// an entry sized exactly at the budget succeeds, one byte over fails.
+func TestExtractTarGzSizeBoundaryExact(t *testing.T) {
+	const maxBytes = 4096
+
+	t.Run("exactly at limit succeeds", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		archivePath := filepath.Join(tmpDir, "exact.tar.gz")
+		extractDir := filepath.Join(tmpDir, "extracted")
+		createTestTarGzZeros(t, archivePath, "exact.bin", maxBytes)
+
+		extracted, err := extractTarGz(archivePath, extractDir, maxBytes, defaultMaxExtractEntries)
+		if err != nil {
+			t.Fatalf("extractTarGz at exact limit: %v", err)
+		}
+		if len(extracted) != 1 {
+			t.Fatalf("extracted %d files, want 1", len(extracted))
+		}
+		info, err := os.Stat(filepath.Join(extractDir, "exact.bin"))
+		if err != nil {
+			t.Fatalf("stat extracted file: %v", err)
+		}
+		if info.Size() != maxBytes {
+			t.Errorf("extracted size = %d, want %d", info.Size(), maxBytes)
+		}
+	})
+
+	t.Run("one byte over limit fails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		archivePath := filepath.Join(tmpDir, "over.tar.gz")
+		extractDir := filepath.Join(tmpDir, "extracted")
+		createTestTarGzZeros(t, archivePath, "over.bin", maxBytes+1)
+
+		_, err := extractTarGz(archivePath, extractDir, maxBytes, defaultMaxExtractEntries)
+		if !errors.Is(err, ErrSizeExceeded) {
+			t.Fatalf("error = %v, want ErrSizeExceeded", err)
+		}
+	})
+}
+
+// TestExtractTarGzBudgetSpansEntries verifies the budget is cumulative across
+// entries: several entries that individually fit but together exceed the budget
+// are rejected.
+func TestExtractTarGzBudgetSpansEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "multi.tar.gz")
+	extractDir := filepath.Join(tmpDir, "extracted")
+
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("creating tar.gz: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	// Three 1 KiB entries = 3 KiB total against a 2 KiB budget.
+	for i := 0; i < 3; i++ {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "part" + string(rune('a'+i)) + ".bin",
+			Mode:     0o644,
+			Size:     1024,
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("writing header: %v", err)
+		}
+		if _, err := io.CopyN(tw, zeroReader{}, 1024); err != nil {
+			t.Fatalf("writing content: %v", err)
+		}
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	_ = f.Close()
+
+	_, err = extractTarGz(archivePath, extractDir, 2048, defaultMaxExtractEntries)
+	if !errors.Is(err, ErrSizeExceeded) {
+		t.Fatalf("error = %v, want ErrSizeExceeded (cumulative budget)", err)
+	}
+	if _, statErr := os.Stat(extractDir); !os.IsNotExist(statErr) {
+		t.Errorf("extract dir should not exist after budget exceeded")
+	}
+}
+
+// TestExtractTarGzEntryCountCap verifies the entry-count cap rejects a
+// "many tiny files" bomb.
+func TestExtractTarGzEntryCountCap(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "manyfiles.tar.gz")
+	extractDir := filepath.Join(tmpDir, "extracted")
+
+	entries := make(map[string]string, 20)
+	for i := 0; i < 20; i++ {
+		entries["f"+string(rune('a'+i))] = "x"
+	}
+	createTestTarGz(t, archivePath, entries)
+
+	_, err := extractTarGz(archivePath, extractDir, defaultMaxExtractSize, 5)
+	if !errors.Is(err, ErrSizeExceeded) {
+		t.Fatalf("error = %v, want ErrSizeExceeded (entry cap)", err)
+	}
+}
+
+// TestExtractTarGzLegitimateUnderCap verifies a normal, small plugin archive
+// still extracts correctly under the default caps via the public entrypoint.
+func TestExtractTarGzLegitimateUnderCap(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "plugin.tar.gz")
+	extractDir := filepath.Join(tmpDir, "extracted")
+
+	entries := map[string]string{
+		"bin/nox-plugin": "#!/bin/sh\necho real plugin",
+		"lib/support.so": "some binary-ish payload",
+		"LICENSE":        "MIT",
+	}
+	createTestTarGz(t, archivePath, entries)
+
+	extracted, err := ExtractTarGz(archivePath, extractDir)
+	if err != nil {
+		t.Fatalf("ExtractTarGz on legitimate archive: %v", err)
+	}
+	if len(extracted) != len(entries) {
+		t.Fatalf("extracted %d files, want %d", len(extracted), len(entries))
+	}
+	for name, want := range entries {
+		got, err := os.ReadFile(filepath.Join(extractDir, name))
+		if err != nil {
+			t.Errorf("reading %s: %v", name, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s content = %q, want %q", name, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`ExtractTarGz` (registry/oci/extract.go) extracted gzip tar archives with **no bound on uncompressed output**:

- `extractFile` did `io.Copy(f, r)` with no `LimitReader`.
- The extraction loop had no cumulative byte accounting and no entry-count cap.

`download()` caps the **compressed** blob at `defaultMaxDownloadSize` (500 MB), but gzip's ~1000x worst-case ratio means an archive within that limit can expand to **hundreds of GB**, exhausting disk (a classic decompression bomb; offline-reachable).

Worse, extraction runs in `fetchArtifact` **before** the caller inspects `VerifyResult.Violations`, so even a **trust-rejected** plugin has its bomb written to the cache first.

## Fix

Bound extraction with a **running uncompressed-byte budget shared across all entries** plus a **per-archive entry-count cap**:

- Each regular-file entry is copied through `io.LimitReader(tr, remaining+1)`; `remaining` is decremented by the bytes written. Reading one byte past the budget lets the loop detect an over-budget entry (`n > remaining`) exactly, so an entry sized **exactly** at the limit succeeds and one byte over is rejected.
- Entry count is capped to bound a "many tiny files" bomb.
- Both conditions return `ErrSizeExceeded`. Because extraction is atomic (temp dir renamed into place only on success), a rejected archive leaves **no partial/expanded output** on disk.

Limits (dedicated constants, justified in comments): **2 GB** total uncompressed (comfortably fits any legitimate plugin while bounding the worst case), **100k** entries.

The public `ExtractTarGz` signature is unchanged; an internal `extractTarGz(src, dst, maxBytes, maxEntries)` carries the limits so tests exercise them with small, fast archives.

## Tests (red → green confirmed)

Reproduced red by temporarily neutering the enforcement (unbounded `io.Copy`, no caps): the bomb / boundary / cumulative-budget / entry-cap tests all failed (`error = <nil>, want ErrSizeExceeded`) while the legitimate archive passed. Restoring the fix makes all pass. Added:

- `TestExtractTarGzDecompressionBomb` — 8 MiB zero payload vs 64 KiB budget: rejected with `ErrSizeExceeded`, extract dir absent, leftover bytes bounded (proves not written unbounded).
- `TestExtractTarGzSizeBoundaryExact` — entry exactly at budget succeeds; one byte over fails.
- `TestExtractTarGzBudgetSpansEntries` — three 1 KiB entries vs 2 KiB budget: rejected (cumulative accounting).
- `TestExtractTarGzEntryCountCap` — 20 entries vs cap of 5: rejected.
- `TestExtractTarGzLegitimateUnderCap` — normal small plugin archive still extracts correctly.

## Verification

- `go build ./...` — clean
- `go test ./...` — pass
- `go test ./registry/oci -race` — pass
- `golangci-lint run ./registry/...` — 0 issues

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts