### PR TITLE
fix(plugin entry): emit the cosign v4 bundle name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`nox plugin entry` emitted signature URLs for files that are never
+  published.** It wrote the cosign v3 names — a detached `checksums.txt.sig` and
+  `checksums.txt.sig.bundle` — but the plugin release workflows sign with cosign
+  v4, which writes a single `checksums.txt.sigstore.json` and no detached
+  signature. Registry entries therefore pointed at assets that did not exist, the
+  signature download returned 404, the artifact was classified `unverified`, and
+  `nox plugin install` was blocked by the default trust policy. Every plugin
+  version published after the move to cosign v4 was uninstallable. The bundle URL
+  is now the v4 name and the dead `.sig` URL is dropped.
+
 - **SARIF now carries `security-severity`, so GitHub Code Scanning can classify
   nox alerts.** SARIF's `level` only distinguishes error/warning/note, and nox
   emitted nothing else, so every alert arrived in Code Scanning with no security

--- a/cli/plugin_entry_cmd.go
+++ b/cli/plugin_entry_cmd.go
@@ -157,11 +157,19 @@ func buildPluginEntry(m *pluginManifest, version, repo, minNox string) registry.
 			Arch:   p.arch,
 			URL:    url,
 			Digest: "sha256:tbd",
-			// Cosign keyless signs checksums.txt. Both the legacy
-			// .sig and the v4-compatible .sig.bundle are published;
-			// nox prefers the bundle when available.
-			CosignSigURL:    fmt.Sprintf("%s/releases/download/v%s/checksums.txt.sig", repoURL, version),
-			CosignBundleURL: fmt.Sprintf("%s/releases/download/v%s/checksums.txt.sig.bundle", repoURL, version),
+			// Cosign keyless signs checksums.txt. The plugin release
+			// workflows run cosign v4, which writes a single
+			// checksums.txt.sigstore.json and NO detached .sig — the v3
+			// pair (.sig + .sig.bundle) is not published at all.
+			//
+			// Emitting the v3 names produced entries pointing at files that
+			// were never uploaded: the signature download 404s, the artifact
+			// is classified "unverified", and the install is blocked by the
+			// default trust policy. Every plugin version published after the
+			// move to cosign v4 was uninstallable until the index was
+			// repaired by hand. CosignSigURL is left empty (omitempty drops
+			// it) because v4 has nothing to put there.
+			CosignBundleURL: fmt.Sprintf("%s/releases/download/v%s/checksums.txt.sigstore.json", repoURL, version),
 			// Case-insensitive prefix: GitHub preserves the org's
 			// canonical case in OIDC certificate SANs (e.g. "Nox-HQ"),
 			// but the registry index conventionally lowercases owners.

--- a/cli/plugin_entry_cmd_test.go
+++ b/cli/plugin_entry_cmd_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The plugin release workflows sign with cosign v4, which writes a single
+// checksums.txt.sigstore.json and no detached .sig. Emitting the v3 names
+// (.sig + .sig.bundle) produced entries pointing at files that were never
+// uploaded: the signature download 404s, the artifact is classified
+// "unverified", and the install is blocked by the default trust policy. Every
+// plugin version published after the move to v4 was uninstallable because of it.
+func TestPluginEntry_UsesCosignV4BundleName(t *testing.T) {
+	src, err := os.ReadFile("plugin_entry_cmd.go")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "checksums.txt.sigstore.json") {
+		t.Error("entry generation must emit the cosign v4 bundle name checksums.txt.sigstore.json")
+	}
+	if strings.Contains(s, "checksums.txt.sig.bundle") {
+		t.Error("entry generation must not emit the cosign v3 bundle name .sig.bundle; the releases do not publish it")
+	}
+	if strings.Contains(s, `CosignSigURL:`) {
+		t.Error("cosign v4 has no detached .sig; CosignSigURL must be left empty so omitempty drops it")
+	}
+}


### PR DESCRIPTION
`nox plugin entry` generates the registry entry that **every plugin release publishes**, and it wrote the cosign **v3** names: a detached `checksums.txt.sig` plus `checksums.txt.sig.bundle`.

The plugin release workflows sign with cosign **v4**, which writes a single `checksums.txt.sigstore.json` and no detached signature — so those files are never uploaded. The stale comment in the code said the opposite ("Both the legacy .sig and the v4-compatible .sig.bundle are published").

**Consequence:** entries pointed at assets that don't exist → signature download 404s → artifact classified `unverified` → install blocked by the default trust policy. **Every plugin version published after the move to cosign v4 was uninstallable** until the index was repaired by hand.

## Fix

Bundle URL is now the v4 name; `CosignSigURL` is left empty so `omitempty` drops it (v4 has nothing to put there).

This is the **last of three places** the wrong name lived:
1. the index itself — corrected (registry #4)
2. the `registry-sync` generator — corrected to read the release's actual assets (registry #5)
3. `nox plugin entry` — **this PR**

## Verification

- Generated a real entry for `taint-analysis 0.7.1`: emits `checksums.txt.sigstore.json`, which returns **HTTP 200**, and no `cosign_sig_url`.
- Guard test pins the v4 name and fails if the v3 names or `CosignSigURL` reappear.
- Full suite 51/51, precision 1.000/1.000, lint clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts