### PR TITLE
chore: ignore the local tool cache that dirties the worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ cli/.github/
 
 # Relicta
 .relicta/
+
+# Local tool scratch: an MCP server writes SHA-named idempotency markers
+# ("session" / "durable", 7 bytes each) into ./data/cache/ of whatever
+# directory it is launched from. Not produced by nox and not project data.
+/data/cache/


### PR DESCRIPTION
An MCP server launched from this directory writes SHA-named idempotency markers (`session` / `durable`, 7 bytes each) into `./data/cache/`. It is not produced by nox and is not project data, but it left 90 untracked files in `git status` on every session.

Scoped to `/data/cache/` rather than `/data/` so a future real `data/` directory would still be tracked.