### PR TITLE
fix(action): stop the GitHub Action failing on a zero-findings scan

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -169,9 +169,19 @@ run_scan() {
   echo "exit-code=${exit_code}" >> "${GITHUB_OUTPUT}"
 
   # Count findings from findings.json if it exists.
+  #
+  # grep -c prints the count but EXITS 1 when there are zero matches, so a
+  # `|| echo "0"` fallback would fire on top of grep's own "0" and make
+  # findings_count the two-line value "0\n0". Writing that to GITHUB_OUTPUT
+  # emits a bare second line and fails the whole step with
+  # "Unable to process file command 'output' ... Invalid format '0'" — i.e. the
+  # action broke on every repository whose scan produced no findings. Swallow
+  # grep's exit status instead and default an empty result (unreadable file) to
+  # 0, so findings_count is always a single clean integer.
   local findings_count=0
   if [[ -f "${output_dir}/findings.json" ]]; then
-    findings_count=$(grep -c '"RuleID"' "${output_dir}/findings.json" 2>/dev/null || echo "0")
+    findings_count=$(grep -c '"RuleID"' "${output_dir}/findings.json" 2>/dev/null || true)
+    findings_count=${findings_count:-0}
     echo "findings-file=${output_dir}/findings.json" >> "${GITHUB_OUTPUT}"
   fi
   echo "findings-count=${findings_count}" >> "${GITHUB_OUTPUT}"

--- a/cli/action_findings_count_test.go
+++ b/cli/action_findings_count_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The nox GitHub Action (action.sh) counted findings with
+//
+//	findings_count=$(grep -c '"RuleID"' findings.json 2>/dev/null || echo "0")
+//
+// grep -c prints the count but EXITS 1 when there are zero matches, so on a
+// clean scan the `|| echo "0"` fallback fired on top of grep's own "0" and made
+// findings_count the two-line value "0\n0". Writing that to $GITHUB_OUTPUT
+// emitted a bare second line and failed the step with
+// "Unable to process file command 'output' ... Invalid format '0'" — the action
+// broke on every repository whose scan produced no findings. This guards the
+// fix from both directions.
+func TestActionFindingsCount_NoDoublingOnZero(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "action.sh"))
+	if err != nil {
+		t.Fatalf("read action.sh: %v", err)
+	}
+	if strings.Contains(string(src), `|| echo "0")`) {
+		t.Error(`action.sh still uses the "|| echo \"0\"" findings-count fallback that doubles the count to "0\n0" on a zero-findings scan`)
+	}
+
+	// Behavioral: the corrected count pipeline must yield exactly one clean
+	// integer line for a zero-findings file, so the GITHUB_OUTPUT write is valid.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "findings.json")
+	if err := os.WriteFile(f, []byte(`{"findings":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := `findings_count=$(grep -c '"RuleID"' "` + f + `" 2>/dev/null || true)
+findings_count=${findings_count:-0}
+printf 'findings-count=%s\n' "$findings_count"`
+	out, err := exec.Command("bash", "-c", script).Output()
+	if err != nil {
+		t.Fatalf("run count pipeline: %v", err)
+	}
+	got := string(out)
+	if extra := strings.Count(strings.TrimRight(got, "\n"), "\n"); extra != 0 {
+		t.Errorf("expected single-line output; got %d extra newline(s): %q", extra, got)
+	}
+	if strings.TrimSpace(got) != "findings-count=0" {
+		t.Errorf("got %q, want findings-count=0", got)
+	}
+}


### PR DESCRIPTION
## Problem

The action counted findings with:
```bash
findings_count=$(grep -c '"RuleID"' findings.json 2>/dev/null || echo "0")
```
`grep -c` prints the count but **exits 1** when there are zero matches, so on a clean scan the `|| echo "0"` fallback fired *on top of* grep's own `0`, making `findings_count` the two-line value `"0\n0"`. Writing that to `$GITHUB_OUTPUT` emits a bare second line and fails the step with:
```
Unable to process file command 'output' successfully.
Invalid format '0'
```

**Impact:** the action broke on *every repository whose scan produced no findings* — most visibly a PR-scoped, changed-files-only gate on a change that touches only `go.mod`/`go.sum`. That is exactly why the plugin repos' **Nox PR Gate** failed while their full-repo **Self-Scan** (which finds ≥1 finding, so `grep -c` exits 0) passed.

## Fix

Swallow grep's exit status with `|| true` and default an empty result to `0`, so `findings_count` is always a single clean integer. Guarded by a test that fails against the old `|| echo "0"` form and checks the corrected pipeline emits one valid `findings-count=N` line for a zero-findings file.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts