### PR TITLE
feat(sarif): emit security-severity so Code Scanning can classify alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SARIF now carries `security-severity`, so GitHub Code Scanning can classify
+  nox alerts.** SARIF's `level` only distinguishes error/warning/note, and nox
+  emitted nothing else, so every alert arrived in Code Scanning with no security
+  severity: the UI could not filter or sort by it, and severity-based alert rules
+  had nothing to match on. Every rule descriptor now carries a CVSS-style score
+  banded the way GitHub reads it — critical 9.5, high 8.0, medium 5.5, low 2.0.
+  Info is deliberately omitted rather than scored 0, which would render as "low"
+  and overstate it.
+
 ## [1.13.3] - 2026-07-21
 
 ### Fixed

--- a/core/report/sarif/sarif.go
+++ b/core/report/sarif/sarif.go
@@ -247,6 +247,31 @@ func (r *Reporter) WriteToFile(fs *findings.FindingSet, path string) error {
 // severityToLevel maps a Nox severity to the corresponding SARIF level
 // string. Critical and high map to "error", medium to "warning", and low/info
 // to "note".
+// securitySeverity maps a nox severity to the SARIF `security-severity`
+// property GitHub Code Scanning reads. SARIF `level` alone only distinguishes
+// error/warning/note, so without this every nox alert arrived with no security
+// severity at all: the Code Scanning UI could not filter or sort by severity,
+// and severity-based alert rules had nothing to match on.
+//
+// The value is a CVSS-style score string, banded the way GitHub interprets it:
+// >= 9.0 critical, 7.0-8.9 high, 4.0-6.9 medium, < 4.0 low. Info is not a
+// security severity and is deliberately omitted (empty) rather than scored 0,
+// which would render as "low" and overstate it.
+func securitySeverity(s findings.Severity) string {
+	switch s {
+	case findings.SeverityCritical:
+		return "9.5"
+	case findings.SeverityHigh:
+		return "8.0"
+	case findings.SeverityMedium:
+		return "5.5"
+	case findings.SeverityLow:
+		return "2.0"
+	default:
+		return ""
+	}
+}
+
 func severityToLevel(s findings.Severity) string {
 	switch s {
 	case findings.SeverityCritical, findings.SeverityHigh:
@@ -307,14 +332,18 @@ func (r *Reporter) buildRuleCatalog(items []findings.Finding) (catalog []Reporti
 			continue
 		}
 		index[id] = len(catalog)
-		catalog = append(catalog, ReportingDescriptor{
+		desc := ReportingDescriptor{
 			ID:               id,
 			Name:             id,
 			ShortDescription: Message{Text: items[i].Message},
 			DefaultConfiguration: Configuration{
 				Level: severityToLevel(items[i].Severity),
 			},
-		})
+		}
+		if ss := securitySeverity(items[i].Severity); ss != "" {
+			desc.Properties = map[string]any{"security-severity": ss}
+		}
+		catalog = append(catalog, desc)
 	}
 	return catalog, index
 }
@@ -360,6 +389,10 @@ func (r *Reporter) buildCatalogFromRuleSet() (catalog []ReportingDescriptor, ind
 		// Emit rule tags in the standard SARIF taxonomy slot.
 		if len(rule.Tags) > 0 {
 			props["tags"] = rule.Tags
+		}
+		// GitHub Code Scanning classifies alerts by this, not by SARIF level.
+		if ss := securitySeverity(rule.Severity); ss != "" {
+			props["security-severity"] = ss
 		}
 		if len(props) > 0 {
 			desc.Properties = props
@@ -432,7 +465,7 @@ func (r *Reporter) buildCatalogFromFindings(items []findings.Finding) (catalog [
 	for _, ri := range unique {
 		idx := len(catalog)
 		index[ri.id] = idx
-		catalog = append(catalog, ReportingDescriptor{
+		desc := ReportingDescriptor{
 			ID:   ri.id,
 			Name: ri.id,
 			ShortDescription: Message{
@@ -441,7 +474,11 @@ func (r *Reporter) buildCatalogFromFindings(items []findings.Finding) (catalog [
 			DefaultConfiguration: Configuration{
 				Level: severityToLevel(ri.severity),
 			},
-		})
+		}
+		if ss := securitySeverity(ri.severity); ss != "" {
+			desc.Properties = map[string]any{"security-severity": ss}
+		}
+		catalog = append(catalog, desc)
 	}
 
 	return catalog, index

--- a/core/report/sarif/sarif_test.go
+++ b/core/report/sarif/sarif_test.go
@@ -465,8 +465,14 @@ func TestRuleCatalogOmitsHelpWhenNoRemediation(t *testing.T) {
 	if entry.HelpURI != "" {
 		t.Fatalf("expected empty helpUri, got %q", entry.HelpURI)
 	}
-	if entry.Properties != nil {
-		t.Fatalf("expected nil properties for empty metadata, got %+v", entry.Properties)
+	// Empty metadata no longer means an empty property bag: every rule carries
+	// security-severity so GitHub Code Scanning can classify the alert. Nothing
+	// else should appear for a rule with no metadata, tags or mapping.
+	if len(entry.Properties) != 1 {
+		t.Fatalf("expected only security-severity in properties, got %+v", entry.Properties)
+	}
+	if entry.Properties["security-severity"] != "2.0" {
+		t.Fatalf("expected security-severity 2.0 for a low-severity rule, got %+v", entry.Properties)
 	}
 }
 
@@ -776,5 +782,62 @@ func TestWriteToFile_ErrorOnInvalidPath(t *testing.T) {
 	err := r.WriteToFile(fs, "/nonexistent/dir/results.sarif")
 	if err == nil {
 		t.Fatal("expected error writing to invalid path, got nil")
+	}
+}
+
+// GitHub Code Scanning classifies alerts by the `security-severity` property,
+// not by SARIF level. nox emitted none, so every alert arrived with no security
+// severity: the UI could not filter or sort by it and severity-based alert rules
+// had nothing to match. Every rule descriptor now carries it.
+func TestSARIF_EmitsSecuritySeverity(t *testing.T) {
+	fs := findings.NewFindingSet()
+	for _, tc := range []struct {
+		rule string
+		sev  findings.Severity
+	}{
+		{"R-CRIT", findings.SeverityCritical},
+		{"R-HIGH", findings.SeverityHigh},
+		{"R-MED", findings.SeverityMedium},
+		{"R-LOW", findings.SeverityLow},
+		{"R-INFO", findings.SeverityInfo},
+	} {
+		fs.Add(findings.Finding{
+			RuleID:   tc.rule,
+			Severity: tc.sev,
+			Message:  "m",
+			Location: findings.Location{FilePath: "a.go", StartLine: 1},
+		})
+	}
+
+	data, err := NewReporter("test", nil).Generate(fs)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	runs := doc["runs"].([]any)
+	ruleDescs := runs[0].(map[string]any)["tool"].(map[string]any)["driver"].(map[string]any)["rules"].([]any)
+
+	got := map[string]string{}
+	for _, r := range ruleDescs {
+		rm := r.(map[string]any)
+		id, _ := rm["id"].(string)
+		if props, ok := rm["properties"].(map[string]any); ok {
+			if ss, ok := props["security-severity"].(string); ok {
+				got[id] = ss
+			}
+		}
+	}
+	want := map[string]string{"R-CRIT": "9.5", "R-HIGH": "8.0", "R-MED": "5.5", "R-LOW": "2.0"}
+	for id, w := range want {
+		if got[id] != w {
+			t.Errorf("%s security-severity = %q, want %q", id, got[id], w)
+		}
+	}
+	// Info is not a security severity: scoring it would render as "low".
+	if ss, ok := got["R-INFO"]; ok {
+		t.Errorf("info severity must not carry security-severity, got %q", ss)
 	}
 }


### PR DESCRIPTION
## Problem

SARIF `level` only distinguishes error/warning/note. **GitHub Code Scanning classifies alerts by the `security-severity` property**, and nox emitted none — so all **388 nox alerts across the plugin fleet** arrived with no security severity. The Code Scanning UI can't filter or sort by severity, and severity-based alert rules have nothing to match on.

nox knows each finding's severity; it just never exported it in the field GitHub reads. (This is also what made my earlier fleet measurement read `0 high/critical` — I was querying an always-null field.)

## Fix

Every rule descriptor now carries a CVSS-style score, banded as GitHub interprets it:

| nox severity | security-severity | GitHub band |
|---|---|---|
| critical | 9.5 | critical (≥9.0) |
| high | 8.0 | high (7.0–8.9) |
| medium | 5.5 | medium (4.0–6.9) |
| low | 2.0 | low (<4.0) |
| info | *omitted* | — |

Info is deliberately omitted rather than scored `0`, which GitHub would render as **low** and overstate it.

Applied on **all three** descriptor paths — the RuleSet catalog, the catalog-from-findings fallback, and the reconcile pass that synthesises descriptors for plugin rules absent from the RuleSet — so plugin findings get classified too.

## Note on an updated test

`TestRuleCatalogOmitsHelpWhenNoRemediation` asserted a **nil** property bag for a rule with no metadata. That's no longer true by design, so it now asserts the bag holds `security-severity` and nothing else — tightened rather than loosened.

## Verification

- Unit test covers all five severities including the info omission.
- **Real scan**: 1539 of 1540 catalogued rules carry the property, correctly correlated with level (8.0↔error, 5.5↔warning); the one without is info.
- Full suite 51/51, precision 1.000/1.000, lint clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts