### PR TITLE
fix(action): retry throttled asset downloads instead of failing the scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The GitHub Action no longer fails a scan because a download was throttled.**
+  It fetched the nox binary and `checksums.txt` in a single unauthenticated
+  attempt, so an HTTP 403 — which GitHub returns when many jobs pull release
+  assets at once — failed the whole step. A burst of CI runs across the plugin
+  fleet triggered exactly that, turning a security gate red for a reason
+  unrelated to security. Both downloads now retry with backoff and send the
+  token when one is available. A download that keeps failing still fails, with
+  the final status reported.
+
 ## [1.13.4] - 2026-07-21
 
 ### Fixed

--- a/action.sh
+++ b/action.sh
@@ -63,6 +63,48 @@ resolve_version() {
   echo "${version}"
 }
 
+# fetch_asset downloads a release asset to a path, retrying transient failures,
+# and echoes the final HTTP status.
+#
+# The single-shot download this replaces failed a security gate on HTTP 403:
+# GitHub throttles release-asset downloads when many jobs fetch at once, and a
+# burst of plugin CI runs triggered exactly that. A gate that goes red for a
+# reason unrelated to security is one people learn to re-run without reading, so
+# a transient throttle must not decide the outcome.
+#
+# Retries are implemented as a loop rather than curl --retry-all-errors, which
+# needs curl >= 7.71; an unknown flag would break the action outright on older
+# curl, trading a rare flake for a hard failure. The Authorization header is sent
+# when a token is available, matching the version lookup above — curl drops it on
+# a cross-host redirect, so it never leaks to the storage backend.
+fetch_asset() {
+  local url="$1" out="$2"
+  local attempt=1 max=3 code=""
+
+  while :; do
+    code=$(curl -sSL -w "%{http_code}" -o "${out}" \
+      ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
+      "${url}" 2>/dev/null || true)
+
+    if [[ -f "${out}" ]] && [[ "${code}" == "200" ]]; then
+      echo "${code}"
+      return 0
+    fi
+
+    if (( attempt >= max )); then
+      echo "${code}"
+      return 1
+    fi
+
+    echo "Download of ${url##*/} returned HTTP ${code:-unknown}; retrying (${attempt}/${max})..." >&2
+    rm -f "${out}"
+    # Backoff base in seconds. Overridable so tests do not pay the real wait;
+    # unset in normal use, which keeps the 3s/6s spacing a throttle needs.
+    sleep $(( attempt * ${NOX_RETRY_BACKOFF_SECS:-3} ))
+    attempt=$(( attempt + 1 ))
+  done
+}
+
 # --- Download and install ---
 
 install_nox() {
@@ -77,7 +119,7 @@ install_nox() {
 
   echo "Downloading nox v${version} for ${platform}..."
   local http_code
-  http_code=$(curl -fsSL -w "%{http_code}" -o "${tmp_dir}/${archive}" "${url}" 2>/dev/null || true)
+  http_code=$(fetch_asset "${url}" "${tmp_dir}/${archive}" || true)
 
   if [[ ! -f "${tmp_dir}/${archive}" ]] || [[ "${http_code}" != "200" ]]; then
     echo "::error::Failed to download nox v${version} for ${platform} (HTTP ${http_code:-unknown})"
@@ -87,7 +129,7 @@ install_nox() {
   fi
 
   # Verify checksum if checksums.txt is available.
-  if curl -fsSL -o "${tmp_dir}/checksums.txt" "${checksums_url}" 2>/dev/null; then
+  if fetch_asset "${checksums_url}" "${tmp_dir}/checksums.txt" >/dev/null 2>&1; then
     local expected actual
     # Match the filename column EXACTLY (sha256sum format: "<hash>  <name>").
     # `grep "$archive"` would also match sibling rows like

--- a/cli/action_download_retry_test.go
+++ b/cli/action_download_retry_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// extractShellFunc pulls a single function out of action.sh so a test can run it
+// without executing the whole action.
+func extractShellFunc(t *testing.T, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("..", "action.sh"))
+	if err != nil {
+		t.Fatalf("read action.sh: %v", err)
+	}
+	re := regexp.MustCompile(`(?ms)^` + regexp.QuoteMeta(name) + `\(\) \{.*?^\}`)
+	m := re.FindString(string(src))
+	if m == "" {
+		t.Fatalf("function %s not found in action.sh", name)
+	}
+	return m
+}
+
+func runFetchAsset(t *testing.T, fn, url, out string) (string, bool) {
+	t.Helper()
+	script := fn + "\ncode=$(fetch_asset \"" + url + "\" \"" + out + "\") && st=0 || st=1\necho \"$code\"\nexit $st\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "NOX_RETRY_BACKOFF_SECS=0")
+	b, err := cmd.Output()
+	return strings.TrimSpace(string(b)), err == nil
+}
+
+// A single-shot download failed a security gate on HTTP 403: GitHub throttles
+// release-asset downloads when many jobs fetch at once, and a burst of plugin CI
+// runs triggered exactly that. A gate that goes red for a reason unrelated to
+// security is one people learn to re-run without reading it.
+func TestActionFetchAsset_RetriesTransientThrottle(t *testing.T) {
+	fn := extractShellFunc(t, "fetch_asset")
+
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&n, 1) <= 2 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		_, _ = w.Write([]byte("payload-ok"))
+	}))
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "asset.tar.gz")
+	code, ok := runFetchAsset(t, fn, srv.URL+"/nox.tar.gz", out)
+	if !ok || code != "200" {
+		t.Fatalf("expected recovery after throttling; got HTTP %q ok=%v", code, ok)
+	}
+	body, err := os.ReadFile(out)
+	if err != nil || string(body) != "payload-ok" {
+		t.Fatalf("downloaded content wrong: %q err=%v", string(body), err)
+	}
+	if got := atomic.LoadInt32(&n); got < 3 {
+		t.Errorf("expected at least 3 attempts, got %d", got)
+	}
+}
+
+// Retrying must not turn a real failure into a hang or a false success.
+func TestActionFetchAsset_StillFailsWhenErrorPersists(t *testing.T) {
+	fn := extractShellFunc(t, "fetch_asset")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "asset.tar.gz")
+	code, ok := runFetchAsset(t, fn, srv.URL+"/nox.tar.gz", out)
+	if ok {
+		t.Fatal("a persistently failing download must not report success")
+	}
+	if code != "403" {
+		t.Errorf("expected the final status to be reported as 403, got %q", code)
+	}
+}


### PR DESCRIPTION
## Problem

The action fetched the nox binary and `checksums.txt` in a **single unauthenticated attempt**. GitHub throttles release-asset downloads when many jobs pull at once, returning **HTTP 403**, and that failed the entire step:

```
curl: (22) The requested URL returned error: 403
##[error]Process completed with exit code 2.
```

That happened for real: a burst of CI runs across the plugin fleet turned a **security gate red for a reason unrelated to security**. A gate that fails like that is one people learn to re-run without reading.

## Fix

Both downloads go through `fetch_asset`, which retries with backoff and sends the `Authorization` header when a token is present — matching the version lookup that already did. curl drops that header on a cross-host redirect, so it's never handed to the storage backend.

The retry is a **loop**, not `curl --retry-all-errors`: that flag needs curl ≥ 7.71, and an unknown flag would break the action outright on older curl — trading a rare flake for a hard failure.

**A persistent failure still fails**, with the final HTTP status reported. This buys tolerance for throttling, not silence about real breakage.

## Verification

Behavioral tests against a local server, both directions:
- two 403s then success → **recovers**, returns HTTP 200 and the correct payload, ≥3 attempts made
- persistent 403 → **still fails**, reporting 403 (no hang, no false success)

Backoff base is overridable via `NOX_RETRY_BACKOFF_SECS` so the tests don't pay the real wait (18s → 0.1s); unset in normal use, keeping the 3s/6s spacing a throttle actually needs.

Full suite 51/51, precision 1.000/1.000, lint clean.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts