### PR TITLE
fix: repair two of nox's own nox:ignore waivers

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,7 +130,7 @@ brews:
     repository:
       owner: felixgeelhaar
       name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}" # nox:ignore SEC-163 -- Go template using env var
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com # nox:ignore DATA-001 -- goreleaser bot email

--- a/core/analyzers/ai/aibom_polyglot.go
+++ b/core/analyzers/ai/aibom_polyglot.go
@@ -186,16 +186,18 @@ func extractSDKInvocations(path string, content []byte) []ModelReference {
 // `process.env.X` style references commonly used to feed LLM clients.
 // Returns the env var name when one matches, or "" otherwise.
 func detectAuthEnvVar(text string) string {
-	// nox:ignore SEC-161,SEC-163,SEC-574 -- these are detector
-	// regex patterns, not credentials. The patterns themselves match
-	// "API_KEY"/"TOKEN"/"SECRET"/"PASSWORD" identifiers in scanned
-	// source; they are not secrets.
+	// These are detector regexes, not credentials: they match
+	// "API_KEY"/"TOKEN"/"SECRET"/"PASSWORD" identifiers in scanned source.
+	//
+	// The waivers are per-line and trailing. A directive applies to exactly one
+	// line, so the single directive that used to sit above this block waived
+	// nothing at all — every pattern below was reported despite looking waived.
 	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`os\.getenv\s*\(\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`),
-		regexp.MustCompile(`os\.environ\[\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`),
+		regexp.MustCompile(`os\.getenv\s*\(\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`), // nox:ignore SEC-161,SEC-163 -- detector pattern, not a credential
+		regexp.MustCompile(`os\.environ\[\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`),   // nox:ignore SEC-161,SEC-163 -- detector pattern, not a credential
 		regexp.MustCompile(`process\.env\.([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))`),
-		regexp.MustCompile(`process\.env\[\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`),
-		regexp.MustCompile(`os\.Getenv\s*\(\s*"([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))"\s*\)`),
+		regexp.MustCompile(`process\.env\[\s*["']([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))["']`), // nox:ignore SEC-161,SEC-163 -- detector pattern, not a credential
+		regexp.MustCompile(`os\.Getenv\s*\(\s*"([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD))"\s*\)`), // nox:ignore SEC-161,SEC-163 -- detector pattern, not a credential
 	}
 	for _, re := range patterns {
 		if m := re.FindStringSubmatch(text); len(m) > 1 {


### PR DESCRIPTION
Reporting unused waivers (#282) immediately caught two in **this** repository.

### `aibom_polyglot.go` — a waiver that never worked

The directive above the detector-pattern block spanned four comment lines, so it applied to the *second comment line* and waived nothing. All **14 SEC-161/SEC-163 findings** on those regexes were being reported despite looking waived — the exact footgun the new report exists to surface, in our own source.

A directive covers one line, so the four pattern lines that actually produce findings now carry their own trailing waivers. `SEC-574` is dropped — verified it does not fire here.

### `.goreleaser.yaml` — a dead waiver

The `SEC-163` waiver on the tap token no longer matches anything; that rule no longer flags a Go template env-var reference. Removed. (The `DATA-001` waiver two lines below **is** live and is untouched.)

### Verification

- Self-scan before: 14 unsuppressed findings in `aibom_polyglot.go` + 2 unused-waiver reports.
- Self-scan after: **14 suppressed, 0 unsuppressed, 0 unused waivers**.
- Waivers applied to exactly the 4 lines that fire (confirmed by scan, not guessed) — no blanket waiving.
- Full suite 51/51, precision 1.000/1.000, lint clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts