### PR TITLE
fix(server): enforce output-size cap on MCP dashboard handlers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1235,6 +1235,22 @@ func (s *Server) handleDataSensitivityReport(_ context.Context, _ emptyInput) (m
 
 // Dashboard tool handler.
 
+// dashboardTooLargeNotice returns a structured JSON notice mirroring the
+// handleGetFindings "output_too_large" pattern. The dashboard is a single HTML
+// document, so a mid-document truncate() would yield broken, unparseable markup
+// with no signal to the caller that data was lost. Instead the dashboard
+// handlers fail closed once the rendered HTML crosses the response budget and
+// point the caller at the cheaper summary / list_findings tools.
+func dashboardTooLargeNotice(size int) string {
+	notice, _ := json.MarshalIndent(map[string]any{
+		"error":       "output_too_large",
+		"total_bytes": size,
+		"limit_bytes": maxOutputBytes,
+		"hint":        "the dashboard HTML exceeds the response budget — use summary for an aggregate overview, or list_findings with limit/offset to page through findings",
+	}, "", "  ")
+	return string(notice)
+}
+
 func (s *Server) handleDashboard(_ context.Context, input dashboardInput) (string, error) {
 	pc := s.getCache(input.Path)
 	if pc == nil {
@@ -1244,6 +1260,10 @@ func (s *Server) handleDashboard(_ context.Context, input dashboardInput) (strin
 	html, err := GenerateDashboardHTML(pc.result, s.version, pc.basePath)
 	if err != nil {
 		return "", fmt.Errorf("generating dashboard: %w", err)
+	}
+
+	if len(html) > maxOutputBytes {
+		return dashboardTooLargeNotice(len(html)), nil
 	}
 
 	return html, nil
@@ -1434,6 +1454,14 @@ func (s *Server) handleResourceDashboard(_ context.Context, uri string, _ map[st
 		return nil, fmt.Errorf("generating dashboard: %w", err)
 	}
 
+	if len(html) > maxOutputBytes {
+		return &mcp.ResourceContent{
+			URI:      uri,
+			MimeType: "application/json",
+			Text:     dashboardTooLargeNotice(len(html)),
+		}, nil
+	}
+
 	return &mcp.ResourceContent{
 		URI:      uri,
 		MimeType: "text/html",
@@ -1582,6 +1610,14 @@ func (s *Server) handleProjectResourceDashboard(_ context.Context, uri string, p
 	html, err := GenerateDashboardHTML(pc.result, s.version, pc.basePath)
 	if err != nil {
 		return nil, fmt.Errorf("generating dashboard: %w", err)
+	}
+
+	if len(html) > maxOutputBytes {
+		return &mcp.ResourceContent{
+			URI:      uri,
+			MimeType: "application/json",
+			Text:     dashboardTooLargeNotice(len(html)),
+		}, nil
 	}
 
 	return &mcp.ResourceContent{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/analyzers/ai"
+	"github.com/nox-hq/nox/core/analyzers/deps"
+	findingspkg "github.com/nox-hq/nox/core/findings"
 	pluginv1 "github.com/nox-hq/nox/gen/nox/plugin/v1"
 	"github.com/nox-hq/nox/plugin"
 	mcp "go.klarlabs.de/mcp"
@@ -1685,6 +1689,95 @@ func TestHandleDashboard_AfterScan(t *testing.T) {
 	}
 	if !strings.Contains(result, "<html") {
 		t.Fatalf("expected HTML content in dashboard")
+	}
+}
+
+// oversizedScanResult builds a ScanResult whose dashboard HTML exceeds
+// maxOutputBytes, used to exercise the output-size cap on the dashboard
+// handlers. The findings carry long messages so the rendered HTML crosses the
+// 1MB response budget.
+func oversizedScanResult(t *testing.T) *nox.ScanResult {
+	t.Helper()
+	fs := findingspkg.NewFindingSet()
+	msg := strings.Repeat("boundary violation in prompt context ", 4)
+	for i := 0; i < 20000; i++ {
+		fs.Add(findingspkg.NewFinding(
+			"SEC-100",
+			findingspkg.SeverityHigh,
+			findingspkg.ConfidenceHigh,
+			findingspkg.Location{FilePath: "cmd/service/handler.go", StartLine: i + 1, EndLine: i + 1},
+			msg,
+		))
+	}
+	return &nox.ScanResult{
+		Findings:    fs,
+		Inventory:   &deps.PackageInventory{},
+		AIInventory: ai.NewInventory(),
+	}
+}
+
+func TestGenerateDashboardHTML_OversizedExceedsBudget(t *testing.T) {
+	html, err := GenerateDashboardHTML(oversizedScanResult(t), "0.1.0", t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(html) <= maxOutputBytes {
+		t.Fatalf("expected oversized dashboard HTML > %d bytes, got %d", maxOutputBytes, len(html))
+	}
+}
+
+func TestHandleDashboard_OversizedReturnsNotice(t *testing.T) {
+	s := New("0.1.0", nil)
+	dir := t.TempDir()
+	s.setCache(dir, oversizedScanResult(t))
+
+	result, err := s.handleDashboard(context.Background(), dashboardInput{Path: dir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) > maxOutputBytes {
+		t.Fatalf("dashboard response exceeded output budget: %d > %d bytes", len(result), maxOutputBytes)
+	}
+	if !strings.Contains(result, "output_too_large") {
+		t.Fatalf("expected structured output_too_large notice, got: %s", result[:min(len(result), 200)])
+	}
+}
+
+func TestHandleResourceDashboard_OversizedReturnsNotice(t *testing.T) {
+	s := New("0.1.0", nil)
+	dir := t.TempDir()
+	s.setCache(dir, oversizedScanResult(t))
+
+	content, err := s.handleResourceDashboard(context.Background(), "nox://dashboard", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content.Text) > maxOutputBytes {
+		t.Fatalf("dashboard resource exceeded output budget: %d > %d bytes", len(content.Text), maxOutputBytes)
+	}
+	if !strings.Contains(content.Text, "output_too_large") {
+		t.Fatalf("expected structured output_too_large notice, got: %s", content.Text[:min(len(content.Text), 200)])
+	}
+}
+
+func TestHandleProjectResourceDashboard_OversizedReturnsNotice(t *testing.T) {
+	s := New("0.1.0", nil)
+	dir := t.TempDir()
+	s.setCache(dir, oversizedScanResult(t))
+
+	content, err := s.handleProjectResourceDashboard(
+		context.Background(),
+		"nox://projects/x/dashboard",
+		map[string]string{"project": dir},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content.Text) > maxOutputBytes {
+		t.Fatalf("project dashboard resource exceeded output budget: %d > %d bytes", len(content.Text), maxOutputBytes)
+	}
+	if !strings.Contains(content.Text, "output_too_large") {
+		t.Fatalf("expected structured output_too_large notice, got: %s", content.Text[:min(len(content.Text), 200)])
 	}
 }
 


### PR DESCRIPTION
## Problem

The three MCP dashboard handlers bypassed the 1MB output cap that every other text handler enforces:

- `handleDashboard` (dashboard tool)
- `handleResourceDashboard` (read of `nox://dashboard`)
- `handleProjectResourceDashboard` (per-project dashboard resource)

All three returned `GenerateDashboardHTML(...)` verbatim. Every other text handler funnels through `truncate()` (cap `maxOutputBytes = 1<<20`) or the structured `output_too_large` notice (`handleGetFindings`). The dashboard handlers enforced neither, so a dashboard tool call / read on a large scan returned a multi-MB string into the MCP response, scaling linearly with scan size — an output / context DoS (MED).

## Fix

A mid-HTML `truncate()` would yield broken, unparseable markup with no signal to the caller that data was lost. So the handlers **fail closed**: when the rendered HTML exceeds `maxOutputBytes`, they return a structured `output_too_large` JSON notice (mirroring the `handleGetFindings` pattern) pointing the caller at `summary` / `list_findings` instead. Small dashboards still return real HTML unchanged.

A shared `dashboardTooLargeNotice(size)` helper builds the notice; the two resource handlers emit it with `application/json` MIME type in that branch. The CLI `dashboard_cmd.go` path (writes to a file) is untouched.

## Tests (red → green)

Added to `server/server_test.go`:

- `TestGenerateDashboardHTML_OversizedExceedsBudget` — a `ScanResult` with 20k findings renders to ~9MB HTML, asserting it exceeds `maxOutputBytes`.
- `TestHandleDashboard_OversizedReturnsNotice`, `TestHandleResourceDashboard_OversizedReturnsNotice`, `TestHandleProjectResourceDashboard_OversizedReturnsNotice` — each drives its handler and asserts the response is bounded (`<= maxOutputBytes`) and contains `output_too_large`.

Confirmed red first (handlers returned 9,181,073 bytes > 1,048,576), then green after the fix. Existing `TestHandleDashboard_AfterScan` / resource dashboard tests still pass, proving small dashboards return real HTML.

## Verification

- `go build ./...` clean
- `go test ./server/...` passing
- `golangci-lint run ./server/...` — 0 issues

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts