### PR TITLE
fix(iac): Dockerfile absence rules no longer fooled by comments or blank lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         continue-on-error: true # nox:ignore IAC-018,IAC-310 -- best-effort SARIF upload
 
       - name: Upload scan results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI scan artifact, not a released binary; release artifacts are signed and attested in release.yml
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI scan artifact, not a released binary; release artifacts carry SLSA provenance (release.yml)
         if: always()
         with:
           name: nox-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Build stage
 # nox:ignore IAC-121 -- nox is a one-shot CLI; a HEALTHCHECK has nothing to poll
-# nox:ignore IAC-122 -- builder stage is discarded; the runtime stage is nonroot
 # nox:ignore IAC-124 -- maintainer is carried by the OCI labels on the runtime stage
 FROM golang:1.25-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS builder
 
@@ -31,7 +30,6 @@ LABEL org.opencontainers.image.title="nox" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="nox-hq"
 
-# nox:ignore IAC-123 -- --chown=nonroot:nonroot is present on this COPY
 COPY --from=builder --chown=nonroot:nonroot /build/nox /usr/local/bin/nox
 
 # Run as non-root user (65534 = nobody in distroless)

--- a/core/analyzers/iac/dockerfile_comment_test.go
+++ b/core/analyzers/iac/dockerfile_comment_test.go
@@ -1,0 +1,136 @@
+package iac
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// The Dockerfile "missing instruction" rules (IAC-121 HEALTHCHECK, IAC-124
+// LABEL maintainer) are absence rules: they fire when the instruction is not
+// present in the file. Their AbsenceProperty matched the bare keyword anywhere
+// in the file, including inside a comment — so a Dockerfile that merely
+// *mentions* the instruction in a comment silently satisfied the rule and the
+// finding disappeared.
+//
+// This is a false negative in a security scanner: `# TODO: add a HEALTHCHECK`
+// makes nox stop reporting the missing HEALTHCHECK. A real instruction begins a
+// line, so the property must be anchored the way the sibling rules (IAC-122
+// USER, IAC-125 CMD) already are.
+//
+// Found while getting nox's own repo to badge grade A: a waiver comment reading
+// "a HEALTHCHECK has nothing to poll" disabled IAC-121 on nox's Dockerfile, and
+// nox correctly reported the waiver as suppressing nothing — the waiver was
+// redundant because the rule had already been silenced by its own keyword.
+func TestDockerfileAbsenceRule_KeywordInCommentDoesNotSatisfy(t *testing.T) {
+	cases := []struct {
+		name   string
+		ruleID string
+		// A Dockerfile with the instruction genuinely absent, but mentioned in
+		// a comment. The finding must still fire.
+		commentedOut string
+		// The same Dockerfile with the instruction genuinely present. The
+		// finding must NOT fire — this guards against over-correcting into a
+		// false positive.
+		instructionPresent string
+	}{
+		{
+			name:   "IAC-121 HEALTHCHECK",
+			ruleID: "IAC-121",
+			commentedOut: `FROM alpine:3.20
+# no HEALTHCHECK is needed for a one-shot CLI
+USER nobody
+ENTRYPOINT ["/app"]
+`,
+			instructionPresent: `FROM alpine:3.20
+HEALTHCHECK --interval=30s CMD /app healthz || exit 1
+USER nobody
+ENTRYPOINT ["/app"]
+`,
+		},
+		{
+			name:   "IAC-124 LABEL maintainer",
+			ruleID: "IAC-124",
+			commentedOut: `FROM alpine:3.20
+# LABEL maintainer is deprecated; we use OCI image labels instead
+USER nobody
+`,
+			instructionPresent: `FROM alpine:3.20
+LABEL maintainer="team@example.com"
+USER nobody
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAnalyzer()
+
+			got, err := a.ScanFile("Dockerfile", []byte(tc.commentedOut))
+			if err != nil {
+				t.Fatalf("scan commentedOut: %v", err)
+			}
+			if !hasRule(got, tc.ruleID) {
+				t.Errorf("%s did not fire when the instruction was only mentioned in a comment; "+
+					"the absence rule is matching its keyword inside comments", tc.ruleID)
+			}
+
+			got, err = a.ScanFile("Dockerfile", []byte(tc.instructionPresent))
+			if err != nil {
+				t.Fatalf("scan instructionPresent: %v", err)
+			}
+			if hasRule(got, tc.ruleID) {
+				t.Errorf("%s fired even though the instruction is genuinely present; "+
+					"the anchoring is too strict", tc.ruleID)
+			}
+		})
+	}
+}
+
+// A blank line before an instruction must not change whether an absence rule
+// fires. The anchors used `^\s*COPY…`, and `\s` includes newlines, so in
+// multiline mode the match began on the preceding blank line. Line-span rules
+// (IAC-123) then computed their span from that blank line, which contains no
+// --chown, and the rule fired on a COPY that was correctly chowned — a false
+// positive on ordinary Dockerfiles, since a blank line before a COPY is
+// idiomatic.
+func TestDockerfileAbsenceRule_BlankLineBeforeInstruction(t *testing.T) {
+	a := NewAnalyzer()
+
+	// COPY has --chown and is preceded by a blank line: IAC-123 must NOT fire.
+	withBlank := `FROM scratch
+LABEL org.opencontainers.image.title="x"
+
+COPY --from=b --chown=nonroot:nonroot /a /b
+`
+	got, err := a.ScanFile("Dockerfile", []byte(withBlank))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hasRule(got, "IAC-123") {
+		t.Error("IAC-123 fired on a COPY that has --chown, because a blank line " +
+			"before it shifted the anchor onto the blank line")
+	}
+
+	// A COPY genuinely missing --chown must still fire, blank line or not.
+	missing := `FROM scratch
+
+COPY /a /b
+`
+	got, err = a.ScanFile("Dockerfile", []byte(missing))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !hasRule(got, "IAC-123") {
+		t.Error("IAC-123 did not fire on a COPY missing --chown; the anchor fix over-corrected")
+	}
+}
+
+func hasRule(results []findings.Finding, ruleID string) bool {
+	for _, r := range results {
+		if r.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -1337,8 +1337,12 @@ func builtinBaseIaCRules() []rules.Rule {
 		// =================================================================
 		{
 			id: "IAC-121", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?im)^\s*FROM\s+\S`,
-			absenceProperty: `(?i)HEALTHCHECK`,
+			absenceAnchor: `(?im)^[ \t]*FROM\s+\S`,
+			// Anchored to a real HEALTHCHECK instruction at line start, not the
+			// bare keyword: an unanchored match treated `# ... HEALTHCHECK ...`
+			// in a comment as the instruction being present and silenced the
+			// rule. Mirrors IAC-122's USER and IAC-125's CMD anchoring.
+			absenceProperty: `(?im)^\s*HEALTHCHECK\s`,
 			absenceSpan:     "file",
 			description:     "Dockerfile missing HEALTHCHECK instruction",
 			cwe:             "CWE-693", keywords: []string{"HEALTHCHECK"},
@@ -1349,7 +1353,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-122", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?im)^\s*FROM\s+\S`,
+			absenceAnchor:   `(?im)^[ \t]*FROM\s+\S`,
 			absenceProperty: `(?im)^\s*USER\s+\S`,
 			absenceSpan:     "file",
 			description:     "Dockerfile has no USER instruction (runs as root by default)",
@@ -1361,7 +1365,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-123", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?im)^\s*COPY\s+\S+\s+\S`,
+			absenceAnchor:   `(?im)^[ \t]*COPY\s+\S+\s+\S`,
 			absenceProperty: `(?i)--chown`,
 			absenceSpan:     "line-continued",
 			description:     "Dockerfile COPY without --chown flag",
@@ -1373,8 +1377,11 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-124", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?im)^\s*FROM\s+\S`,
-			absenceProperty: `(?i)LABEL\s+maintainer`,
+			absenceAnchor: `(?im)^[ \t]*FROM\s+\S`,
+			// Anchored to a real LABEL instruction at line start: an unanchored
+			// match let `# LABEL maintainer is deprecated` in a comment satisfy
+			// the rule. Same false-negative class as IAC-121.
+			absenceProperty: `(?im)^\s*LABEL\s+maintainer`,
 			absenceSpan:     "file",
 			description:     "Dockerfile missing LABEL maintainer",
 			cwe:             "CWE-1059", keywords: []string{"LABEL", "maintainer"},
@@ -1385,7 +1392,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-125", severity: findings.SeverityLow, confidence: findings.ConfidenceMedium,
-			absenceAnchor:   `(?im)^\s*CMD\s+\S`,
+			absenceAnchor:   `(?im)^[ \t]*CMD\s+\S`,
 			absenceProperty: `(?im)^\s*CMD\s+\[`,
 			absenceSpan:     "line",
 			description:     "Dockerfile CMD uses shell form instead of exec form",
@@ -1397,7 +1404,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-126", severity: findings.SeverityLow, confidence: findings.ConfidenceHigh,
-			absenceAnchor:   `(?im)^\s*RUN\s+.*apt-get\s+install`,
+			absenceAnchor:   `(?im)^[ \t]*RUN\s+.*apt-get\s+install`,
 			absenceProperty: `(?i)--no-install-recommends`,
 			absenceSpan:     "line-continued",
 			description:     "Dockerfile apt-get install without --no-install-recommends",
@@ -1409,7 +1416,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-127", severity: findings.SeverityLow, confidence: findings.ConfidenceHigh,
-			absenceAnchor:   `(?im)^\s*RUN\s+.*pip\s+install`,
+			absenceAnchor:   `(?im)^[ \t]*RUN\s+.*pip\s+install`,
 			absenceProperty: `(?i)--no-cache-dir`,
 			absenceSpan:     "line-continued",
 			description:     "Dockerfile pip install without --no-cache-dir",
@@ -1431,7 +1438,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-129", severity: findings.SeverityLow, confidence: findings.ConfidenceHigh,
-			absenceAnchor:   `(?im)^\s*RUN\s+.*apk\s+add`,
+			absenceAnchor:   `(?im)^[ \t]*RUN\s+.*apk\s+add`,
 			absenceProperty: `(?i)--no-cache`,
 			absenceSpan:     "line-continued",
 			description:     "Dockerfile apk add without --no-cache",


### PR DESCRIPTION
Two false-behaviours in the Dockerfile "missing instruction" rules, found while getting nox's own repo to badge grade A. Both explain why a batch of `nox:ignore` waivers appeared to suppress nothing — **nox's unused-waiver report was correct; the rules were the problem.**

## 1. A comment keyword satisfies the rule (false negative)

`IAC-121`'s `absenceProperty` was the bare `(?i)HEALTHCHECK`, matched over the whole file. So:

```dockerfile
FROM alpine:3.20
# no HEALTHCHECK needed for a one-shot CLI
USER nobody
```

...made nox conclude a HEALTHCHECK was present and **stop reporting its absence**. `IAC-124` had the identical shape with `LABEL maintainer`. A comment *claiming* an instruction exists silently disables the check — a false negative in a security scanner.

Fixed by anchoring to a real instruction at line start (`^\s*HEALTHCHECK\s`, `^\s*LABEL\s+maintainer`), exactly how siblings `IAC-122` (USER) and `IAC-125` (CMD) were already written.

## 2. A blank line before an instruction fires a false positive

The anchors were `^\s*COPY…`, and `\s` includes newlines. Under multiline matching the anchor began on the **preceding blank line**; the line-span rule `IAC-123` (COPY-without-chown) then took its span from that blank line, found no `--chown`, and fired on a COPY that was correctly chowned:

```dockerfile
FROM scratch
LABEL org.opencontainers.image.title="x"

COPY --from=b --chown=nonroot:nonroot /a /b   # <- IAC-123 fired here
```

A blank line before a COPY is idiomatic, so this hit ordinary Dockerfiles. All eight Dockerfile anchors now use `^[ \t]*`, which cannot cross a newline.

## Tests

Both directions for each rule: instruction-only-in-a-comment must still fire, genuinely-present must not, and a blank line must not change either verdict.

## Effect on nox's own repo

- The waiver "a HEALTHCHECK has nothing to poll" had been disabling IAC-121 via bug 1.
- A chowned runtime COPY after a blank line was flagged via bug 2.

With both fixed, three now-redundant waivers are removed (Dockerfile + ci.yml). Keeping them would have **masked a real finding** if a future edit dropped `USER` / `--chown` / the artifact step.

## Honest scope note

One ci.yml waiver's reason contained the word "attested", which was satisfying `IAC-153`'s `(?i)attest` property the same way bug 1 works — but through a YAML **trailing** comment. Anchoring doesn't apply to a keyword property, and safely stripping trailing `#` in YAML needs quote-aware parsing, so that wider class is **not fixed here**. I reworded the reason to avoid the trigger and will file the YAML trailing-comment variant as a follow-up.

Full `./core/...` and `./cli/...` suites pass; `golangci-lint` clean.
