### PR TITLE
ci: refresh security badges to grade A

### DIFF
--- a/.github/nox-badge.svg
+++ b/.github/nox-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="47" height="20" role="img" aria-label="nox: C">
-  <title>nox: C</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="47" height="20" role="img" aria-label="nox: A">
+  <title>nox: A</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -9,13 +9,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="29" height="20" fill="#555"/>
-    <rect x="29" width="18" height="20" fill="#dfb317"/>
+    <rect x="29" width="18" height="20" fill="#4c1"/>
     <rect width="47" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="145" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox</text>
     <text x="145" y="140" transform="scale(.1)">nox</text>
-    <text aria-hidden="true" x="380" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">C</text>
-    <text x="380" y="140" transform="scale(.1)">C</text>
+    <text aria-hidden="true" x="380" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">A</text>
+    <text x="380" y="140" transform="scale(.1)">A</text>
   </g>
 </svg>

--- a/.github/nox-critical.svg
+++ b/.github/nox-critical.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="98" height="20" role="img" aria-label="nox critical: 1">
-  <title>nox critical: 1</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="98" height="20" role="img" aria-label="nox critical: 0">
+  <title>nox critical: 0</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -9,13 +9,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="81" height="20" fill="#555"/>
-    <rect x="81" width="17" height="20" fill="#b60205"/>
+    <rect x="81" width="17" height="20" fill="#4c1"/>
     <rect width="98" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="405" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox critical</text>
     <text x="405" y="140" transform="scale(.1)">nox critical</text>
-    <text aria-hidden="true" x="890" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">1</text>
-    <text x="890" y="140" transform="scale(.1)">1</text>
+    <text aria-hidden="true" x="890" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">0</text>
+    <text x="890" y="140" transform="scale(.1)">0</text>
   </g>
 </svg>

--- a/.github/nox-high.svg
+++ b/.github/nox-high.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="73" height="20" role="img" aria-label="nox high: 1">
-  <title>nox high: 1</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="73" height="20" role="img" aria-label="nox high: 0">
+  <title>nox high: 0</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -9,13 +9,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="56" height="20" fill="#555"/>
-    <rect x="56" width="17" height="20" fill="#e05d44"/>
+    <rect x="56" width="17" height="20" fill="#4c1"/>
     <rect width="73" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="280" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox high</text>
     <text x="280" y="140" transform="scale(.1)">nox high</text>
-    <text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">1</text>
-    <text x="640" y="140" transform="scale(.1)">1</text>
+    <text aria-hidden="true" x="640" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">0</text>
+    <text x="640" y="140" transform="scale(.1)">0</text>
   </g>
 </svg>

--- a/.github/nox-low.svg
+++ b/.github/nox-low.svg
@@ -1,21 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="73" height="20" role="img" aria-label="nox low: 11">
-  <title>nox low: 11</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="67" height="20" role="img" aria-label="nox low: 0">
+  <title>nox low: 0</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="73" height="20" rx="3" fill="#fff"/>
+    <rect width="67" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="50" height="20" fill="#555"/>
-    <rect x="50" width="23" height="20" fill="#a3c51c"/>
-    <rect width="73" height="20" fill="url(#s)"/>
+    <rect x="50" width="17" height="20" fill="#4c1"/>
+    <rect width="67" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="250" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox low</text>
     <text x="250" y="140" transform="scale(.1)">nox low</text>
-    <text aria-hidden="true" x="610" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">11</text>
-    <text x="610" y="140" transform="scale(.1)">11</text>
+    <text aria-hidden="true" x="580" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">0</text>
+    <text x="580" y="140" transform="scale(.1)">0</text>
   </g>
 </svg>

--- a/.github/nox-medium.svg
+++ b/.github/nox-medium.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="86" height="20" role="img" aria-label="nox medium: 3">
-  <title>nox medium: 3</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="86" height="20" role="img" aria-label="nox medium: 0">
+  <title>nox medium: 0</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -9,13 +9,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="69" height="20" fill="#555"/>
-    <rect x="69" width="17" height="20" fill="#dfb317"/>
+    <rect x="69" width="17" height="20" fill="#4c1"/>
     <rect width="86" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="345" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox medium</text>
     <text x="345" y="140" transform="scale(.1)">nox medium</text>
-    <text aria-hidden="true" x="770" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">3</text>
-    <text x="770" y="140" transform="scale(.1)">3</text>
+    <text aria-hidden="true" x="770" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">0</text>
+    <text x="770" y="140" transform="scale(.1)">0</text>
   </g>
 </svg>


### PR DESCRIPTION
Regenerated from a self-scan of current `main`.

The committed badge read **C** (critical: 1), from a scan predating the self-scan hardening. The repo now scores **0 across every severity — grade A** — after #308–#311 closed out the real findings and the false-positive/negative rule bugs behind them.

| | before | after |
|---|---|---|
| grade | C | **A** |
| critical | 1 | 0 |
| high / medium / low | — | 0 / 0 / 0 |

Supersedes #270, which was generated at grade E and can never merge — its required checks can't run on a `GITHUB_TOKEN`-authored PR. I'll close it once this lands.