### PR TITLE
fix(fix): stop pinning GitHub Actions backward to a stale release

### DIFF
--- a/cli/fix_actions.go
+++ b/cli/fix_actions.go
@@ -357,23 +357,51 @@ func (g *githubResolver) latest(repo string) (tag, sha string, err error) {
 	return tag, sha, nil
 }
 
+// latestTag returns the newest version an action actually serves.
+//
+// It used to return the GitHub Release and stop. Tags were consulted only as a
+// fallback "for repos without GitHub Releases". That is the wrong precedence: a
+// GitHub Release is an announcement, but an Action is consumed by TAG, so a
+// repository that tags v1.0.1 without cutting a Release is already serving
+// v1.0.1 to every workflow pinned to @v1.
+//
+// The consequence was a silent DOWNGRADE. nox-hq/nox-remediate-action has one
+// Release (v1.0.0) and tags v1.0.1 and v1; @v1 resolves to v1.0.1's commit.
+// `nox fix -actions` read the Release, decided "latest" was v1.0.0, and planned
+// to rewrite @v1 to v1.0.0's commit — moving the pinned action BACKWARD while
+// labelling it v1. A tool whose purpose is supply-chain pinning must never pin
+// to something older than what is already running, least of all silently.
+//
+// Both sources are now consulted and the newer wins.
 func (g *githubResolver) latestTag(repo string) (string, error) {
+	best := ""
+
+	// The Release, when present, is the maintainer's explicit statement of what
+	// is current, so it seeds the comparison.
 	var rel struct {
 		TagName string `json:"tag_name"`
 	}
 	if err := g.get("/repos/"+repo+"/releases/latest", &rel); err == nil && rel.TagName != "" {
-		return rel.TagName, nil
+		best = rel.TagName
 	}
-	// Fallback: newest tag (repos without GitHub Releases).
+
 	var tags []struct {
 		Name string `json:"name"`
 	}
 	if err := g.get("/repos/"+repo+"/tags?per_page=100", &tags); err != nil {
+		// Tags unreachable: fall back to the Release rather than failing, since
+		// a stale-but-real version beats no answer. Only error when neither
+		// source produced anything.
+		if best != "" {
+			return best, nil
+		}
 		return "", err
 	}
-	best := ""
 	for _, t := range tags {
-		if commentVerRe.MatchString(t.Name) && (best == "" || versionLess(best, t.Name)) {
+		if !commentVerRe.MatchString(t.Name) {
+			continue
+		}
+		if best == "" || preferTag(best, t.Name) {
 			best = t.Name
 		}
 	}
@@ -381,6 +409,28 @@ func (g *githubResolver) latestTag(repo string) (string, error) {
 		return "", fmt.Errorf("no version tag found")
 	}
 	return best, nil
+}
+
+// preferTag reports whether candidate should replace current as "latest".
+//
+// Higher version wins. On an exact version tie it prefers the MORE specific
+// tag, so a repo carrying both `v1.0.1` and the moving `v1` pins to v1.0.1 —
+// they denote the same commit, but only the specific one still means that
+// commit tomorrow, and it is what the pin comment should record.
+func preferTag(current, candidate string) bool {
+	switch cmpVersion(current, candidate) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+	return specificity(candidate) > specificity(current)
+}
+
+// specificity counts the dotted components in a version tag: v1 → 1, v1.0 → 2,
+// v1.0.1 → 3.
+func specificity(tag string) int {
+	return len(strings.Split(strings.TrimPrefix(strings.TrimSpace(tag), "v"), "."))
 }
 
 func (g *githubResolver) tagSHA(repo, tag string) (string, error) {

--- a/cli/fix_actions_test.go
+++ b/cli/fix_actions_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,5 +178,111 @@ func TestIsSHA(t *testing.T) {
 	}
 	if isSHA("v4") || isSHA("main") {
 		t.Error("tags/branches are not SHAs")
+	}
+}
+
+// TestLatestTag_PrefersNewestTagOverStaleRelease guards against pinning an
+// action BACKWARD.
+//
+// latestTag used to return the GitHub Release and consult tags only as a
+// fallback for repos that publish no Releases. But an Action is consumed by
+// TAG, not by Release object, so a repo that tags v1.0.1 without cutting a
+// Release is already serving v1.0.1 to every workflow pinned to @v1.
+//
+// nox-hq/nox-remediate-action is exactly that shape, and the result was that
+// `nox fix -actions` planned to rewrite @v1 (serving v1.0.1) to v1.0.0's
+// commit — a silent downgrade, performed by the tool whose entire purpose is
+// supply-chain pinning. The fixture below reproduces that repository.
+func TestLatestTag_PrefersNewestTagOverStaleRelease(t *testing.T) {
+	t.Parallel()
+
+	var hits []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			_, _ = io.WriteString(w, `{"tag_name":"v1.0.0"}`)
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			// Newest first, as GitHub returns them, including the moving major.
+			_, _ = io.WriteString(w, `[{"name":"v1.0.1"},{"name":"v1.0.0"},{"name":"v1"}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	g := &githubResolver{client: srv.Client(), base: srv.URL}
+
+	got, err := g.latestTag("nox-hq/nox-remediate-action")
+	if err != nil {
+		t.Fatalf("latestTag: %v", err)
+	}
+	if got != "v1.0.1" {
+		t.Errorf("latestTag = %q, want v1.0.1 (the tag actually served; v1.0.0 is the stale Release)", got)
+	}
+
+	// Confirm the premise: the Release endpoint really was consulted, so this
+	// passes because both sources were compared rather than because the
+	// Release lookup silently failed.
+	var sawRelease bool
+	for _, h := range hits {
+		if strings.HasSuffix(h, "/releases/latest") {
+			sawRelease = true
+		}
+	}
+	if !sawRelease {
+		t.Error("premise broken: the Release endpoint was never queried")
+	}
+}
+
+// TestLatestTag_TiePrefersSpecificTag pins the moving-vs-specific choice.
+//
+// v1 and v1.0.1 can denote the same commit, but only the specific tag still
+// means that commit tomorrow — and it is what belongs in the `# version` pin
+// comment.
+func TestLatestTag_TiePrefersSpecificTag(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusNotFound) // repo publishes no Releases
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			_, _ = io.WriteString(w, `[{"name":"v2"},{"name":"v2.0.0"}]`)
+		}
+	}))
+	defer srv.Close()
+
+	g := &githubResolver{client: srv.Client(), base: srv.URL}
+	got, err := g.latestTag("some/action")
+	if err != nil {
+		t.Fatalf("latestTag: %v", err)
+	}
+	if got != "v2.0.0" {
+		t.Errorf("latestTag = %q, want v2.0.0 (specific beats the moving v2 on a tie)", got)
+	}
+}
+
+// TestLatestTag_FallsBackToReleaseWhenTagsUnavailable keeps a transient tags
+// failure from erroring out a run that already has a usable answer.
+func TestLatestTag_FallsBackToReleaseWhenTagsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/releases/latest") {
+			_, _ = io.WriteString(w, `{"tag_name":"v3.1.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	g := &githubResolver{client: srv.Client(), base: srv.URL}
+	got, err := g.latestTag("some/action")
+	if err != nil {
+		t.Fatalf("latestTag should fall back to the Release, got error: %v", err)
+	}
+	if got != "v3.1.0" {
+		t.Errorf("latestTag = %q, want v3.1.0", got)
 	}
 }


### PR DESCRIPTION
`nox fix -actions` could rewrite an action pin to an **older commit than the one already running**, and say nothing about it.

`latestTag` asked `/releases/latest` and returned, consulting tags only as a fallback *"for repos without GitHub Releases"*. That precedence is wrong: a Release is an **announcement**, but an Action is consumed by **tag**. A repo that tags `v1.0.1` without cutting a Release is already serving it to every workflow pinned to `@v1`.

`nox-hq/nox-remediate-action` is exactly that shape — one Release (v1.0.0), tags `v1.0.1` and `v1`, with `@v1` → v1.0.1's commit. So against nox's own `remediation.yml`:

```
plan: nox-hq/nox-remediate-action pin v1 (f7d6cc12bf27)   # ← v1.0.0. A downgrade.
```

The entire purpose of this feature is supply-chain pinning. Pinning to something **older than what is deployed, silently**, is the worst failure it can have. Four other actions in the same run resolved correctly — it only bites repos whose newest tag has no matching Release, which is why it went unnoticed.

**Verified end to end against the live repository:**

| | plan |
|---|---|
| before | `pin v1 (f7d6cc12bf27)` — v1.0.0 |
| after | `v1 -> v1.0.1 (1c16a4bb803d)` |
| ground truth (`commits/v1`) | `1c16a4bb803d` ✓ |

Both sources are now compared and the newer wins. On an exact tie the **more specific** tag is preferred (`v1.0.1` over the moving `v1`) — same commit today, but only the specific one still means that commit tomorrow, and it's what belongs in the pin comment. A failed tags request falls back to the Release rather than erroring.

Three tests, red-green verified: with the old precedence restored, the first fails with `latestTag = "v1.0.0", want v1.0.1`.

Unblocks replacing Dependabot with `nox-remediate-action` — see the follow-up to make the action actually pass `-actions`.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts