### PR TITLE
fix(deps): patch the brace-expansion DoS the weekly audit has flagged since June

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -44,9 +44,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -54,6 +54,9 @@
   "dependencies": {
     "vscode-languageclient": "^9.0.1"
   },
+  "overrides": {
+    "brace-expansion": "^2.1.2"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.75.0",


### PR DESCRIPTION
The scheduled **dependency-CVE audit has failed every run for at least five weeks**:

```
failure  2026-07-20    failure  2026-07-13    failure  2026-07-06
failure  2026-06-29    failure  2026-06-22
```

on **GHSA-3jxr-9vmj-r5cp** — exponential-time expansion of consecutive non-expanding `{}` groups in `brace-expansion@2.1.1`, reached through `minimatch` in the VS Code extension.

It went unnoticed because that job runs **only on the weekly schedule and is skipped on push**, so its failure never appeared on main. The audit was working correctly the whole time; nothing was reading it.

**Pinned to 2.1.2** (the patched release for the `>=2.0.0, <2.1.2` range) via an `overrides` entry rather than by adding a dependency — `npm install brace-expansion@2.1.2` promotes a transitive package to a direct one, which fixes the version but makes `package.json` claim a dependency the extension never imports.

**Verified:** a full `nox scan` of the repo now reports **0** dependency CVE findings, where it previously reported this one as fixable.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts