### PR TITLE
docs(changelog): 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-07-25
+
 ### Security
 
 - **`brace-expansion` in the VS Code extension is bumped past a newly-published


### PR DESCRIPTION
Stamps Unreleased as **1.14.1** for release.

Patch version — every entry is a fix or a security bump; no new feature or interface:
- **Security:** brace-expansion ReDoS (GHSA-mh99-v99m-4gvg) in the VS Code extension
- **Fixed:** role-aware AI taint (fewer false positives), data-URI secret FP, two Dockerfile absence-rule bugs, the comment-property fix

Internal work since 1.14.0 (lexctx refactor #317, metamorphic CI gate #316, self-scan hardening, badge) is deliberately not in the notes — it doesn't change the released binary.