### PR TITLE
feat(action): expose fail-on-degraded, and test that inputs are wired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ cli/.github/
 
 # Relicta
 .relicta/
+
+# Local tool scratch: an MCP server writes SHA-named idempotency markers
+# ("session" / "durable", 7 bytes each) into ./data/cache/ of whatever
+# directory it is launched from. Not produced by nox and not project data.
+/data/cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The GitHub Action exposes `fail-on-degraded`.** nox has had the flag since
+  1.11.0, but the Action never mapped it, so a workflow could not make "a check
+  did not complete" fail the build without dropping to a raw `run` step — the
+  gate most likely to rely on it was the one that could not reach it. An
+  invariant test now fails the build if any declared Action input is not wired
+  through to `action.sh`, which is the defect class that hid this one: an input
+  can be declared and documented while silently never reaching the scanner.
+
+### Changed
+
+- **An exit 2 under `fail-on-degraded` no longer reports itself as a crash.**
+  nox returns 2 both for a hard error and for an incomplete scan, and the Action
+  annotated both as "Nox scan failed with exit code 2" — sending the reader to
+  look for a failure that did not happen, when the scan had in fact run and
+  written its reports. The annotation now names the degradation case and points
+  at `meta.degradations`.
+
 ## [1.13.6] - 2026-07-21
 
 ### Fixed

--- a/action.sh
+++ b/action.sh
@@ -205,6 +205,9 @@ run_scan() {
   if [[ "${INPUT_OFFLINE:-false}" == "true" ]]; then
     extra_args+=(--offline)
   fi
+  if [[ "${INPUT_FAIL_ON_DEGRADED:-false}" == "true" ]]; then
+    extra_args+=(--fail-on-degraded)
+  fi
   "${install_dir}/nox" --format "${scan_format}" --output "${output_dir}" -q scan "${scan_path}" "${extra_args[@]}" || exit_code=$?
 
   # Set outputs.
@@ -262,7 +265,16 @@ run_scan() {
       fi
       ;;
     2)
-      echo "::error::Nox scan failed with exit code 2"
+      # nox exits 2 both for a hard error and for an incomplete scan under
+      # --fail-on-degraded. Reporting the second as "scan failed" sends the
+      # reader looking for a crash that did not happen: the scan ran and wrote
+      # its reports, but a check could not complete. nox names the specific
+      # degradations on stderr; point at them rather than restating the code.
+      if [[ "${INPUT_FAIL_ON_DEGRADED:-false}" == "true" ]]; then
+        echo "::error::Nox exited 2 — either a scan error, or a check did not complete while fail-on-degraded is set. See the [degraded] lines above and meta.degradations in findings.json."
+      else
+        echo "::error::Nox scan failed with exit code 2"
+      fi
       ;;
     *)
       echo "::error::Nox scan failed with unexpected exit code ${exit_code}"

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: 'Guarantee zero network: disable every feature that could make an outbound connection (no API, no token, no telemetry).'
     required: false
     default: 'false'
+  fail-on-degraded:
+    description: 'Fail the step if any check could not complete (OSV lookup, plugin, lockfile parse). A scan that could not look is otherwise indistinguishable from one that found nothing.'
+    required: false
+    default: 'false'
 
 outputs:
   findings-count:
@@ -74,7 +78,7 @@ outputs:
     description: 'Path to findings.json (if generated)'
     value: ${{ steps.scan.outputs.findings-file }}
   exit-code:
-    description: 'Raw nox exit code (0 = no findings, 1 = findings, 2 = error)'
+    description: 'Raw nox exit code (0 = no findings, 1 = findings, 2 = error, or an incomplete check under fail-on-degraded)'
     value: ${{ steps.scan.outputs.exit-code }}
 
 runs:
@@ -98,4 +102,5 @@ runs:
         INPUT_VEX: ${{ inputs.vex }}
         INPUT_CHANGED_SINCE: ${{ inputs.changed-since }}
         INPUT_OFFLINE: ${{ inputs.offline }}
+        INPUT_FAIL_ON_DEGRADED: ${{ inputs.fail-on-degraded }}
       run: bash "${{ github.action_path }}/action.sh"

--- a/cli/action_inputs_test.go
+++ b/cli/action_inputs_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// action.yml declares inputs; action.sh consumes them as INPUT_<UPPER_SNAKE>
+// environment variables that action.yml's `env:` block has to map. Nothing
+// connects the two halves automatically, so an input can be declared and
+// documented while never reaching the scanner — the step accepts it, the flag
+// is silently dropped, and a workflow that sets it is not doing what it says.
+//
+// `fail-on-degraded` was missing this way round: nox has had the flag since
+// 1.11.0, the Action never exposed it, so a CI job could not make "a check did
+// not complete" fail the build without dropping to a raw run step.
+func TestActionInputsAreWiredToTheScript(t *testing.T) {
+	yml := readActionFile(t, "action.yml")
+	sh := readActionFile(t, "action.sh")
+
+	declared := declaredInputs(t, yml)
+	if len(declared) == 0 {
+		t.Fatal("parsed no inputs from action.yml — the parser or the file layout changed")
+	}
+
+	envBlock := actionEnvBlock(t, yml)
+
+	for _, name := range declared {
+		envVar := "INPUT_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+
+		if !strings.Contains(envBlock, envVar+":") {
+			t.Errorf("input %q is declared in action.yml but never mapped to %s in the env: block, so action.sh cannot see it", name, envVar)
+			continue
+		}
+		if !strings.Contains(sh, envVar) {
+			t.Errorf("input %q reaches action.sh as %s but the script never reads it", name, envVar)
+		}
+	}
+}
+
+// The flag exists in nox and the Action now exposes it; this pins the specific
+// wiring so a refactor of the argument assembly cannot quietly drop it.
+func TestActionPassesFailOnDegraded(t *testing.T) {
+	yml := readActionFile(t, "action.yml")
+	sh := readActionFile(t, "action.sh")
+
+	if !strings.Contains(yml, "fail-on-degraded:") {
+		t.Error("action.yml does not declare a fail-on-degraded input; CI cannot fail on an incomplete scan without a raw run step")
+	}
+	if !strings.Contains(sh, "--fail-on-degraded") {
+		t.Error("action.sh never appends --fail-on-degraded, so the input would be accepted and ignored")
+	}
+}
+
+func readActionFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// declaredInputs returns the input names under action.yml's top-level
+// `inputs:` key. Inputs are the only two-space-indented keys in that block;
+// their attributes are indented four.
+func declaredInputs(t *testing.T, yml string) []string {
+	t.Helper()
+
+	block := sectionAfter(yml, "inputs:")
+	if block == "" {
+		t.Fatal("action.yml has no inputs: block")
+	}
+
+	re := regexp.MustCompile(`(?m)^ {2}([a-z0-9-]+):`)
+	var names []string
+	for _, m := range re.FindAllStringSubmatch(block, -1) {
+		names = append(names, m[1])
+	}
+	return names
+}
+
+// actionEnvBlock returns the `env:` mapping inside the composite run step.
+func actionEnvBlock(t *testing.T, yml string) string {
+	t.Helper()
+
+	block := sectionAfter(yml, "      env:")
+	if block == "" {
+		t.Fatal("action.yml env: block is empty")
+	}
+	return block
+}
+
+// sectionAfter returns the lines following header up to the next line that
+// starts at or left of header's own indentation.
+func sectionAfter(s, header string) string {
+	_, rest, found := strings.Cut(s, header)
+	if !found {
+		return ""
+	}
+	indent := len(header) - len(strings.TrimLeft(header, " "))
+
+	var out []string
+	for line := range strings.SplitSeq(rest, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lead := len(line) - len(strings.TrimLeft(line, " "))
+		if lead <= indent {
+			break
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1123,7 +1123,30 @@ jobs:
 | `output` | `nox-results` | Output directory for reports |
 | `version` | `latest` | Nox version to install (e.g., `0.1.0` or `latest`) |
 | `fail-on-findings` | `true` | Fail the step if findings are detected |
+| `fail-on-degraded` | `false` | Fail the step if any check could not complete (OSV lookup, plugin, lockfile parse) |
 | `annotate` | `true` | Post inline PR annotations for findings |
+| `severity-threshold` | — | Report only findings at or above this severity (`critical`, `high`, `medium`, `low`) |
+| `min-confidence` | — | Report only findings at or above this confidence (`high`, `medium`, `low`) |
+| `vex` | — | Path to an OpenVEX waiver document |
+| `changed-since` | — | Scan only files changed since this git ref (e.g. `origin/main`) |
+| `offline` | `false` | Guarantee zero network: no API, no token, no telemetry |
+| `pr-comment` | `false` | Post inline PR review comments with finding details |
+| `max-comments` | `25` | Maximum number of inline PR comments to post |
+| `min-severity` | `low` | Minimum severity for PR comments |
+
+`fail-on-degraded` is worth setting on a gate you actually rely on. Without it,
+an OSV outage, a required plugin that failed to install, or a lockfile nox
+cannot parse produces a green step that proves nothing — a scan that could not
+look is indistinguishable from one that found nothing. The degraded exit
+outranks the findings verdict, and reports are written before it, so the job
+still uploads its SARIF:
+
+```yaml
+      - uses: nox-hq/nox@v1
+        with:
+          format: sarif
+          fail-on-degraded: 'true'
+```
 
 **Action outputs:**
 
@@ -1132,7 +1155,7 @@ jobs:
 | `findings-count` | Number of findings detected |
 | `sarif-file` | Path to `results.sarif` (if generated) |
 | `findings-file` | Path to `findings.json` (if generated) |
-| `exit-code` | Raw nox exit code (`0`/`1`/`2`) |
+| `exit-code` | Raw nox exit code (`0` no findings, `1` findings, `2` error or an incomplete check under `fail-on-degraded`) |
 
 **Generate all formats and upload as artifact:**
 


### PR DESCRIPTION
nox has had `--fail-on-degraded` since 1.11.0, but the GitHub Action never mapped it. A workflow could not make "a check did not complete" fail the build without dropping to a raw `run` step — so the gate most likely to depend on it was the one that could not reach it. Without it, an OSV outage, a required plugin that failed to install, or an unparseable lockfile produces a green step that proves nothing.

## The defect class

`action.yml` declares inputs; `action.sh` reads `INPUT_<UPPER_SNAKE>` environment variables that `action.yml`'s own `env:` block has to map. Nothing connects the two halves, so an input can be declared, documented, and set by a user while silently never reaching the scanner.

`TestActionInputsAreWiredToTheScript` walks every declared input and fails if it is not both mapped and read. It passes against the other 14 inputs today — `fail-on-degraded` was the only gap — so it goes in as a guard, not a fix.

## Exit 2 no longer reports itself as a crash

nox returns 2 both for a hard error and for an incomplete scan under the flag. The Action annotated both as `Nox scan failed with exit code 2`, sending the reader to look for a failure that did not happen: the scan ran and wrote its reports (1.11.1 moved report generation ahead of the degraded exit for exactly this reason). The annotation now names the degradation case and points at `meta.degradations`.

## Also

The Action input table in `docs/usage.md` listed 6 of the then-14 inputs. It now lists all 15.

## Verification

- `go test ./cli/...` — pass
- `golangci-lint run ./cli/...` — 0 issues
- `bash -n action.sh`, `action.yml` parses
- New test fails without the `action.yml`/`action.sh` change (checked before implementing)