### PR TITLE
fix(scan): report a nox:ignore that suppresses nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `nox:ignore` that suppresses nothing is now reported.** A dedicated
+  directive applies to the next non-blank line, so a reason that wrapped onto a
+  second comment line made the waiver land on that continuation comment — the
+  finding below stayed reported, and nothing indicated the suppression had
+  missed. A mistyped rule ID, or a waiver left behind after the finding was
+  fixed, failed just as silently. Unused waivers now surface as a suppression
+  degradation naming the file, line and rule. Correctly-applied waivers and
+  deliberately-expired ones stay quiet (verified: nox's own self-scan, which
+  carries many `nox:ignore` comments, reports none).
+
 ## [1.13.1] - 2026-07-20
 
 ### Fixed

--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -498,3 +498,56 @@ func TestScan_PathlessFindingIsNotASuppressionDegradation(t *testing.T) {
 			result.Degradations)
 	}
 }
+
+// A dedicated nox:ignore applies to the next non-blank line, so a reason that
+// wraps onto a second comment line makes the waiver land on that continuation
+// comment — the finding below stays reported and nothing said so. The operator
+// believed it was waived. An unused waiver is now surfaced.
+func TestScan_UnusedSuppressionIsReported(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// The reason wraps, so the directive targets the second comment line.
+	content := "# nox:ignore SEC-652 -- this reason wraps onto\n# a second comment line\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "conf.py"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if !hasDegradationKind(result, "suppression") {
+		t.Errorf("a waiver that suppressed nothing must be reported; got %+v", result.Degradations)
+	}
+	// And it genuinely did not waive: the finding is still reported.
+	var stillReported bool
+	for _, f := range result.Findings.Findings() {
+		if f.RuleID == "SEC-652" && f.Status != findings.StatusSuppressed {
+			stillReported = true
+		}
+	}
+	if !stillReported {
+		t.Error("expected the finding to remain reported when the waiver missed")
+	}
+}
+
+// The counterpart: a correctly-placed waiver suppresses its finding and must NOT
+// be reported as unused, or the new signal would be noise on every clean repo.
+func TestScan_UsedSuppressionIsNotReportedAsUnused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := "# nox:ignore SEC-652 -- single-line reason\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "conf.py"), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if hasDegradationKind(result, "suppression") {
+		t.Errorf("a waiver that applied must not be reported as unused: %+v", result.Degradations)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -1165,14 +1165,50 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 		}
 
 		items := fs.Findings()
+		// Every matching suppression is marked used, not just the first: two
+		// waivers may legitimately cover the same finding, and breaking early
+		// would report the second as unused below.
+		used := make([]bool, len(suppressions))
 		for _, idx := range indices {
 			f := items[idx]
-			for _, s := range suppressions {
-				if s.MatchesFinding(f.RuleID, f.Location.StartLine, timeNow()) {
-					fs.SetStatus(idx, findings.StatusSuppressed)
-					break
+			suppressed := false
+			for si := range suppressions {
+				if suppressions[si].MatchesFinding(f.RuleID, f.Location.StartLine, timeNow()) {
+					used[si] = true
+					suppressed = true
 				}
 			}
+			if suppressed {
+				fs.SetStatus(idx, findings.StatusSuppressed)
+			}
+		}
+
+		// A waiver that suppressed nothing is reported. The operator believes a
+		// finding is waived when it is not, and nothing else says otherwise.
+		//
+		// The common cause is a dedicated directive whose reason wrapped onto a
+		// second comment line: the directive applies to the next non-blank line,
+		// so it lands on the continuation comment and the code below stays
+		// reported. A mistyped rule ID and a waiver left behind after the finding
+		// was fixed produce the same silence.
+		//
+		// An unparseable expiry is already reported above; do not say it twice.
+		// A correctly-parsed EXPIRED waiver is also excluded: it is meant to stop
+		// applying, so its findings returning is the feature working, not a
+		// mistake to warn about.
+		for si := range suppressions {
+			if used[si] || suppressions[si].InvalidExpiry != "" {
+				continue
+			}
+			if suppressions[si].Expires != nil && timeNow().After(*suppressions[si].Expires) {
+				continue
+			}
+			deg.Add(degrade.Suppression,
+				fmt.Sprintf("%s:%d waives %s but matched no finding",
+					filePath, suppressions[si].Line, strings.Join(suppressions[si].RuleIDs, ",")),
+				"this waiver is not suppressing anything — check the rule ID, whether the finding moved, "+
+					"and that a dedicated nox:ignore comment sits on the line directly above the code (a reason "+
+					"wrapped onto a second comment line takes the waiver with it)")
 		}
 	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -936,6 +936,21 @@ INSERT INTO users (token) VALUES ('test-token');
 
 **Supported comment styles:** `//` (Go, JS, Java, C, Rust), `#` (Python, Ruby, Shell, YAML), `--` (SQL, Lua), `/*` (CSS, C), `<!--` (HTML, XML).
 
+**Keep a dedicated directive on one line.** A dedicated comment applies to the
+**next non-blank line**. If the reason wraps onto a second comment line, the
+waiver lands on that continuation comment instead of the code — the finding is
+still reported, with nothing to indicate the suppression missed:
+
+```go
+// nox:ignore SEC-001 -- this reason wraps onto
+// a second line, so the waiver targets THIS comment
+var testKey = "AKIAEXAMPLEFAKEKEY" // still reported
+```
+
+Write it on a single line, or put it as a trailing comment on the finding's own
+line. Consecutive `nox:ignore` comments are fine — stacked directives all apply
+to the next line of code.
+
 Suppressed findings are marked with `status: "suppressed"` in the output and do not count toward policy failure.
 
 ---


### PR DESCRIPTION
## Problem

A dedicated `nox:ignore` applies to the **next non-blank line**. If the reason wraps onto a second comment line, the waiver lands on that continuation comment — the finding below stays reported, and **nothing indicates the suppression missed**:

```go
// nox:ignore SEC-001 -- this reason wraps onto
// a second comment line, so the waiver targets THIS line
var testKey = "AKIAEXAMPLEFAKEKEY" // still reported, silently
```

I hit this for real waiving findings across the plugin fleet: two waivers silently failed and their gates stayed red with no explanation. A mistyped rule ID, or a waiver left behind after the finding was fixed, fails exactly as silently.

## Fix

Unused waivers now surface as a **suppression degradation** naming the file, line and rule IDs — alongside the existing unreadable-file and unparseable-expiry reports.

Deliberately **excluded**, so the signal isn't noise:
- correctly-applied waivers (they matched something)
- a correctly-parsed **expired** waiver — it's *meant* to stop applying (guarded; an existing test asserts this)
- an unparseable expiry — already reported separately

Also: every matching suppression is now marked used rather than breaking on the first, so two waivers covering one finding don't report the second as unused.

## What I did *not* change

The targeting logic. A continuation comment and a finding that legitimately sits *on* a comment line (a secret in a comment — which nox detects) are structurally identical, so silently retargeting could break valid waivers. Making the failure visible is the safe fix.

## Verification

- New tests both directions: the wrapped-reason waiver is reported **and** its finding stays reported; a correct waiver is **not** flagged.
- Existing expiry tests still pass (expired → no degradation; unexpired → still waives).
- **nox's own repo**, which carries many `nox:ignore` comments: **0** unused-waiver degradations — precise, not noisy.
- Full suite 51/51, precision 1.000/1.000, lint clean.

Follows #281, which documented this footgun; this makes it self-reporting.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts