### PR TITLE
docs: state what `nox fix` does not remediate

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -478,6 +478,28 @@ nox fix --content --write
 choice (a UID, a pinned digest, an allowlist, a rotated secret) are never
 touched. It previews the diff and applies nothing without `--write`.
 
+#### What `fix` does not remediate
+
+`fix` covers dependencies, Action pins and mechanical configuration. It does
+**not** fix SAST findings — taint flows (`TAINT-*`) and the code-level `SEC-*`
+rules are reported and left alone.
+
+That is deliberate rather than unfinished. A taint finding says user input
+reaches a dangerous sink; removing it means choosing the right sanitiser for
+that specific sink, which depends on what the code is meant to do. The failure
+mode is not a broken build — it is inserting something the taint engine
+recognises as a sanitiser that does not actually sanitise, so the finding
+disappears while the vulnerability stays. nox would then be marking its own
+homework, and a green scan would mean less than it does now.
+
+The same logic is why a hardcoded secret is not auto-fixed. Moving the literal
+into an environment variable silences the rule, but the credential is already in
+the git history and is compromised the moment it is committed; the fix that
+matters is rotating it at the provider, which no tool can do for you.
+
+So: a clean `fix` run means the remediable classes were handled. It is not a
+statement that the SAST findings were.
+
 ### variants
 
 Report first-party code that reproduces the root-cause pattern of a known CVE —


### PR DESCRIPTION
The `fix` section lists the three passes it performs and says nothing about the boundary — leaving a reader free to assume a clean run covered everything the scan reported. It doesn't: **taint flows and the code-level `SEC-*` rules are reported and left alone.**

Says so, and gives the reason.

Removing a taint finding means choosing the right sanitiser for that *specific* sink, which depends on what the code is meant to do. The failure mode isn't a broken build — it's inserting something the taint engine **recognises** as a sanitiser that doesn't actually sanitise. The finding disappears, the vulnerability stays, and nox ends up marking its own homework.

The hardcoded-secret case is the same shape and worth stating explicitly *because the code change looks like a fix*: moving the literal into an env var silences the rule, but the credential entered git history the moment it was committed and is compromised regardless. Rotating it at the provider is the part that matters, and no tool can do that for you.

Notably `--content` **already refuses this class** — its own docs name *"a rotated secret"* among the value choices it never makes. This extends that stated principle from one flag to the whole command.

Context: prompted by reviewing whether nox could remediate SAST. Related work in flight — `nox-plugin-remediate` currently *does* rewrite hardcoded secrets without mentioning rotation, which contradicts the principle core states here.

https://claude.ai/code/session_01UCLAAksd3a1cmQz2LVs3ts
