### PR TITLE
ci(metamorphic): add rule-robustness invariance gate

### DIFF
--- a/.github/workflows/metamorphic.yml
+++ b/.github/workflows/metamorphic.yml
@@ -1,0 +1,57 @@
+name: Metamorphic rule-robustness gate
+
+# Enforces a metamorphic relation on nox's own detection rules:
+#
+#   A *semantics-preserving* edit to a file must not change nox's finding set.
+#
+# Three real nox rule bugs had exactly this shape (a blank line before a
+# Dockerfile COPY -> false positive; a comment mentioning HEALTHCHECK -> false
+# negative). This gate mutates the labeled corpus + synthetic Dockerfile/
+# workflow seeds with inert edits (blank lines, whitespace, CRLF, keyword
+# comments), scans before/after with a freshly built nox, and fails on any
+# finding that appears or disappears under such an edit.
+#
+# Deterministic: sorted seeds, fixed mutation order, no randomness, nox run
+# with --offline. The self-test (positive controls) proves the gate can go red.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  metamorphic:
+    name: Metamorphic invariance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build nox
+        run: make build
+
+      - name: Positive-control self-test
+        # A gate that cannot go red is worthless. This proves the harness
+        # flags a real finding-removing edit, ignores pure line shifts, and
+        # catches a planted HEALTHCHECK false negative.
+        run: python3 scripts/metamorphic/selftest.py --bin ./nox
+
+      - name: Metamorphic invariance sweep
+        # Exits non-zero on any surviving violation, writing a minimal repro.
+        run: python3 scripts/metamorphic/harness.py --bin ./nox --results metamorphic-out
+
+      - name: Upload repros on failure
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI diagnostic repro bundle, not a released binary; release artifacts are signed and attested in release.yml
+        if: failure()
+        with:
+          name: metamorphic-repros
+          path: metamorphic-out/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/scripts/metamorphic/.gitignore
+++ b/scripts/metamorphic/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/metamorphic/README.md
+++ b/scripts/metamorphic/README.md
@@ -1,0 +1,127 @@
+# Metamorphic rule-robustness gate
+
+CI tooling that finds bugs in nox's own detection rules by enforcing a
+**metamorphic relation**:
+
+> A *semantics-preserving* edit to a file must not change nox's finding set.
+> Any finding that appears or disappears under such an edit is a rule bug — a
+> false positive (appeared) or a false negative (disappeared).
+
+This is the same technique that found three nox rule bugs by hand (a blank
+line before a Dockerfile `COPY` → false positive; a comment mentioning
+`HEALTHCHECK` → false negative). The harness automates and scales it, and runs
+as a `pull_request` gate (`.github/workflows/metamorphic.yml`).
+
+## Run it locally
+
+```bash
+make build                                        # produces ./nox
+python3 scripts/metamorphic/selftest.py --bin ./nox   # positive controls (must pass)
+python3 scripts/metamorphic/harness.py --bin ./nox    # the sweep (exit non-zero on any violation)
+```
+
+`harness.py` flags: `--bin <nox>` (default repo `./nox`), `--seeds <dir>`
+(repeatable; default = precision corpus + committed synthetic seeds),
+`--results <dir>` (report + repros; default a temp dir), `--limit N` (first N
+seed files, for a quick run).
+
+## What it does (pipeline)
+
+1. **Seed** — walks the real labeled corpus `testdata/precision-suite/`
+   (read-only; never written to) plus `scripts/metamorphic/seeds/` (synthetic
+   Dockerfiles + GitHub workflows), because the acute known-bug class lives in
+   Dockerfile/YAML *absence* rules the corpus does not contain.
+2. **Mutate** — applies each semantics-preserving mutation (below), one
+   transform at a time, as a list of *atomic edits* over the original lines.
+3. **Scan** — runs nox on the original file and on each mutated file, each in an
+   isolated one-file temp dir (`--offline`, deterministic). Exit code is ignored
+   (nox exits non-zero merely when findings exist); results come from
+   `findings.json`.
+4. **Diff** — compares finding sets under a line-shift-invariant equivalence
+   (below) to get candidate violations.
+5. **Adversarial re-verify + minimize** — every candidate is re-run on a freshly
+   materialised before/after pair **twice** (also catching nondeterminism); only
+   deltas that reproduce survive. Survivors are reduced to a minimal repro with
+   delta-debugging (ddmin) over the atomic edit set.
+6. **Report** — writes `invariance_report.json` plus, for each survivor, a
+   `repros/<id>/` directory with `before/`, `after/`, and `REPRO.md`; **exits
+   non-zero** if any survive.
+
+## The equivalence (line-shift vs. real bug)
+
+Getting this right is the whole game: a blank-line insert legitimately shifts
+absolute line numbers, and reporting that as a violation would flood the tool
+with false alarms — the exact failure mode a security tool must avoid. Matching
+ignores absolute line numbers via a **two-layer key**:
+
+- **Layer 1 — nox's own fingerprint.** Fingerprint v2 is line-independent and
+  path-normalised, and is empirically identical across every mutation class here
+  (line shift, whitespace reflow, CRLF, inert comment insertion). Equal
+  fingerprint ⇒ same finding, regardless of line number.
+- **Layer 2 — `(RuleID, normalised-anchor)`.** The anchor is the
+  whitespace-normalised text of the source line the finding points at, read from
+  the file that was actually scanned. Because the anchor text travels with the
+  line, it is invariant under line shifts. This layer absorbs *benign*
+  fingerprint drift, so a single moved finding is never double-reported as both a
+  false positive and a false negative. File-level / absence findings (e.g.
+  "missing HEALTHCHECK") fall back to a `<file-level>` anchor keyed by rule.
+
+Whatever is unmatched after both layers is a genuine delta:
+`before-only → disappeared (candidate FN)`, `after-only → appeared (candidate
+FP)`. Matching is multiset-based, so a change in *count* is also caught. Layer 2
+cannot hide the FP/FN classes: an FN removes the finding (no anchor to match on
+the after side); an FP adds a finding with a new anchor (nothing to match on the
+before side).
+
+## Mutations (all provably semantics-preserving)
+
+| Mutation | Notes |
+|---|---|
+| `blank_line_top` / `blank_line_bottom` | single blank line |
+| `blank_line_before_each` / `after_each` | one per line (minimised by ddmin) |
+| `trailing_whitespace` | trailing spaces+tab per line |
+| `crlf` | LF → CRLF, per line |
+| `pad_before_trailing_comment` | widens the gap before an *existing* inline comment — never touches indentation or tokens, so safe even in indentation-sensitive Python/YAML |
+| `keyword_comments` | inserts inert comments mentioning rule keywords (`HEALTHCHECK`, `USER`, `--chown`, `attested`, `eval`, `yaml.load`, `pickle`, ...) at top and after line 1 — the class that caused the real HEALTHCHECK false negative |
+
+**Deliberately excluded:** aggressive intra-token whitespace reflow and
+variable renaming. Neither can be *proven* inert generically (reflow can change
+Python/YAML indentation semantics; a naive rename can cross scopes and
+legitimately change a taint finding). `keyword_comments` uses directive/English
+words only — never real secrets, emails, or URLs — so the comment payload is
+genuinely inert (a comment containing a real email would make nox correctly
+report it, which is not a rule bug).
+
+## Why a green run is trustworthy — positive controls
+
+A "0 violations" from a security tool is worthless unless you can show the tool
+would have gone red on a real bug. `selftest.py` proves it (a gate that cannot
+go red is worthless), and it runs in CI alongside the sweep:
+
+- **PC1 detection** — deleting the `os.system` sink from `tp_injection.py` is
+  reported as `TAINT-002 disappeared`.
+- **PC2 line-shift invariance** — prepending 5 blank lines shifts findings but
+  yields **zero** violations. This is the core requirement.
+- **PC3 verify+minimize** — a real delta survives the adversarial re-verifier and
+  ddmin reduces it to the single responsible edit.
+- **PC4 synthetic HEALTHCHECK FN** — a hand-faked buggy output (IAC-121 dropped
+  after a `# HEALTHCHECK` comment) is correctly flagged as `IAC-121
+  disappeared`, demonstrating the harness *would* catch that historical bug were
+  it still present.
+
+## Determinism
+
+Seed files are sorted, mutation order is fixed, there is no randomness, and nox
+is invoked with `--offline`. Same repo state ⇒ same result. The synthetic seeds
+under `seeds/` are intentionally vulnerable (unpinned base images, mutable
+action tags, missing HEALTHCHECK/USER) so the absence/presence rules actually
+fire; `scripts/` is excluded from the repo self-scan (`.nox.yaml`), so they do
+not affect nox's own security grade, while the harness still exercises them in
+isolated temp dirs.
+
+## Files
+
+- `harness.py` — the harness (mutations, equivalence, diff, verify, ddmin, report).
+- `selftest.py` — positive controls (run to trust a green result).
+- `seeds/` — committed synthetic Dockerfiles + GitHub workflows (the acute
+  Dockerfile/YAML absence-rule bug class).

--- a/scripts/metamorphic/harness.py
+++ b/scripts/metamorphic/harness.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Metamorphic rule-robustness harness for the `nox` security scanner.
+
+Metamorphic relation under test:
+    A *semantics-preserving* edit to a source file must not change nox's
+    finding set. Any finding that appears or disappears under such an edit is
+    a rule bug (a false positive or a false negative).
+
+This is the same technique that found three nox rule bugs by hand (a blank
+line before a Dockerfile `COPY` -> false positive; a comment mentioning
+`HEALTHCHECK` -> false negative). The harness automates and scales it, and is
+wired into CI as a gate: it exits non-zero on any surviving violation.
+
+Pipeline:
+    1. For each seed file, scan the original in isolation  -> "before" findings.
+    2. Apply each semantics-preserving mutation (a list of atomic edits) and
+       scan the mutated file in isolation                  -> "after" findings.
+    3. Diff before/after under a line-shift-invariant equivalence.
+    4. For every candidate violation, ADVERSARIALLY re-verify by re-running
+       nox on a freshly materialised minimal before/after pair (twice, to also
+       catch nondeterminism); drop anything that does not reproduce.
+    5. Emit a JSON report and minimal repros, and exit non-zero if any survive.
+
+Seeds are the REAL corpus plus a small committed synthetic set:
+    - testdata/precision-suite/          (read-only; never written to)
+    - scripts/metamorphic/seeds/         (synthetic Dockerfiles + workflows —
+                                          the acute Dockerfile/YAML bug class)
+
+Determinism: seed files are sorted, mutation order is fixed, there is no
+randomness, and nox is invoked with --offline. Same repo state => same result.
+
+Run:  python3 scripts/metamorphic/harness.py --bin ./nox
+See scripts/metamorphic/README.md for the full write-up.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(HERE))  # scripts/metamorphic -> repo
+DEFAULT_BIN = os.path.join(REPO_ROOT, "nox")
+# Seed roots walked by default: the real labeled corpus (read-only) plus the
+# committed synthetic Dockerfile/workflow seeds that exercise the acute
+# absence-rule bug class the corpus does not contain.
+DEFAULT_SEED_ROOTS = [
+    os.path.join(REPO_ROOT, "testdata", "precision-suite"),
+    os.path.join(HERE, "seeds"),
+]
+# Files inside a seed root that are not scan targets.
+SEED_SKIP = {"README.md", "baseline.json"}
+
+# ---------------------------------------------------------------------------
+# nox invocation
+# ---------------------------------------------------------------------------
+
+
+class Nox:
+    def __init__(self, binary):
+        self.binary = os.path.abspath(binary)
+        self.scans = 0
+        if not os.path.exists(self.binary):
+            sys.exit(f"nox binary not found: {self.binary} (run `make build`)")
+
+    def scan_dir(self, scan_dir):
+        """Scan a directory, return list of finding dicts (order as emitted)."""
+        with tempfile.TemporaryDirectory() as out:
+            # nox exits non-zero when findings exist; that is NOT an error.
+            # --offline guarantees zero network for determinism.
+            subprocess.run(
+                [self.binary, "scan", scan_dir,
+                 "--output", out, "--quiet", "--offline"],
+                capture_output=True, text=True,
+            )
+            self.scans += 1
+            fj = os.path.join(out, "findings.json")
+            if not os.path.exists(fj):
+                return []
+            with open(fj) as f:
+                data = json.load(f)
+        return data.get("findings", [])
+
+    def scan_one_file(self, filename, content_bytes):
+        """Materialise a single file (by basename) in a temp dir and scan it.
+
+        Keeping one file per scan dir isolates line-shift semantics to that
+        file and makes minimal repros trivial to reproduce.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, filename)
+            with open(path, "wb") as f:
+                f.write(content_bytes)
+            return self.scan_dir(d)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence / matching  (the heart of the harness)
+# ---------------------------------------------------------------------------
+#
+# A blank-line insert legitimately shifts absolute line numbers, so we must
+# NOT treat a pure line shift as a violation. We match findings across an edit
+# with a two-layer key:
+#
+#   Layer 1 (primary): nox's own fingerprint. Fingerprint v2 is documented as
+#       line-independent + path-normalised, and we verified it is stable under
+#       every mutation class we apply (line shift, whitespace reflow, CRLF,
+#       inert comment insertion). So identical fingerprint == same finding,
+#       regardless of line number.
+#
+#   Layer 2 (fallback): (RuleID, normalised-anchor). The anchor is the
+#       whitespace-normalised text of the source line the finding points at,
+#       taken from the file that was actually scanned. Because the anchor text
+#       travels with the line, it is invariant under line shifts. This layer
+#       absorbs *benign* fingerprint drift (e.g. a fingerprint that folds in
+#       whitespace) so we do not double-report one moved finding as both a
+#       false positive and a false negative.
+#
+# Whatever stays unmatched after both layers is a real delta:
+#   before-only  -> a finding DISAPPEARED  (candidate false negative)
+#   after-only   -> a finding APPEARED     (candidate false positive)
+
+
+def norm_ws(s):
+    return re.sub(r"\s+", " ", s.strip())
+
+
+def anchor_for(finding, file_lines):
+    """Line-shift-invariant semantic location for a finding."""
+    loc = finding.get("Location", {})
+    sl = loc.get("StartLine", 0) or 0
+    text = ""
+    if 1 <= sl <= len(file_lines):
+        text = norm_ws(file_lines[sl - 1])
+    if not text:
+        # File-level / absence finding (e.g. "missing HEALTHCHECK") — anchor to
+        # the file so it is matched by rule regardless of where nox pins it.
+        text = "<file-level>"
+    return (finding["RuleID"], text)
+
+
+def index_findings(findings, file_text):
+    """Return (by_fp, anchor_multiset) for one finding set.
+
+    file_text is the exact bytes-as-text that was scanned (for anchor lookup).
+    """
+    lines = file_text.split("\n")
+    by_fp = {}
+    anchors = {}
+    for fi in findings:
+        fp = fi.get("Fingerprint")
+        if fp:
+            by_fp.setdefault(fp, []).append(fi)
+        a = anchor_for(fi, lines)
+        anchors.setdefault(a, []).append(fi)
+    return by_fp, anchors
+
+
+def diff_findings(before, before_text, after, after_text):
+    """Return list of violations: {direction, ruleid, anchor, finding}.
+
+    direction: 'disappeared' (before-only) or 'appeared' (after-only).
+    """
+    b_fp, b_anch = index_findings(before, before_text)
+    a_fp, a_anch = index_findings(after, after_text)
+
+    matched_before = set()   # id() of matched before findings
+    matched_after = set()
+
+    # Layer 1: fingerprint identity.
+    for fp, blist in b_fp.items():
+        alist = a_fp.get(fp, [])
+        k = min(len(blist), len(alist))
+        for i in range(k):
+            matched_before.add(id(blist[i]))
+            matched_after.add(id(alist[i]))
+
+    # Layer 2: (RuleID, anchor) fallback for still-unmatched findings.
+    for anchor, blist in b_anch.items():
+        b_un = [f for f in blist if id(f) not in matched_before]
+        a_un = [f for f in a_anch.get(anchor, []) if id(f) not in matched_after]
+        k = min(len(b_un), len(a_un))
+        for i in range(k):
+            matched_before.add(id(b_un[i]))
+            matched_after.add(id(a_un[i]))
+
+    violations = []
+    b_lines = before_text.split("\n")
+    a_lines = after_text.split("\n")
+    for fi in before:
+        if id(fi) not in matched_before:
+            violations.append({
+                "direction": "disappeared",
+                "ruleid": fi["RuleID"],
+                "anchor": anchor_for(fi, b_lines)[1],
+                "finding": fi,
+            })
+    for fi in after:
+        if id(fi) not in matched_after:
+            violations.append({
+                "direction": "appeared",
+                "ruleid": fi["RuleID"],
+                "anchor": anchor_for(fi, a_lines)[1],
+                "finding": fi,
+            })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Mutations  (each returns a list of atomic edits; all must be semantics-
+# preserving for the file's language)
+# ---------------------------------------------------------------------------
+#
+# An atomic edit is a dict:
+#   {"op": "insert", "pos": i, "text": s}   insert line s before original line i
+#   {"op": "replace", "idx": i, "text": s}  replace original line i with s
+# Working on a list of ORIGINAL lines (no trailing newline entries), we can
+# apply any *subset* of edits deterministically — this is what makes minimal-
+# repro reduction (ddmin) possible.
+
+COMMENT_PREFIX = {
+    ".py": "#", ".tf": "#", ".yml": "#", ".yaml": "#",
+    ".go": "//", ".js": "//", ".ts": "//",
+    "Dockerfile": "#",
+}
+
+# Rule keywords to smuggle inside comments. These are DIRECTIVE / ENGLISH words
+# only — never real secrets, emails, or URLs — so the comment is genuinely
+# inert. A finding that reacts to one of these words in a comment is a rule
+# that greps for keywords without parsing, i.e. a bug.
+KEYWORD_COMMENTS = [
+    "HEALTHCHECK", "USER appuser", "LABEL maintainer here", "--chown",
+    "--no-cache", "digest pinned", "attested", "verified", "sha256 pinned",
+    "eval", "os.system", "subprocess", "password handling below",
+    "yaml.load", "pickle", "innerHTML", "exec",
+]
+
+
+def comment_prefix_for(filename):
+    if filename == "Dockerfile" or filename.startswith("Dockerfile"):
+        return "#"
+    _, ext = os.path.splitext(filename)
+    return COMMENT_PREFIX.get(ext, "#")
+
+
+def mut_blank_line_top(lines, filename):
+    return [("blank_line_top", [{"op": "insert", "pos": 0, "text": ""}])]
+
+
+def mut_blank_line_bottom(lines, filename):
+    return [("blank_line_bottom", [{"op": "insert", "pos": len(lines), "text": ""}])]
+
+
+def mut_blank_line_before_each(lines, filename):
+    edits = [{"op": "insert", "pos": i, "text": ""} for i in range(len(lines))]
+    return [("blank_line_before_each", edits)]
+
+
+def mut_blank_line_after_each(lines, filename):
+    edits = [{"op": "insert", "pos": i + 1, "text": ""} for i in range(len(lines))]
+    return [("blank_line_after_each", edits)]
+
+
+def mut_trailing_whitespace(lines, filename):
+    edits = [{"op": "replace", "idx": i, "text": ln + "   \t"}
+             for i, ln in enumerate(lines) if ln.strip() != ""]
+    return [("trailing_whitespace", edits)]
+
+
+def mut_crlf(lines, filename):
+    # Represented as per-line replace adding a CR; joined with \n later, so each
+    # line ends \r\n. Minimisable per line.
+    edits = [{"op": "replace", "idx": i, "text": ln + "\r"}
+             for i, ln in enumerate(lines)]
+    return [("crlf", edits)]
+
+
+def mut_pad_before_trailing_comment(lines, filename):
+    """Horizontal-whitespace reflow that is provably inert: widen the gap in
+    front of an existing end-of-line comment. Never touches indentation or
+    tokens, so it is safe even in Python/YAML."""
+    prefix = comment_prefix_for(filename)
+    edits = []
+    for i, ln in enumerate(lines):
+        # find a ' <prefix>' that is not at column 0 (an inline trailing comment)
+        m = re.search(r"\S(\s+)(" + re.escape(prefix) + r")", ln)
+        if m and ln.lstrip().startswith(prefix) is False:
+            pos = m.start(1)
+            new = ln[:pos] + "    " + ln[pos:]
+            edits.append({"op": "replace", "idx": i, "text": new})
+    if not edits:
+        return []
+    return [("pad_before_trailing_comment", edits)]
+
+
+def mut_keyword_comments(lines, filename):
+    """Insert inert comments that mention rule keywords, at top and after the
+    first line. This is the class that caused the real HEALTHCHECK false
+    negative. One variant per keyword so repros are minimal by construction."""
+    prefix = comment_prefix_for(filename)
+    variants = []
+    for kw in KEYWORD_COMMENTS:
+        text = f"{prefix} {kw}"
+        # insert after line 0 (or at top for empty files)
+        pos = 1 if lines else 0
+        variants.append((f"comment[{kw}]@1",
+                         [{"op": "insert", "pos": pos, "text": text}]))
+        variants.append((f"comment[{kw}]@top",
+                         [{"op": "insert", "pos": 0, "text": text}]))
+    return variants
+
+
+MUTATIONS = [
+    mut_blank_line_top,
+    mut_blank_line_bottom,
+    mut_blank_line_before_each,
+    mut_blank_line_after_each,
+    mut_trailing_whitespace,
+    mut_crlf,
+    mut_pad_before_trailing_comment,
+    mut_keyword_comments,
+]
+
+
+def apply_edits(orig_lines, edits):
+    """Apply a subset of atomic edits to original lines -> new lines list."""
+    replaced = {}
+    inserts = {}
+    for e in edits:
+        if e["op"] == "replace":
+            replaced[e["idx"]] = e["text"]
+        else:  # insert before pos
+            inserts.setdefault(e["pos"], []).append(e["text"])
+    out = []
+    for i in range(len(orig_lines) + 1):
+        for t in inserts.get(i, []):
+            out.append(t)
+        if i < len(orig_lines):
+            out.append(replaced.get(i, orig_lines[i]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Minimal-repro reduction (ddmin over atomic edits)
+# ---------------------------------------------------------------------------
+
+def ddmin(edits, predicate):
+    """Return a minimal subset of `edits` still satisfying predicate(subset).
+
+    Classic delta-debugging (Zeller) over the edit list.
+    """
+    if not predicate(edits):
+        return edits  # shouldn't happen; caller checks first
+    n = 2
+    cur = list(edits)
+    while len(cur) >= 2:
+        chunk = max(1, len(cur) // n)
+        subsets = [cur[i:i + chunk] for i in range(0, len(cur), chunk)]
+        reduced = False
+        # try complements first (remove a chunk)
+        for s in subsets:
+            comp = [e for e in cur if e not in s]
+            if comp and predicate(comp):
+                cur = comp
+                n = max(n - 1, 2)
+                reduced = True
+                break
+        if not reduced:
+            if n >= len(cur):
+                break
+            n = min(len(cur), n * 2)
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+def read_seed(path):
+    with open(path, "rb") as f:
+        raw = f.read()
+    # Work in text with LF line model; keep no trailing empty element noise.
+    text = raw.decode("utf-8", errors="replace")
+    lines = text.split("\n")
+    # A trailing newline yields a final "" element; drop it so line indices map
+    # to real lines. Re-added on join.
+    trailing_nl = text.endswith("\n")
+    if trailing_nl and lines and lines[-1] == "":
+        lines = lines[:-1]
+    return lines, trailing_nl
+
+
+def join_lines(lines, trailing_nl):
+    s = "\n".join(lines)
+    if trailing_nl:
+        s += "\n"
+    return s
+
+
+def discover_seeds(seed_roots):
+    """Return sorted list of (abs_path, display_name) for every scan target.
+
+    display_name is the path relative to the repo root, so multi-root corpora
+    report stable, human-readable identities regardless of basename collisions.
+    """
+    seeds = []
+    for root in seed_roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _dirs, files in os.walk(root):
+            for fn in files:
+                if fn in SEED_SKIP:
+                    continue
+                abs_path = os.path.join(dirpath, fn)
+                if not os.path.isfile(abs_path):
+                    continue
+                display = os.path.relpath(abs_path, REPO_ROOT)
+                seeds.append((abs_path, display))
+    seeds.sort(key=lambda t: t[1])
+    return seeds
+
+
+def run(seeds, nox):
+    candidates = []
+    stats = {"files": 0, "mutations_applied": 0}
+
+    for path, display in seeds:
+        filename = os.path.basename(path)
+        lines, trailing_nl = read_seed(path)
+        orig_text = join_lines(lines, trailing_nl)
+        before = nox.scan_one_file(filename, orig_text.encode("utf-8"))
+        stats["files"] += 1
+
+        for mut in MUTATIONS:
+            for label, edits in mut(lines, filename):
+                if not edits:
+                    continue
+                new_lines = apply_edits(lines, edits)
+                after_text = join_lines(new_lines, trailing_nl)
+                after = nox.scan_one_file(filename, after_text.encode("utf-8"))
+                stats["mutations_applied"] += 1
+                viols = diff_findings(before, orig_text, after, after_text)
+                for v in viols:
+                    candidates.append({
+                        "seed": display,
+                        "filename": filename,
+                        "mutation": label,
+                        "direction": v["direction"],
+                        "ruleid": v["ruleid"],
+                        "anchor": v["anchor"],
+                        "message": v["finding"].get("Message", ""),
+                        "edits": edits,
+                        "_orig_lines": lines,
+                        "_trailing_nl": trailing_nl,
+                    })
+    stats["candidates"] = len(candidates)
+    return candidates, stats
+
+
+def verify_and_minimize(candidates, nox):
+    """Adversarial self-verification + minimal-repro reduction.
+
+    For each candidate we (a) re-run nox on the exact before/after pair in
+    FRESH dirs, twice, and require the delta to reproduce identically; only
+    then (b) ddmin the edit set to the smallest repro, re-verifying at the end.
+    """
+    survivors = []
+
+    def repro(direction, ruleid, filename, orig_lines, edits, trailing_nl):
+        """Does applying `edits` produce the given appear/disappear of ruleid?
+        Runs twice for determinism."""
+        orig_text = join_lines(orig_lines, trailing_nl)
+        new_text = join_lines(apply_edits(orig_lines, edits), trailing_nl)
+        deltas = []
+        for _ in range(2):
+            before = nox.scan_one_file(filename, orig_text.encode("utf-8"))
+            after = nox.scan_one_file(filename, new_text.encode("utf-8"))
+            v = diff_findings(before, orig_text, after, new_text)
+            hit = any(x["direction"] == direction and x["ruleid"] == ruleid
+                      for x in v)
+            deltas.append(hit)
+        return all(deltas)
+
+    for c in candidates:
+        ok = repro(c["direction"], c["ruleid"], c["filename"],
+                   c["_orig_lines"], c["edits"], c["_trailing_nl"])
+        if not ok:
+            c["verified"] = False
+            continue
+
+        pred = lambda subset, c=c: bool(subset) and repro(
+            c["direction"], c["ruleid"], c["filename"],
+            c["_orig_lines"], subset, c["_trailing_nl"])
+        minimal = ddmin(c["edits"], pred)
+        # Final confirmation on the minimal set.
+        if not pred(minimal):
+            minimal = c["edits"]
+        c["verified"] = True
+        c["minimal_edits"] = minimal
+        survivors.append(c)
+    return survivors
+
+
+def write_repro(results_dir, c, idx):
+    d = os.path.join(results_dir, "repros",
+                     f"{idx:03d}_{c['ruleid']}_{c['direction']}")
+    before_dir = os.path.join(d, "before")
+    after_dir = os.path.join(d, "after")
+    os.makedirs(before_dir, exist_ok=True)
+    os.makedirs(after_dir, exist_ok=True)
+    orig_text = join_lines(c["_orig_lines"], c["_trailing_nl"])
+    new_text = join_lines(apply_edits(c["_orig_lines"], c["minimal_edits"]),
+                          c["_trailing_nl"])
+    with open(os.path.join(before_dir, c["filename"]), "w") as f:
+        f.write(orig_text)
+    with open(os.path.join(after_dir, c["filename"]), "w") as f:
+        f.write(new_text)
+    with open(os.path.join(d, "REPRO.md"), "w") as f:
+        f.write(f"# Repro: {c['ruleid']} {c['direction']}\n\n")
+        f.write(f"- seed: `{c['seed']}`\n")
+        f.write(f"- mutation class: `{c['mutation']}`\n")
+        f.write(f"- direction: **{c['direction']}** "
+                f"({'false negative' if c['direction']=='disappeared' else 'false positive'})\n")
+        f.write(f"- rule message: {c['message']}\n")
+        f.write(f"- minimal edit(s): {len(c['minimal_edits'])} atomic edit(s)\n\n")
+        f.write("Reproduce:\n\n```\n")
+        f.write(f"nox scan before/ --output /tmp/b   # {c['ruleid']} "
+                f"{'present' if c['direction']=='disappeared' else 'absent'}\n")
+        f.write(f"nox scan after/  --output /tmp/a   # {c['ruleid']} "
+                f"{'absent (BUG)' if c['direction']=='disappeared' else 'present (BUG)'}\n")
+        f.write("```\n")
+    return d
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bin", default=DEFAULT_BIN,
+                    help="path to the nox binary (default: repo ./nox)")
+    ap.add_argument("--seeds", action="append", default=None,
+                    help="seed root to walk (repeatable; default: precision "
+                         "corpus + committed synthetic seeds)")
+    ap.add_argument("--results", default=None,
+                    help="directory for the JSON report + repros "
+                         "(default: a temp dir)")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="limit number of seed files (for a quick run)")
+    args = ap.parse_args()
+
+    seed_roots = args.seeds if args.seeds else DEFAULT_SEED_ROOTS
+    seeds = discover_seeds(seed_roots)
+    if not seeds:
+        sys.exit(f"no seed files found under: {seed_roots}")
+    if args.limit:
+        seeds = seeds[:args.limit]
+
+    nox = Nox(args.bin)
+    results_dir = args.results or tempfile.mkdtemp(prefix="nox-metamorphic-")
+    os.makedirs(results_dir, exist_ok=True)
+
+    t0 = time.time()
+    candidates, stats = run(seeds, nox)
+    survivors = verify_and_minimize(candidates, nox)
+    elapsed = time.time() - t0
+
+    # De-duplicate survivors by (seed, ruleid, direction, mutation-class-root).
+    seen = set()
+    unique = []
+    for c in survivors:
+        key = (c["seed"], c["ruleid"], c["direction"],
+               c["mutation"].split("[")[0])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(c)
+
+    for i, c in enumerate(unique):
+        c["repro_dir"] = os.path.relpath(write_repro(results_dir, c, i),
+                                         results_dir)
+
+    report = {
+        "nox_binary": nox.binary,
+        "seed_roots": [os.path.relpath(r, REPO_ROOT) for r in seed_roots
+                       if os.path.isdir(r)],
+        "seed_file_count": len(seeds),
+        "mutations_applied": stats["mutations_applied"],
+        "total_nox_scans": nox.scans,
+        "elapsed_seconds": round(elapsed, 1),
+        "candidate_violations": stats["candidates"],
+        "verified_violations": len(survivors),
+        "unique_verified_violations": len(unique),
+        "violations": [
+            {k: c[k] for k in ("seed", "filename", "mutation", "direction",
+                               "ruleid", "anchor", "message", "repro_dir")}
+            | {"minimal_edit_count": len(c["minimal_edits"])}
+            for c in unique
+        ],
+    }
+    report_path = os.path.join(results_dir, "invariance_report.json")
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"seed files:            {report['seed_file_count']}")
+    print(f"mutations applied:     {report['mutations_applied']}")
+    print(f"total nox scans:       {report['total_nox_scans']}")
+    print(f"elapsed:               {report['elapsed_seconds']}s")
+    print(f"candidate violations:  {report['candidate_violations']}")
+    print(f"verified violations:   {report['verified_violations']}")
+    print(f"unique verified:       {report['unique_verified_violations']}")
+    print(f"report:                {report_path}")
+    for c in unique:
+        print(f"  - [{c['direction']:11s}] {c['ruleid']:9s} "
+              f"seed={c['seed']} via {c['mutation']}  -> {c['repro_dir']}")
+
+    if unique:
+        print(f"\nFAIL: {len(unique)} metamorphic invariance violation(s). "
+              f"See repros under {results_dir}/repros/.", file=sys.stderr)
+        sys.exit(1)
+    print("\nOK: no metamorphic invariance violations.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/metamorphic/seeds/docker/Dockerfile.alpine
+++ b/scripts/metamorphic/seeds/docker/Dockerfile.alpine
@@ -1,0 +1,4 @@
+FROM alpine:3.19
+RUN apk add --no-cache curl
+COPY app /app
+CMD ["/app"]

--- a/scripts/metamorphic/seeds/docker/Dockerfile.multistage
+++ b/scripts/metamorphic/seeds/docker/Dockerfile.multistage
@@ -1,0 +1,8 @@
+FROM golang:1.22 AS build
+WORKDIR /src
+COPY . .
+RUN go build -o /bin/app ./...
+
+FROM debian:bookworm
+COPY --from=build /bin/app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/scripts/metamorphic/seeds/docker/Dockerfile.node
+++ b/scripts/metamorphic/seeds/docker/Dockerfile.node
@@ -1,0 +1,7 @@
+FROM node:20
+WORKDIR /srv
+COPY package.json .
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/scripts/metamorphic/seeds/workflows/.github/workflows/mutable-tags.yml
+++ b/scripts/metamorphic/seeds/workflows/.github/workflows/mutable-tags.yml
@@ -1,0 +1,10 @@
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: some/action@main
+      - uses: other/thing@master
+      - run: make build

--- a/scripts/metamorphic/seeds/workflows/.github/workflows/release.yml
+++ b/scripts/metamorphic/seeds/workflows/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v5
+      - uses: my/deployer@latest
+      - run: ./scripts/publish.sh

--- a/scripts/metamorphic/selftest.py
+++ b/scripts/metamorphic/selftest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Positive controls for the metamorphic harness.
+
+A green run of harness.py is only trustworthy if we can show the harness would
+have gone red on a real bug. These controls exercise the three pieces that a
+false "no violations" could hide:
+
+  PC1  detection      — a genuinely finding-removing edit MUST be reported.
+  PC2  line-shift      — a pure blank-line shift MUST NOT be reported.
+  PC3  verify+minimize — the adversarial re-verifier confirms a real delta and
+                         ddmin reduces it to the single responsible edit.
+  PC4  synthetic FN bug — emulates the historical "comment mentioning
+                          HEALTHCHECK hides IAC-121" bug by hand and shows the
+                          diff logic flags it as a disappeared finding.
+
+A gate that cannot go red is worthless — this is mandatory and runs in CI.
+
+Run:  python3 scripts/metamorphic/selftest.py --bin ./nox   (exit 0 = all pass)
+"""
+import argparse
+import os
+import sys
+
+import harness as H
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--bin", default=H.DEFAULT_BIN)
+args = ap.parse_args()
+
+nox = H.Nox(args.bin)
+# Drive PC1–PC3 off the real corpus seed, not a copy.
+SEED = os.path.join(H.REPO_ROOT, "testdata", "precision-suite", "tp_injection.py")
+fails = []
+
+
+def check(name, cond, detail=""):
+    print(f"[{'PASS' if cond else 'FAIL'}] {name}  {detail}")
+    if not cond:
+        fails.append(name)
+
+
+# PC1 — deleting the os.system sink removes TAINT-002.
+lines, tnl = H.read_seed(SEED)
+orig = H.join_lines(lines, tnl)
+mut = H.join_lines([l for i, l in enumerate(lines) if i != 3], tnl)
+b = nox.scan_one_file("tp_injection.py", orig.encode())
+a = nox.scan_one_file("tp_injection.py", mut.encode())
+v = H.diff_findings(b, orig, a, mut)
+check("PC1 detection",
+      any(x["direction"] == "disappeared" and x["ruleid"] == "TAINT-002" for x in v),
+      str([(x["direction"], x["ruleid"]) for x in v]))
+
+# PC2 — a 5-blank-line shift must produce no violations.
+shift = H.join_lines([""] * 5 + lines, tnl)
+a2 = nox.scan_one_file("tp_injection.py", shift.encode())
+v2 = H.diff_findings(b, orig, a2, shift)
+check("PC2 line-shift invariance", v2 == [],
+      f"(startlines {sorted(f['Location']['StartLine'] for f in a2)})")
+
+# PC3 — verify + minimize a real delta down to one atomic edit.
+cand = [{
+    "seed": "tp_injection.py", "filename": "tp_injection.py", "mutation": "control",
+    "direction": "disappeared", "ruleid": "TAINT-002", "anchor": "", "message": "",
+    "edits": [{"op": "replace", "idx": 3, "text": ""}],
+    "_orig_lines": lines, "_trailing_nl": tnl,
+}]
+surv = H.verify_and_minimize(cand, nox)
+check("PC3 verify+minimize",
+      len(surv) == 1 and surv[0]["verified"] and len(surv[0]["minimal_edits"]) == 1)
+
+# PC4 — synthetic HEALTHCHECK-comment false negative. We hand-fake the *buggy*
+# scanner output (IAC-121 absent after inserting a "# HEALTHCHECK" comment) and
+# confirm the diff logic reports it as a disappeared finding, i.e. the harness
+# WOULD catch that historical bug were it still present.
+before_fp = [{"RuleID": "IAC-121", "Fingerprint": "fp121",
+              "Location": {"StartLine": 1}, "Message": "missing HEALTHCHECK"}]
+btext = "FROM alpine:3.19\nCOPY app /app\n"
+after_fp = []  # buggy scanner drops IAC-121
+atext = "FROM alpine:3.19\n# HEALTHCHECK\nCOPY app /app\n"
+v4 = H.diff_findings(before_fp, btext, after_fp, atext)
+check("PC4 synthetic HEALTHCHECK FN caught",
+      any(x["direction"] == "disappeared" and x["ruleid"] == "IAC-121" for x in v4))
+
+print()
+if fails:
+    print(f"{len(fails)} control(s) FAILED: {fails}")
+    sys.exit(1)
+print("all positive controls passed")
+sys.exit(0)


### PR DESCRIPTION
## What

Graduates the metamorphic rule-robustness harness from research prototype into a maintained **CI gate**. It enforces one relation on nox's own detection rules:

> A *semantics-preserving* edit to a file must not change nox's finding set.

Three real nox rule bugs this cycle had exactly this shape — a blank line before a Dockerfile `COPY` caused a false positive; a comment mentioning `HEALTHCHECK` caused a false negative. This gate catches that class **pre-merge**.

## How it works

`scripts/metamorphic/harness.py`:
1. Seeds from the **real** `testdata/precision-suite/` corpus (read-only) plus committed synthetic Dockerfile/workflow seeds under `scripts/metamorphic/seeds/` (the acute Dockerfile/YAML absence-rule bug class — IAC-121/122/123/124, CONT-001, IAC-013).
2. Applies semantics-preserving mutations one at a time: blank lines, trailing whitespace, CRLF, inert keyword-comment insertion (`# HEALTHCHECK`, `# attested`, ...), and inline-comment padding.
3. Scans before/after with a freshly built nox (`--offline`), diffs finding sets under a **line-shift-invariant equivalence** (nox v2 fingerprint, with a `(RuleID, normalised-anchor)` fallback so a blank-line insert that merely shifts line numbers is *not* a violation).
4. **Adversarially re-verifies** every candidate twice (also catching nondeterminism), reduces to a minimal repro via ddmin, and **exits non-zero** on any survivor.

## The gate can go red — positive controls (mandatory, run in CI)

`scripts/metamorphic/selftest.py`:
- **PC1** deleting an `os.system` sink is flagged as `TAINT-002 disappeared`.
- **PC2** a pure 5-blank-line shift yields **zero** violations (the core requirement).
- **PC3** the adversarial re-verifier confirms a real delta and ddmin reduces it to one edit.
- **PC4** a planted `# HEALTHCHECK`-comment false negative is caught as `IAC-121 disappeared`.

## CI wiring

New `.github/workflows/metamorphic.yml` runs on `pull_request`: builds nox, runs the self-test, then the sweep. Actions SHA-pinned (IAC-013), `permissions: contents: read`, the one deliberate finding carries `# nox:ignore IAC-153`, `timeout-minutes: 20`. Deterministic: sorted seeds, fixed mutation order, no randomness, `--offline`.

## Evidence (local, against this branch)

```
selftest: PC1 PASS  PC2 PASS  PC3 PASS  PC4 PASS  -> all positive controls passed
harness:  42 seed files, 1702 mutations, 1744 scans, 0 candidate / 0 verified violations -> exit 0
```

Gates: `go build ./...` OK, `go vet ./...` OK, `golangci-lint run` 0 issues, `go test ./...` all pass. Self-scan grade is unchanged (my additions introduce zero findings; verified score-neutral against baseline main).

## Scope

Additive only. No detection logic touched (`matcher.go`, analyzers, taint untouched). `CHANGELOG.md` untouched.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj