### PR TITLE
docs(changelog): 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-07-22
+
 ### Added
 
 - **The GitHub Action exposes `fail-on-degraded`.** nox has had the flag since
@@ -25,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   look for a failure that did not happen, when the scan had in fact run and
   written its reports. The annotation now names the degradation case and points
   at `meta.degradations`.
+
+- **Dependency upgrades in the shipped binary**: `google.golang.org/grpc`
+  1.82.0 → 1.82.1 and `golang.org/x/text` 0.38.0 → 0.39.0, applied by nox's own
+  remediation run.
 
 ## [1.13.6] - 2026-07-21
 


### PR DESCRIPTION
Stamps the Unreleased section as 1.14.0.

Minor rather than patch: #304 adds a user-facing Action input (`fail-on-degraded`), which is a new interface, not a fix.

Also records the dependency upgrades from #303 — `google.golang.org/grpc` 1.82.0→1.82.1 and `golang.org/x/text` 0.38.0→0.39.0. They arrived via a `chore(security)` commit but they ship inside the binary, so they belong in release notes rather than being invisible to anyone auditing what changed.

The other six commits in the range touch only `.github/workflows/remediation.yml`, `docs/`, and `.gitignore` — nox's own CI and repo hygiene, nothing a consumer receives.