### PR TITLE
refactor(lexctx): unify comment-context matching onto lexctx

### DIFF
--- a/core/lexctx/lang.go
+++ b/core/lexctx/lang.go
@@ -14,6 +14,15 @@
 // static binary, and every classifier here degrades gracefully: an unknown
 // language yields one big code region, so gating on lexctx is never worse than
 // today's behavior (it only ever removes matches that are provably non-code).
+//
+// This package is the single source of truth for lexical context in Nox. No
+// analyzer or matcher should reinvent "is this byte inside a comment, a string,
+// or an encoded blob" with its own hand-rolled scanner — reach for Classify /
+// KindAt / InCode / SuppressNonCode / InDataBlob (whole-file, offset-based) or
+// HashCommentStart (a single line of a #-comment config format) instead. Four
+// separate rule false-positive/false-negative bugs were all the same shape — a
+// pattern trusted in a lexical context where it cannot mean what the rule
+// assumed — and unifying that judgement here retires the whole class.
 package lexctx
 
 import (
@@ -50,6 +59,8 @@ const (
 	LangElixir     // Elixir — # comments (no block comments), "…" (#{…} interp), '…' charlist, """…"""/'''…''' heredocs, ~s()/~r()/~w() sigils, ?c char code
 	LangClojure    // Clojure — ; comments, "…" (Java escapes), #"…" regex, \c char literals; s-expression Lisp
 	LangGroovy     // Groovy — //, /*…*/ (non-nesting), "…" ($var/${…} GString), '…' (plain), """…"""/'''…''' (multiline), /…/ slashy (regex), $/…/$ dollar-slashy
+	LangYAML       // YAML / GitHub Actions workflows — # line comments, '…' / "…" quoted scalars
+	LangDockerfile // Dockerfile / Containerfile — # line comments, '…' / "…" quoted arguments
 )
 
 // String returns a stable, lowercase label for the language. Used in metadata
@@ -98,6 +109,10 @@ func (l Lang) String() string {
 		return "clojure"
 	case LangGroovy:
 		return "groovy"
+	case LangYAML:
+		return "yaml"
+	case LangDockerfile:
+		return "dockerfile"
 	default:
 		return "unknown"
 	}
@@ -189,6 +204,13 @@ var filenameToLang = map[string]Lang{
 // extension-only on purpose: it is deterministic, offline, and cheap, and a
 // wrong guess only costs us the FP-suppression benefit for that file (never
 // correctness) because the scanner degrades to a single code region.
+//
+// Note: LangYAML and LangDockerfile are deliberately NOT mapped here. They are
+// reachable via Classify (and the absence matcher's HashCommentStart), but the
+// secrets, taint, ai, and agentflow analyzers all gate on LangFromPath, so
+// mapping .yml/.yaml/Dockerfile would silently change their behavior on every
+// such file. That is a separate, larger decision; the comment-context
+// unification keeps LangFromPath's answers unchanged.
 func LangFromPath(path string) Lang {
 	ext := strings.ToLower(filepath.Ext(path))
 	if l, ok := extToLang[ext]; ok {

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -87,6 +87,8 @@ func Classify(lang Lang, content []byte) []Region {
 		return scanDart(content)
 	case LangGroovy:
 		return scanGroovy(content)
+	case LangYAML, LangDockerfile:
+		return scanConfig(content)
 	default:
 		return []Region{{Start: 0, End: len(content), Kind: KindCode}}
 	}

--- a/core/lexctx/scan_config.go
+++ b/core/lexctx/scan_config.go
@@ -1,0 +1,130 @@
+package lexctx
+
+// scanConfig classifies `#`-comment configuration formats — YAML (including
+// GitHub Actions workflows) and Dockerfiles — into code, string, and comment
+// regions. These formats share one lexical grammar for our purposes: `#` line
+// comments, single-quoted `'…'` scalars, and double-quoted `"…"` scalars. HCL
+// and TOML line comments look the same, so the scanner degrades acceptably on
+// them too (their `//` and `/*…*/` forms are simply left as code, which only
+// forgoes suppression, never invents it).
+//
+// It is the single source of truth for the one question the IaC absence matcher
+// asks: "is this `#` a live comment, or does it sit inside a quoted value?" A
+// keyword mentioned only in a comment must never satisfy a "must contain X"
+// requirement, and — the far more dangerous direction for a security scanner —
+// a `#` inside a quoted value, a JSON string, or a URL fragment must never be
+// mistaken for a comment, because cutting it would strip real content and flip a
+// present property to absent (a false positive).
+//
+// Like the other scanners it emits strictly increasing, contiguous spans so the
+// returned regions are gap-free and cover [0,len(content)). Every heuristic
+// degrades safely: a misread only forgoes FP-suppression, never correctness.
+func scanConfig(content []byte) []Region {
+	var b regionBuilder
+	i := 0
+	n := len(content)
+	// prev is the immediately preceding source byte (0 at start of file, reset to
+	// a newline at each line break). A `#` opens a comment only when prev is a
+	// line/word boundary — start of line or after whitespace — which mirrors
+	// YAML's rule that an inline comment must be separated from the value by a
+	// space, and keeps `abc#x` / `$#` / a URL fragment out of comment territory.
+	var prev byte
+
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '\n':
+			b.emit(i, i+1, KindCode)
+			i++
+			prev = '\n'
+			continue
+
+		case c == '\'' || c == '"':
+			end := scanConfigString(content, i)
+			b.emit(i, end, KindString)
+			i = end
+			// The real preceding byte is now the closing quote; recording the
+			// quote is enough for comment-start detection (a `#` glued to a closing
+			// quote is not a comment anyway).
+			prev = c
+			continue
+
+		case c == '#' && isConfigCommentStart(prev):
+			start := i
+			for i < n && content[i] != '\n' {
+				i++
+			}
+			b.emit(start, i, KindComment)
+			prev = '#'
+			continue
+
+		default:
+			b.emit(i, i+1, KindCode)
+			prev = c
+			i++
+			continue
+		}
+	}
+	return b.finish(n)
+}
+
+// isConfigCommentStart reports whether a `#` following prev begins a comment. A
+// `#` opens a comment only at the start of a line (prev is 0 or a newline) or
+// after whitespace. After any other byte it is literal — part of `abc#x`, a URL
+// fragment, or a `$#`-style token.
+func isConfigCommentStart(prev byte) bool {
+	switch prev {
+	case 0, '\n', ' ', '\t', '\r':
+		return true
+	}
+	return false
+}
+
+// scanConfigString returns the offset just past a quoted scalar opening at
+// start. Strings do not cross a line break in this pragmatic model (a stray
+// newline closes the string), matching the per-line reset the absence matcher
+// has always used. In a double-quoted scalar a backslash escapes the next byte
+// (so `"a\" # b"` does not close early); single-quoted scalars are literal and
+// close at the next `'`. An unterminated string runs to end of line / EOF, which
+// is the conservative choice: it keeps a trailing `#` classified as string
+// (never a comment) so no real content is cut.
+func scanConfigString(content []byte, start int) int {
+	n := len(content)
+	q := content[start]
+	i := start + 1
+	for i < n {
+		c := content[i]
+		switch {
+		case c == '\n':
+			return i
+		case c == '\\' && q == '"':
+			i += 2
+			continue
+		case c == q:
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// HashCommentStart returns the byte index at which a `#` line comment begins in
+// a single line of a `#`-comment configuration format (YAML, Dockerfile, and
+// the like), or -1 when the line has no comment. It is the reusable primitive
+// the core/rules absence matcher uses in place of its former hand-rolled quote
+// tracking, so that "where does the comment start" has exactly one
+// implementation — this package.
+//
+// A `#` is reported only when it opens a comment: at line start or after
+// whitespace, and outside any quoted scalar. A `#` inside a quoted value, a JSON
+// string, or a URL fragment returns -1, preserving the guarantee that comment
+// stripping never removes real content. The argument should be a single line
+// (no trailing newline); the first comment region's start is returned.
+func HashCommentStart(line []byte) int {
+	for _, r := range scanConfig(line) {
+		if r.Kind == KindComment {
+			return r.Start
+		}
+	}
+	return -1
+}

--- a/core/lexctx/scan_config_test.go
+++ b/core/lexctx/scan_config_test.go
@@ -1,0 +1,111 @@
+package lexctx
+
+import "testing"
+
+// TestConfigLangString pins the stable lowercase labels used in metadata.
+func TestConfigLangString(t *testing.T) {
+	if got := LangYAML.String(); got != "yaml" {
+		t.Errorf("LangYAML.String() = %q, want %q", got, "yaml")
+	}
+	if got := LangDockerfile.String(); got != "dockerfile" {
+		t.Errorf("LangDockerfile.String() = %q, want %q", got, "dockerfile")
+	}
+}
+
+// TestScanYAMLComment: a YAML `#` inline comment (preceded by whitespace) is a
+// comment; the following mapping value stays code, and a `#` inside a quoted
+// scalar stays string. These are the exact roles the absence matcher depends
+// on to know a keyword mentioned only in a comment cannot satisfy a rule.
+func TestScanYAMLComment(t *testing.T) {
+	src := "on: [push]\n" +
+		"name: build # attested elsewhere\n" +
+		"tag: \"v1 # not a comment\"\n" +
+		"note: 'single # kept'\n"
+	cases := []struct {
+		needle string
+		want   Kind
+	}{
+		{"on: [push]", KindCode},
+		{"attested elsewhere", KindComment},
+		{`"v1 # not a comment"`, KindString},
+		{`'single # kept'`, KindString},
+	}
+	for _, c := range cases {
+		if k := kindOfSubstring(t, LangYAML, src, c.needle); k != c.want {
+			t.Errorf("needle %q: got %v, want %v", c.needle, k, c.want)
+		}
+	}
+}
+
+// TestScanDockerfileComment: a full-line `#` comment is a comment; the FROM/USER
+// instructions around it are code. This is the language the IAC-121 keyword bug
+// lived in — a HEALTHCHECK mentioned only in a comment must be classified as a
+// comment so it cannot satisfy the absence rule.
+func TestScanDockerfileComment(t *testing.T) {
+	src := "FROM alpine:3.20\n" +
+		"# no HEALTHCHECK is needed for a one-shot CLI\n" +
+		"USER nobody\n"
+	if k := kindOfSubstring(t, LangDockerfile, src, "no HEALTHCHECK is needed"); k != KindComment {
+		t.Errorf("commented HEALTHCHECK mention must be a comment, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangDockerfile, src, "FROM alpine:3.20"); k != KindCode {
+		t.Errorf("FROM instruction must be code, got %v", k)
+	}
+	if k := kindOfSubstring(t, LangDockerfile, src, "USER nobody"); k != KindCode {
+		t.Errorf("USER instruction must be code, got %v", k)
+	}
+}
+
+// TestConfigHashNotCommentWithoutLeadingSpace: a `#` not preceded by whitespace
+// (e.g. a URL fragment or an identifier `abc#x`) is NOT a comment — it is part
+// of the value. Treating it as a comment would cut real content.
+func TestConfigHashNotCommentWithoutLeadingSpace(t *testing.T) {
+	src := "value: abc#attest\n"
+	if k := kindOfSubstring(t, LangYAML, src, "abc#attest"); k != KindCode {
+		t.Errorf("`abc#attest` (no leading space before #) must be code, got %v", k)
+	}
+}
+
+// TestHashCommentStart is the single-line comment-boundary primitive that the
+// core/rules absence matcher relies on. It must find a genuine trailing/whole
+// line `#` comment, but NEVER report a `#` that sits inside a quoted value, a
+// JSON string, or a URL fragment — cutting such a `#` would strip real content
+// and flip a present property to absent (a false positive for a security tool).
+func TestHashCommentStart(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want int
+	}{
+		{"whole-line comment", "# no HEALTHCHECK here", 0},
+		{"trailing comment, no prior quote", "uses: actions/upload-artifact@sha # attested elsewhere", 34},
+		{"hash inside double quotes is kept", `name: "release # attested"`, -1},
+		{"hash inside single quotes is kept", "tag: 'v1 # attest'", -1},
+		{"url fragment inside quotes is kept", `url: "https://x/a#attest"`, -1},
+		{"hash not preceded by whitespace", "value: abc#attest", -1},
+		{"comment after an unquoted value", "attestations: read # keep this key", 19},
+		{"JSON: all # are inside quotes", `{"note": "requires # attestation"}`, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HashCommentStart([]byte(tc.line)); got != tc.want {
+				t.Errorf("HashCommentStart(%q) = %d, want %d", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfigLangFromPathUnchanged documents a deliberate scoping decision:
+// LangYAML / LangDockerfile are reachable via Classify (and the absence
+// matcher's HashCommentStart) but are intentionally NOT wired into LangFromPath.
+// Wiring them would silently change what the secrets, taint, ai, and agentflow
+// analyzers do on every .yml/.yaml/Dockerfile (they all gate on LangFromPath),
+// which is out of scope for the comment-context unification. This test pins that
+// choice so a future edit to LangFromPath is a conscious one.
+func TestConfigLangFromPathUnchanged(t *testing.T) {
+	for _, p := range []string{"ci.yml", ".github/workflows/build.yaml", "Dockerfile"} {
+		if got := LangFromPath(p); got != LangUnknown {
+			t.Errorf("LangFromPath(%q) = %v, want LangUnknown (see scan_config.go)", p, got)
+		}
+	}
+}

--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/nox-hq/nox/core/lexctx"
 )
 
 // MatchResult describes a single match of a rule pattern within file content.
@@ -240,20 +242,19 @@ func (m *AbsenceMatcher) compile(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// stripLineComments blanks out `#` line comments so a keyword that appears only
-// in a comment cannot satisfy an absence rule's required property. A comment can
-// never fulfil a "the config must contain X" requirement, so removing comments
+// stripLineComments removes `#` line comments so a keyword that appears only in
+// a comment cannot satisfy an absence rule's required property. A comment can
+// never fulfil a "the config must contain X" requirement, so dropping comments
 // before the property check is semantically correct.
 //
-// It is deliberately conservative, because for an absence rule wrongly cutting
-// real content turns a present property into an absent one — a false positive,
-// the worse failure for a security scanner. A `#` is treated as a comment only
-// when it is preceded by whitespace (or starts the line) AND no quote has
-// appeared earlier on that line. When a quote precedes the `#`, the line is left
-// untouched: `#` inside a quoted YAML value or a JSON string, or after any
-// quoted scalar, is never stripped. The rare "trailing comment after a quoted
-// value on the same line" is left as-is (property still satisfied, same as
-// before) rather than risk cutting a quoted value.
+// The decision of where a comment begins is delegated to lexctx — the single
+// source of truth for lexical context in Nox — via lexctx.HashCommentStart, so
+// no analyzer reinvents "is this `#` a live comment or part of a quoted value".
+// That classifier is deliberately conservative in the safe direction: a `#`
+// inside a quoted YAML value, a JSON string, or a URL fragment is never treated
+// as a comment. This matters because for an absence rule wrongly cutting real
+// content turns a present property into an absent one — a false positive, the
+// worse failure for a security scanner.
 //
 // The result is only used for the boolean property check; finding locations
 // come from the anchor match against the original content, so the stripped copy
@@ -269,7 +270,7 @@ func stripLineComments(content []byte) []byte {
 			line = content[lineStart : lineStart+nl]
 		}
 
-		if cut := commentCut(line); cut >= 0 {
+		if cut := lexctx.HashCommentStart(line); cut >= 0 {
 			line = bytes.TrimRight(line[:cut], " \t")
 		}
 		out = append(out, line...)
@@ -281,27 +282,6 @@ func stripLineComments(content []byte) []byte {
 		lineStart += nl + 1
 	}
 	return out
-}
-
-// commentCut returns the index at which a `#` line comment begins, or -1 if the
-// line has none. A `#` opens a comment only when it starts the line (after
-// optional whitespace) or is preceded by whitespace, and no quote has appeared
-// earlier on the line — so a `#` inside a quoted value, or after any quoted
-// scalar, is never treated as a comment.
-func commentCut(line []byte) int {
-	sawQuote := false
-	prevSpace := true
-	for i := range len(line) {
-		c := line[i]
-		if c == '"' || c == '\'' {
-			sawQuote = true
-		}
-		if c == '#' && prevSpace && !sawQuote {
-			return i
-		}
-		prevSpace = c == ' ' || c == '\t'
-	}
-	return -1
 }
 
 // Match reports each AbsenceAnchor occurrence whose span lacks AbsenceProperty


### PR DESCRIPTION
## The class of bug this retires

Four separate rule bugs this cycle were the **same shape**: a pattern trusted in a lexical context where it can't mean what the rule assumes — a keyword in a comment satisfying an absence rule, an API-key pattern inside a base64 image. Each was fixed bespoke and the logic was duplicated. This makes **`core/lexctx` the single source of truth** for "is this byte inside a comment / string / encoded blob," so no analyzer reinvents it.

## What was unified

**lexctx now understands the two formats the bugs lived in.** Added `LangYAML` + `LangDockerfile`, backed by a shared `scanConfig` scanner (`#` line comments; `'`/`"` quoted scalars), wired into `Classify`. Previously these were `LangUnknown` — one big code region, zero comment awareness — which is exactly why `IAC-121`/`IAC-153` keyword-in-comment false-negatives were possible.

**A single comment-boundary primitive.** `lexctx.HashCommentStart(line)` returns where a `#` comment begins, and is conservative in the safe direction: a `#` inside a quoted value, a JSON string, or a URL fragment is **never** a comment. That preserves the guarantee that comment stripping can't cut real content and flip a present property to absent (the false-positive failure, the worse one for an absence rule).

**The absence matcher stopped rolling its own.** `core/rules/matcher.go` `stripLineComments` now delegates the comment-boundary decision to `lexctx.HashCommentStart`. The bespoke `commentCut` quote/hash loop is **deleted**.

### Before → after (bespoke checks now gone)
| Before | After |
|---|---|
| `matcher.go` `commentCut` — hand-rolled `sawQuote`/`prevSpace` `#` detector | deleted; `lexctx.HashCommentStart` |
| Dockerfile/YAML → `LangUnknown` (no comment model) | `LangYAML` / `LangDockerfile` via `scanConfig` |

## Deliberately left un-migrated (honest scoping)
- **`LangFromPath` not extended** to `.yml`/`.yaml`/`Dockerfile`. The secrets, taint, ai, and agentflow analyzers all gate on `LangFromPath`; mapping these extensions would silently change their behavior on every such file — out of scope and out of lane for this refactor. A guard test (`TestConfigLangFromPathUnchanged`) pins the choice so a future edit is conscious.
- **secrets `inDataURIPayload` left bespoke.** It must handle `.html/.css/.md`, which are `LangUnknown`, and `lexctx.InDataBlob` returns false for `LangUnknown` by contract — so it can't be cleanly expressed through the region model. Its existing doc comment already explains this.

## Tests & gates
- **Test-first**: `core/lexctx/scan_config_test.go` added (YAML/Dockerfile comment classification + `HashCommentStart` quote-safety table), shown red → green.
- The three bugs from this cycle stay fixed: `core/analyzers/iac/dockerfile_comment_test.go` (IAC-121 comment keyword, IAC-123 blank line, IAC-153 trailing comment) and `core/rules/comment_strip_test.go` are **unchanged and green**.
- `go build ./...`, `go test ./...`, `golangci-lint run` — all pass.
- **Finding-neutral**: built the binary from `main` and from this branch and diffed the self-scan (`scan --format all --vex vex.json .`). Both produce **80 findings, byte-identical** in rule / location / status.

### Note on self-scan grade
The self-scan is **Grade C / Score 5 on both `main` and this branch** (verified by building both binaries). The four grade-driving findings — `VULN-001` (dependency vuln in `editors/vscode/package-lock.json`), `IAC-308` ×2 (example workflows), `IAC-348` (`examples/gitlab-ci`) — are unrelated to lexctx/absence-matching and pre-exist this change; the committed badge (advertising A) is stale relative to current `main`. This PR does not change the finding set, so there is nothing here to reconcile; the pre-existing grade drift is a separate maintenance item outside this task's scope.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj