### PR TITLE
fix(suppress): do not report doc examples as unused waivers

### DIFF
--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -551,3 +551,27 @@ func TestScan_UsedSuppressionIsNotReportedAsUnused(t *testing.T) {
 		t.Errorf("a waiver that applied must not be reported as unused: %+v", result.Degradations)
 	}
 }
+
+// Documentation that demonstrates nox:ignore must not be reported as a pile of
+// unused waivers. nox's own README shows the syntax in fenced code blocks whose
+// sample secrets are deliberately too short to match a rule, so every example
+// waived nothing and was reported — noise, in a file that is behaving correctly.
+func TestScan_MarkdownDocExamplesAreNotReportedUnused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A doc example in a fence (waives nothing) plus a real finding in the same
+	// file, so the file reaches the suppression pass at all.
+	md := "# Docs\n\nSuppress like this:\n\n```go\n// nox:ignore SEC-001 -- false positive in test data\nvar testKey = \"AKIAEXAMPLEFAKEKEY\"\n```\n\nA real token below:\n\njenkins_token = \"AbcdefghijklmnopqrstUVWX\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(md), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	result, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if hasDegradationKind(result, "suppression") {
+		t.Errorf("doc examples in fenced blocks must not be reported as unused waivers: %+v", result.Degradations)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -1203,6 +1203,12 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 			if suppressions[si].Expires != nil && timeNow().After(*suppressions[si].Expires) {
 				continue
 			}
+			// A directive inside a fenced code block in markdown is documentation
+			// showing the syntax, not a waiver anyone expects to apply — reporting
+			// it as unused is pure noise. nox's own README trips this.
+			if suppressions[si].DocExample {
+				continue
+			}
 			deg.Add(degrade.Suppression,
 				fmt.Sprintf("%s:%d waives %s but matched no finding",
 					filePath, suppressions[si].Line, strings.Join(suppressions[si].RuleIDs, ",")),

--- a/core/suppress/suppress.go
+++ b/core/suppress/suppress.go
@@ -16,6 +16,7 @@ package suppress
 import (
 	"bufio"
 	"bytes"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -39,6 +40,24 @@ type Suppression struct {
 	// do not match, so the finding is reported — failing toward showing
 	// findings rather than hiding them — and the caller reports it.
 	InvalidExpiry string
+
+	// DocExample marks a directive written inside a fenced code block in a
+	// markdown file — i.e. documentation showing what a nox:ignore looks like,
+	// not a waiver an operator expects to apply. It changes nothing about
+	// matching: such a directive still suppresses a real finding on its target
+	// line, exactly as before. It only tells the caller not to report it as an
+	// unused waiver, because prose demonstrating the syntax waives nothing by
+	// design and that report would be pure noise. nox's own README trips this.
+	DocExample bool
+}
+
+// markdownExts are the file types whose fenced code blocks hold illustrative
+// directives rather than operative ones.
+var markdownExts = map[string]bool{".md": true, ".markdown": true, ".mdx": true}
+
+// isFence reports whether a trimmed line opens or closes a fenced code block.
+func isFence(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
 }
 
 // suppressionRE matches nox:ignore / nox:disable directives in any
@@ -65,8 +84,16 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 		lines = append(lines, scanner.Text())
 	}
 
+	// Fenced code blocks in markdown hold directives that illustrate the syntax
+	// rather than waive anything; track them so the caller can tell the two apart.
+	isMarkdown := markdownExts[strings.ToLower(filepath.Ext(filePath))]
+	inFence := false
+
 	for i, line := range lines {
 		lineNum := i + 1
+		if isMarkdown && isFence(strings.TrimSpace(line)) {
+			inFence = !inFence
+		}
 		match := suppressionRE.FindStringSubmatch(line)
 		if match == nil {
 			continue
@@ -127,6 +154,7 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 			Reason:        reason,
 			Expires:       expires,
 			InvalidExpiry: invalidExpiry,
+			DocExample:    isMarkdown && inFence,
 		})
 	}
 

--- a/core/suppress/suppress_test.go
+++ b/core/suppress/suppress_test.go
@@ -302,3 +302,42 @@ func TestScanForSuppressions_DisableTrailingComment(t *testing.T) {
 		t.Errorf("line = %d, want 1 (trailing comment applies to same line)", supps[0].Line)
 	}
 }
+
+// A nox:ignore inside a fenced code block in markdown is documentation showing
+// the syntax, not a waiver anyone expects to apply. It is flagged so the caller
+// can skip reporting it as unused — but it must still parse and still match, so
+// a genuine waiver written in a doc keeps working.
+func TestScanForSuppressions_MarkdownFenceIsDocExample(t *testing.T) {
+	md := "# Docs\n\nExample:\n\n```go\n// nox:ignore SEC-001 -- shown in docs\nvar k = \"AKIAEXAMPLEFAKEKEY\"\n```\n\n<!-- nox:ignore SEC-002 -- a real waiver, outside any fence -->\nreal line\n"
+
+	got := ScanForSuppressions([]byte(md), "README.md")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 suppressions, got %d: %+v", len(got), got)
+	}
+	byRule := map[string]Suppression{}
+	for _, s := range got {
+		byRule[s.RuleIDs[0]] = s
+	}
+	if !byRule["SEC-001"].DocExample {
+		t.Error("directive inside a fenced block should be marked DocExample")
+	}
+	if byRule["SEC-002"].DocExample {
+		t.Error("directive outside a fence must NOT be marked DocExample")
+	}
+	// Marking must not disturb matching: the fenced one still targets its line.
+	if !byRule["SEC-001"].MatchesFinding("SEC-001", byRule["SEC-001"].Line, time.Now()) {
+		t.Error("a fenced directive must still match a finding on its target line")
+	}
+}
+
+// The same directive in a non-markdown file is never a doc example.
+func TestScanForSuppressions_FenceOnlyAppliesToMarkdown(t *testing.T) {
+	src := "```\n// nox:ignore SEC-001 -- not markdown\nvar k = 1\n"
+	got := ScanForSuppressions([]byte(src), "main.go")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(got))
+	}
+	if got[0].DocExample {
+		t.Error("backticks in a .go file must not mark a directive as a doc example")
+	}
+}


### PR DESCRIPTION
Reporting unused waivers (v1.13.2, #282) flagged **documentation that demonstrates the syntax**. nox's own README shows `nox:ignore` inside fenced code blocks whose sample secrets are deliberately too short to match a rule, so every example waived nothing and got reported:

```
[degraded] README.md:322 waives SEC-001 but matched no finding
[degraded] README.md:324 waives SEC-005 but matched no finding
```

Noise, in a file behaving exactly as intended.

## Fix

A directive inside a fenced code block in a markdown file is marked `DocExample` and skipped by the unused-waiver report.

**Matching is deliberately untouched** — such a directive still suppresses a real finding on its target line, so a genuine waiver written inside a doc keeps working. Backticks in a non-markdown file mean nothing and are ignored.

## Verification

- Against the **real README**: 2 spurious degradations before, **0 after**, with the file's genuine finding still reported (no detection lost).
- Unit tests: fenced directive marked, non-fenced in the same file not marked, `.go` file with backticks not marked, and a fenced directive still `MatchesFinding` on its target line.
- End-to-end test: a markdown file with a doc example *and* a real finding produces no suppression degradation.
- The genuine signal is intact — the wrapped-reason and typo'd-rule cases still report.
- Full suite 51/51, precision 1.000/1.000, lint clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts