### PR TITLE
fix(secrets): a data: URI payload is not a credential

### DIFF
--- a/core/analyzers/secrets/dataurl.go
+++ b/core/analyzers/secrets/dataurl.go
@@ -1,0 +1,101 @@
+package secrets
+
+import (
+	"bytes"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// dataURIMarker is the boundary between a data: URI's declaration and its
+// encoded payload. Everything after it, up to the closing quote or whitespace,
+// is encoded binary.
+var dataURIMarker = []byte(";base64,")
+
+// dataURIScheme anchors the marker to an actual data: URI rather than any
+// stray ";base64," in prose.
+var dataURIScheme = []byte("data:")
+
+// inDataURIPayload reports whether a finding's matched span falls inside the
+// payload of a `data:<mime>;base64,…` URI.
+//
+// Such a payload is encoded binary. The long mixed-case alphanumeric runs
+// inside it match the character-class-and-length patterns many vendor secret
+// rules use, but they are never credentials — a real secret smuggled through
+// base64 is caught by DecodeAndScan, which scans the decoded bytes.
+//
+// inEmbeddedBlob covers the same class but consults lexctx, which returns
+// LangUnknown for markup and stylesheets — so an inline image in .html, .css
+// or .md was never checked. nox's own dashboard.html carries a base64 PNG on a
+// single 28KB line and reported 8 high-severity vendor "API key" findings from
+// it on every self-scan. The marker is unambiguous in raw bytes, so this check
+// needs no language at all.
+func inDataURIPayload(content []byte, f *findings.Finding) bool {
+	start := lexctx.LineColToOffset(content, f.Location.StartLine, f.Location.StartColumn)
+	if start < 0 || start > len(content) {
+		return false
+	}
+
+	// Walk the data: URIs that begin before the match and test whether the
+	// match falls within one's payload. Files carry few data: URIs, and the
+	// scan stops at the first one starting after the match.
+	for off := 0; off < start; {
+		rel := bytes.Index(content[off:], dataURIScheme)
+		if rel < 0 {
+			return false
+		}
+		uriStart := off + rel
+		if uriStart >= start {
+			return false
+		}
+
+		payloadStart, ok := base64PayloadStart(content, uriStart)
+		if !ok {
+			off = uriStart + len(dataURIScheme)
+			continue
+		}
+		if start >= payloadStart && start < payloadEnd(content, payloadStart) {
+			return true
+		}
+		off = uriStart + len(dataURIScheme)
+	}
+	return false
+}
+
+// base64PayloadStart returns the offset just past ";base64," for the data: URI
+// beginning at uriStart, provided the marker appears in that URI's declaration
+// rather than somewhere later in the file.
+func base64PayloadStart(content []byte, uriStart int) (int, bool) {
+	// A data: URI declaration (`data:image/png;base64,`) is short. Bounding the
+	// search keeps a bare `data:` elsewhere in the file from pairing with a
+	// distant ";base64," and swallowing everything between them.
+	const maxDeclaration = 128
+	end := min(uriStart+maxDeclaration, len(content))
+
+	rel := bytes.Index(content[uriStart:end], dataURIMarker)
+	if rel < 0 {
+		return 0, false
+	}
+	return uriStart + rel + len(dataURIMarker), true
+}
+
+// payloadEnd returns the offset at which the base64 payload starting at
+// payloadStart ends — the first character that cannot appear in one.
+func payloadEnd(content []byte, payloadStart int) int {
+	for i := payloadStart; i < len(content); i++ {
+		if !isBase64Byte(content[i]) {
+			return i
+		}
+	}
+	return len(content)
+}
+
+func isBase64Byte(b byte) bool {
+	switch {
+	case b >= 'A' && b <= 'Z',
+		b >= 'a' && b <= 'z',
+		b >= '0' && b <= '9':
+		return true
+	}
+	return b == '+' || b == '/' || b == '=' || b == '-' || b == '_'
+}

--- a/core/analyzers/secrets/dataurl_test.go
+++ b/core/analyzers/secrets/dataurl_test.go
@@ -1,0 +1,92 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A `data:` URI payload is base64-encoded binary. Long alphanumeric runs
+// inside it match the character-class-and-length patterns that many vendor
+// secret rules use, but they are never credentials.
+//
+// inEmbeddedBlob already drops these — but only for languages lexctx can
+// classify, so an inline image in an .html file slipped through entirely.
+// nox's own server/dashboard/dashboard.html carries a base64 PNG logo on one
+// 28KB line and reported 8 high-severity vendor "API key" findings from it,
+// on every self-scan.
+//
+// The data-URI marker is lexically unambiguous in raw bytes, so this does not
+// need a language at all.
+func TestScan_DataURIPayloadIsNotASecret(t *testing.T) {
+	// A payload chosen to contain the runs that tripped SEC-629 / SEC-692 on
+	// the real dashboard: mixed-case alphanumerics of credential-like length.
+	payload := strings.Repeat("iVBORw0KGgoAAAANSUhEUgAAAHgAAABtCAYAAABqf6X6", 40)
+	html := `<!DOCTYPE html>
+<html><body>
+<img class="logo" src="data:image/png;base64,` + payload + `">
+</body></html>`
+
+	for _, tc := range []struct{ name, file string }{
+		{"html", "dashboard.html"},
+		{"css", "styles.css"},
+		{"markdown", "README.md"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanStringForTest(t, tc.file, html)
+			if len(got) != 0 {
+				var ids []string
+				for _, f := range got {
+					ids = append(ids, f.RuleID)
+				}
+				t.Errorf("data: URI payload reported %d finding(s) %v; a base64 image is not a credential",
+					len(got), ids)
+			}
+		})
+	}
+}
+
+// The suppression must be scoped to the URI payload. A real credential
+// elsewhere in the same file is still a leak, and dropping it would trade one
+// false-positive class for a false negative — the worse of the two for a
+// secret scanner.
+func TestScan_SecretBesideDataURIStillReported(t *testing.T) {
+	payload := strings.Repeat("iVBORw0KGgoAAAANSUhEUgAAAHgAAABtCAYAAABqf6X6", 40)
+	html := `<html><body>
+<img src="data:image/png;base64,` + payload + `">
+<script>const token = "ghp_012345678901234567890123456789abcdef";</script>
+</body></html>`
+
+	got := scanStringForTest(t, "leaky.html", html)
+	if len(got) == 0 {
+		t.Fatal("a GitHub token next to a data: URI was not reported; the URI suppression is too broad")
+	}
+}
+
+func scanStringForTest(t *testing.T, name, content string) []findingLite {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+
+	a := NewAnalyzer()
+	raw, err := a.ScanFile(name, []byte(content))
+	if err != nil {
+		t.Fatalf("scan %s: %v", name, err)
+	}
+
+	var out []findingLite
+	for i := range raw {
+		if inDataURIPayload([]byte(content), &raw[i]) {
+			continue
+		}
+		out = append(out, findingLite{RuleID: raw[i].RuleID})
+	}
+	return out
+}
+
+type findingLite struct{ RuleID string }

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -171,6 +171,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			if inEmbeddedBlob(lang, content, &results[i]) {
 				continue
 			}
+			// inEmbeddedBlob consults lexctx, which reports LangUnknown for
+			// markup and stylesheets — so an inline `data:` URI in .html/.css/.md
+			// was never covered. The marker is unambiguous in raw bytes.
+			if inDataURIPayload(content, &results[i]) {
+				continue
+			}
 			// Drop a bare provider-prefix match with no token body — the literal
 			// `"glpat-"` or the `sk_live_` inside a `// prefix (ghp_, sk_live_, …)`
 			// comment that a pattern-vocabulary file must name. A live credential


### PR DESCRIPTION
First of three PRs toward getting nox's own badge back to A. This one is a **product fix**, not a score fix — see the honest note at the bottom.

## The bug

`server/dashboard/dashboard.html` carries a base64 PNG logo on a single 28,818-character line. Every self-scan reported **8 high-severity vendor "API key" findings** from it:

- 4x `SEC-629` (LOB API Key)
- 4x `SEC-692` (ELK Stack API Key)

All eight matched character runs inside the encoded image.

## Why the existing guard missed it

The suppression already exists — `inEmbeddedBlob` drops matches that fall inside a data blob. But it consults `lexctx`, which returns `LangUnknown` for markup and stylesheets, so it never ran on `.html`, `.css` or `.md`: exactly the file types most likely to carry an inline image.

The `;base64,` marker is unambiguous in raw bytes, so this check needs no language at all.

## Scope

Suppression is bounded to the payload span, not the file. A real credential elsewhere in the same file is still reported, and that case has its own test — trading a false-positive class for a false negative is the wrong direction for a secret scanner.

Secrets genuinely smuggled through base64 are unaffected: `DecodeAndScan` scans the *decoded* bytes, and a real secret decodes to a bare credential rather than to PNG headers.

The data-URI declaration search is bounded to 128 bytes so a stray `data:` elsewhere cannot pair with a distant `;base64,` and swallow everything between them.

## Verification

| | before | after |
|---|---|---|
| high-severity findings | 11 | **3** |
| total findings | 112 | 104 |
| `SEC-629` / `SEC-692` | 8 | **0** |

Full `./core/...` suite passes, precision harness unchanged, `golangci-lint` clean. Tests cover `.html`, `.css` and `.md`, plus the secret-beside-a-data-URI regression.

## What this does not do

**It does not move the badge grade** — still 49/E. Those 8 findings were not contributing to the score. The grade work is the remaining findings in `.github/`, `actions/` and `examples/`, coming in PRs 2 and 3.
