### PR TITLE
fix(ci): harden nox's own workflows and images, waive what is deliberate

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -13,19 +13,19 @@ on:
     types: [published]      # primary trigger — every published release
   schedule:
     - cron: "17 6 * * 1"    # weekly safety net (Mon). Release+CI events keep badges fresh.
-  workflow_dispatch:
+  workflow_dispatch: # nox:ignore IAC-308 -- badge refresh is run on demand after a release
   workflow_run:
     workflows: ["CI"]
     types: [completed]
     branches: [main]
 
 permissions:
-  contents: write
+  contents: write # nox:ignore IAC-314 -- opens the badge-refresh PR
   pull-requests: write
 
 concurrency:
   group: badge-refresh
-  cancel-in-progress: true
+  cancel-in-progress: true # nox:ignore IAC-309 -- only the newest badge scan is meaningful
 
 jobs:
   refresh:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
   # the PR gate (changed-files only) would miss.
   schedule:
     - cron: '0 6 * * 1' # Mondays 06:00 UTC
-  workflow_dispatch: {}
+  workflow_dispatch: {} # nox:ignore IAC-308 -- used to run the full OS matrix on a branch before merge
 
 permissions:
   contents: write # nox:ignore IAC-314 -- needed for badge commits and SARIF upload
@@ -30,7 +30,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: true # nox:ignore IAC-309 -- superseded pushes need not finish
 
 jobs:
   lint:
@@ -111,7 +111,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        shell: bash
+        shell: bash # nox:ignore IAC-193 -- composite-style step, not Ansible
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Coverage summary
@@ -370,7 +370,7 @@ jobs:
         continue-on-error: true # nox:ignore IAC-018,IAC-310 -- best-effort SARIF upload
 
       - name: Upload scan results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI scan artifact, not a released binary; release artifacts are signed and attested in release.yml
         if: always()
         with:
           name: nox-results
@@ -437,7 +437,7 @@ jobs:
         with:
           sarif_file: nox-pr/results.sarif
           category: nox-pr
-        continue-on-error: true
+        continue-on-error: true # nox:ignore IAC-018,IAC-310 -- best-effort SARIF upload for the PR-scoped scan
 
       - name: Upload PR scan artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,7 +3,7 @@ name: Dependabot Auto-merge
 on: pull_request
 
 permissions:
-  contents: write
+  contents: write # nox:ignore IAC-314 -- enables auto-merge on Dependabot PRs
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
 
 permissions:
   contents: write # nox:ignore IAC-314 -- needed for creating GitHub releases
-  packages: write # needed for pushing to ghcr.io
-  id-token: write # needed for cosign keyless signing
+  packages: write # nox:ignore IAC-315 -- pushing the release image to ghcr.io (needed for pushing to ghcr.io)
+  id-token: write # nox:ignore IAC-306 -- OIDC is the keyless-signing mechanism; removing it unsigns the release (needed for cosign keyless signing)
 
 jobs:
   release:

--- a/.github/workflows/remediation.yml
+++ b/.github/workflows/remediation.yml
@@ -13,7 +13,7 @@ on:
   schedule:
     # Weekly Mon 03:00 UTC.
     - cron: '0 3 * * 1'
-  workflow_dispatch:
+  workflow_dispatch: # nox:ignore IAC-308 -- remediation is run on demand as well as on schedule
     inputs:
       include-major:
         description: 'Apply major-version bumps too (off by default; review manually).'
@@ -21,7 +21,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: write # nox:ignore IAC-314 -- opens the remediation PR
   pull-requests: write
 
 jobs:

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -11,7 +11,7 @@ on:
   workflow_run:
     workflows: ["Release"]
     types: [completed]
-  workflow_dispatch:
+  workflow_dispatch: # nox:ignore IAC-308 -- provenance can be regenerated for an existing release on demand
     inputs:
       tag:
         description: "Release tag to backfill provenance for (e.g. v0.10.1). Leave blank to attest the latest published release."
@@ -82,8 +82,8 @@ jobs:
     needs: subjects
     permissions:
       actions: read       # required by the reusable workflow
-      id-token: write     # OIDC token for sigstore keyless signing
-      contents: write     # upload provenance to the release
+      id-token: write # nox:ignore IAC-306 -- OIDC is the keyless-signing mechanism for the attestation (OIDC token for sigstore keyless signing)
+      contents: write # nox:ignore IAC-314 -- uploads the provenance attestation to the release (upload provenance to the release)
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@361859811395a7dfc81e24fb4dfe843a59715a40 # v2.1.0-rc.3
     with:
       base64-subjects: ${{ needs.subjects.outputs.hashes }}

--- a/.nox.yaml
+++ b/.nox.yaml
@@ -38,6 +38,11 @@ scan:
     - "scripts/"
     # Rule definition files contain high-entropy regex patterns (expected false positives)
     - "core/analyzers/secrets/rules.go"
+    # The taint sink catalog is a static list of API names. Long camel-case
+    # identifiers (NSKeyedUnarchiver.unarchiveTopLevelObjectWithData) score as
+    # high-entropy strings. JSON carries no comments, so an inline nox:ignore
+    # is not available for this one file.
+    - "core/taint/data/catalog.json"
     - "core/analyzers/iac/rules*.go"
     - "core/analyzers/ai/rules.go"
     - "registry/trust/signature.go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # Build stage
+# nox:ignore IAC-121 -- nox is a one-shot CLI; a HEALTHCHECK has nothing to poll
+# nox:ignore IAC-122 -- builder stage is discarded; the runtime stage is nonroot
+# nox:ignore IAC-124 -- maintainer is carried by the OCI labels on the runtime stage
 FROM golang:1.25-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS builder
 
 ARG VERSION=dev
@@ -7,9 +10,11 @@ ARG DATE=unknown
 
 WORKDIR /build
 
+# nox:ignore IAC-123 -- builder stage, layer is discarded
 COPY go.mod go.sum ./
 RUN go mod download
 
+# nox:ignore IAC-123 -- builder stage, layer is discarded
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build \
@@ -20,7 +25,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Runtime stage — distroless for minimal attack surface
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
-COPY --from=builder /build/nox /usr/local/bin/nox
+LABEL org.opencontainers.image.title="nox" \
+      org.opencontainers.image.description="Language-agnostic security scanner with first-class AI application security" \
+      org.opencontainers.image.source="https://github.com/nox-hq/nox" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="nox-hq"
+
+# nox:ignore IAC-123 -- --chown=nonroot:nonroot is present on this COPY
+COPY --from=builder --chown=nonroot:nonroot /build/nox /usr/local/bin/nox
 
 # Run as non-root user (65534 = nobody in distroless)
 USER nonroot:nonroot

--- a/actions/remediate/action.yml
+++ b/actions/remediate/action.yml
@@ -78,7 +78,10 @@ runs:
   using: 'composite'
   steps:
     - name: Install Nox
-      uses: nox-hq/nox@v1
+      # Pinned by commit SHA, not the floating @v1 tag: IAC-013 is nox's own
+      # rule, and an action that remediates supply-chain risk must not itself
+      # consume a mutable ref.
+      uses: nox-hq/nox@774d22ac2c0b83692802729163f848c7596d2460 # v1.14.0
       with:
         path: ${{ inputs.path }}
         format: ${{ inputs.scan-format }}
@@ -88,7 +91,7 @@ runs:
 
     - name: Build remediation plan
       id: plan
-      shell: bash
+      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
       env:
         INPUT_OUTPUT: ${{ inputs.scan-output }}
         INPUT_INCLUDE_MAJOR: ${{ inputs.include-major }}
@@ -97,7 +100,7 @@ runs:
 
     - name: Apply remediation
       if: steps.plan.outputs.has-updates == 'true' && inputs.apply == 'true'
-      shell: bash
+      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
       env:
         INPUT_OUTPUT: ${{ inputs.scan-output }}
         INPUT_INCLUDE_MAJOR: ${{ inputs.include-major }}
@@ -106,7 +109,7 @@ runs:
 
     - name: Verify changes
       if: steps.plan.outputs.has-updates == 'true' && inputs.apply == 'true' && inputs.verify-cmd != ''
-      shell: bash
+      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
       working-directory: ${{ inputs.manifest-root }}
       run: ${{ inputs.verify-cmd }}
 
@@ -126,7 +129,7 @@ runs:
 
     - name: Upload remediation plan
       if: always()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0 # nox:ignore IAC-153 -- remediation plan for PR review, not a released binary
       with:
         name: nox-remediation-plan
         path: ${{ inputs.scan-output }}/remediation-plan.txt

--- a/cli/fix_content.go
+++ b/cli/fix_content.go
@@ -45,6 +45,7 @@ var contentFixes = map[string]contentFix{
 	"IAC-042": {regexp.MustCompile(`(?i)(enable_https_traffic_only\s*=\s*)false`), "${1}true", "enable_https_traffic_only = false → true"},
 	// Terraform: HTTPS listener, private ACL.
 	"IAC-041": {regexp.MustCompile(`(?i)(protocol\s*=\s*["'])HTTP(["'])`), "${1}HTTPS${2}", `protocol "HTTP" → "HTTPS"`},
+	// nox:ignore SEC-163 -- regex literal for a remediation pattern, not a secret
 	"IAC-040": {regexp.MustCompile(`(?i)(acl\s*=\s*["'])(?:public-read|public-read-write)(["'])`), "${1}private${2}", `acl "public-read" → "private"`},
 	// Dockerfile: COPY instead of ADD (ADD's implicit fetch/extract is a footgun).
 	"IAC-003": {regexp.MustCompile(`(?im)(^\s*)ADD(\s+)`), "${1}COPY${2}", "ADD → COPY"},

--- a/cli/templates/Dockerfile.tmpl
+++ b/cli/templates/Dockerfile.tmpl
@@ -1,12 +1,18 @@
 # nox:ignore CONT-001 -- scaffolding template; users pin digests for their builds
+# nox:ignore IAC-121 -- a plugin binary is one-shot; a HEALTHCHECK has nothing to poll
+# nox:ignore IAC-122 -- build stage is discarded; the scratch runtime has no users to switch to
+# nox:ignore IAC-124 -- scaffolding template; the generated plugin supplies its own labels
 FROM golang:1.25-alpine AS build
 WORKDIR /src
+# nox:ignore IAC-123 -- build stage, layer is discarded
 COPY go.mod go.sum ./
 RUN go mod download
+# nox:ignore IAC-123 -- build stage, layer is discarded
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /plugin .
 
 # nox:ignore IAC-002 -- minimal runtime image for plugins
 FROM scratch
+# nox:ignore IAC-123 -- scratch image has no users; --chown would fail
 COPY --from=build /plugin /plugin
 ENTRYPOINT ["/plugin"]


### PR DESCRIPTION
PR 2 of 3 toward getting nox's own badge back to A. Clears **everything outside `examples/`**.

| | Score | Grade |
|---|---|---|
| before | 49 | E |
| after | **22** | **D** |

The remaining 22 points are all in `examples/`, handled in PR 3.

## Real fixes

**`actions/remediate/action.yml` consumed `nox-hq/nox@v1` — a mutable tag.** IAC-013 is nox's own rule, and 1.13.6's changelog called out this exact file. An action whose job is remediating supply-chain risk must not itself consume a floating ref. Now pinned to `774d22ac` (v1.14.0). Worth 3.5 of the 27 points, and it would have been worth fixing at any score.

**The runtime image** gains OCI labels and copies the binary with `--chown=nonroot:nonroot`.

## Waived, with a reason

Following the `# nox:ignore RULE -- why` convention already in `ci.yml`. Every one of these findings is *correct* — the configuration is deliberate:

| Rule | Why it stays |
|---|---|
| `IAC-306` `id-token: write` | OIDC **is** the keyless-signing mechanism. Removing it unsigns the release. |
| `IAC-314`/`315` | Release upload, badge/remediation PRs, ghcr.io push. |
| `IAC-308`/`309` | `workflow_dispatch` is how the full OS matrix runs on a branch pre-merge. |
| `IAC-193` "Ansible shell module" | These are composite GitHub Actions, not Ansible. |
| `IAC-153` attestation | CI scan artifacts and remediation plans, not released binaries — those are signed and attested in `release.yml`. |
| `IAC-121`/`122`/`124` | nox is a one-shot CLI with nothing for a HEALTHCHECK to poll; the builder stage is discarded. |
| `SEC-163` on `fix_content.go` | A regex literal for a remediation pattern, not a credential. |

`core/taint/data/catalog.json` is excluded rather than waived inline — it is a static catalog of API names whose long camel-case identifiers (`NSKeyedUnarchiver.unarchiveTopLevelObjectWithData`) score as high-entropy, and JSON carries no comments. Same class as the rule-definition files already on that list.

## Verification

- `docker build` succeeds. **A first pass put the ignore comments inline on `COPY` lines** — Dockerfile only supports full-line comments, so it would have tried to copy files literally named `#` and `nox:ignore`. Caught by actually building rather than by reading the diff.
- All edited YAML parses.
- `go test ./...` green, `golangci-lint` clean.
