### PR TITLE
test(sbom): freeze the clock in the CycloneDX determinism test (fix CI flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-07-20
+
+### Fixed
+
+- **The GitHub Action failed on any scan that produced no findings.** The action
+  counted findings with `grep -c … || echo "0"`; because `grep -c` exits non-zero
+  when there are zero matches, the fallback fired on top of grep's own `0` and
+  wrote a two-line `findings-count` value to `$GITHUB_OUTPUT`, failing the step
+  with *"Unable to process file command 'output' … Invalid format '0'"*. Any
+  repository whose scan found nothing — for example a PR-scoped, changed-files
+  gate on a change touching only `go.mod`/`go.sum` — saw its Nox gate go red for
+  no real reason. The count is now always a single clean integer.
+
 ## [1.13.0] - 2026-07-20
 
 A large security-hardening and correctness release. Two adversarial audits of

--- a/core/report/sbom/sbom_test.go
+++ b/core/report/sbom/sbom_test.go
@@ -746,7 +746,13 @@ func TestSPDX_DeclaredLicense(t *testing.T) {
 // only on vuln.ID leaves their relative order to Go's randomized map iteration.
 // Generating repeatedly must produce the exact same bytes every time.
 func TestCycloneDX_SharedCVEDeterministic(t *testing.T) {
-	t.Parallel()
+	// Freeze the clock. Byte-identical output is nox's reproducibility guarantee
+	// only WITH SOURCE_DATE_EPOCH set; otherwise the CycloneDX metadata timestamp
+	// is wall-clock (report.GeneratedAt -> time.Now at second resolution), so 100
+	// rapid Generate calls occasionally straddle a one-second boundary and this
+	// test flakes on the timestamp — not on the ordering it means to check.
+	// (t.Setenv precludes t.Parallel, which is why this test is not parallel.)
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
 
 	build := func() *deps.PackageInventory {
 		inv := &deps.PackageInventory{}


### PR DESCRIPTION
`TestCycloneDX_SharedCVEDeterministic` asserts 100 `Generate` calls are byte-identical but didn't set `SOURCE_DATE_EPOCH`. The CycloneDX metadata timestamp is `report.GeneratedAt()`, which falls back to wall-clock `time.Now()` (second resolution) when `SOURCE_DATE_EPOCH` is unset — so when the 100 rapid calls straddle a one-second boundary (rare, timing/load dependent), the timestamp changes and the test fails. **It was flaking CI on unrelated PRs** (e.g. it blocked the 1.13.1 changelog PR).

Byte-identical output is nox's reproducibility guarantee only *with* `SOURCE_DATE_EPOCH` set — that's the variable's entire purpose — so the test now sets it, isolating the property it actually checks (deterministic ordering when one CVE affects several packages). `t.Setenv` precludes `t.Parallel`, so the test is no longer parallel.

Verified stable across **300 in-process iterations and 20 separate processes**, 0 failures.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts