### PR TITLE
fix(ci): stop the remediation PR failing on duplicate Authorization headers

### DIFF
--- a/.github/workflows/remediation.yml
+++ b/.github/workflows/remediation.yml
@@ -18,6 +18,17 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # create-pull-request inside the remediation action sets its own
+          # AUTHORIZATION extraheader. Without this, checkout's persisted one is
+          # still present and git sends both, which GitHub rejects:
+          #
+          #   remote: Duplicate header: "Authorization"
+          #   fatal: ... The requested URL returned error: 400
+          #
+          # This never showed up before because the PR step had never actually
+          # run: has-updates was computed from the package pass alone and was
+          # always false, so the failure sat latent behind it. Do not remove.
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
The first remediation run that actually **had something to do** failed at the PR step:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/Nox-HQ/nox/': ... error: 400
```

`actions/checkout` persists an `AUTHORIZATION` extraheader, and `create-pull-request` inside the remediation action configures its own. Both get sent; GitHub rejects it. `persist-credentials: false` is the standard fix — `Nox-HQ/registry` hit the identical collision in its reconcile job.

**This was latent, not new.** The PR step had never run: `has-updates` was computed from the package pass alone, which always reported nothing to do, so the workflow went green every week *without ever exercising the step that was broken*. Fixing that detection in nox-remediate-action v1.0.2 is what surfaced it.

Worth noting as a pattern — a green weekly job proved nothing here, because the interesting half was permanently skipped.

The rest of the run worked: `--actions` executed, and `has-updates` correctly went true off the `plan:` line.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts