### PR TITLE
docs(changelog): 1.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.5] - 2026-07-21
+
 ### Fixed
 
 - **The GitHub Action no longer fails a scan because a download was throttled.**


### PR DESCRIPTION
Changelog for 1.13.5 — the GitHub Action retries throttled asset downloads instead of failing the scan (#290).

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts