### PR TITLE
fix(scan): resolve relative paths against the directory when the target is a file

### DIFF
--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -125,7 +125,7 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 	policy := plugin.DefaultPolicy()
 	var overrides plugin.Policy
 	ignoreTrackProfiles := false
-	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
+	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(core.ConfigRoot(target), ".nox.yaml")); cfgErr == nil {
 		policy = cfg.PluginPolicy.ToPolicy()
 		overrides = cfg.PluginPolicy.Overrides()
 		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
@@ -170,7 +170,7 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 	policy := plugin.DefaultPolicy()
 	var overrides plugin.Policy
 	ignoreTrackProfiles := false
-	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(target, ".nox.yaml")); cfgErr == nil {
+	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(core.ConfigRoot(target), ".nox.yaml")); cfgErr == nil {
 		policy = cfg.PluginPolicy.ToPolicy()
 		overrides = cfg.PluginPolicy.Overrides()
 		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles

--- a/core/degradation_test.go
+++ b/core/degradation_test.go
@@ -575,3 +575,67 @@ func TestScan_MarkdownDocExamplesAreNotReportedUnused(t *testing.T) {
 		t.Errorf("doc examples in fenced blocks must not be reported as unused waivers: %+v", result.Degradations)
 	}
 }
+
+// TestScan_SingleFileTargetResolvesRelativePaths guards the file-target case.
+//
+// A scan target may be a single file (`nox scan main.go`). Relative lookups were
+// joined onto that target as if it were a directory, producing paths like
+// main.go/.nox/baseline.json and main.go/main.go — neither of which can exist.
+// The consequences were not symmetrical: the baseline miss was merely reported,
+// but the failed re-read meant the file's nox:ignore comments were never
+// applied, so a single-file scan reported findings the operator had waived.
+//
+// Both halves are asserted here because fixing only the visible one would leave
+// the silent one in place.
+func TestScan_SingleFileTargetResolvesRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// The waiver sits on its own line, so it applies to the next non-blank
+	// line — the eval() call that AI-009 flags.
+	src := "import x\nresponse = get()\n# nox:ignore AI-009 -- reviewed\ndata = eval(response)\n"
+	file := filepath.Join(dir, "app.py")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("writing source: %v", err)
+	}
+
+	// Confirm the premise: without the waiver this file really does produce
+	// AI-009, or the assertion below would pass vacuously.
+	bare := filepath.Join(t.TempDir(), "app.py")
+	if err := os.WriteFile(bare, []byte("import x\nresponse = get()\ndata = eval(response)\n"), 0o644); err != nil {
+		t.Fatalf("writing control source: %v", err)
+	}
+	control, err := RunScanWithOptions(bare, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("control scan failed: %v", err)
+	}
+	var controlHasAI009 bool
+	for _, f := range control.Findings.Findings() {
+		if f.RuleID == "AI-009" {
+			controlHasAI009 = true
+		}
+	}
+	if !controlHasAI009 {
+		t.Fatal("premise broken: control file produced no AI-009, so the waiver assertion proves nothing")
+	}
+
+	result, err := RunScanWithOptions(file, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	// The waiver must be honoured on a file target exactly as on a directory.
+	for _, f := range result.Findings.Findings() {
+		if f.RuleID == "AI-009" && f.Status != findings.StatusSuppressed {
+			t.Errorf("AI-009 reported despite an inline waiver; suppressions were not applied to a file target")
+		}
+	}
+
+	// And an absent baseline beside a file target is simply absent — not a
+	// degradation about a path that could never have existed.
+	for _, d := range result.Degradations {
+		if strings.Contains(d.Detail, "baseline") || strings.Contains(d.Detail, "inline suppressions") {
+			t.Errorf("unexpected degradation on a file target: %s", d.Detail)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -452,7 +452,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	}
 	if customPath != "" {
 		if !filepath.IsAbs(customPath) {
-			customPath = filepath.Join(target, customPath)
+			customPath = filepath.Join(ConfigRoot(target), customPath)
 		}
 		customRules, err := loadCustomRules(customPath)
 		if err != nil {
@@ -766,7 +766,7 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	if opts.TerraformPlanPath != "" {
 		tfPlanPath := opts.TerraformPlanPath
 		if !filepath.IsAbs(tfPlanPath) {
-			tfPlanPath = filepath.Join(target, tfPlanPath)
+			tfPlanPath = filepath.Join(ConfigRoot(target), tfPlanPath)
 		}
 		tfFindings, tfErr := iac.ScanTerraformPlan(tfPlanPath)
 		if tfErr != nil {
@@ -788,9 +788,9 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		baselinePath = cfg.Policy.BaselinePath
 	}
 	if baselinePath == "" {
-		baselinePath = baseline.DefaultPath(target)
+		baselinePath = baseline.DefaultPath(ConfigRoot(target))
 	} else if !filepath.IsAbs(baselinePath) {
-		baselinePath = filepath.Join(target, baselinePath)
+		baselinePath = filepath.Join(ConfigRoot(target), baselinePath)
 	}
 	applyBaseline(allFindings, baselinePath, deg)
 
@@ -804,7 +804,7 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	// that would leave every waiver unapplied.
 	if vexPath != "" {
 		if !filepath.IsAbs(vexPath) {
-			vexPath = filepath.Join(target, vexPath)
+			vexPath = filepath.Join(ConfigRoot(target), vexPath)
 		}
 		vexDoc, vexErr := vex.LoadVEX(vexPath)
 		if vexErr != nil {
@@ -1111,6 +1111,28 @@ func ConfidenceMeetsThreshold(confidence, threshold findings.Confidence) bool {
 	return cr <= tr
 }
 
+// ConfigRoot returns the directory that paths relative to a scan target
+// resolve against — the baseline, the VEX document, custom rules, a Terraform
+// plan, and the source files findings point at.
+//
+// A target may be a single file (`nox scan main.go`), and joining a relative
+// path onto a file path yields main.go/.nox/baseline.json, which cannot exist.
+// Every such lookup then failed: the baseline was reported unloadable, and the
+// file could not be re-read to apply its nox:ignore comments — so a single-file
+// scan silently reported findings the operator had waived. Resolving against
+// the file's directory is both what the operator means and what the rest of the
+// scan already assumes: for a file target, finding paths are recorded relative
+// to that same directory.
+//
+// A target that cannot be stat'd is returned unchanged, leaving the caller's
+// existing error handling to report it rather than guessing here.
+func ConfigRoot(target string) string {
+	if fi, err := os.Stat(target); err == nil && !fi.IsDir() {
+		return filepath.Dir(target)
+	}
+	return target
+}
+
 // applySuppressions reads files that have findings and marks suppressed findings.
 func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degradations) {
 	// Group findings by file.
@@ -1132,7 +1154,7 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 
 		fullPath := filePath
 		if !filepath.IsAbs(fullPath) {
-			fullPath = filepath.Join(target, fullPath)
+			fullPath = filepath.Join(ConfigRoot(target), fullPath)
 		}
 
 		content, err := os.ReadFile(fullPath)


### PR DESCRIPTION
`nox scan main.go` joined every relative lookup onto the target **as if it were a directory**:

```
[degraded] app.py/.nox/baseline.json could not be loaded: ... not a directory
[degraded] app.py could not be re-read to apply inline suppressions: open app.py/app.py: not a directory
```

**The consequences were not symmetrical.** The baseline miss was merely reported — noisy but visible. The failed re-read meant the file's `nox:ignore` comments were **never parsed**, so a single-file scan reported findings the operator had explicitly waived, with the reason buried in a degradation line about a path they never wrote.

Scanning one file is what a pre-commit hook or editor integration does. This is the common case, not an exotic one.

`ConfigRoot` centralises the rule: **a file target resolves relative paths against its directory.** That's what the rest of the pipeline already assumes — `LoadScanConfig` has always resolved a file target to its directory to find `.nox.yaml`, and for a file target finding paths are recorded relative to that same directory (verified: target `sub/deep/vuln.py` → `FilePath: vuln.py`).

Applied to all six sites: baseline, VEX, custom rules, Terraform plan, the suppression re-read, and the plugin `.nox.yaml` load.

**The test asserts both halves** — fixing only the reported one would leave the more damaging silent one in place. Verified red-green: with the fix reverted it fails on the unapplied waiver *and* both degradations.

Found while scanning a single workflow file during #294.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts