### PR TITLE
test: fix the three Windows-only failures that have kept main red

### DIFF
--- a/cli/fix_content_test.go
+++ b/cli/fix_content_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,13 +17,25 @@ func TestRunContentFix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// findings.json referencing the two fixable lines.
-	findingsJSON := `{"findings":[
-	  {"RuleID":"IAC-007","Severity":"critical","Location":{"FilePath":"` + deploy + `","StartLine":3}},
-	  {"RuleID":"IAC-035","Severity":"high","Location":{"FilePath":"` + deploy + `","StartLine":4}}
-	]}`
+	// findings.json referencing the two fixable lines. Built with the JSON
+	// encoder rather than string concatenation: a Windows temp path contains
+	// backslashes, and pasting one straight into a JSON literal turns
+	// C:\Users into the invalid escapes \U and \A, so the document fails to
+	// parse and the fix finds nothing to do. That is a test artefact with no
+	// bearing on the product, but it read as a real failure.
+	findingsJSON, err := json.Marshal(map[string]any{
+		"findings": []map[string]any{
+			{"RuleID": "IAC-007", "Severity": "critical",
+				"Location": map[string]any{"FilePath": deploy, "StartLine": 3}},
+			{"RuleID": "IAC-035", "Severity": "high",
+				"Location": map[string]any{"FilePath": deploy, "StartLine": 4}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	inputPath := filepath.Join(dir, "findings.json")
-	if err := os.WriteFile(inputPath, []byte(findingsJSON), 0o644); err != nil {
+	if err := os.WriteFile(inputPath, findingsJSON, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/lsp/lsp_test.go
+++ b/cli/lsp/lsp_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -76,6 +77,23 @@ func drainMessages(t *testing.T, buf *bytes.Buffer) []outMessage {
 // TestServeFullFlow drives initialize -> didOpen -> shutdown -> exit against
 // in-memory streams and asserts a publishDiagnostics with a real AI-009
 // finding (from `eval(response)` in a temp .py file).
+// fileURI builds the file:// URI an LSP client would send for a local path.
+//
+// It cannot be url.URL{Scheme: "file", Path: p}.String() with a native path: a
+// Windows path (C:\dir\f.py) has no leading slash, so String() emits the opaque
+// form file:C:%5Cdir%5Cf.py. url.Parse then leaves Path empty, uriToPath
+// resolves nothing, and the scan silently returns zero diagnostics — which
+// looked like the LSP was broken on Windows when it is only this construction
+// that was. Real clients send file:///C:/dir/f.py, which uriToPath already
+// handles; producing that same form keeps the test honest about what ships.
+func fileURI(p string) string {
+	slashed := filepath.ToSlash(p)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed // drive-letter paths need the LSP leading slash
+	}
+	return (&url.URL{Scheme: "file", Path: slashed}).String()
+}
+
 func TestServeFullFlow(t *testing.T) {
 	dir := t.TempDir()
 	pyPath := filepath.Join(dir, "vuln.py")
@@ -83,7 +101,7 @@ func TestServeFullFlow(t *testing.T) {
 	if err := os.WriteFile(pyPath, []byte(src), 0o644); err != nil {
 		t.Fatalf("write temp py: %v", err)
 	}
-	uri := (&url.URL{Scheme: "file", Path: pyPath}).String()
+	uri := fileURI(pyPath)
 
 	var in bytes.Buffer
 	mustWrite(t, &in, map[string]interface{}{

--- a/plugin/auth_test.go
+++ b/plugin/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,13 @@ func TestStartBinary_TokenRoundTrip(t *testing.T) {
 		t.Skip("builds a plugin binary; skipped under -short")
 	}
 
+	// Windows will not exec a file without an executable extension: the built
+	// binary is found but rejected with "executable file not found in %PATH%".
+	// go build honours -o verbatim, so the suffix has to be added here.
 	bin := filepath.Join(t.TempDir(), "authplugin")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	build := exec.Command("go", "build", "-o", bin, "./testdata/authplugin")
 	if out, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("building test plugin: %v\n%s", err, out)


### PR DESCRIPTION
**CI on main has not passed in over 100 consecutive runs.** Lint, macOS, Ubuntu and the fuzz job are green every time; only `Test (windows-latest)` fails — on three tests that are wrong about Windows, not on anything the product does wrong.

A gate that is permanently red reports nothing. Five releases went out over it this week without the state being noticed.

| test | why it failed on Windows |
|---|---|
| `TestRunContentFix` | built `findings.json` by concatenating a temp path into a JSON literal — `C:\Users` becomes the invalid escapes `\U`/`\A`, so the doc never parsed and the fix correctly found nothing to do |
| `TestServeFullFlow` | built the URI as `url.URL{Scheme:"file", Path: nativePath}` — a Windows path has no leading slash, so it emits the **opaque** form `file:C:%5Cdir%5Cf.py`, `Path` parses empty, and the scan returns 0 diagnostics |
| `TestStartBinary_TokenRoundTrip` | built its plugin binary with no `.exe`; `go build` honours `-o` verbatim and Windows refuses to exec it |

**No production code changes** — all three are test defects. Notably `uriToPath` already handles the `file:///C:/dir/f.py` form real clients send, so the LSP was never broken on Windows; only the test's construction was.

The value is restoring signal. Windows coverage of the content-fix path, the LSP flow, and **the plugin token handshake** has been reported failing for so long it was effectively switched off — the auth boundary was unverified on that platform.

Verified locally on macOS (all three pass); the real proof is the Windows job on this PR.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts