### PR TITLE
feat(ci): let the remediation action upgrade GitHub Action pins too

### DIFF
--- a/.github/workflows/remediation.yml
+++ b/.github/workflows/remediation.yml
@@ -23,11 +23,17 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: nox-hq/nox-remediate-action@1c16a4bb803d73ca96a17760f847c9ad80e162cd # v1.0.1
+      - uses: nox-hq/nox-remediate-action@bd80743be12912cec91111b9d0a988b7845788f0 # v1.0.2
         with:
           path: .
           manifest-root: .
           # Run the full test suite before opening the PR so reviewers
           # don't get untested upgrades.
           verify-cmd: 'go test ./...'
+          # Upgrade GitHub Action pins too, not just Go modules. nox has no
+          # dependabot.yml, so nothing else does this — 8 pins were stale when
+          # this was turned on. Requires nox >= 1.13.6: earlier versions resolve
+          # a moving major tag to the latest GitHub Release, which pins BACKWARD
+          # when a newer tag exists without one.
+          upgrade-actions: 'true'
           pr-labels: 'security,dependencies,nox-remediation'


### PR DESCRIPTION
Final step of the Dependabot switch. nox has **no `dependabot.yml`**, and `nox-remediate-action` only ran nox's *package* pass — so nothing upgraded nox's own GitHub Action pins. **Eight were stale.**

Enables the `upgrade-actions` input added in [nox-remediate-action v1.0.2](https://github.com/Nox-HQ/nox-remediate-action/releases/tag/v1.0.2) and moves the pin from v1.0.1 → v1.0.2.

### Why this lands last

The action installs the latest released nox, and `nox fix --actions` only became safe in **1.13.6**. Before that it resolved a moving major tag to the latest GitHub *Release*, which pins **backward** when a newer tag exists without one. Turning this on any earlier would have had the workflow downgrade action pins on a schedule.

Verified with the released 1.13.6 binary against the live repo:

| nox | plan for `nox-remediate-action@v1` |
|---|---|
| 1.13.5 | `f7d6cc12bf27` — v1.0.0, a downgrade |
| **1.13.6** | `1c16a4bb803d` — v1.0.1 ✓ |

Also cut a proper GitHub Release for the action's v1.0.2 — v1.0.1 having a tag but no Release is precisely the shape that triggered the bug, and `releases/latest` and the newest tag now agree.

`remediation.yml` self-scan: the high-severity IAC-013 mutable-tag finding is gone; the 2 remaining are pre-existing by-design (`workflow_dispatch`, `contents: write`).

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts