### PR TITLE
feat(taint): role-aware AI prompt-injection (TAINT-AI-001 / AGENTFLOW-001)

### DIFF
--- a/core/analyzers/agentflow/agentflow.go
+++ b/core/analyzers/agentflow/agentflow.go
@@ -197,12 +197,26 @@ func (a *Analyzer) analyzeUnit(unit *taint.Unit) []findings.Finding {
 			}
 			// If a sanitizer wraps the value at the call site, treat it as cleared.
 			inlineSafe := a.stmtHasSanitizer(lang, st)
+			// Role-awareness: reaching an LLM is necessary but not sufficient. The
+			// same call's message array tells us WHERE the untrusted value lands. A
+			// value confined to the user role behind a static system message is the
+			// recommended pattern (suppressed); a value in the system/developer role
+			// inverts the trust boundary (kept); an undetermined role is kept
+			// conservatively. Determined for Python only (see detectPromptRoles).
+			roles, staticSystem := promptRoleInfo(st, rawCall)
 			for _, v := range promptArgVars(st, rawCall) {
 				src, ok := untrusted[v]
 				if !ok || inlineSafe {
 					continue
 				}
-				out = append(out, a.untrustedToPromptFinding(unit, st, rawCall, v, src, untrustedLine[v]))
+				role := taint.PromptRoleUnknown
+				if r, known := roles[v]; known {
+					role = r
+				}
+				if taint.SuppressPromptRole(role, staticSystem) {
+					continue // untrusted content confined to the user role (safe pattern)
+				}
+				out = append(out, a.untrustedToPromptFinding(unit, st, rawCall, v, src, untrustedLine[v], role))
 				break
 			}
 		}
@@ -339,10 +353,14 @@ func (a *Analyzer) stmtHasSanitizer(lang string, st *taint.Statement) bool {
 }
 
 // untrustedToPromptFinding builds the AGENTFLOW-001 finding at the prompt call.
-func (a *Analyzer) untrustedToPromptFinding(unit *taint.Unit, st *taint.Statement, call, srcVar string, src taint.Source, srcLine int) findings.Finding {
+// role is the chat role the tainted value lands in ("system"/"developer"/"user"/
+// "unknown"), recorded on the finding so the role-based verdict is auditable. A
+// system/developer role is the trust-inverting injection; an unknown role is a
+// conservatively-kept ambiguous case.
+func (a *Analyzer) untrustedToPromptFinding(unit *taint.Unit, st *taint.Statement, call, srcVar string, src taint.Source, srcLine int, role string) findings.Finding {
 	msg := fmt.Sprintf(
-		"Untrusted input (%s via %q) reaches LLM prompt call %q without sanitization — the model can be goal-hijacked (ASI01).",
-		src.Kind, srcVar, call,
+		"Untrusted input (%s via %q) reaches LLM prompt call %q in the %s role without sanitization — the model can be goal-hijacked (ASI01).",
+		src.Kind, srcVar, call, role,
 	)
 	return findings.Finding{
 		RuleID:     ruleUntrustedToPrompt,
@@ -359,9 +377,31 @@ func (a *Analyzer) untrustedToPromptFinding(unit *taint.Unit, st *taint.Statemen
 			"source_call": src.Call,
 			"source_var":  srcVar,
 			"source_line": fmt.Sprintf("%d", srcLine),
+			"sink_role":   role,
 			"function":    unit.FuncName,
 		},
 	}
+}
+
+// promptRoleInfo returns the per-variable chat-role map and the static-system-message
+// flag for a specific prompt call in st, resolved from the extractor's per-call
+// argument evidence (with dotted-suffix fallback so a framework/aliased prefix
+// resolves). Both are empty/false when the call is not chat-message-shaped or the
+// language is not Python, in which case every reaching value keeps its conservative
+// (role-blind) verdict.
+func promptRoleInfo(st *taint.Statement, rawCall string) (map[string]string, bool) {
+	if st.SinkArgs == nil {
+		return nil, false
+	}
+	if info, ok := st.SinkArgs[rawCall]; ok {
+		return info.PromptRoles, info.PromptHasStaticSystem
+	}
+	for _, key := range suffixKeys(rawCall) {
+		if info, ok := st.SinkArgs[key]; ok {
+			return info.PromptRoles, info.PromptHasStaticSystem
+		}
+	}
+	return nil, false
 }
 
 // outputToSinkFinding builds the AGENTFLOW-002 finding at the dangerous sink.

--- a/core/analyzers/agentflow/agentflow_test.go
+++ b/core/analyzers/agentflow/agentflow_test.go
@@ -151,6 +151,56 @@ func TestAgentflow(t *testing.T) {
 			want: ruleOutputToSink,
 		},
 
+		// -------- Role-aware AGENTFLOW-001 (P3) --------
+		// Reaching an LLM is necessary but not sufficient: WHERE the untrusted value
+		// lands is the differentiator. These three cases encode the design contract.
+		{
+			// TRUE POSITIVE kept: untrusted value in the SYSTEM role inverts the
+			// trust boundary (a real prompt injection).
+			name: "tainted value in system role fires",
+			file: "sys.py",
+			src: `def personalize():
+    persona = request.args.get("persona")
+    openai.chat.completions.create(messages=[{"role": "system", "content": persona}, {"role": "user", "content": "hi"}])
+`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			// TRUE POSITIVE kept: f-string interpolation into the system role.
+			name: "tainted value in system role via f-string fires",
+			file: "sysf.py",
+			src: `def personalize():
+    persona = request.args.get("persona")
+    openai.chat.completions.create(messages=[{"role": "system", "content": f"You are a {persona} bot."}, {"role": "user", "content": "hi"}])
+`,
+			want: ruleUntrustedToPrompt,
+		},
+		{
+			// FALSE POSITIVE removed: untrusted value confined to the user role,
+			// behind a STATIC system message — the recommended data-boundary pattern
+			// (this is exactly examples/ai-app/safe.py).
+			name: "tainted value in user role behind static system does not fire",
+			file: "usr.py",
+			src: `def chat():
+    user_q = request.args.get("q")
+    openai.chat.completions.create(messages=[{"role": "system", "content": "Answer concisely."}, {"role": "user", "content": user_q}])
+`,
+			want:    "",
+			notWant: ruleUntrustedToPrompt,
+		},
+		{
+			// CONSERVATIVE: the message array is built dynamically (a bare variable),
+			// so the landing role is undetermined — keep the finding.
+			name: "dynamic message construction still fires",
+			file: "dyn.py",
+			src: `def chat():
+    q = request.args.get("q")
+    msgs = [{"role": "system", "content": q}]
+    openai.chat.completions.create(messages=msgs)
+`,
+			want: ruleUntrustedToPrompt,
+		},
+
 		// -------- No-fire cases --------
 		{
 			name: "hardcoded constant prompt does not fire",

--- a/core/analyzers/taintflow/taintflow.go
+++ b/core/analyzers/taintflow/taintflow.go
@@ -195,6 +195,13 @@ func (a *Analyzer) toFinding(flow *taint.Flow) findings.Finding {
 		meta["interprocedural"] = "true"
 		meta["via"] = strings.Join(flow.Via, " -> ")
 	}
+	// For a role-aware prompt-injection (LLM) sink, record the chat role the
+	// tainted value lands in so the verdict is auditable: "system"/"developer" is
+	// the trust-inverting injection this keeps; a user-role placement behind a
+	// static system message was already suppressed upstream and never reaches here.
+	if flow.SinkRole != "" {
+		meta["sink_role"] = flow.SinkRole
+	}
 	return findings.Finding{
 		RuleID:     sink.RuleID,
 		Severity:   severityForClass(sink.VulnClass),

--- a/core/analyzers/taintflow/taintflow_test.go
+++ b/core/analyzers/taintflow/taintflow_test.go
@@ -191,6 +191,62 @@ def handler():
 	}
 }
 
+// scanFindings runs the analyzer and returns the full findings for metadata
+// assertions (scan() projects to rule IDs only).
+func scanFindings(t *testing.T, arts ...discovery.Artifact) []findingRec {
+	t.Helper()
+	a := NewAnalyzer()
+	fs, err := a.ScanArtifacts(context.Background(), arts)
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	items := fs.Findings()
+	out := make([]findingRec, 0, len(items))
+	for i := range items {
+		out = append(out, findingRec{ruleID: items[i].RuleID, meta: items[i].Metadata})
+	}
+	return out
+}
+
+type findingRec struct {
+	ruleID string
+	meta   map[string]string
+}
+
+// TestAnalyzerRoleAwarePromptInjection is the end-to-end proof at the analyzer
+// boundary: the system-role prompt injection fires TAINT-AI-001 and carries the
+// auditable sink_role=system metadata, while the user-role-behind-static-system
+// pattern produces no finding at all.
+func TestAnalyzerRoleAwarePromptInjection(t *testing.T) {
+	dir := t.TempDir()
+	sys := writeArtifact(t, dir, "sys.py", `def personalize():
+    persona = request.args.get("persona")
+    client.chat.completions.create(messages=[{"role": "system", "content": persona}, {"role": "user", "content": "hi"}])
+`)
+	recs := scanFindings(t, sys)
+	var got *findingRec
+	for i := range recs {
+		if recs[i].ruleID == "TAINT-AI-001" {
+			got = &recs[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("system-role injection did not fire TAINT-AI-001; got %v", recs)
+	}
+	if got.meta["sink_role"] != "system" {
+		t.Errorf("sink_role = %q, want system", got.meta["sink_role"])
+	}
+
+	dir2 := t.TempDir()
+	safe := writeArtifact(t, dir2, "safe.py", `def chat():
+    user_q = request.args.get("q")
+    client.chat.completions.create(messages=[{"role": "system", "content": "Answer concisely."}, {"role": "user", "content": user_q}])
+`)
+	if ids := scan(t, safe); len(ids) != 0 {
+		t.Fatalf("user-role-behind-static-system must be clean of TAINT-AI-001, got %v", ids)
+	}
+}
+
 func TestAnalyzerRules(t *testing.T) {
 	rs := NewAnalyzer().Rules()
 	want := map[string]bool{"TAINT-001": false, "TAINT-002": false, "TAINT-005": false}

--- a/core/taint/engine.go
+++ b/core/taint/engine.go
@@ -73,6 +73,23 @@ type SinkArgInfo struct {
 	// variable and so is invisible to variable-based propagation. Keyword arguments
 	// are excluded. Best-effort; empty when unobserved.
 	PositionalArgs []string
+	// PromptRoles maps a variable that appears inside a chat/LLM prompt argument to
+	// the chat role of the message it lands in ("system", "developer", "user", …).
+	// It is populated only for chat-message-shaped LLM calls (an OpenAI/Anthropic
+	// messages=[{role,content}] list or a system= parameter) and is empty for every
+	// other call. It is the evidence a role-aware consumer uses to tell a
+	// trust-inverting system-role injection (untrusted content in the system role)
+	// from the recommended pattern (untrusted content confined to the user role).
+	// A variable absent from the map has an undetermined role — the caller MUST
+	// treat that conservatively (keep the finding), never as safe.
+	PromptRoles map[string]string
+	// PromptHasStaticSystem is true when the same chat/LLM call carries a system (or
+	// developer) message whose content is a static literal with no interpolated
+	// variable — the data boundary that makes untrusted content in the user role
+	// the recommended, non-injection pattern. It is false when no such message
+	// exists or the system content is itself variable/tainted. A user-role flow is
+	// only downgraded to safe when this is true.
+	PromptHasStaticSystem bool
 }
 
 // Unit is a single intraprocedural scope (typically one function body) presented
@@ -109,6 +126,15 @@ type Flow struct {
 	// (e.g. ["wrap", "run"]). Empty for a purely intraprocedural flow. It lets a
 	// finding explain the summary-composed path. Deterministically ordered.
 	Via []string
+	// SinkRole records, for a prompt-injection (LLM) sink, the chat role the
+	// tainted value lands in: "system"/"developer" (a trust-inverting injection),
+	// "user"/other recognized role, or "unknown" when the role could not be
+	// determined (dynamic message construction). Empty for every non-LLM sink. It
+	// makes the role-based verdict auditable on the emitted finding. A user-role
+	// flow behind a static system message is suppressed by the engine and never
+	// reaches a Flow, so SinkRole on an emitted prompt-injection flow is "system",
+	// "developer", "unknown", or another non-user role that was kept conservatively.
+	SinkRole string
 }
 
 // TaintEngine analyzes one intraprocedural Unit and returns the taint flows that

--- a/core/taint/engine/args.go
+++ b/core/taint/engine/args.go
@@ -56,6 +56,12 @@ func argInfo(lang langKind, c callChain) sinkArgDraft {
 		}
 	}
 	sortStrings(info.taintedArgVars)
+	// Role-awareness for LLM prompt sinks: if this call is chat-message-shaped
+	// (a messages=[{role,content}] list or a system= parameter), map each argument
+	// variable to the chat role it lands in and note whether a static system message
+	// establishes the instruction/data boundary. Populated for Python only; other
+	// languages keep the role-blind behavior (documented in detectPromptRoles).
+	info.promptRoles, info.promptStaticSystem = detectPromptRoles(lang, c.rawArgs, c.codeArgs)
 	return info
 }
 

--- a/core/taint/engine/extract.go
+++ b/core/taint/engine/extract.go
@@ -72,6 +72,14 @@ type sinkArgDraft struct {
 	// SOURCE used directly as a sink argument (sink(source())), which binds no
 	// variable and is otherwise invisible to variable propagation.
 	positionalArgs []string
+	// promptRoles maps a variable appearing inside a chat/LLM prompt argument to the
+	// chat role of the message it lands in (see taint.SinkArgInfo.PromptRoles). Only
+	// populated for Python chat-message-shaped calls; nil otherwise.
+	promptRoles map[string]string
+	// promptStaticSystem records that the call carries a static (untainted) system
+	// message — the data boundary that makes user-role untrusted content the safe
+	// pattern (see taint.SinkArgInfo.PromptHasStaticSystem).
+	promptStaticSystem bool
 }
 
 // extractUnits parses content into unit drafts for the given language. It walks

--- a/core/taint/engine/prompt_roles.go
+++ b/core/taint/engine/prompt_roles.go
@@ -1,0 +1,313 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/nox-hq/nox/core/taint"
+)
+
+// detectPromptRoles inspects a call's argument text and, when the call is
+// chat-message-shaped, returns (a) a map from each variable that appears inside a
+// prompt message to the chat role that message occupies, and (b) whether a static
+// (untainted) system message is present. It is the substrate that makes the
+// prompt-injection rules role-aware: reaching an LLM is necessary but not
+// sufficient — WHERE the untrusted value lands (the trust-bearing system role vs
+// the data-carrying user role) is the real differentiator.
+//
+// HOW THE ROLE IS DETERMINED (deterministic, no code execution):
+//   - rawArgs (string literals intact) and codeArgs (literals blanked, only real
+//     code — including f-string interpolations — surviving) are byte-aligned slices
+//     of the SAME call's argument text, so a span located in one view slices the
+//     same bytes in the other. The role LITERAL (e.g. "system") is read from the
+//     raw view; the interpolated variable identifiers are read from the code view.
+//   - The call's top-level arguments are split at bracket depth 0. A messages=[…]
+//     (or contents=[…]) keyword whose value is a list literal is parsed into its
+//     {…} message objects; for each object the "role" key's string literal gives
+//     the role and the object's surviving code identifiers are the variables that
+//     land in that role. A system= / system_prompt= / system_instruction= keyword
+//     (Anthropic/Gemini) treats its value's identifiers as system-role, and a
+//     static string value there counts as a static system message.
+//   - A message object whose role is dynamic (no readable string literal) yields no
+//     mapping for its variables — they stay undetermined, which the caller keeps
+//     conservatively. A messages= value that is a bare variable (dynamic message
+//     construction) yields an empty map for the same reason.
+//
+// PRECEDENCE: a variable that appears in more than one role keeps the most
+// privileged (system/developer beats a data role), so a value used in both a
+// system and a user message is still judged an injection.
+//
+// LANGUAGE SCOPE: Python only. The chat-message shape here is the Python SDK form
+// (keyword args with `=`, dict literals with `{"role": ...}`). JS/TS and the other
+// languages the taint engine supports pass an object literal positionally
+// (`create({ messages: [...] })`) with a different punctuation; determining role
+// there cleanly is out of reach for this line recognizer, so those languages keep
+// their existing role-blind behavior (every reaching value is reported) — a
+// deliberate, documented conservative limit, never a downgrade. Returns (nil,
+// false) for any non-Python language or any call with no recognizable role
+// structure.
+func detectPromptRoles(lang langKind, rawArgs, codeArgs string) (map[string]string, bool) {
+	if lang != langPython {
+		return nil, false // other languages: keep role-blind behavior (see doc).
+	}
+	// The two views must be byte-aligned for span slicing to be sound; if they are
+	// not (should not happen), fail safe by reporting no role structure.
+	if len(rawArgs) != len(codeArgs) {
+		return nil, false
+	}
+	// Cheap gate: only chat-message-shaped calls carry these keywords. Avoids
+	// parsing every call's arguments.
+	if !strings.Contains(codeArgs, "messages") &&
+		!strings.Contains(codeArgs, "contents") &&
+		!strings.Contains(codeArgs, "system") {
+		return nil, false
+	}
+
+	roles := map[string]string{}
+	staticSystem := false
+
+	for _, slot := range topLevelCommaSpans(codeArgs, 0, len(codeArgs)) {
+		name, valStart := keywordAndValueStart(codeArgs, slot.start, slot.end)
+		if name == "" {
+			continue // positional argument: not a recognized role-bearing keyword.
+		}
+		switch name {
+		case "messages", "contents":
+			ss := addMessageListRoles(roles, rawArgs, codeArgs, valStart, slot.end)
+			staticSystem = staticSystem || ss
+		case "system", "system_prompt", "system_instruction":
+			// A separate system parameter (Anthropic/Gemini): its identifiers are
+			// system-role, and a purely static string value is a static system
+			// boundary.
+			ids := freeIdentifiers(langPython, codeArgs[valStart:slot.end])
+			for _, id := range ids {
+				promoteRole(roles, id, taint.PromptRoleSystem)
+			}
+			if len(ids) == 0 && strings.TrimSpace(rawArgs[valStart:slot.end]) != "" {
+				staticSystem = true
+			}
+		}
+	}
+
+	if len(roles) == 0 && !staticSystem {
+		return nil, false
+	}
+	return roles, staticSystem
+}
+
+// promptSinkRole returns the chat role the variable v lands in at a prompt sink,
+// per the call's detected role map, or taint.PromptRoleUnknown when v's role could
+// not be determined (dynamic construction, non-Python language, unreadable role).
+// Unknown is reported on the finding and never suppresses — ambiguity is kept.
+func promptSinkRole(info taint.SinkArgInfo, v string) string {
+	if role, ok := info.PromptRoles[v]; ok {
+		return role
+	}
+	return taint.PromptRoleUnknown
+}
+
+// byteSpan is a half-open [start,end) byte range into an argument string.
+type byteSpan struct{ start, end int }
+
+// topLevelCommaSpans splits s[lo:hi) into comma-separated spans at bracket depth 0
+// (commas nested inside (), [], or {} do not split). Deterministic; always returns
+// at least one span.
+func topLevelCommaSpans(s string, lo, hi int) []byteSpan {
+	var spans []byteSpan
+	depth := 0
+	start := lo
+	for i := lo; i < hi && i < len(s); i++ {
+		switch s[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				spans = append(spans, byteSpan{start, i})
+				start = i + 1
+			}
+		}
+	}
+	spans = append(spans, byteSpan{start, hi})
+	return spans
+}
+
+// keywordAndValueStart, for the argument slot code[start:end), returns the keyword
+// name and the byte offset (into code) where its value begins, when the slot is a
+// keyword argument `name = value` at top level. Returns ("", 0) for a positional
+// argument, a comparison, or an empty slot. The `=` must be top level (not inside
+// brackets) and a real assignment (not ==, <=, >=, !=).
+func keywordAndValueStart(code string, start, end int) (name string, valStart int) {
+	depth := 0
+	for i := start; i < end; i++ {
+		switch code[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '=':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < end && code[i+1] == '=' {
+				return "", 0 // comparison, not a keyword arg
+			}
+			if i > start {
+				switch code[i-1] {
+				case '=', '!', '<', '>', '+', '-', '*', '/', '%', '&', '|', '^':
+					return "", 0
+				}
+			}
+			nm := strings.TrimSpace(code[start:i])
+			if !isSimpleIdent(nm) {
+				return "", 0
+			}
+			return nm, i + 1
+		}
+	}
+	return "", 0
+}
+
+// addMessageListRoles parses a messages=[…] value (raw and code views, byte-aligned)
+// and records, for each {role, content} object, the role of every variable it
+// carries. It returns whether a static (variable-free) system/developer message was
+// found — the data boundary that legitimizes untrusted content in the user role.
+// A value that is not a `[…]` list literal (a bare variable: dynamic construction)
+// records nothing and returns false, so such calls stay conservatively reported.
+func addMessageListRoles(roles map[string]string, raw, code string, valStart, valEnd int) bool {
+	// Locate the list literal within the value span.
+	open := indexAt(code, '[', valStart, valEnd)
+	if open < 0 {
+		return false // messages is a variable / not a literal list: dynamic.
+	}
+	closeIdx := matchBracket(code, open, '[', ']')
+	if closeIdx < 0 || closeIdx > valEnd {
+		return false
+	}
+	staticSystem := false
+	for _, obj := range topLevelCommaSpans(code, open+1, closeIdx) {
+		codeObj := code[obj.start:obj.end]
+		rawObj := raw[obj.start:obj.end]
+		if strings.TrimSpace(codeObj) == "" {
+			continue // trailing comma / empty slot
+		}
+		role := roleLiteral(rawObj)
+		if role == "" {
+			continue // dynamic/unreadable role: leave this object's vars undetermined.
+		}
+		ids := contentIdentifiers(codeObj)
+		if len(ids) == 0 {
+			// A message with no interpolated variable is static content. A static
+			// system/developer message is the instruction/data boundary we look for.
+			if taint.IsPrivilegedPromptRole(role) {
+				staticSystem = true
+			}
+			continue
+		}
+		for _, id := range ids {
+			promoteRole(roles, id, role)
+		}
+	}
+	return staticSystem
+}
+
+// roleLiteral extracts the value of the "role" key from a raw message-object text
+// like `{"role": "system", "content": …}`. It finds the `role` key (an identifier
+// immediately followed, after an optional closing quote and spaces, by a colon —
+// which distinguishes the key from the word "role" appearing inside content text)
+// and returns the next quoted string, lowercased and trimmed. Returns "" when the
+// role is absent or dynamic (not a string literal).
+func roleLiteral(rawObj string) string {
+	n := len(rawObj)
+	for i := 0; i+4 <= n; i++ {
+		if rawObj[i:i+4] != "role" {
+			continue
+		}
+		// Reject a longer identifier that merely contains "role" (e.g. "roles").
+		if i > 0 && isIdentPart(rawObj[i-1]) {
+			continue
+		}
+		if i+4 < n && isIdentPart(rawObj[i+4]) {
+			continue
+		}
+		// After the key, skip an optional closing quote and whitespace; require a
+		// colon so this is the KEY position, not the word inside content.
+		j := i + 4
+		for j < n && (rawObj[j] == '"' || rawObj[j] == '\'' || rawObj[j] == ' ' || rawObj[j] == '\t') {
+			j++
+		}
+		if j >= n || rawObj[j] != ':' {
+			continue
+		}
+		return firstQuotedString(rawObj[j+1:])
+	}
+	return ""
+}
+
+// firstQuotedString returns the contents of the first single- or double-quoted
+// string in s, lowercased and trimmed, or "" if the next non-space token is not a
+// quoted string (a dynamic role value).
+func firstQuotedString(s string) string {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	if i >= len(s) || (s[i] != '"' && s[i] != '\'') {
+		return "" // dynamic role (a variable/expression), not a literal.
+	}
+	q := s[i]
+	i++
+	start := i
+	for i < len(s) && s[i] != q {
+		i++
+	}
+	if i >= len(s) {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(s[start:i]))
+}
+
+// contentIdentifiers returns the variable identifiers surviving in a message
+// object's CODE view (string literals — the "role"/"content" keys and any static
+// text — already blanked), which are exactly the values interpolated into the
+// message content (directly or via an f-string). Deterministic and deduplicated.
+func contentIdentifiers(codeObj string) []string {
+	return freeIdentifiers(langPython, codeObj)
+}
+
+// promoteRole records role for variable v, keeping the most privileged role when v
+// appears in more than one message. Precedence: system/developer (privileged) beats
+// any non-privileged role; among non-privileged roles a non-user role (assistant/
+// tool/function) beats user, so a value used in both user and another role is kept
+// (conservatively reported) rather than suppressed as a pure user-role value.
+func promoteRole(roles map[string]string, v, role string) {
+	cur, ok := roles[v]
+	if !ok || rolePriority(role) > rolePriority(cur) {
+		roles[v] = role
+	}
+}
+
+// rolePriority ranks roles so promoteRole keeps the most dangerous placement.
+func rolePriority(role string) int {
+	switch {
+	case taint.IsPrivilegedPromptRole(role):
+		return 3
+	case role == taint.PromptRoleUser:
+		return 1
+	default:
+		return 2 // assistant/tool/function/other recognized-but-non-user role
+	}
+}
+
+// indexAt returns the index of the first byte b in s within [lo,hi), or -1.
+func indexAt(s string, b byte, lo, hi int) int {
+	if hi > len(s) {
+		hi = len(s)
+	}
+	for i := lo; i < hi; i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}

--- a/core/taint/engine/prompt_roles_test.go
+++ b/core/taint/engine/prompt_roles_test.go
@@ -1,0 +1,104 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/taint"
+)
+
+// sinkRoleFor returns the SinkRole of the first TAINT-AI-001 (prompt-injection)
+// flow in flows, and whether such a flow was found. It is how the role-aware tests
+// assert both that the finding fired and which role it landed in.
+func sinkRoleFor(flows []taint.Flow) (string, bool) {
+	for i := range flows {
+		if flows[i].Sink.RuleID == "TAINT-AI-001" {
+			return flows[i].SinkRole, true
+		}
+	}
+	return "", false
+}
+
+// TestPromptRoleAwareTaint is the end-to-end discrimination proof for the
+// role-aware prompt-injection rule (TAINT-AI-001), driven through the real
+// extractor + structural engine. It encodes all three directions the design
+// requires: system-role FIRES, user-role-behind-a-static-system does NOT, and
+// ambiguous/dynamic construction FIRES (conservative).
+func TestPromptRoleAwareTaint(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantFire bool
+		wantRole string // asserted only when wantFire is true
+	}{
+		{
+			// The false positive this whole change removes: untrusted input reaches
+			// the model ONLY in the user role, behind a static system message.
+			name: "user role behind static system does not fire",
+			src: `def chat():
+    user_q = request.args.get("q")
+    client.chat.completions.create(messages=[{"role": "system", "content": "Answer concisely."}, {"role": "user", "content": user_q}])
+`,
+			wantFire: false,
+		},
+		{
+			// The true positive that must survive: untrusted persona in the SYSTEM
+			// role inverts the trust boundary — a real prompt injection.
+			name: "system role fires",
+			src: `def personalize():
+    persona = request.args.get("persona")
+    client.chat.completions.create(messages=[{"role": "system", "content": persona}, {"role": "user", "content": "hi"}])
+`,
+			wantFire: true,
+			wantRole: taint.PromptRoleSystem,
+		},
+		{
+			// f-string interpolation into the system role still lands in system.
+			name: "system role via f-string fires",
+			src: `def personalize():
+    persona = request.args.get("persona")
+    client.chat.completions.create(messages=[{"role": "system", "content": f"You are a {persona} bot."}, {"role": "user", "content": "hi"}])
+`,
+			wantFire: true,
+			wantRole: taint.PromptRoleSystem,
+		},
+		{
+			// Conservative: the message array is built dynamically (a bare variable),
+			// so the landing role is undetermined — keep the finding.
+			name: "dynamic message construction fires conservatively",
+			src: `def chat():
+    q = request.args.get("q")
+    msgs = [{"role": "system", "content": q}]
+    client.chat.completions.create(messages=msgs)
+`,
+			wantFire: true,
+			wantRole: taint.PromptRoleUnknown,
+		},
+		{
+			// A lone user message with NO system boundary: there is no static
+			// data/instruction separation, so the value is kept (conservative). This
+			// mirrors the existing agentflow expectation and prevents an over-broad
+			// suppression that would hide real injections.
+			name: "user role without static system fires",
+			src: `def chat():
+    q = request.args.get("q")
+    client.chat.completions.create(messages=[{"role": "user", "content": q}])
+`,
+			wantFire: true,
+			wantRole: taint.PromptRoleUser,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flows := analyze(t, lexctx.LangPython, tt.src)
+			role, fired := sinkRoleFor(flows)
+			if fired != tt.wantFire {
+				t.Fatalf("TAINT-AI-001 fired = %v, want %v (flows: %v)", fired, tt.wantFire, ruleIDs(flows))
+			}
+			if tt.wantFire && role != tt.wantRole {
+				t.Errorf("sink_role = %q, want %q", role, tt.wantRole)
+			}
+		})
+	}
+}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -56,12 +56,14 @@ func toStatement(d *stmtDraft) taint.Statement {
 		st.SinkArgs = make(map[string]taint.SinkArgInfo, len(d.sinkArgs))
 		for call, a := range d.sinkArgs {
 			st.SinkArgs[call] = taint.SinkArgInfo{
-				TaintedArgVars:  append([]string(nil), a.taintedArgVars...),
-				ArgCount:        a.argCount,
-				ShellTrue:       a.shellTrue,
-				FirstArgTainted: a.firstArgTainted,
-				PositionalVars:  copyPositional(a.positionalVars),
-				PositionalArgs:  append([]string(nil), a.positionalArgs...),
+				TaintedArgVars:        append([]string(nil), a.taintedArgVars...),
+				ArgCount:              a.argCount,
+				ShellTrue:             a.shellTrue,
+				FirstArgTainted:       a.firstArgTainted,
+				PositionalVars:        copyPositional(a.positionalVars),
+				PositionalArgs:        append([]string(nil), a.positionalArgs...),
+				PromptRoles:           copyRoles(a.promptRoles),
+				PromptHasStaticSystem: a.promptStaticSystem,
 			}
 		}
 	}
@@ -77,6 +79,19 @@ func copyPositional(src [][]string) [][]string {
 	out := make([][]string, len(src))
 	for i := range src {
 		out[i] = append([]string(nil), src[i]...)
+	}
+	return out
+}
+
+// copyRoles copies the prompt-role map so the foundation's SinkArgInfo never
+// aliases the extractor's internal map. nil stays nil (no role structure).
+func copyRoles(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
 	}
 	return out
 }
@@ -257,6 +272,18 @@ func (e *StructuralEngine) forwardPass(
 				if inlineCleared[v][sink.VulnClass] {
 					continue // sanitized inline at the sink call
 				}
+				// Role-aware gating for LLM prompt sinks: reaching an LLM is necessary
+				// but not sufficient. Determine the chat role the tainted value lands
+				// in; suppress ONLY the recommended pattern (user role behind a static
+				// system message), keep every system/developer/unknown placement. See
+				// promptSinkRole / taint.SuppressPromptRole.
+				sinkRole := ""
+				if sink.VulnClass == taint.VulnPromptInjection {
+					sinkRole = promptSinkRole(info, v)
+					if taint.SuppressPromptRole(sinkRole, info.PromptHasStaticSystem) {
+						continue // untrusted content confined to the user role (safe pattern)
+					}
+				}
 				flows = append(flows, taint.Flow{
 					Source:     ti.src,
 					SourceLine: ti.srcLine,
@@ -268,6 +295,7 @@ func (e *StructuralEngine) forwardPass(
 					FuncName:   unit.FuncName,
 					Language:   unit.Language,
 					Via:        append([]string(nil), ti.via...),
+					SinkRole:   sinkRole,
 				})
 				break // one flow per sink call is enough
 			}

--- a/core/taint/prompt_role.go
+++ b/core/taint/prompt_role.go
@@ -1,0 +1,49 @@
+package taint
+
+// Chat/LLM message roles recognized by the role-aware prompt-injection analysis.
+// They are the canonical, lowercased role strings used by the OpenAI/Anthropic
+// chat-message schema (`{"role": "...", "content": ...}`) and by the separate
+// system= parameter. Only these role placements are reasoned over; any other or
+// unreadable role literal is treated as an undetermined role (kept conservatively).
+const (
+	// PromptRoleSystem and PromptRoleDeveloper are the instruction (trust-bearing)
+	// roles. The model is trained to defer to their content, so untrusted input
+	// here inverts the trust boundary — a real prompt injection.
+	PromptRoleSystem    = "system"
+	PromptRoleDeveloper = "developer"
+	// PromptRoleUser is the data role. Untrusted input confined to the user role,
+	// behind a static system message, is the recommended pattern — not a
+	// high-severity injection.
+	PromptRoleUser = "user"
+	// PromptRoleUnknown marks a prompt sink whose landing role could not be
+	// determined (dynamic message construction, indirection the analyzer cannot
+	// follow). It is reported on the finding so the conservative verdict is
+	// auditable; it never suppresses.
+	PromptRoleUnknown = "unknown"
+)
+
+// IsPrivilegedPromptRole reports whether role is a trust-bearing instruction role
+// (system or developer). Untrusted content landing in a privileged role is the
+// genuine prompt injection this analysis must always keep; it is never suppressed.
+func IsPrivilegedPromptRole(role string) bool {
+	return role == PromptRoleSystem || role == PromptRoleDeveloper
+}
+
+// SuppressPromptRole reports whether a tainted value landing in role, at a call
+// that also carries a static system message (hasStaticSystem), is the recommended
+// data-boundary pattern rather than an injection — i.e. whether the prompt-injection
+// finding for this landing should be suppressed.
+//
+// Policy — deliberately conservative, because for a security tool a missed real
+// system-role injection (false negative) is worse than an extra lower-confidence
+// finding:
+//   - Suppress ONLY when the tainted value lands in the user role AND a static,
+//     untainted system message establishes the instruction/data boundary. This is
+//     exactly the shape the SDKs recommend and that examples/ai-app/safe.py models.
+//   - NEVER suppress a privileged (system/developer) role — that is the injection.
+//   - NEVER suppress an unknown/undetermined role, nor a user role that lacks a
+//     static system boundary, nor any other role (assistant/tool/function): all are
+//     kept so ambiguity and novel shapes fail toward reporting, not silence.
+func SuppressPromptRole(role string, hasStaticSystem bool) bool {
+	return role == PromptRoleUser && hasStaticSystem
+}

--- a/examples/ai-app/safe.py
+++ b/examples/ai-app/safe.py
@@ -13,11 +13,11 @@ client = OpenAI()
 
 @app.post("/chat")
 def chat():
-    # User input stays in the user role; system content is static.
+    # User input stays in the user role; system content is static. nox models
+    # role placement, so this recommended pattern is not flagged (no waiver needed).
     user_q = request.json.get("question", "")
     if len(user_q) > 4000:
         return {"error": "input too long"}, 400
-    # nox:ignore TAINT-AI-001 -- user input stays in the user role; role separation is not modelled
     response = client.chat.completions.create(
         model="gpt-4o",
         messages=[


### PR DESCRIPTION
## P3: role-aware AI taint

Static AI-taint hit a precision ceiling: **"an untrusted value reached an LLM call" is necessary but not sufficient** for prompt injection. Nox flagged BOTH the vulnerable and the fixed form of the same app:

- `examples/ai-app/agent.py` — untrusted `persona` interpolated into the **system** role (a genuine trust-boundary inversion). **True positive.**
- `examples/ai-app/safe.py` — untrusted input confined to the **user** role behind a static system message (the recommended, documented-safe pattern). **False positive** — it carried a `# nox:ignore TAINT-AI-001` waiver purely to hide it.

The real differentiator is **where the taint lands**. This PR makes the prompt-injection rules role-aware.

### How role is determined
A new deterministic parser (`core/taint/engine/prompt_roles.go`) reads a chat call's argument text and maps each variable that reaches a message to the chat **role** of the message it lands in. Role literals (`"system"`/`"user"`) are read from the raw view; interpolated variables (including f-string interpolations) from the byte-aligned code view. It also handles an Anthropic/Gemini `system=` parameter and records whether a **static, untainted system message** establishes the instruction/data boundary.

### Gating policy (conservative)
`taint.SuppressPromptRole` suppresses **only** the recommended pattern — a value in the **user** role **behind a static system message**. It keeps:
- every **system/developer** placement (the injection),
- every **undetermined** role — dynamic message construction, non-Python languages, unreadable role literal.

A missed system-role injection (false negative) is worse than an extra lower-confidence finding, so ambiguity fails toward reporting.

Findings now carry a `sink_role` metadata field (`system`/`developer`/`user`/`unknown`) so the verdict is auditable. Applied to both the structural taint engine (**TAINT-AI-001**) and the agentflow analyzer (**AGENTFLOW-001**) — whose prior "correct" behavior on these two files was incidental (source-form recognition), not role-based.

### Discrimination proof
| File / line | Role | TAINT-AI-001 | AGENTFLOW-001 |
|---|---|---|---|
| `agent.py:35` (persona → system) | system | **FIRES** (`sink_role=system`) | **FIRES** (`sink_role=system`) |
| `safe.py:21` (user_q → user, static system) | user | clean | clean |

The now-redundant `safe.py` waiver is removed and does **not** become an unused-waiver degradation. `agent.py`'s waiver stays used.

### Tests (test-first, all three directions)
- `core/taint/engine/prompt_roles_test.go` — system FIRES, user-behind-static-system does NOT, dynamic/unknown FIRES, user-without-static-system FIRES (conservative).
- `core/analyzers/agentflow/agentflow_test.go` — same directions for AGENTFLOW-001; existing user-role-only expectations preserved.
- `core/analyzers/taintflow/taintflow_test.go` — end-to-end `sink_role=system` metadata + safe.py clean.

### Scope / limits
- Role detection is **Python-only**; JS/TS and other languages keep their existing role-blind (conservative, always-report) behavior — documented, not a downgrade.
- Interprocedural prompt flows keep the conservative verdict.

### Gates
- `go build ./...` ✅
- `go test ./...` ✅ (precision-harness guards green)
- `golangci-lint run` ✅ 0 issues
- Self-scan: **no new findings vs baseline**, **zero unused-waiver degradations**; the only high-severity finding is the pre-existing brace-expansion `VULN-001` (out of scope). Precision suite unchanged (35 TP / 0 FP / 0 FN).

Out of scope, untouched: `CHANGELOG.md`, `core/rules/matcher.go`, secrets/IaC comment-context code, metamorphic harness.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj
