### PR TITLE
fix(iac): a comment keyword can't satisfy an absence rule's property (closes #312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         continue-on-error: true # nox:ignore IAC-018,IAC-310 -- best-effort SARIF upload
 
       - name: Upload scan results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI scan artifact, not a released binary; release artifacts carry SLSA provenance (release.yml)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI scan artifact, not a released binary; release artifacts are signed and attested in release.yml
         if: always()
         with:
           name: nox-results

--- a/core/analyzers/iac/dockerfile_comment_test.go
+++ b/core/analyzers/iac/dockerfile_comment_test.go
@@ -126,6 +126,49 @@ COPY /a /b
 	}
 }
 
+// The same comment-keyword class as IAC-121, but through a YAML trailing
+// comment rather than a Dockerfile line. IAC-153 fires when an artifact upload
+// has no attestation; its property is the bare keyword `(?i)attest`, matched
+// over the whole file. A trailing comment containing "attest" (a nox:ignore
+// reason, a note) satisfied it and silenced the rule. Anchoring does not apply
+// to a free keyword, so this is fixed by stripping comments before the
+// property match — see core/rules stripLineComments.
+func TestWorkflowAbsenceRule_KeywordInTrailingCommentDoesNotSatisfy(t *testing.T) {
+	a := NewAnalyzer()
+
+	// Upload step with no attestation, but a comment mentions "attested".
+	// IAC-153 must still fire.
+	commented := `on: [push]
+jobs:
+  build:
+    steps:
+      - uses: actions/upload-artifact@abc123 # artifacts are attested in release.yml
+`
+	got, err := a.ScanFile(".github/workflows/ci.yml", []byte(commented))
+	if err != nil {
+		t.Fatalf("scan commented: %v", err)
+	}
+	if !hasRule(got, "IAC-153") {
+		t.Error("IAC-153 did not fire when 'attested' appeared only in a trailing comment")
+	}
+
+	// A genuine attestation step present: IAC-153 must NOT fire.
+	present := `on: [push]
+jobs:
+  build:
+    steps:
+      - uses: actions/attest-build-provenance@abc123
+      - uses: actions/upload-artifact@abc123
+`
+	got, err = a.ScanFile(".github/workflows/ci.yml", []byte(present))
+	if err != nil {
+		t.Fatalf("scan present: %v", err)
+	}
+	if hasRule(got, "IAC-153") {
+		t.Error("IAC-153 fired even though a real attestation step is present")
+	}
+}
+
 func hasRule(results []findings.Finding, ruleID string) bool {
 	for _, r := range results {
 		if r.RuleID == ruleID {

--- a/core/rules/comment_strip_test.go
+++ b/core/rules/comment_strip_test.go
@@ -1,0 +1,67 @@
+package rules
+
+import "testing"
+
+// stripLineComments must remove `#` comments so a keyword mentioned only in a
+// comment cannot satisfy an absence rule's required property — but it must
+// never cut real content, because for an absence rule that would turn a
+// present property into an absent one and fire a false positive. The guard is
+// deliberately conservative: a `#` is a comment only at line start or when
+// preceded by whitespace with no quote earlier on the line.
+func TestStripLineComments(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "full-line comment removed",
+			in:   "FROM alpine\n# no HEALTHCHECK here\nUSER x\n",
+			want: "FROM alpine\n\nUSER x\n",
+		},
+		{
+			name: "trailing comment with no prior quote removed",
+			in:   "uses: actions/upload-artifact@sha # attested elsewhere\n",
+			want: "uses: actions/upload-artifact@sha\n",
+		},
+		{
+			name: "hash inside a double-quoted value is kept",
+			in:   `name: "release # attested"` + "\n",
+			want: `name: "release # attested"` + "\n",
+		},
+		{
+			name: "hash inside a single-quoted value is kept",
+			in:   "tag: 'v1 # attest'\n",
+			want: "tag: 'v1 # attest'\n",
+		},
+		{
+			name: "url fragment inside quotes is kept",
+			in:   `url: "https://x/a#attest"` + "\n",
+			want: `url: "https://x/a#attest"` + "\n",
+		},
+		{
+			name: "hash not preceded by whitespace is not a comment",
+			in:   "value: abc#attest\n",
+			want: "value: abc#attest\n",
+		},
+		{
+			name: "comment after an unquoted value removed",
+			in:   "attestations: read # keep this key, drop the note\n",
+			want: "attestations: read\n",
+		},
+		{
+			name: "JSON is unaffected (all # are inside quotes)",
+			in:   `{"note": "requires # attestation"}` + "\n",
+			want: `{"note": "requires # attestation"}` + "\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(stripLineComments([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("stripLineComments(%q)\n  = %q\n want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -240,6 +240,70 @@ func (m *AbsenceMatcher) compile(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
+// stripLineComments blanks out `#` line comments so a keyword that appears only
+// in a comment cannot satisfy an absence rule's required property. A comment can
+// never fulfil a "the config must contain X" requirement, so removing comments
+// before the property check is semantically correct.
+//
+// It is deliberately conservative, because for an absence rule wrongly cutting
+// real content turns a present property into an absent one — a false positive,
+// the worse failure for a security scanner. A `#` is treated as a comment only
+// when it is preceded by whitespace (or starts the line) AND no quote has
+// appeared earlier on that line. When a quote precedes the `#`, the line is left
+// untouched: `#` inside a quoted YAML value or a JSON string, or after any
+// quoted scalar, is never stripped. The rare "trailing comment after a quoted
+// value on the same line" is left as-is (property still satisfied, same as
+// before) rather than risk cutting a quoted value.
+//
+// The result is only used for the boolean property check; finding locations
+// come from the anchor match against the original content, so the stripped copy
+// need not preserve offsets.
+func stripLineComments(content []byte) []byte {
+	var out []byte
+	for lineStart := 0; lineStart <= len(content); {
+		nl := bytes.IndexByte(content[lineStart:], '\n')
+		var line []byte
+		if nl < 0 {
+			line = content[lineStart:]
+		} else {
+			line = content[lineStart : lineStart+nl]
+		}
+
+		if cut := commentCut(line); cut >= 0 {
+			line = bytes.TrimRight(line[:cut], " \t")
+		}
+		out = append(out, line...)
+
+		if nl < 0 {
+			break
+		}
+		out = append(out, '\n')
+		lineStart += nl + 1
+	}
+	return out
+}
+
+// commentCut returns the index at which a `#` line comment begins, or -1 if the
+// line has none. A `#` opens a comment only when it starts the line (after
+// optional whitespace) or is preceded by whitespace, and no quote has appeared
+// earlier on the line — so a `#` inside a quoted value, or after any quoted
+// scalar, is never treated as a comment.
+func commentCut(line []byte) int {
+	sawQuote := false
+	prevSpace := true
+	for i := range len(line) {
+		c := line[i]
+		if c == '"' || c == '\'' {
+			sawQuote = true
+		}
+		if c == '#' && prevSpace && !sawQuote {
+			return i
+		}
+		prevSpace = c == ' ' || c == '\t'
+	}
+	return -1
+}
+
 // Match reports each AbsenceAnchor occurrence whose span lacks AbsenceProperty
 // (and, when set, contains AbsenceRequire). The returned MatchResult points at
 // the anchor so the finding lands on the resource declaration.
@@ -269,7 +333,11 @@ func (m *AbsenceMatcher) Match(content []byte, rule *Rule) []MatchResult {
 	// companion PodDisruptionBudget is a separate manifest, or a Dockerfile
 	// missing a HEALTHCHECK entirely.
 	if rule.AbsenceSpan == "file" || rule.AbsenceSpan == "" {
-		if propRe.Match(content) {
+		// The property is matched against comment-stripped content: a keyword
+		// mentioned only in a comment cannot fulfil a "must be present"
+		// requirement. The anchor, the requirement and the finding location
+		// stay on the original content.
+		if propRe.Match(stripLineComments(content)) {
 			return nil
 		}
 		if requireRe != nil && !requireRe.Match(content) {
@@ -288,7 +356,7 @@ func (m *AbsenceMatcher) Match(content []byte, rule *Rule) []MatchResult {
 		if requireRe != nil && !requireRe.Match(span) {
 			continue
 		}
-		if propRe.Match(span) {
+		if propRe.Match(stripLineComments(span)) {
 			continue
 		}
 		r := makeMatchResult(content, lineStarts, loc)


### PR DESCRIPTION
Closes #312. Companion to #311, which fixed the Dockerfile instances by anchoring instruction properties to line start. This handles the wider class **anchoring can't** reach: a file-span absence rule whose property is a *free keyword*, satisfied by that keyword appearing in a comment.

## The bug

`IAC-153` ("artifact upload without attestation"), property `(?i)attest` over the whole file:

```yaml
- uses: actions/upload-artifact@sha  # attested in release.yml
```

The word "attested" in the trailing comment matched the property, so IAC-153 concluded attestation was present and **never fired**. nox's own repo hit exactly this — a `nox:ignore IAC-153` waiver whose *reason* said "attested" disabled the rule it was waiving. That was the "phantom unused waiver" that started this whole investigation.

## The fix

The matcher strips `#` comments before evaluating the absence property. A comment can never fulfil a "must be present" requirement, so removing comments before the check is semantically correct. The anchor, the requirement, and the finding location all stay on the original content.

## Why it's safe (the reason I deferred it in #312)

For an absence rule, cutting *real* content turns a present property into an absent one — a **false positive**, the worse failure for a scanner. So the comment detection is deliberately conservative:

> A `#` opens a comment only at line start, or preceded by whitespace **and** with no quote earlier on the line.

That means a `#` inside a quoted YAML value, a JSON string, or a URL fragment is **never** stripped. The rare trailing comment after a quoted value on the same line is left as-is (property still satisfied — status quo) rather than risk cutting a quoted value.

Unit tests pin each safety case explicitly:

| input | kept / stripped |
|---|---|
| `name: "release # attested"` | kept (quoted) |
| `tag: 'v1 # attest'` | kept (quoted) |
| `url: "https://x/a#attest"` | kept (URL in quotes) |
| `value: abc#attest` | kept (no whitespace before `#`) |
| `{"note": "requires # attestation"}` | kept (JSON) |
| `uses: foo@sha # attested` | stripped |
| `# no HEALTHCHECK here` | stripped |

## Verification

- End-to-end: with the clearer "attested" wording **restored** to nox's own waiver, IAC-153 now fires and the waiver suppresses it (`status=suppressed`, no degradation). The earlier reword was a band-aid; it's gone.
- Grade A holds on nox's repo, zero new findings from stripping.
- Full `./core/...` + `./cli/...` suites pass; precision harness unchanged; `golangci-lint` clean.
