### PR TITLE
fix(deps): bump brace-expansion past GHSA-mh99-v99m-4gvg (restores grade A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`brace-expansion` in the VS Code extension is bumped past a newly-published
+  ReDoS.** GHSA-mh99-v99m-4gvg affects every `brace-expansion` up to 5.0.8, so
+  the 2.1.2 pin an earlier release added (to fix a *different* brace-expansion
+  advisory) became vulnerable when this one was published. Reached transitively
+  through `minimatch` in the extension's build toolchain — not the extension's
+  runtime — but a high-severity advisory nonetheless. The `overrides` entry now
+  forces `^5.0.8`; the extension still compiles clean and nox's own self-scan
+  returns to grade A.
+
 ### Fixed
 
 - **A `data:` URI payload is no longer mistaken for a secret.** A base64-encoded

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -38,18 +38,24 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -55,7 +55,7 @@
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {
-    "brace-expansion": "^2.1.2"
+    "brace-expansion": "^5.0.8"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
A newly-published ReDoS advisory — **GHSA-mh99-v99m-4gvg** — affects every `brace-expansion` through 5.0.8. The VS Code extension pinned `2.1.2` via `overrides` to fix an *earlier* brace-expansion advisory; **that pin became vulnerable the moment this one was published.** The supply-chain treadmill, caught by nox's own live OSV scan.

## Impact
- Reached transitively through `minimatch` in the build toolchain — the extension's only runtime dep is `vscode-languageclient` — so real-world exposure is low.
- But OSV reports it high, and nox's self-scan correctly surfaced it: **the repo dropped from grade A to C** (Score 5) between 07-23 and 07-25. Nothing in the codebase changed; the vuln database did.

## Fix
Override forced to `^5.0.8` (the only fixed line — brace-expansion ships parallel majors and the ReDoS fix landed in 5.0.8). It's a single `expand()` function behind a dual CommonJS/ESM package, so the toolchain still resolves it.

## Verified
- `npm install` → **0 vulnerabilities**
- `npm run compile` (`tsc -p ./`) → clean
- nox self-scan: **VULN-001 clears, Score 0 / Grade A restored**
- Minimal diff: one override line + the regenerated lockfile

Found while running the P1/P2/P3 parallel workstreams — a background agent's self-scan flagged the grade regression, which I then confirmed independently.