### PR TITLE
feat(slop): predictive slopsquat feed (SLOP-002) — offline, signed, default-safe

### DIFF
--- a/cmd/slopfeed/candidates.go
+++ b/cmd/slopfeed/candidates.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+// candidate is a package name an LLM is plausibly likely to emit, together with
+// a prior in [0,1] estimating that emission likelihood INDEPENDENT of whether
+// the name is registered. Registration is decided later by the checker; final
+// risk (scorer.go) combines the two. Keeping the prior separate lets the
+// harness spend its request budget on the highest-likelihood names.
+type candidate struct {
+	name       string
+	ecosystem  string  // "pypi" | "npm"
+	pattern    string  // composition | typo | obvious
+	prior      float64 // [0,1]
+	neighborOf string  // real stem it derives from ("" if none)
+	reason     string
+}
+
+// typoPlausibility scales a typo prior by how likely the variant is to be what
+// a MODEL actually writes, as opposed to a purely mechanical human fat-finger.
+// Slopsquatting is about model output, so semantic-looking variants
+// (plural/singular, separator swaps) rank far above a dropped first letter.
+var typoPlausibility = map[string]float64{
+	"sep":       0.95, // hyphen<->underscore, separator removal
+	"plural":    0.90, // pluralise / de-pluralise
+	"transpose": 0.60, // adjacent swap in the interior
+	"omit":      0.45, // dropped character
+	"double":    0.40, // doubled character
+	"first":     0.25, // anything mangling the first char (rare in LLMs)
+}
+
+// popularityWeight maps a stem's rank in its seed list to a weight in
+// [0.5,1.0]: earlier in the list == more popular == an LLM reaches for it more.
+func popularityWeight(stem string, seedList []string) float64 {
+	idx := -1
+	for i, s := range seedList {
+		if s == stem {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return 0.6
+	}
+	n := math.Max(1, float64(len(seedList)-1))
+	return 1.0 - 0.5*(float64(idx)/n)
+}
+
+type typoVariant struct {
+	name string
+	kind string
+	why  string
+}
+
+// typoNeighbours returns edit-distance-~1 neighbours of a stem.
+func typoNeighbours(stem string) []typoVariant {
+	var out []typoVariant
+	s := []rune(stem)
+
+	// adjacent-character transposition
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == s[i+1] {
+			continue
+		}
+		v := string(s[:i]) + string(s[i+1]) + string(s[i]) + string(s[i+2:])
+		kind := "transpose"
+		if i == 0 {
+			kind = "first"
+		}
+		out = append(out, typoVariant{v, kind, "transposed adjacent chars"})
+	}
+	// single-character omission
+	for i := 0; i < len(s); i++ {
+		v := string(s[:i]) + string(s[i+1:])
+		if len([]rune(v)) >= 3 {
+			kind := "omit"
+			if i == 0 {
+				kind = "first"
+			}
+			out = append(out, typoVariant{v, kind, "omitted a char"})
+		}
+	}
+	// double a single character
+	for i := 0; i < len(s); i++ {
+		v := string(s[:i]) + string(s[i]) + string(s[i:])
+		kind := "double"
+		if i == 0 {
+			kind = "first"
+		}
+		out = append(out, typoVariant{v, kind, "doubled a char"})
+	}
+	// hyphen<->underscore swaps and separator removal
+	if strings.Contains(stem, "-") {
+		out = append(out,
+			typoVariant{strings.ReplaceAll(stem, "-", "_"), "sep", "hyphen->underscore"},
+			typoVariant{strings.ReplaceAll(stem, "-", ""), "sep", "hyphen removed"},
+		)
+	}
+	if strings.Contains(stem, "_") {
+		out = append(out, typoVariant{strings.ReplaceAll(stem, "_", "-"), "sep", "underscore->hyphen"})
+	}
+	// singular/plural
+	if strings.HasSuffix(stem, "s") {
+		out = append(out, typoVariant{strings.TrimSuffix(stem, "s"), "plural", "de-pluralised"})
+	} else {
+		out = append(out, typoVariant{stem + "s", "plural", "pluralised"})
+	}
+
+	// dedup, drop identity, trim separators
+	seen := map[string]struct{}{}
+	uniq := out[:0:0]
+	for _, tv := range out {
+		v := strings.Trim(tv.name, "-_")
+		if v == stem || v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		tv.name = v
+		uniq = append(uniq, tv)
+	}
+	return uniq
+}
+
+type composed struct {
+	name string
+	sub  string
+	why  string
+}
+
+// compose returns compositional variants of a stem (stem-suffix, prefix-stem).
+func compose(stem string) []composed {
+	var out []composed
+	for _, suf := range suffixes {
+		out = append(out, composed{stem + "-" + suf, "suffix", "popular stem + '-" + suf + "'"})
+	}
+	for _, pre := range prefixes {
+		out = append(out, composed{pre + "-" + stem, "prefix", "'" + pre + "-' + popular stem"})
+	}
+	return out
+}
+
+// generateCandidates deterministically produces the full candidate set (no
+// network, no randomness). A candidate that collides with a real seed name is
+// dropped; when the same name arises from multiple derivations, the
+// highest-prior explanation wins.
+func generateCandidates() []candidate {
+	realSeeds := map[string]struct{}{}
+	for _, n := range pypiSeeds {
+		realSeeds["pypi\x00"+n] = struct{}{}
+	}
+	for _, n := range npmSeeds {
+		realSeeds["npm\x00"+n] = struct{}{}
+	}
+
+	cands := map[string]candidate{}
+	add := func(c candidate) {
+		key := c.ecosystem + "\x00" + c.name
+		if _, isReal := realSeeds[key]; isReal {
+			return
+		}
+		if cur, ok := cands[key]; !ok || c.prior > cur.prior {
+			cands[key] = c
+		}
+	}
+
+	for _, es := range []struct {
+		eco   string
+		seeds []string
+	}{{"pypi", pypiSeeds}, {"npm", npmSeeds}} {
+		for _, stem := range es.seeds {
+			w := popularityWeight(stem, es.seeds)
+			for _, tv := range typoNeighbours(stem) {
+				plaus := typoPlausibility[tv.kind]
+				prior := round3(0.30 + 0.45*plaus*w)
+				add(candidate{
+					name: tv.name, ecosystem: es.eco, pattern: "typo",
+					prior: prior, neighborOf: stem,
+					reason: "edit-distance-1 typo of '" + stem + "' (" + tv.why + ")",
+				})
+			}
+			for _, cp := range compose(stem) {
+				base := 0.30
+				if cp.sub == "suffix" {
+					base = 0.42
+				}
+				add(candidate{
+					name: cp.name, ecosystem: es.eco, pattern: "composition",
+					prior: round3(base + 0.30*w), neighborOf: stem,
+					reason: "compositional: " + cp.why,
+				})
+			}
+		}
+	}
+
+	for _, on := range obviousNames {
+		add(candidate{
+			name: on.name, ecosystem: on.eco, pattern: "obvious",
+			prior: 0.78, neighborOf: "",
+			reason: "'obvious API' name an LLM invents for a common task",
+		})
+	}
+
+	out := make([]candidate, 0, len(cands))
+	for _, c := range cands {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].prior != out[j].prior {
+			return out[i].prior > out[j].prior
+		}
+		if out[i].ecosystem != out[j].ecosystem {
+			return out[i].ecosystem < out[j].ecosystem
+		}
+		return out[i].name < out[j].name
+	})
+	return out
+}
+
+func round3(f float64) float64 { return math.Round(f*1000) / 1000 }

--- a/cmd/slopfeed/candidates_test.go
+++ b/cmd/slopfeed/candidates_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+)
+
+func TestGenerateIsDeterministic(t *testing.T) {
+	a := generateCandidates()
+	b := generateCandidates()
+	if len(a) != len(b) || len(a) == 0 {
+		t.Fatalf("generation not deterministic in length: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("generation not deterministic at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestGenerateNeverEmitsRealSeed(t *testing.T) {
+	// A candidate that collides with a real, popular seed must be dropped — the
+	// generator only ever proposes names that are NOT known-real packages.
+	realSeeds := map[string]struct{}{}
+	for _, n := range pypiSeeds {
+		realSeeds["pypi\x00"+n] = struct{}{}
+	}
+	for _, n := range npmSeeds {
+		realSeeds["npm\x00"+n] = struct{}{}
+	}
+	for _, c := range generateCandidates() {
+		if _, isReal := realSeeds[c.ecosystem+"\x00"+c.name]; isReal {
+			t.Errorf("candidate collides with a real seed: %s/%s", c.ecosystem, c.name)
+		}
+	}
+}
+
+func TestGeneratePriorsInRange(t *testing.T) {
+	for _, c := range generateCandidates() {
+		if c.prior < 0 || c.prior > 1 {
+			t.Errorf("prior out of range for %s: %v", c.name, c.prior)
+		}
+		if c.ecosystem != "pypi" && c.ecosystem != "npm" {
+			t.Errorf("unexpected ecosystem %q for %s", c.ecosystem, c.name)
+		}
+	}
+}
+
+func TestKnownSquattableNamesAreGenerated(t *testing.T) {
+	// The names the research verified as squattable must actually be produced by
+	// the generator model — otherwise the harness could never have found them.
+	want := map[string]string{
+		"openai-utils":      "pypi",
+		"anthropic-async":   "pypi",
+		"axios-retry-async": "npm",
+		"numpys":            "pypi",
+		"requests-sdk":      "pypi",
+	}
+	got := map[string]string{}
+	for _, c := range generateCandidates() {
+		got[c.name] = c.ecosystem
+	}
+	for name, eco := range want {
+		if got[name] != eco {
+			t.Errorf("expected generator to produce %s (%s); it did not", name, eco)
+		}
+	}
+}
+
+func TestScoreSquattableProducesValidFeedEntry(t *testing.T) {
+	c := candidate{name: "openai-utils", ecosystem: "pypi", pattern: "obvious", prior: 0.78, reason: "obvious API name"}
+	r := checkResult{name: c.name, ecosystem: c.ecosystem, verdict: unregistered}
+	e, ok := scoreSquattable(c, r, "2026-07-25")
+	if !ok {
+		t.Fatal("expected an unregistered high-prior candidate to score squattable")
+	}
+	if e.Tier != feed.TierCritical && e.Tier != feed.TierHigh && e.Tier != feed.TierMedium {
+		t.Errorf("unexpected tier %q", e.Tier)
+	}
+	if e.VerifiedAt != "2026-07-25" {
+		t.Errorf("verified_at not stamped: %q", e.VerifiedAt)
+	}
+}
+
+func TestLowRiskCandidateNotWritten(t *testing.T) {
+	// A composition name with a low prior falls below the medium tier and must
+	// not be written to the feed even when unregistered.
+	c := candidate{name: "requests-x", ecosystem: "pypi", pattern: "composition", prior: 0.40}
+	r := checkResult{verdict: unregistered}
+	if _, ok := scoreSquattable(c, r, "2026-07-25"); ok {
+		t.Fatal("a sub-medium-risk candidate must not be written to the feed")
+	}
+}

--- a/cmd/slopfeed/checker.go
+++ b/cmd/slopfeed/checker.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// verdict classifies a name against a registry.
+type verdict string
+
+const (
+	unregistered verdict = "unregistered" // 404 confirmed twice — claimable
+	registered   verdict = "registered"   // 200 — a package already owns the name
+	inconclusive verdict = "inconclusive" // anything we could not resolve confidently
+)
+
+// checkResult is the outcome of checking one name.
+type checkResult struct {
+	name      string
+	ecosystem string
+	verdict   verdict
+	httpCode  int
+	note      string
+}
+
+// userAgent identifies the generator to registries — a good-citizen contact
+// string so operators can reach us if the polling is a problem.
+const userAgent = "nox-slopfeed/1.0 (+https://github.com/nox-hq/nox; supply-chain security research)"
+
+// checker queries PyPI / npm to classify names. It is a good citizen: a
+// descriptive User-Agent, a sleep between requests, exponential backoff on
+// 429/5xx, and — critically — it RE-VERIFIES every 404 with a second query
+// before ever asserting a name is unregistered (registries are eventually
+// consistent; a single 404 is not proof). It NEVER marks a registered package
+// as claimable.
+type checker struct {
+	client     *http.Client
+	sleep      time.Duration
+	maxRetries int
+	// Base URLs are injectable so tests drive the checker against httptest
+	// servers. In production these point at the real registries.
+	pypiBase string // e.g. "https://pypi.org/pypi"
+	npmBase  string // e.g. "https://registry.npmjs.org"
+	requests int
+}
+
+func newChecker(client *http.Client, sleep time.Duration) *checker {
+	return &checker{
+		client:     client,
+		sleep:      sleep,
+		maxRetries: 4,
+		pypiBase:   "https://pypi.org/pypi",
+		npmBase:    "https://registry.npmjs.org",
+	}
+}
+
+// urlFor builds the metadata URL for a name in an ecosystem.
+func (c *checker) urlFor(name, ecosystem string) string {
+	switch ecosystem {
+	case "pypi":
+		return c.pypiBase + "/" + url.PathEscape(name) + "/json"
+	default: // npm
+		return c.npmBase + "/" + url.PathEscape(name)
+	}
+}
+
+// get performs one GET, returning the HTTP status code. It sleeps after every
+// request (politeness) and backs off exponentially on 429/5xx. A code of -1
+// means the request could not be completed.
+func (c *checker) get(ctx context.Context, u string) (int, error) {
+	backoff := time.Second
+	for attempt := 0; attempt < c.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+		if err != nil {
+			return -1, err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		c.requests++
+		resp, err := c.client.Do(req)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return -1, ctx.Err()
+			case <-time.After(backoff * time.Duration(1<<attempt)):
+			}
+			continue
+		}
+		code := resp.StatusCode
+		_ = resp.Body.Close()
+		switch code {
+		case http.StatusTooManyRequests, http.StatusInternalServerError,
+			http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			select {
+			case <-ctx.Done():
+				return -1, ctx.Err()
+			case <-time.After(backoff * time.Duration(1<<attempt)):
+			}
+			continue
+		}
+		c.polite(ctx)
+		return code, nil
+	}
+	return -1, fmt.Errorf("exhausted retries for %s", u)
+}
+
+func (c *checker) polite(ctx context.Context) {
+	if c.sleep <= 0 {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(c.sleep):
+	}
+}
+
+// check classifies a single name. It re-verifies a 404 before trusting it.
+func (c *checker) check(ctx context.Context, name, ecosystem string) checkResult {
+	u := c.urlFor(name, ecosystem)
+	res := checkResult{name: name, ecosystem: ecosystem, verdict: inconclusive}
+
+	code, err := c.get(ctx, u)
+	if err != nil {
+		res.note = err.Error()
+		return res
+	}
+	res.httpCode = code
+
+	switch code {
+	case http.StatusOK:
+		res.verdict = registered
+	case http.StatusNotFound:
+		// RE-VERIFY: a squattable verdict requires two independent 404s.
+		code2, err2 := c.get(ctx, u)
+		if err2 != nil {
+			res.verdict = inconclusive
+			res.note = "404 then error on re-query: " + err2.Error()
+			return res
+		}
+		switch code2 {
+		case http.StatusNotFound:
+			res.verdict = unregistered
+		case http.StatusOK:
+			// Eventual consistency: the name exists after all. Never accuse it.
+			res.verdict = registered
+			res.note = "404 then 200 on re-query (eventual consistency); treated as registered"
+		default:
+			res.verdict = inconclusive
+			res.httpCode = code2
+			res.note = fmt.Sprintf("404 then %d on re-query; inconclusive", code2)
+		}
+	default:
+		res.verdict = inconclusive
+	}
+	return res
+}

--- a/cmd/slopfeed/checker_test.go
+++ b/cmd/slopfeed/checker_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// newTestChecker points a checker at a test server, with no politeness delay.
+func newTestChecker(base string) *checker {
+	c := newChecker(&http.Client{}, 0)
+	c.pypiBase = base + "/pypi"
+	c.npmBase = base
+	return c
+}
+
+func TestCheckerRegisteredNeverSquattable(t *testing.T) {
+	// A registered package always returns 200. It must NEVER be reported
+	// unregistered — the core no-false-accusation guarantee.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"info":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL)
+	got := c.check(context.Background(), "requests", "pypi")
+	if got.verdict != registered {
+		t.Fatalf("200 must classify as registered, got %q", got.verdict)
+	}
+	if _, ok := scoreSquattable(candidateStub(), got, "2026-07-25"); ok {
+		t.Fatalf("a registered package must never be scored squattable")
+	}
+}
+
+func TestCheckerReverifies404(t *testing.T) {
+	// A single 404 is not proof. Only a name that returns 404 TWICE is trusted
+	// as unregistered.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL)
+	got := c.check(context.Background(), "openai-utils", "pypi")
+	if got.verdict != unregistered {
+		t.Fatalf("two 404s must classify as unregistered, got %q", got.verdict)
+	}
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("expected exactly 2 registry queries (initial + re-verify), got %d", n)
+	}
+}
+
+func TestChecker404ThenRegisteredIsNotSquattable(t *testing.T) {
+	// Eventual consistency: first query 404, second 200. Must be treated as
+	// registered and never asserted claimable.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL)
+	got := c.check(context.Background(), "flaky-name", "pypi")
+	if got.verdict == unregistered {
+		t.Fatalf("404-then-200 must NOT be unregistered, got %q", got.verdict)
+	}
+	if _, ok := scoreSquattable(candidateStub(), got, "2026-07-25"); ok {
+		t.Fatalf("404-then-200 must never be scored squattable")
+	}
+}
+
+func TestCheckerBacksOffOn429(t *testing.T) {
+	// First response 429, then 404 twice. The checker retries past the 429 and
+	// still lands on the correct unregistered verdict.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL)
+	c.maxRetries = 5
+	got := c.check(context.Background(), "anthropic-async", "pypi")
+	if got.verdict != unregistered {
+		t.Fatalf("expected unregistered after backoff, got %q (note: %s)", got.verdict, got.note)
+	}
+}
+
+func TestCheckerSendsPoliteUserAgent(t *testing.T) {
+	var ua string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL)
+	c.check(context.Background(), "x", "npm")
+	if !strings.Contains(ua, "nox-slopfeed") {
+		t.Fatalf("expected descriptive User-Agent, got %q", ua)
+	}
+}
+
+func candidateStub() candidate {
+	return candidate{name: "openai-utils", ecosystem: "pypi", pattern: "obvious", prior: 0.78}
+}

--- a/cmd/slopfeed/main.go
+++ b/cmd/slopfeed/main.go
@@ -1,0 +1,183 @@
+// Command slopfeed generates the predictive slopsquat blocklist that nox's SLOP
+// analyzer consumes offline. It is the maintained port of the research
+// prototype (scratchpad/research/slopsquat): it models how LLMs hallucinate
+// package names, generates the names they are likely to emit, checks public
+// registries read-only (rate-limited, re-verifying every 404), and writes only
+// names that are BOTH high-likelihood AND currently unregistered — never
+// accusing a registered package.
+//
+// Only this tool touches the network; the scanner consumes the frozen, signed,
+// content-addressed artifact it writes. See docs/slopsquat-feed.md.
+//
+// Usage:
+//
+//	slopfeed --out core/analyzers/slop/feed/data/slopsquat-blocklist.v1.json \
+//	         --limit 180 --sleep 400ms --version 2026.07.25
+//	slopfeed --dry-run          # generate candidates only, no network
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"time"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+)
+
+func main() {
+	var (
+		out      = flag.String("out", "core/analyzers/slop/feed/data/slopsquat-blocklist.v1.json", "output feed path")
+		limit    = flag.Int("limit", 180, "max candidates to check against registries (stratified across patterns)")
+		sleep    = flag.Duration("sleep", 400*time.Millisecond, "delay between registry requests (politeness)")
+		version  = flag.String("version", time.Now().UTC().Format("2006.01.02"), "feed version string")
+		dryRun   = flag.Bool("dry-run", false, "generate + select candidates but make no network calls; print a summary")
+		timeout  = flag.Duration("timeout", 20*time.Second, "per-request HTTP timeout")
+		printTop = flag.Int("print", 20, "print the top-N produced entries to stderr")
+	)
+	flag.Parse()
+
+	if err := run(*out, *limit, *sleep, *timeout, *version, *dryRun, *printTop); err != nil {
+		fmt.Fprintln(os.Stderr, "slopfeed:", err)
+		os.Exit(1)
+	}
+}
+
+func run(out string, limit int, sleep, timeout time.Duration, version string, dryRun bool, printTop int) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	cands := generateCandidates()
+	selected := stratifiedSelect(cands, limit)
+	fmt.Fprintf(os.Stderr, "generated %d candidates; checking %d (stratified)\n", len(cands), len(selected))
+
+	if dryRun {
+		summarize(selected)
+		return nil
+	}
+
+	chk := newChecker(&http.Client{Timeout: timeout}, sleep)
+	today := time.Now().UTC().Format("2006-01-02")
+
+	var (
+		entries []feed.Entry
+		nUnreg  int
+		nReg    int
+		nInconc int
+	)
+	for i, c := range selected {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		r := chk.check(ctx, c.name, c.ecosystem)
+		switch r.verdict {
+		case unregistered:
+			nUnreg++
+			if e, ok := scoreSquattable(c, r, today); ok {
+				entries = append(entries, e)
+			}
+		case registered:
+			nReg++
+		default:
+			nInconc++
+		}
+		if (i+1)%25 == 0 {
+			fmt.Fprintf(os.Stderr, "  checked %d/%d (%d requests)\n", i+1, len(selected), chk.requests)
+		}
+	}
+
+	// Deterministic ordering in the written file: highest risk first.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Risk != entries[j].Risk {
+			return entries[i].Risk > entries[j].Risk
+		}
+		if entries[i].Ecosystem != entries[j].Ecosystem {
+			return entries[i].Ecosystem < entries[j].Ecosystem
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	f := &feed.Feed{
+		SchemaVersion: feed.SchemaVersion,
+		Version:       version,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        "cmd/slopfeed",
+		Entries:       entries,
+	}
+	f.SetDigest()
+
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling feed: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(out, data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", out, err)
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"\nwrote %s\n  entries: %d  (unregistered %d / registered %d / inconclusive %d)\n  requests: %d  digest: %s\n",
+		out, len(entries), nUnreg, nReg, nInconc, chk.requests, f.Digest)
+	if printTop > 0 {
+		n := printTop
+		if n > len(entries) {
+			n = len(entries)
+		}
+		for _, e := range entries[:n] {
+			fmt.Fprintf(os.Stderr, "  %.2f %-8s %-4s %s\n", e.Risk, e.Tier, e.Ecosystem, e.Name)
+		}
+	}
+	return nil
+}
+
+// stratifiedSelect takes the highest-prior slice of each pattern so every
+// research class (obvious / typo / composition) gets real registry coverage
+// rather than one class dominating the budget. Mirrors the prototype harness.
+func stratifiedSelect(cands []candidate, limit int) []candidate {
+	if limit <= 0 || limit >= len(cands) {
+		return cands
+	}
+	quota := map[string]int{"obvious": 40, "typo": 70, "composition": 70}
+	byPat := map[string][]candidate{}
+	for _, c := range cands {
+		byPat[c.pattern] = append(byPat[c.pattern], c)
+	}
+	seen := map[string]struct{}{}
+	var out []candidate
+	for _, pat := range []string{"obvious", "typo", "composition"} {
+		list := byPat[pat] // already prior-sorted (generateCandidates sorts globally)
+		q := quota[pat]
+		for i := 0; i < len(list) && i < q && len(out) < limit; i++ {
+			key := list[i].ecosystem + "\x00" + list[i].name
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, list[i])
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].prior > out[j].prior })
+	return out
+}
+
+func summarize(selected []candidate) {
+	byPat, byEco := map[string]int{}, map[string]int{}
+	for _, c := range selected {
+		byPat[c.pattern]++
+		byEco[c.ecosystem]++
+	}
+	fmt.Fprintf(os.Stderr, "selected by pattern: %v\n", byPat)
+	fmt.Fprintf(os.Stderr, "selected by ecosystem: %v\n", byEco)
+	n := 15
+	if n > len(selected) {
+		n = len(selected)
+	}
+	for _, c := range selected[:n] {
+		fmt.Fprintf(os.Stderr, "  %.3f [%s/%s] %s\n", c.prior, c.ecosystem, c.pattern, c.name)
+	}
+}

--- a/cmd/slopfeed/scorer.go
+++ b/cmd/slopfeed/scorer.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+)
+
+// neighbourBoost lifts the risk of names that are also classic typosquat lures
+// (likely-emitted AND a lure). Composition names get no boost.
+func neighbourBoost(prior float64, pattern string) float64 {
+	switch pattern {
+	case "typo":
+		return math.Min(1.0, prior+0.08)
+	case "obvious":
+		return math.Min(1.0, prior+0.04)
+	default:
+		return prior
+	}
+}
+
+// tierFor buckets a risk score. A score below 0.50 is not high-likelihood
+// enough to assert as a predictive target and is dropped by the caller.
+func tierFor(score float64) string {
+	switch {
+	case score >= 0.80:
+		return feed.TierCritical
+	case score >= 0.65:
+		return feed.TierHigh
+	case score >= 0.50:
+		return feed.TierMedium
+	default:
+		return ""
+	}
+}
+
+// scoreSquattable turns a candidate that was re-verified UNREGISTERED into a
+// feed entry. It returns ok=false for anything that must not be written: a
+// candidate that is not unregistered (never accuse a registered package) or one
+// whose risk falls below the medium tier. verifiedAt is the date the 404 was
+// confirmed (stamped into the entry so the claim is time-bound and honest).
+func scoreSquattable(c candidate, r checkResult, verifiedAt string) (feed.Entry, bool) {
+	if r.verdict != unregistered {
+		return feed.Entry{}, false
+	}
+	risk := round3(neighbourBoost(c.prior, c.pattern))
+	tier := tierFor(risk)
+	if tier == "" {
+		return feed.Entry{}, false
+	}
+	reason := fmt.Sprintf(
+		"UNREGISTERED (404 confirmed twice on %s) and matches a high-likelihood "+
+			"hallucination pattern [%s]: %s. An attacker could register this name "+
+			"today and capture installs of hallucinated `%s`.",
+		verifiedAt, c.pattern, c.reason, c.name,
+	)
+	return feed.Entry{
+		Name:       c.name,
+		Ecosystem:  c.ecosystem,
+		Pattern:    c.pattern,
+		NeighborOf: c.neighborOf,
+		Risk:       risk,
+		Tier:       tier,
+		Reason:     reason,
+		VerifiedAt: verifiedAt,
+	}, true
+}

--- a/cmd/slopfeed/seeds.go
+++ b/cmd/slopfeed/seeds.go
@@ -1,0 +1,90 @@
+package main
+
+// Seed lists of genuinely popular, real packages. These are the anchors the
+// hallucination generator perturbs and extends. Every name here is a real,
+// widely-installed package; the generator NEVER asserts anything about these
+// real packages — they are used only as stems/neighbours for candidate names,
+// and a generated candidate that collides with a real seed is dropped.
+//
+// Ported from the research prototype (scratchpad/research/slopsquat/seeds.py),
+// kept deliberately small (~40 per ecosystem) and hardcoded for determinism.
+
+// pypiSeeds are popular PyPI packages (real).
+var pypiSeeds = []string{
+	"requests", "numpy", "pandas", "flask", "django", "fastapi", "pydantic",
+	"sqlalchemy", "boto3", "aiohttp", "httpx", "pytest", "click", "rich",
+	"scipy", "scikit-learn", "matplotlib", "pillow", "beautifulsoup4",
+	"selenium", "celery", "redis", "pymongo", "psycopg2", "cryptography",
+	"pyyaml", "jinja2", "tenacity", "openai", "anthropic", "langchain",
+	"tiktoken", "transformers", "torch", "tensorflow", "uvicorn", "starlette",
+	"typer", "loguru", "python-dateutil",
+}
+
+// npmSeeds are popular npm packages (real).
+var npmSeeds = []string{
+	"react", "express", "lodash", "axios", "chalk", "commander", "moment",
+	"dayjs", "webpack", "vite", "eslint", "prettier", "typescript", "jest",
+	"vitest", "next", "vue", "svelte", "zod", "yup", "dotenv", "cors",
+	"mongoose", "sequelize", "prisma", "nodemon", "socket.io", "uuid",
+	"bcrypt", "jsonwebtoken", "passport", "redux", "tailwindcss", "rxjs",
+	"puppeteer", "playwright", "cheerio", "nanoid", "pino", "winston",
+}
+
+// prefixes and suffixes are the domain/task words an LLM commonly welds onto a
+// stem when it invents a helper package that "should" exist.
+var prefixes = []string{
+	"fast", "py", "node", "ai", "async", "auto", "smart", "easy", "simple",
+	"super", "pro",
+}
+
+var suffixes = []string{
+	"utils", "async", "sdk", "client", "toolkit", "helpers", "core", "tools",
+	"kit", "api", "cli", "plus", "x", "js", "py",
+}
+
+// obviousName is a fully-formed name an LLM confidently invents for a common
+// task, tagged with the ecosystem (nox canonical: "pypi" | "npm").
+type obviousName struct {
+	name string
+	eco  string
+}
+
+// obviousNames are curated by hand from the patterns in the slopsquatting
+// literature (Spracklen et al. 2024) and everyday LLM output.
+var obviousNames = []obviousName{
+	{"openai-helpers", "pypi"},
+	{"openai-utils", "pypi"},
+	{"openai-async", "pypi"},
+	{"requests-cache-async", "pypi"},
+	{"requests-async", "pypi"},
+	{"flask-jwt-auth", "pypi"},
+	{"flask-auth", "pypi"},
+	{"django-rest-auth-jwt", "pypi"},
+	{"fastapi-jwt-auth", "pypi"},
+	{"fastapi-auth", "pypi"},
+	{"langchain-utils", "pypi"},
+	{"langchain-helpers", "pypi"},
+	{"anthropic-async", "pypi"},
+	{"anthropic-helpers", "pypi"},
+	{"pandas-utils", "pypi"},
+	{"pandas-helpers", "pypi"},
+	{"numpy-utils", "pypi"},
+	{"boto3-helpers", "pypi"},
+	{"sqlalchemy-utils-async", "pypi"},
+	{"pydantic-utils", "pypi"},
+	{"openai-client", "npm"},
+	{"openai-sdk", "npm"},
+	{"express-jwt-auth", "npm"},
+	{"express-auth", "npm"},
+	{"react-use-fetch", "npm"},
+	{"react-hooks-utils", "npm"},
+	{"axios-retry-async", "npm"},
+	{"axios-cache", "npm"},
+	{"lodash-async", "npm"},
+	{"zod-utils", "npm"},
+	{"prisma-utils", "npm"},
+	{"jwt-auth-express", "npm"},
+	{"node-fetch-retry", "npm"},
+	{"vite-plugin-env", "npm"},
+	{"next-auth-jwt", "npm"},
+}

--- a/core/analyzers/slop/feed/data/slopsquat-blocklist.v1.json
+++ b/core/analyzers/slop/feed/data/slopsquat-blocklist.v1.json
@@ -1,0 +1,620 @@
+{
+  "schema_version": "slopsquat-blocklist/v1",
+  "version": "2026.07.25",
+  "generated_at": "2026-07-25T10:30:22Z",
+  "source": "cmd/slopfeed",
+  "digest": "sha256:f9ae0d9a50569e6ab8a6ed2e138a69f13fdcb8f51160eccfb3b73620ab9871e1",
+  "entries": [
+    {
+      "name": "axios-retry-async",
+      "ecosystem": "npm",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `axios-retry-async`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "anthropic-async",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `anthropic-async`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "anthropic-helpers",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `anthropic-helpers`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "django-rest-auth-jwt",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `django-rest-auth-jwt`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "fastapi-auth",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `fastapi-auth`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "langchain-helpers",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `langchain-helpers`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "openai-utils",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `openai-utils`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "pydantic-utils",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `pydantic-utils`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-cache-async",
+      "ecosystem": "pypi",
+      "pattern": "obvious",
+      "risk": 0.82,
+      "tier": "critical",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [obvious]: 'obvious API' name an LLM invents for a common task. An attacker could register this name today and capture installs of hallucinated `requests-cache-async`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "numpys",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "numpy",
+      "risk": 0.78,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'numpy' (pluralised). An attacker could register this name today and capture installs of hallucinated `numpys`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "djangos",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "django",
+      "risk": 0.764,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'django' (pluralised). An attacker could register this name today and capture installs of hallucinated `djangos`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "pydantics",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "pydantic",
+      "risk": 0.754,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'pydantic' (pluralised). An attacker could register this name today and capture installs of hallucinated `pydantics`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "sqlalchemys",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "sqlalchemy",
+      "risk": 0.749,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'sqlalchemy' (pluralised). An attacker could register this name today and capture installs of hallucinated `sqlalchemys`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "boto3s",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "boto3",
+      "risk": 0.743,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'boto3' (pluralised). An attacker could register this name today and capture installs of hallucinated `boto3s`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "vites",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "vite",
+      "risk": 0.738,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'vite' (pluralised). An attacker could register this name today and capture installs of hallucinated `vites`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "aiohttps",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "aiohttp",
+      "risk": 0.738,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'aiohttp' (pluralised). An attacker could register this name today and capture installs of hallucinated `aiohttps`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "eslints",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "eslint",
+      "risk": 0.733,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'eslint' (pluralised). An attacker could register this name today and capture installs of hallucinated `eslints`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "httpxs",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "httpx",
+      "risk": 0.733,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'httpx' (pluralised). An attacker could register this name today and capture installs of hallucinated `httpxs`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "prettiers",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "prettier",
+      "risk": 0.728,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'prettier' (pluralised). An attacker could register this name today and capture installs of hallucinated `prettiers`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "pytests",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "pytest",
+      "risk": 0.728,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'pytest' (pluralised). An attacker could register this name today and capture installs of hallucinated `pytests`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "typescripts",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "typescript",
+      "risk": 0.723,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'typescript' (pluralised). An attacker could register this name today and capture installs of hallucinated `typescripts`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "react-js",
+      "ecosystem": "npm",
+      "pattern": "composition",
+      "neighbor_of": "react",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-js'. An attacker could register this name today and capture installs of hallucinated `react-js`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-cli",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-cli'. An attacker could register this name today and capture installs of hallucinated `requests-cli`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-helpers",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-helpers'. An attacker could register this name today and capture installs of hallucinated `requests-helpers`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-js",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-js'. An attacker could register this name today and capture installs of hallucinated `requests-js`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-kit",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-kit'. An attacker could register this name today and capture installs of hallucinated `requests-kit`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-py",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-py'. An attacker could register this name today and capture installs of hallucinated `requests-py`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-sdk",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-sdk'. An attacker could register this name today and capture installs of hallucinated `requests-sdk`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-toolkit",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-toolkit'. An attacker could register this name today and capture installs of hallucinated `requests-toolkit`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requests-x",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "requests",
+      "risk": 0.72,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-x'. An attacker could register this name today and capture installs of hallucinated `requests-x`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "richs",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "rich",
+      "risk": 0.718,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'rich' (pluralised). An attacker could register this name today and capture installs of hallucinated `richs`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "express-js",
+      "ecosystem": "npm",
+      "pattern": "composition",
+      "neighbor_of": "express",
+      "risk": 0.716,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-js'. An attacker could register this name today and capture installs of hallucinated `express-js`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "express-py",
+      "ecosystem": "npm",
+      "pattern": "composition",
+      "neighbor_of": "express",
+      "risk": 0.716,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-py'. An attacker could register this name today and capture installs of hallucinated `express-py`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "express-x",
+      "ecosystem": "npm",
+      "pattern": "composition",
+      "neighbor_of": "express",
+      "risk": 0.716,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-x'. An attacker could register this name today and capture installs of hallucinated `express-x`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "numpy-api",
+      "ecosystem": "pypi",
+      "pattern": "composition",
+      "neighbor_of": "numpy",
+      "risk": 0.716,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [composition]: compositional: popular stem + '-api'. An attacker could register this name today and capture installs of hallucinated `numpy-api`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "vitests",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "vitest",
+      "risk": 0.712,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'vitest' (pluralised). An attacker could register this name today and capture installs of hallucinated `vitests`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "scipys",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "scipy",
+      "risk": 0.712,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'scipy' (pluralised). An attacker could register this name today and capture installs of hallucinated `scipys`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "matplotlibs",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "matplotlib",
+      "risk": 0.702,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'matplotlib' (pluralised). An attacker could register this name today and capture installs of hallucinated `matplotlibs`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "sveltes",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "svelte",
+      "risk": 0.697,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'svelte' (pluralised). An attacker could register this name today and capture installs of hallucinated `sveltes`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "pillows",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "pillow",
+      "risk": 0.697,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'pillow' (pluralised). An attacker could register this name today and capture installs of hallucinated `pillows`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "zods",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "zod",
+      "risk": 0.692,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'zod' (pluralised). An attacker could register this name today and capture installs of hallucinated `zods`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "beautifulsoup4s",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "beautifulsoup4",
+      "risk": 0.692,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'beautifulsoup4' (pluralised). An attacker could register this name today and capture installs of hallucinated `beautifulsoup4s`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "yups",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "yup",
+      "risk": 0.686,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'yup' (pluralised). An attacker could register this name today and capture installs of hallucinated `yups`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "seleniums",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "selenium",
+      "risk": 0.686,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'selenium' (pluralised). An attacker could register this name today and capture installs of hallucinated `seleniums`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "celerys",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "celery",
+      "risk": 0.681,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'celery' (pluralised). An attacker could register this name today and capture installs of hallucinated `celerys`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "sequelizes",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "sequelize",
+      "risk": 0.666,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'sequelize' (pluralised). An attacker could register this name today and capture installs of hallucinated `sequelizes`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "psycopg2s",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "psycopg2",
+      "risk": 0.666,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'psycopg2' (pluralised). An attacker could register this name today and capture installs of hallucinated `psycopg2s`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "prismas",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "prisma",
+      "risk": 0.66,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'prisma' (pluralised). An attacker could register this name today and capture installs of hallucinated `prismas`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "nodemons",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "nodemon",
+      "risk": 0.655,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'nodemon' (pluralised). An attacker could register this name today and capture installs of hallucinated `nodemons`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "pyyamls",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "pyyaml",
+      "risk": 0.655,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'pyyaml' (pluralised). An attacker could register this name today and capture installs of hallucinated `pyyamls`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "socket.ios",
+      "ecosystem": "npm",
+      "pattern": "typo",
+      "neighbor_of": "socket.io",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'socket.io' (pluralised). An attacker could register this name today and capture installs of hallucinated `socket.ios`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "jinja2s",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "jinja2",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'jinja2' (pluralised). An attacker could register this name today and capture installs of hallucinated `jinja2s`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "reqeusts",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `reqeusts`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requesst",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `requesst`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requetss",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `requetss`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "requsets",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `requsets`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "reuqests",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `reuqests`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "rqeuests",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "requests",
+      "risk": 0.65,
+      "tier": "high",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'requests' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `rqeuests`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "nmupy",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "numpy",
+      "risk": 0.647,
+      "tier": "medium",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'numpy' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `nmupy`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "numyp",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "numpy",
+      "risk": 0.647,
+      "tier": "medium",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'numpy' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `numyp`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "nupmy",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "numpy",
+      "risk": 0.647,
+      "tier": "medium",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'numpy' (transposed adjacent chars). An attacker could register this name today and capture installs of hallucinated `nupmy`.",
+      "verified_at": "2026-07-25"
+    },
+    {
+      "name": "tenacitys",
+      "ecosystem": "pypi",
+      "pattern": "typo",
+      "neighbor_of": "tenacity",
+      "risk": 0.645,
+      "tier": "medium",
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) and matches a high-likelihood hallucination pattern [typo]: edit-distance-1 typo of 'tenacity' (pluralised). An attacker could register this name today and capture installs of hallucinated `tenacitys`.",
+      "verified_at": "2026-07-25"
+    }
+  ]
+}

--- a/core/analyzers/slop/feed/feed.go
+++ b/core/analyzers/slop/feed/feed.go
@@ -1,0 +1,350 @@
+// Package feed defines the versioned, offline "predictive slopsquat blocklist"
+// that nox's SLOP analyzer consumes as an additional deterministic signal.
+//
+// The feed is a signed, versioned, content-addressed data artifact: a list of
+// high-risk package names — per ecosystem — that an LLM is likely to
+// hallucinate and that were verified UNREGISTERED (squattable) at generation
+// time. Intelligence accumulates centrally (a generator queries registries
+// out-of-band), and every device enforces it deterministically and offline —
+// the same shape as nox's OSV integration, but with the network fully removed
+// from scan time: only the generator touches a registry; the scanner reads a
+// frozen artifact.
+//
+// # Trust model
+//
+// The format mirrors the plugin registry's trust model (see registry/trust):
+//
+//   - Every feed carries a content digest, "sha256:<hex>", computed over a
+//     canonical serialization of its entries. A consumer recomputes the digest
+//     and rejects any feed whose bytes do not match — this catches truncation,
+//     tampering, and accidental corruption. Verification fails closed: a feed
+//     that does not verify is never trusted, and never crashes the scanner.
+//   - The format reserves an Ed25519 signature over the same canonical bytes,
+//     so a feed can later be Sigstore/cosign-signed exactly like a plugin
+//     artifact. Signature verification is a pluggable hook (SignatureVerifier);
+//     nothing here stands up real signing infrastructure, but the consumer has
+//     a verification seam and can be configured to require a valid signature.
+//
+// The package has no network access and no side effects. It depends only on
+// the standard library, so it does not couple core to the registry package.
+package feed
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// SchemaVersion is the feed schema identifier this build understands. It is a
+// namespaced, versioned string so future breaking changes get a new value and
+// an old consumer refuses a feed it cannot interpret rather than misreading it.
+const SchemaVersion = "slopsquat-blocklist/v1"
+
+// Ecosystem values used in the feed. These match nox's canonical internal
+// ecosystem names (see the slop analyzer), so the consumer can look up an
+// imported package without translation.
+const (
+	EcosystemPyPI = "pypi"
+	EcosystemNPM  = "npm"
+)
+
+// Tier buckets a squattable name by risk. Only these three tiers are ever
+// written to a feed — a name that scores below "medium" is not high-likelihood
+// enough to assert as a predictive target.
+const (
+	TierCritical = "critical"
+	TierHigh     = "high"
+	TierMedium   = "medium"
+)
+
+// Entry is a single high-risk, currently-unregistered package name.
+//
+// The only claim an Entry makes is the narrow, defensible one from the
+// research: this name was UNREGISTERED (verified at VerifiedAt) and matches a
+// high-likelihood hallucination pattern, so an attacker could register it to
+// catch hallucinated installs. It never accuses an existing package — the
+// generator only ever writes names it re-verified as unregistered.
+type Entry struct {
+	Name       string  `json:"name"`
+	Ecosystem  string  `json:"ecosystem"`             // "pypi" | "npm"
+	Pattern    string  `json:"pattern"`               // obvious | composition | typo
+	NeighborOf string  `json:"neighbor_of,omitempty"` // real stem it derives from
+	Risk       float64 `json:"risk"`                  // [0,1] LLM-emission-derived risk
+	Tier       string  `json:"tier"`                  // critical | high | medium
+	Reason     string  `json:"reason"`                // human-readable rationale
+	VerifiedAt string  `json:"verified_at"`           // date the 404 was confirmed
+}
+
+// Signature carries an Ed25519 signature over the feed's canonical entry bytes.
+// It is optional: the digest alone provides integrity; the signature adds
+// authenticity once a signing pipeline exists. Value is base64-standard.
+type Signature struct {
+	Algorithm    string `json:"algorithm"` // "ed25519"
+	KeyID        string `json:"key_id,omitempty"`
+	PublicKeyPEM string `json:"public_key_pem,omitempty"`
+	Value        string `json:"value"` // base64(signature)
+}
+
+// Feed is the on-disk artifact: metadata plus the entry list, bound together by
+// a content digest.
+type Feed struct {
+	SchemaVersion string     `json:"schema_version"`
+	Version       string     `json:"version"`      // human feed version, e.g. "2026.07.25"
+	GeneratedAt   string     `json:"generated_at"` // RFC3339 timestamp
+	Source        string     `json:"source"`       // generator identity
+	Digest        string     `json:"digest"`       // "sha256:<hex>" over CanonicalEntries
+	Signature     *Signature `json:"signature,omitempty"`
+	Entries       []Entry    `json:"entries"`
+}
+
+// CanonicalEntries returns a deterministic byte serialization of entries that
+// the digest and any signature are computed over. Entries are sorted by
+// (ecosystem, name) so the bytes do not depend on input ordering, and each
+// field is emitted in a fixed order via the struct definition. This is the sole
+// definition of "the content" for integrity purposes.
+func CanonicalEntries(entries []Entry) []byte {
+	sorted := make([]Entry, len(entries))
+	copy(sorted, entries)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Ecosystem != sorted[j].Ecosystem {
+			return sorted[i].Ecosystem < sorted[j].Ecosystem
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	// json.Marshal of a []Entry is deterministic: struct field order is fixed
+	// and there are no maps. Errors are impossible for this concrete type.
+	data, _ := json.Marshal(sorted)
+	return data
+}
+
+// ComputeDigest returns the "sha256:<hex>" digest over the canonical entries.
+func ComputeDigest(entries []Entry) string {
+	sum := sha256.Sum256(CanonicalEntries(entries))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// SetDigest computes and stores the digest for the feed's current entries. The
+// generator calls this after assembling entries and before writing the file.
+func (f *Feed) SetDigest() { f.Digest = ComputeDigest(f.Entries) }
+
+// verifyDigest recomputes the digest and compares it to the stored value.
+func (f *Feed) verifyDigest() error {
+	if f.Digest == "" {
+		return errors.New("feed carries no digest")
+	}
+	alg, hexVal, ok := strings.Cut(f.Digest, ":")
+	if !ok || alg != "sha256" {
+		return fmt.Errorf("unsupported or malformed digest %q", f.Digest)
+	}
+	if len(hexVal) != sha256.Size*2 {
+		return fmt.Errorf("digest hex has wrong length: %d", len(hexVal))
+	}
+	if _, err := hex.DecodeString(hexVal); err != nil {
+		return fmt.Errorf("digest hex invalid: %w", err)
+	}
+	if got := ComputeDigest(f.Entries); got != f.Digest {
+		return fmt.Errorf("feed digest mismatch: computed %s, declared %s", got, f.Digest)
+	}
+	return nil
+}
+
+// SignatureVerifier verifies a feed's signature over its canonical content.
+// It returns nil when the signature is valid, an error otherwise. Making it a
+// hook lets nox pin a key, defer to cosign, or accept a build-time key without
+// this package embedding any trust root.
+type SignatureVerifier func(content []byte, sig *Signature) error
+
+// Ed25519Verifier returns a SignatureVerifier that checks the feed's Ed25519
+// signature against the given public key, ignoring any key embedded in the feed
+// (a self-described key is not a trust root). This mirrors registry/trust's
+// Ed25519 signature checking.
+func Ed25519Verifier(pub ed25519.PublicKey) SignatureVerifier {
+	return func(content []byte, sig *Signature) error {
+		if sig == nil {
+			return errors.New("no signature present")
+		}
+		if sig.Algorithm != "ed25519" {
+			return fmt.Errorf("unsupported signature algorithm %q", sig.Algorithm)
+		}
+		raw, err := base64.StdEncoding.DecodeString(sig.Value)
+		if err != nil {
+			return fmt.Errorf("decoding signature: %w", err)
+		}
+		if len(raw) != ed25519.SignatureSize {
+			return fmt.Errorf("signature has wrong length: %d", len(raw))
+		}
+		if !ed25519.Verify(pub, content, raw) {
+			return errors.New("signature does not verify under the configured key")
+		}
+		return nil
+	}
+}
+
+// PEMEd25519Verifier builds an Ed25519Verifier from a PEM-encoded public key.
+func PEMEd25519Verifier(pemData []byte) (SignatureVerifier, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, errors.New("no PEM block in public key")
+	}
+	// Accept a raw 32-byte key body; PKIX parsing is left to callers that need
+	// it, to keep this package free of crypto/x509.
+	if len(block.Bytes) == ed25519.PublicKeySize {
+		return Ed25519Verifier(ed25519.PublicKey(block.Bytes)), nil
+	}
+	return nil, fmt.Errorf("unexpected public key length: %d", len(block.Bytes))
+}
+
+// VerifyOptions controls how strictly a feed is verified on load.
+type VerifyOptions struct {
+	// RequireSignature rejects a feed that has no signature, and requires the
+	// signature to verify under Verifier. When false, a signature is verified
+	// only if present (and Verifier is set), and its absence is tolerated.
+	RequireSignature bool
+	// Verifier checks the signature. When nil, signature checking is skipped
+	// (digest integrity is always enforced regardless).
+	Verifier SignatureVerifier
+}
+
+// Loaded is a verified, indexed feed ready for O(1) lookups by the analyzer.
+type Loaded struct {
+	Feed  *Feed
+	index map[string]map[string]Entry // ecosystem -> normalized name -> entry
+}
+
+// Parse decodes, verifies, and indexes a feed from raw JSON bytes. It fails
+// closed: any decode error, schema mismatch, digest mismatch, or failed
+// required-signature check returns a non-nil error and a nil *Loaded, and never
+// panics on malformed input.
+func Parse(data []byte, opts VerifyOptions) (*Loaded, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty feed")
+	}
+	var f Feed
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("decoding feed: %w", err)
+	}
+	if f.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("unsupported feed schema %q (want %q)", f.SchemaVersion, SchemaVersion)
+	}
+	if err := f.verifyDigest(); err != nil {
+		return nil, err
+	}
+
+	content := CanonicalEntries(f.Entries)
+	if opts.RequireSignature {
+		if f.Signature == nil {
+			return nil, errors.New("feed requires a signature but carries none")
+		}
+		if opts.Verifier == nil {
+			return nil, errors.New("feed requires a signature but no verifier is configured")
+		}
+		if err := opts.Verifier(content, f.Signature); err != nil {
+			return nil, fmt.Errorf("feed signature verification failed: %w", err)
+		}
+	} else if f.Signature != nil && opts.Verifier != nil {
+		// Opportunistic: if a signature is present and we have a verifier, a bad
+		// signature is still a hard failure — a present-but-invalid signature is
+		// a stronger red flag than no signature at all.
+		if err := opts.Verifier(content, f.Signature); err != nil {
+			return nil, fmt.Errorf("feed signature verification failed: %w", err)
+		}
+	}
+
+	idx := make(map[string]map[string]Entry, 2)
+	for _, e := range f.Entries {
+		eco := e.Ecosystem
+		if idx[eco] == nil {
+			idx[eco] = make(map[string]Entry)
+		}
+		idx[eco][NormalizeName(eco, e.Name)] = e
+	}
+	return &Loaded{Feed: &f, index: idx}, nil
+}
+
+// Load reads and verifies a feed from a file path.
+func Load(path string, opts VerifyOptions) (*Loaded, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading feed %s: %w", path, err)
+	}
+	return Parse(data, opts)
+}
+
+//go:embed data/slopsquat-blocklist.v1.json
+var bundledFS embed.FS
+
+// Bundled returns the feed shipped in the repo, verified. It lets the feature
+// work out of the box for a project that opts in without hosting its own feed.
+func Bundled() (*Loaded, error) {
+	data, err := bundledFS.ReadFile("data/slopsquat-blocklist.v1.json")
+	if err != nil {
+		return nil, fmt.Errorf("reading bundled feed: %w", err)
+	}
+	return Parse(data, VerifyOptions{})
+}
+
+// Lookup reports whether name (in ecosystem) is a high-risk feed entry. Names
+// are normalized so that, e.g., "OpenAI_Utils" and "openai-utils" match on
+// PyPI. Returns the entry and true on a hit.
+func (l *Loaded) Lookup(ecosystem, name string) (Entry, bool) {
+	if l == nil {
+		return Entry{}, false
+	}
+	m := l.index[ecosystem]
+	if m == nil {
+		return Entry{}, false
+	}
+	e, ok := m[NormalizeName(ecosystem, name)]
+	return e, ok
+}
+
+// Len returns the number of entries in the feed.
+func (l *Loaded) Len() int {
+	if l == nil || l.Feed == nil {
+		return 0
+	}
+	return len(l.Feed.Entries)
+}
+
+// Version returns the feed's version string.
+func (l *Loaded) Version() string {
+	if l == nil || l.Feed == nil {
+		return ""
+	}
+	return l.Feed.Version
+}
+
+// Digest returns the feed's content digest.
+func (l *Loaded) Digest() string {
+	if l == nil || l.Feed == nil {
+		return ""
+	}
+	return l.Feed.Digest
+}
+
+// NormalizeName canonicalizes a package name for cross-referencing. PyPI names
+// follow PEP 503 (lowercase; runs of "._-" collapse to a single "-"); npm names
+// are matched case-sensitively (npm lowercases but preserves scopes), trimmed.
+func NormalizeName(ecosystem, name string) string {
+	name = strings.TrimSpace(name)
+	switch ecosystem {
+	case EcosystemPyPI:
+		name = strings.ToLower(name)
+		name = strings.NewReplacer("_", "-", ".", "-").Replace(name)
+		for strings.Contains(name, "--") {
+			name = strings.ReplaceAll(name, "--", "-")
+		}
+		return name
+	default:
+		return name
+	}
+}

--- a/core/analyzers/slop/feed/feed_test.go
+++ b/core/analyzers/slop/feed/feed_test.go
@@ -1,0 +1,196 @@
+package feed
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleEntries returns a small, deterministic entry set for tests.
+func sampleEntries() []Entry {
+	return []Entry{
+		{
+			Name:       "openai-utils",
+			Ecosystem:  "pypi",
+			Pattern:    "obvious",
+			Risk:       0.82,
+			Tier:       "critical",
+			Reason:     "unregistered and high-likelihood hallucination",
+			VerifiedAt: "2026-07-25",
+		},
+		{
+			Name:       "axios-retry-async",
+			Ecosystem:  "npm",
+			Pattern:    "obvious",
+			Risk:       0.82,
+			Tier:       "critical",
+			Reason:     "unregistered and high-likelihood hallucination",
+			VerifiedAt: "2026-07-25",
+		},
+	}
+}
+
+// buildFeed assembles a Feed with a correct digest over sampleEntries.
+func buildFeed(t *testing.T) *Feed {
+	t.Helper()
+	f := &Feed{
+		SchemaVersion: SchemaVersion,
+		Version:       "2026.07.25",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries:       sampleEntries(),
+	}
+	f.SetDigest()
+	return f
+}
+
+func TestFeedRoundTripAndDigestVerifies(t *testing.T) {
+	f := buildFeed(t)
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	loaded, err := Parse(data, VerifyOptions{})
+	if err != nil {
+		t.Fatalf("parse valid feed: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", loaded.Len())
+	}
+	if got := loaded.Digest(); !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("digest not sha256-prefixed: %q", got)
+	}
+
+	// Lookup is normalized: PyPI names compare under PEP 503 canonical form.
+	if _, ok := loaded.Lookup("pypi", "OpenAI_Utils"); !ok {
+		t.Errorf("expected normalized PyPI lookup to hit openai-utils")
+	}
+	if _, ok := loaded.Lookup("npm", "axios-retry-async"); !ok {
+		t.Errorf("expected npm lookup to hit axios-retry-async")
+	}
+	if _, ok := loaded.Lookup("pypi", "requests"); ok {
+		t.Errorf("did not expect a hit for a name absent from the feed")
+	}
+}
+
+func TestTamperedEntriesRejected(t *testing.T) {
+	f := buildFeed(t)
+	// Tamper: mutate an entry AFTER the digest was computed. A consumer must
+	// reject this — the digest no longer covers the content.
+	f.Entries[0].Name = "evil-injected-name"
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := Parse(data, VerifyOptions{}); err == nil {
+		t.Fatalf("expected tampered feed to be rejected, got nil error")
+	}
+}
+
+func TestMalformedFeedFailsClosedNoPanic(t *testing.T) {
+	cases := map[string][]byte{
+		"not json":        []byte("{not json"),
+		"empty":           []byte(""),
+		"missing digest":  mustJSON(t, &Feed{SchemaVersion: SchemaVersion, Entries: sampleEntries()}),
+		"bad schema":      mustJSON(t, &Feed{SchemaVersion: "bogus/v9", Digest: "sha256:00", Entries: sampleEntries()}),
+		"garbage digest":  mustJSON(t, &Feed{SchemaVersion: SchemaVersion, Digest: "not-a-digest", Entries: sampleEntries()}),
+		"truncated bytes": []byte(`{"schema_version":"slopsquat-blocklist/v1","digest":`),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Must never panic and must return an error (fail closed).
+			loaded, err := Parse(data, VerifyOptions{})
+			if err == nil {
+				t.Fatalf("expected error for %s, got a loaded feed", name)
+			}
+			if loaded != nil {
+				t.Fatalf("expected nil loaded feed on error for %s", name)
+			}
+		})
+	}
+}
+
+func TestSignatureVerificationHook(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := buildFeed(t)
+	// Sign the canonical content (the same bytes the digest covers).
+	content := CanonicalEntries(f.Entries)
+	sig := ed25519.Sign(priv, content)
+	f.Signature = &Signature{
+		Algorithm: "ed25519",
+		KeyID:     "test-key",
+		Value:     base64.StdEncoding.EncodeToString(sig),
+	}
+	data := mustJSON(t, f)
+
+	// A verifier that trusts our test public key accepts the feed.
+	good := Ed25519Verifier(pub)
+	if _, err := Parse(data, VerifyOptions{RequireSignature: true, Verifier: good}); err != nil {
+		t.Fatalf("valid signature should verify: %v", err)
+	}
+
+	// A verifier with the wrong key must reject when a signature is required.
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	bad := Ed25519Verifier(otherPub)
+	if _, err := Parse(data, VerifyOptions{RequireSignature: true, Verifier: bad}); err == nil {
+		t.Fatalf("signature under wrong key must be rejected")
+	}
+
+	// RequireSignature with no signature present must fail closed.
+	unsigned := buildFeed(t)
+	if _, err := Parse(mustJSON(t, unsigned), VerifyOptions{RequireSignature: true, Verifier: good}); err == nil {
+		t.Fatalf("RequireSignature must reject an unsigned feed")
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	f := buildFeed(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "feed.json")
+	if err := os.WriteFile(path, mustJSON(t, f), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path, VerifyOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", loaded.Len())
+	}
+}
+
+func TestBundledFeedVerifies(t *testing.T) {
+	loaded, err := Bundled()
+	if err != nil {
+		t.Fatalf("bundled feed must load and verify: %v", err)
+	}
+	if loaded.Len() == 0 {
+		t.Fatalf("bundled feed should not be empty")
+	}
+	// Every bundled entry must carry the fields the consumer relies on.
+	for _, e := range loaded.Feed.Entries {
+		if e.Name == "" || (e.Ecosystem != "pypi" && e.Ecosystem != "npm") {
+			t.Errorf("bundled entry malformed: %+v", e)
+		}
+		if e.Tier != "critical" && e.Tier != "high" && e.Tier != "medium" {
+			t.Errorf("bundled entry has unexpected tier: %+v", e)
+		}
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/core/analyzers/slop/slop.go
+++ b/core/analyzers/slop/slop.go
@@ -17,16 +17,45 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
 )
 
-// Analyzer performs phantom-import detection.
-type Analyzer struct{}
+// Analyzer performs phantom-import detection and, when a predictive feed is
+// loaded, high-risk slopsquat-target detection (SLOP-002).
+type Analyzer struct {
+	// feed is an optional, verified predictive slopsquat blocklist. When nil
+	// (the default), the analyzer's behavior is exactly the reactive SLOP-001
+	// check and nothing else — no feed means zero behavior change. When set, an
+	// imported name that matches a feed entry additionally raises a distinct
+	// SLOP-002 predictive finding; the SLOP-001 baseline is never altered.
+	feed *feed.Loaded
+}
 
-// NewAnalyzer returns a slop analyzer.
-func NewAnalyzer() *Analyzer { return &Analyzer{} }
+// Option configures an Analyzer.
+type Option func(*Analyzer)
+
+// WithFeed attaches a verified predictive slopsquat blocklist. Passing a nil
+// feed is a no-op, so callers can wire it unconditionally.
+func WithFeed(f *feed.Loaded) Option {
+	return func(a *Analyzer) {
+		if f != nil {
+			a.feed = f
+		}
+	}
+}
+
+// NewAnalyzer returns a slop analyzer. With no options it is the reactive
+// SLOP-001 analyzer; WithFeed adds the predictive SLOP-002 dimension.
+func NewAnalyzer(opts ...Option) *Analyzer {
+	a := &Analyzer{}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
 
 // Rules returns the rule set for the slopsquatting analyzer.
 func (a *Analyzer) Rules() *rules.RuleSet {
@@ -45,7 +74,36 @@ func (a *Analyzer) Rules() *rules.RuleSet {
 		},
 		Metadata: map[string]string{"cwe": "CWE-1357"},
 	})
+	rs.Add(&rules.Rule{
+		ID:          "SLOP-002",
+		Version:     "1.0",
+		Description: "Imported package matches a known high-risk slopsquat target from the predictive blocklist feed",
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"dependency", "supply-chain", "slopsquatting", "ai", "predictive", "owasp-asi04", "owasp-llm03"},
+		Remediation: "This source file imports a package name that appears on a predictive slopsquat blocklist: a name an LLM is likely to hallucinate that was verified UNREGISTERED (squattable) when the feed was generated. Either the name is a phantom import (a hallucinated dependency you should remove) or — if the package is now installed — it may be a squat an attacker registered after the feed date. Do not install or run it until you confirm, on the official registry, that the package exists, is the one you intend, and is published by a trusted maintainer. Prefer the real upstream package the name imitates.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/1357.html",
+			"https://genai.owasp.org/llmrisk/llm03-supply-chain/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-1357"},
+	})
 	return rs
+}
+
+// predictiveSeverity maps a feed risk tier to a SLOP-002 finding severity. The
+// mapping is deliberately one notch below the tier's face value: SLOP-002 is a
+// predictive heuristic ("this name is a known squat target"), not proof of
+// compromise, so a critical-tier target is reported High, not Critical.
+func predictiveSeverity(tier string) findings.Severity {
+	switch tier {
+	case feed.TierCritical:
+		return findings.SeverityHigh
+	case feed.TierHigh:
+		return findings.SeverityMedium
+	default: // medium and anything unexpected
+		return findings.SeverityLow
+	}
 }
 
 // manifestBasenames are the dependency manifests slop reads to learn which
@@ -109,6 +167,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 // each undeclared external package (deduplicated per package within the file).
 func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string, content []byte, declared *declaredSet, local map[string]struct{}) {
 	seen := make(map[string]struct{})
+	seenPred := make(map[string]struct{})
 	for _, imp := range extractImports(eco, content) {
 		pkg, ok := packageName(eco, imp.spec)
 		if !ok {
@@ -120,6 +179,16 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 		if _, isLocal := local[pkg]; isLocal && eco == ecoPyPI {
 			continue // first-party Python module
 		}
+
+		// Predictive dimension (additive, opt-in): when a feed is loaded and the
+		// imported name matches a high-risk squattable target, raise a distinct
+		// SLOP-002 finding. This runs BEFORE the declared-manifest check because
+		// a name that is already declared/installed and on the blocklist is the
+		// dangerous "you may have installed the squat" case that SLOP-001, which
+		// only fires on unresolved imports, cannot catch. With no feed loaded
+		// this block is skipped entirely — zero behavior change.
+		a.emitPredictive(fs, eco, path, pkg, imp, seenPred)
+
 		if declaredHas(declared, eco, pkg) {
 			continue
 		}
@@ -140,6 +209,45 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 			},
 		})
 	}
+}
+
+// emitPredictive raises a SLOP-002 finding when a loaded feed classifies pkg as
+// a high-risk slopsquat target. It is a no-op when no feed is loaded, so the
+// analyzer's baseline (SLOP-001) output is identical with or without a feed.
+// Findings are deduplicated per package within a file.
+func (a *Analyzer) emitPredictive(fs *findings.FindingSet, eco ecosystem, path, pkg string, imp importRef, seen map[string]struct{}) {
+	if a.feed == nil {
+		return
+	}
+	entry, ok := a.feed.Lookup(string(eco), pkg)
+	if !ok {
+		return
+	}
+	if _, dup := seen[pkg]; dup {
+		return
+	}
+	seen[pkg] = struct{}{}
+	fs.Add(findings.Finding{
+		RuleID:     "SLOP-002",
+		Severity:   predictiveSeverity(entry.Tier),
+		Confidence: findings.ConfidenceMedium,
+		Location:   findings.Location{FilePath: path, StartLine: imp.line, EndLine: imp.line},
+		Message: "Imported package \"" + pkg + "\" is a known high-risk slopsquat target (" + entry.Tier +
+			" tier): a name an LLM is likely to hallucinate that was verified unregistered on " + entry.VerifiedAt +
+			". Verify it on the official registry before installing or running it.",
+		Metadata: map[string]string{
+			"package":      pkg,
+			"ecosystem":    string(eco),
+			"import":       imp.spec,
+			"tier":         entry.Tier,
+			"pattern":      entry.Pattern,
+			"neighbor_of":  entry.NeighborOf,
+			"verified_at":  entry.VerifiedAt,
+			"feed_version": a.feed.Version(),
+			"feed_digest":  a.feed.Digest(),
+			"cwe":          "CWE-1357",
+		},
+	})
 }
 
 func declaredHas(d *declaredSet, eco ecosystem, pkg string) bool {

--- a/core/analyzers/slop/slop_predictive_test.go
+++ b/core/analyzers/slop/slop_predictive_test.go
@@ -1,0 +1,197 @@
+package slop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// loadedFeed builds an in-memory verified feed with the given entries.
+func loadedFeed(t *testing.T, entries ...feed.Entry) *feed.Loaded {
+	t.Helper()
+	f := &feed.Feed{
+		SchemaVersion: feed.SchemaVersion,
+		Version:       "test",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries:       entries,
+	}
+	f.SetDigest()
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := feed.Parse(data, feed.VerifyOptions{})
+	if err != nil {
+		t.Fatalf("parse test feed: %v", err)
+	}
+	return loaded
+}
+
+func scanWith(t *testing.T, a *Analyzer, files map[string]string) []findings.Finding {
+	t.Helper()
+	arts := writeTree(t, files)
+	fs, err := a.ScanArtifacts(context.Background(), arts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+func ruleIDs(fs []findings.Finding, ruleID string) []findings.Finding {
+	var out []findings.Finding
+	for i := range fs {
+		if fs[i].RuleID == ruleID {
+			out = append(out, fs[i])
+		}
+	}
+	return out
+}
+
+// TestNoFeedBaselineUnchanged proves the default-safe property: with NO feed
+// configured, the analyzer behaves exactly as today — SLOP-001 as before, and
+// no SLOP-002 predictive findings, even for an import that a feed WOULD flag.
+func TestNoFeedBaselineUnchanged(t *testing.T) {
+	files := map[string]string{
+		"requirements.txt": "flask\n",
+		"app.py":           "import flask\nimport openai_utils\n",
+	}
+	base := scanWith(t, NewAnalyzer(), files)
+
+	// SLOP-001 fires for the undeclared import, as it always has.
+	if got := ruleIDs(base, "SLOP-001"); len(got) != 1 || got[0].Metadata["package"] != "openai_utils" {
+		t.Fatalf("expected exactly one SLOP-001 for openai_utils, got %+v", got)
+	}
+	// No predictive findings without a feed.
+	if got := ruleIDs(base, "SLOP-002"); len(got) != 0 {
+		t.Fatalf("expected no SLOP-002 without a feed, got %+v", got)
+	}
+}
+
+// TestFeedMatchEmitsPredictiveFinding: with a feed loaded, an import whose name
+// matches a high-risk entry raises a distinct SLOP-002 predictive finding, and
+// the underlying SLOP-001 baseline finding is untouched.
+func TestFeedMatchEmitsPredictiveFinding(t *testing.T) {
+	fd := loadedFeed(t, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "unregistered high-risk", VerifiedAt: "2026-07-25",
+	})
+	files := map[string]string{
+		"requirements.txt": "flask\n",
+		// PEP 503: `openai_utils` import normalizes to the feed's `openai-utils`.
+		"app.py": "import flask\nimport openai_utils\n",
+	}
+	got := scanWith(t, NewAnalyzer(WithFeed(fd)), files)
+
+	pred := ruleIDs(got, "SLOP-002")
+	if len(pred) != 1 {
+		t.Fatalf("expected one SLOP-002, got %+v", pred)
+	}
+	p := pred[0]
+	if p.Severity != findings.SeverityHigh {
+		t.Errorf("critical-tier target should map to High severity, got %q", p.Severity)
+	}
+	if p.Metadata["tier"] != "critical" || p.Metadata["package"] != "openai_utils" {
+		t.Errorf("predictive metadata missing/wrong: %+v", p.Metadata)
+	}
+	if p.Metadata["feed_version"] != "test" {
+		t.Errorf("expected feed_version metadata, got %+v", p.Metadata)
+	}
+	// The baseline SLOP-001 finding is still present and unchanged.
+	if base := ruleIDs(got, "SLOP-001"); len(base) != 1 || base[0].Severity != findings.SeverityMedium {
+		t.Errorf("SLOP-001 baseline changed: %+v", base)
+	}
+}
+
+// TestPredictiveFiresOnDeclaredPackage: the dangerous middle case. A developer
+// has DECLARED (installed) a name that the feed knows is a squattable target.
+// SLOP-001 stays silent (the import resolves to a manifest entry), but the
+// predictive rule must still warn — they may have installed the squat.
+func TestPredictiveFiresOnDeclaredPackage(t *testing.T) {
+	fd := loadedFeed(t, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "unregistered high-risk", VerifiedAt: "2026-07-25",
+	})
+	files := map[string]string{
+		"requirements.txt": "openai-utils\n",
+		"app.py":           "import openai_utils\n",
+	}
+	got := scanWith(t, NewAnalyzer(WithFeed(fd)), files)
+
+	if base := ruleIDs(got, "SLOP-001"); len(base) != 0 {
+		t.Fatalf("SLOP-001 must stay silent for a declared package, got %+v", base)
+	}
+	if pred := ruleIDs(got, "SLOP-002"); len(pred) != 1 {
+		t.Fatalf("SLOP-002 must fire for a declared squat target, got %+v", pred)
+	}
+}
+
+// TestPredictiveNoMatchNoFinding: an ordinary hallucinated import not in the
+// feed gets only the baseline SLOP-001, never a predictive finding.
+func TestPredictiveNoMatchNoFinding(t *testing.T) {
+	fd := loadedFeed(t, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	files := map[string]string{"app.py": "import some_random_phantom_pkg\n"}
+	got := scanWith(t, NewAnalyzer(WithFeed(fd)), files)
+	if pred := ruleIDs(got, "SLOP-002"); len(pred) != 0 {
+		t.Fatalf("expected no SLOP-002 for a non-feed name, got %+v", pred)
+	}
+	if base := ruleIDs(got, "SLOP-001"); len(base) != 1 {
+		t.Fatalf("expected SLOP-001 for the phantom import, got %+v", base)
+	}
+}
+
+// TestPredictiveSeverityByTier checks the tier->severity mapping.
+func TestPredictiveSeverityByTier(t *testing.T) {
+	cases := []struct {
+		tier string
+		want findings.Severity
+	}{
+		{"critical", findings.SeverityHigh},
+		{"high", findings.SeverityMedium},
+		{"medium", findings.SeverityLow},
+	}
+	for _, tc := range cases {
+		fd := loadedFeed(t, feed.Entry{
+			Name: "ghostpkg", Ecosystem: "pypi", Pattern: "typo",
+			Risk: 0.7, Tier: tc.tier, Reason: "x", VerifiedAt: "2026-07-25",
+		})
+		got := scanWith(t, NewAnalyzer(WithFeed(fd)), map[string]string{"a.py": "import ghostpkg\n"})
+		pred := ruleIDs(got, "SLOP-002")
+		if len(pred) != 1 || pred[0].Severity != tc.want {
+			t.Errorf("tier %s: expected severity %s, got %+v", tc.tier, tc.want, pred)
+		}
+	}
+}
+
+// TestPredictiveDedupPerFile: multiple imports of the same feed name in one
+// file yield a single predictive finding.
+func TestPredictiveDedupPerFile(t *testing.T) {
+	fd := loadedFeed(t, feed.Entry{
+		Name: "ghostpkg", Ecosystem: "pypi", Pattern: "typo",
+		Risk: 0.7, Tier: "high", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	files := map[string]string{"a.py": "import ghostpkg\nimport ghostpkg\nfrom ghostpkg import x\n"}
+	got := scanWith(t, NewAnalyzer(WithFeed(fd)), files)
+	if pred := ruleIDs(got, "SLOP-002"); len(pred) != 1 {
+		t.Fatalf("expected one deduplicated SLOP-002, got %d", len(pred))
+	}
+}
+
+// TestRuleSetIncludesPredictive ensures SLOP-002 is registered in the rule set.
+func TestRuleSetIncludesPredictive(t *testing.T) {
+	var found bool
+	for _, r := range NewAnalyzer().Rules().Rules() {
+		if r.ID == "SLOP-002" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("SLOP-002 must be registered in the rule set")
+	}
+}

--- a/core/catalog/catalog_test.go
+++ b/core/catalog/catalog_test.go
@@ -10,7 +10,7 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	cat := Catalog()
 
 	// We expect 1553 built-in rules across all analyzers (SEC + DATA + AI
-	// + IAC + VULN + SLOP-001 slopsquatting + VARIANT-001..006 CVE variants
+	// + IAC + VULN + SLOP-001/002 slopsquatting + VARIANT-001..006 CVE variants
 	// + PROV-001/002 provenance). AI includes AI-PI-* (LLM01),
 	// AI-EMBED-* (LLM06), MCP-* families: MCP-001..008 (server
 	// hardening), MCP-009..014 (tool poisoning, OWASP MCP03),
@@ -27,8 +27,10 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	// deleted (SEC-356..SEC-370 and SEC-430..SEC-433): they fired on
 	// password-less URLs, and the credential-aware DSN rules SEC-073/074/076
 	// already cover connection strings carrying userinfo credentials.
-	if got := len(cat); got != 1528 {
-		t.Errorf("Catalog() returned %d rules, want 1528", got)
+	// 1529 = 1528 plus SLOP-002 (predictive slopsquat-target match, emitted by
+	// the slop analyzer when a verified blocklist feed is loaded).
+	if got := len(cat); got != 1529 {
+		t.Errorf("Catalog() returned %d rules, want 1529", got)
 	}
 }
 

--- a/core/config.go
+++ b/core/config.go
@@ -127,6 +127,7 @@ type ScanSettings struct {
 	AnalyzerRules        []AnalyzerRuleConfig    `yaml:"analyzer_rules"`
 	ConditionalSeverity  []ConditionalSeverity   `yaml:"conditional_severity"`
 	OSV                  OSVConfig               `yaml:"osv"`
+	Slop                 SlopConfig              `yaml:"slop"`
 	Entropy              EntropyConfig           `yaml:"entropy"`
 	GeneratedPaths       GeneratedPathsConfig    `yaml:"generated_paths"`
 	SAST                 SASTConfig              `yaml:"sast"`
@@ -364,6 +365,31 @@ type EntropyConfig struct {
 // OSVConfig controls OSV.dev vulnerability enrichment for dependency scanning.
 type OSVConfig struct {
 	Disabled bool `yaml:"disabled"`
+}
+
+// SlopConfig enables the SLOP analyzer's predictive slopsquat dimension
+// (SLOP-002). It is off by default: with no Feed configured the analyzer keeps
+// exactly its reactive SLOP-001 behavior and adds no findings. The feed is a
+// versioned, content-addressed, offline data file — no network is touched at
+// scan time (only the out-of-band generator queries registries). See
+// docs/slopsquat-feed.md.
+type SlopConfig struct {
+	// Feed selects the predictive blocklist. Empty (default) disables the
+	// predictive dimension entirely. The special value "bundled" uses the feed
+	// shipped in the nox binary; any other value is a path to a feed JSON file
+	// (relative to the scan root or absolute).
+	Feed string `yaml:"feed"`
+	// RequireSignature, when true, rejects a feed that is unsigned or whose
+	// signature does not verify — the predictive dimension then stays off rather
+	// than trusting an unverified feed. Digest integrity is always enforced
+	// regardless of this setting. Verifying a signature requires a configured
+	// public key (SignatureKeyPath); without one, a required signature fails
+	// closed.
+	RequireSignature bool `yaml:"require_signature"`
+	// SignatureKeyPath points at a PEM-encoded Ed25519 public key used to verify
+	// the feed signature. Optional; when set, a present signature is verified
+	// against it (and a bad signature is always a hard failure).
+	SignatureKeyPath string `yaml:"signature_key_path"`
 }
 
 // RulesConfig allows disabling rules or overriding their severity.

--- a/core/degrade/degrade.go
+++ b/core/degrade/degrade.go
@@ -36,6 +36,14 @@ const (
 	// suppression comments, so its findings are reported unsuppressed.
 	Suppression Kind = "suppression"
 
+	// SlopFeed means a predictive slopsquat blocklist feed was configured but
+	// could not be loaded or verified (missing, malformed, digest mismatch, or a
+	// required signature that did not verify). The scan continues with the
+	// predictive SLOP-002 dimension disabled — failing closed rather than
+	// trusting an unverified feed — so its absence of predictive findings must
+	// not be read as "no high-risk slopsquat targets present".
+	SlopFeed Kind = "slop_feed"
+
 	// MCP means a file that structurally looks like an MCP client config
 	// (named mcp.json or containing an mcpServers object) could not be parsed,
 	// or an MCP pin store existed but could not be read. Either way an MCP

--- a/core/scan.go
+++ b/core/scan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/provenance"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
 	"github.com/nox-hq/nox/core/analyzers/slop"
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
 	"github.com/nox-hq/nox/core/analyzers/taintflow"
 	"github.com/nox-hq/nox/core/analyzers/variants"
 	"github.com/nox-hq/nox/core/analyzers/weakcrypto"
@@ -248,7 +249,22 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		}))
 	}
 	depsAnalyzer := deps.NewAnalyzer(depsOpts...)
-	slopAnalyzer := slop.NewAnalyzer()
+	// The SLOP analyzer gains a predictive dimension only when a feed is
+	// configured (default: off, exact reactive behavior preserved). Loading is
+	// offline: a file read plus digest/signature verification, no network. A
+	// misconfigured or tampered feed fails closed — the predictive dimension
+	// stays off and the failure is recorded as a visible degradation.
+	var slopOpts []slop.Option
+	if fp := cfg.Scan.Slop.Feed; fp != "" {
+		if loaded, ferr := loadSlopFeed(target, cfg.Scan.Slop); ferr != nil {
+			degradations.Add(degrade.SlopFeed,
+				fmt.Sprintf("predictive slopsquat feed %q could not be loaded: %v", fp, ferr),
+				"the SLOP-002 predictive dimension is disabled; high-risk slopsquat targets are not being flagged from the feed")
+		} else {
+			slopOpts = append(slopOpts, slop.WithFeed(loaded))
+		}
+	}
+	slopAnalyzer := slop.NewAnalyzer(slopOpts...)
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
 	// A signature database that fails to parse leaves every VARIANT-* rule
@@ -562,6 +578,59 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		Degradations: degradations.Items(),
 		SASTProfile:  cfg.Scan.SAST.ResolvedProfile(),
 	}, nil
+}
+
+// loadSlopFeed resolves and verifies the predictive slopsquat feed named in the
+// config. The special value "bundled" loads the feed embedded in the binary;
+// any other value is a file path resolved relative to the scan root (unless
+// absolute). Verification is offline and fails closed: a digest mismatch,
+// decode error, or an unmet signature requirement returns an error and the
+// caller disables the predictive dimension rather than trusting the feed.
+func loadSlopFeed(target string, cfg SlopConfig) (*feed.Loaded, error) {
+	opts := feed.VerifyOptions{RequireSignature: cfg.RequireSignature}
+	if cfg.SignatureKeyPath != "" {
+		keyPath := cfg.SignatureKeyPath
+		if !filepath.IsAbs(keyPath) {
+			keyPath = filepath.Join(scanRootDir(target), keyPath)
+		}
+		pem, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading signature key %s: %w", keyPath, err)
+		}
+		verifier, err := feed.PEMEd25519Verifier(pem)
+		if err != nil {
+			return nil, fmt.Errorf("parsing signature key: %w", err)
+		}
+		opts.Verifier = verifier
+	}
+
+	if cfg.Feed == "bundled" {
+		loaded, err := feed.Bundled()
+		if err != nil {
+			return nil, err
+		}
+		// A signature requirement cannot be met by the unsigned bundled feed;
+		// surface that clearly rather than silently ignoring the requirement.
+		if cfg.RequireSignature {
+			return nil, fmt.Errorf("the bundled feed is unsigned but require_signature is set")
+		}
+		return loaded, nil
+	}
+
+	path := cfg.Feed
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(scanRootDir(target), path)
+	}
+	return feed.Load(path, opts)
+}
+
+// scanRootDir returns the directory a relative config path is resolved against:
+// the target itself when it is a directory, or its parent when it is a file.
+func scanRootDir(target string) string {
+	if info, err := os.Stat(target); err == nil && !info.IsDir() {
+		return filepath.Dir(target)
+	}
+	return target
 }
 
 // discoverArtifacts walks the target, honoring .gitignore and config excludes,

--- a/core/scan_slop_feed_test.go
+++ b/core/scan_slop_feed_test.go
@@ -1,0 +1,193 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// writeProject writes files under a temp dir and returns the root.
+func writeProject(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		abs := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func countRule(res *ScanResult, ruleID string) int {
+	if res.Findings == nil {
+		return 0
+	}
+	n := 0
+	for _, f := range res.Findings.Findings() {
+		if f.RuleID == ruleID {
+			n++
+		}
+	}
+	return n
+}
+
+func writeFeedFile(t *testing.T, dir, name string, entries ...feed.Entry) string {
+	t.Helper()
+	f := &feed.Feed{
+		SchemaVersion: feed.SchemaVersion,
+		Version:       "test-2026.07.25",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries:       entries,
+	}
+	f.SetDigest()
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestScanDefaultSafeNoFeed proves that, with no slop.feed configured, the scan
+// produces the exact same SLOP findings as before this feature existed: SLOP-001
+// as usual and zero SLOP-002.
+func TestScanDefaultSafeNoFeed(t *testing.T) {
+	root := writeProject(t, map[string]string{
+		"requirements.txt": "flask\n",
+		"app.py":           "import flask\nimport openai_utils\n",
+	})
+	res, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := countRule(res, "SLOP-001"); got != 1 {
+		t.Fatalf("expected 1 SLOP-001, got %d", got)
+	}
+	if got := countRule(res, "SLOP-002"); got != 0 {
+		t.Fatalf("expected 0 SLOP-002 without a feed, got %d", got)
+	}
+}
+
+// TestScanWithFeedAddsPredictiveOnly proves the feature is additive: enabling a
+// feed adds SLOP-002 findings without changing the SLOP-001 baseline.
+func TestScanWithFeedAddsPredictiveOnly(t *testing.T) {
+	root := writeProject(t, map[string]string{
+		"requirements.txt": "flask\n",
+		"app.py":           "import flask\nimport openai_utils\n",
+	})
+	// Baseline (no feed).
+	baseRes, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseSlop001 := countRule(baseRes, "SLOP-001")
+
+	// Configure a feed that flags openai-utils, then re-scan.
+	writeFeedFile(t, root, "slopfeed.json", feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "unregistered high-risk", VerifiedAt: "2026-07-25",
+	})
+	if err := os.WriteFile(filepath.Join(root, ".nox.yaml"),
+		[]byte("scan:\n  slop:\n    feed: slopfeed.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	feedRes, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countRule(feedRes, "SLOP-001"); got != baseSlop001 {
+		t.Fatalf("SLOP-001 baseline changed with feed on: was %d, now %d", baseSlop001, got)
+	}
+	if got := countRule(feedRes, "SLOP-002"); got != 1 {
+		t.Fatalf("expected 1 SLOP-002 with feed on, got %d", got)
+	}
+	for _, f := range feedRes.Findings.Findings() {
+		if f.RuleID == "SLOP-002" && f.Severity != findings.SeverityHigh {
+			t.Errorf("critical-tier predictive finding should be High severity, got %q", f.Severity)
+		}
+	}
+}
+
+// TestScanTamperedFeedFailsClosed proves a tampered feed disables the predictive
+// dimension (no SLOP-002) and records a degradation, without crashing the scan
+// or altering the SLOP-001 baseline.
+func TestScanTamperedFeedFailsClosed(t *testing.T) {
+	root := writeProject(t, map[string]string{
+		"app.py": "import openai_utils\n",
+	})
+	path := writeFeedFile(t, root, "slopfeed.json", feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	// Tamper: flip a byte in an entry so the digest no longer matches.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["entries"].([]any)[0].(map[string]any)["name"] = "evil-swapped-name"
+	tampered, _ := json.Marshal(m)
+	if err := os.WriteFile(path, tampered, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".nox.yaml"),
+		[]byte("scan:\n  slop:\n    feed: slopfeed.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan must not fail on a bad feed: %v", err)
+	}
+	if got := countRule(res, "SLOP-002"); got != 0 {
+		t.Fatalf("tampered feed must yield no SLOP-002, got %d", got)
+	}
+	// The SLOP-001 baseline is unaffected.
+	if got := countRule(res, "SLOP-001"); got != 1 {
+		t.Fatalf("expected SLOP-001 baseline intact, got %d", got)
+	}
+	// A degradation must be visible so the missing predictive coverage is not
+	// mistaken for "nothing high-risk found".
+	var found bool
+	for _, d := range res.Degradations {
+		if d.Kind == "slop_feed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a slop_feed degradation to be recorded, got %+v", res.Degradations)
+	}
+}
+
+// TestScanBundledFeedLoads proves the bundled feed wires end to end.
+func TestScanBundledFeedLoads(t *testing.T) {
+	root := writeProject(t, map[string]string{
+		"app.py":    "import openai_utils\n",
+		".nox.yaml": "scan:\n  slop:\n    feed: bundled\n",
+	})
+	res, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// openai-utils is in the bundled feed, so it must flag predictively.
+	if got := countRule(res, "SLOP-002"); got < 1 {
+		t.Fatalf("expected the bundled feed to flag openai_utils, got %d SLOP-002", got)
+	}
+}

--- a/docs/slopsquat-feed.md
+++ b/docs/slopsquat-feed.md
@@ -1,0 +1,188 @@
+# Predictive slopsquat feed (SLOP-002)
+
+Nox's `SLOP-001` rule is **reactive**: it flags an import at scan time when the
+imported package appears in no manifest, no standard library, and no local
+module — a name your code depends on that resolves to nothing you brought in.
+That catches a hallucinated dependency *after* an LLM has already written it
+into your code.
+
+The **predictive slopsquat feed** adds a second, forward-looking dimension
+(`SLOP-002`). A feed is a versioned, content-addressed list of package names
+that an LLM is *likely to hallucinate* and that were verified **unregistered
+(squattable)** when the feed was generated. When an imported name matches a
+high-risk feed entry, `SLOP-002` fires — even if the name is already declared in
+a manifest, which is the dangerous "you may have installed the squat" case that
+`SLOP-001` cannot see.
+
+This mirrors the pattern proven by nox's OSV integration: **intelligence
+accumulates centrally as a versioned data feed; every device enforces it
+deterministically and offline.** The difference is that the network is removed
+from scan time entirely — only the out-of-band generator touches a registry; the
+scanner consumes a frozen artifact.
+
+## Default-safe
+
+The predictive dimension is **opt-in and off by default**. With no feed
+configured, the SLOP analyzer behaves exactly as it always has: `SLOP-001` only,
+no `SLOP-002`, identical findings, identical grade. Enabling a feed is purely
+*additive* — it never changes the `SLOP-001` baseline.
+
+## Enabling it
+
+In `.nox.yaml`:
+
+```yaml
+scan:
+  slop:
+    # "bundled" uses the feed shipped inside the nox binary. Any other value is
+    # a path to a feed JSON file (relative to the scan root, or absolute).
+    feed: bundled
+
+    # Optional signature enforcement (see "Trust model"). Digest integrity is
+    # always enforced regardless of these.
+    require_signature: false          # reject an unsigned / bad-signature feed
+    signature_key_path: keys/slopsquat.pub.pem  # PEM Ed25519 public key
+```
+
+To point at your own regenerated feed instead of the bundled one:
+
+```yaml
+scan:
+  slop:
+    feed: security/slopsquat-blocklist.v1.json
+```
+
+## What `SLOP-002` reports
+
+For an imported name that matches a feed entry, `SLOP-002` emits a finding whose
+severity is derived from the entry's risk tier (deliberately one notch below the
+tier's face value — it is a predictive heuristic, not proof of compromise):
+
+| feed tier  | `SLOP-002` severity | confidence |
+|------------|---------------------|------------|
+| `critical` | High                | Medium     |
+| `high`     | Medium              | Medium     |
+| `medium`   | Low                 | Medium     |
+
+The finding carries the feed provenance in its metadata: `tier`, `pattern`,
+`neighbor_of`, `verified_at`, `feed_version`, and `feed_digest`, so every
+predictive finding is traceable back to the exact feed that produced it.
+
+## Feed format
+
+A feed is a single JSON document (schema `slopsquat-blocklist/v1`):
+
+```json
+{
+  "schema_version": "slopsquat-blocklist/v1",
+  "version": "2026.07.25",
+  "generated_at": "2026-07-25T10:30:22Z",
+  "source": "cmd/slopfeed",
+  "digest": "sha256:f9ae0d9a…",
+  "signature": {                      // optional
+    "algorithm": "ed25519",
+    "key_id": "…",
+    "value": "base64(sig)"
+  },
+  "entries": [
+    {
+      "name": "openai-utils",
+      "ecosystem": "pypi",            // "pypi" | "npm"
+      "pattern": "obvious",           // obvious | composition | typo
+      "risk": 0.82,
+      "tier": "critical",             // critical | high | medium
+      "reason": "UNREGISTERED (404 confirmed twice on 2026-07-25) …",
+      "verified_at": "2026-07-25"
+    }
+  ]
+}
+```
+
+The only claim an entry makes is the narrow, defensible one: *this name was
+unregistered (verified on `verified_at`) and is one an LLM is likely to emit, so
+an attacker could register it to catch hallucinated installs.* A feed never
+contains a registered package — see "No false accusations" below.
+
+## Trust model
+
+The format mirrors the plugin registry's trust model (`registry/trust`):
+
+- **Content digest.** Every feed carries `digest: "sha256:<hex>"` computed over a
+  canonical (sorted, fixed-field-order) serialization of its entries. On load,
+  nox recomputes the digest and **rejects any feed whose bytes do not match.**
+  This catches truncation, tampering, and corruption.
+- **Fails closed.** A feed that does not decode, whose schema is unknown, whose
+  digest mismatches, or whose required signature does not verify is **rejected**:
+  the predictive dimension stays off, the scan continues, and a visible
+  *degradation* (`slop_feed`) is recorded so the missing coverage is never
+  mistaken for "nothing high-risk found". A malformed feed never crashes the
+  scan.
+- **Signature (optional).** The format reserves an Ed25519 signature over the
+  same canonical bytes, so a feed can be Sigstore/cosign-signed exactly like a
+  plugin artifact. Verification is a pluggable hook; set `require_signature:
+  true` with a `signature_key_path` to enforce it. A present-but-invalid
+  signature is always a hard failure, even when `require_signature` is false.
+
+Only this repository ships a real feed today; **standing up a signed CDN
+distribution channel is org infrastructure and is intentionally deferred** (see
+"Deferred"). The consumer already has the verification seam.
+
+## Regenerating the feed
+
+The feed is produced by `cmd/slopfeed`, the maintained port of the research
+prototype. It models how LLMs hallucinate names, generates the candidates, and
+checks public registries **read-only, rate-limited, re-verifying every 404**:
+
+```bash
+# Live regeneration (writes the bundled feed). Good-citizen defaults: a
+# descriptive User-Agent, a 300–400ms delay between requests, exponential
+# backoff on 429/5xx, and a stratified request budget.
+go run ./cmd/slopfeed \
+  --out core/analyzers/slop/feed/data/slopsquat-blocklist.v1.json \
+  --limit 150 --sleep 350ms --version "$(date -u +%Y.%m.%d)"
+
+# Candidate model only, no network (inspect what would be checked):
+go run ./cmd/slopfeed --dry-run
+```
+
+The generator writes the digest automatically. Re-run periodically: registries
+change, and a name unregistered today can be claimed tomorrow (by a defender
+*or* an attacker), so each entry is stamped with the `verified_at` date it was
+confirmed unregistered.
+
+### No false accusations
+
+The generator asserts exactly one thing — "**unregistered + high-likelihood =
+squattable**" — and it verifies the "unregistered" half before writing it:
+
+- A `404` is **re-queried a second time**; only a name that returns `404`
+  **twice** is written (registries are eventually consistent, so one `404` is not
+  proof). A `404`-then-`200` is treated as registered.
+- A **registered** name (HTTP `200`) is **never** written to the feed and never
+  accused of anything. The generator only ever proposes names that are *not*
+  known-real packages, and drops any candidate that collides with a real seed.
+
+## Responsible disclosure / dual-use
+
+A predictive blocklist is, by construction, also an attacker's shopping list:
+the entries are unregistered names an attacker could claim. The constructive use
+is **defensive registration** — the same move security teams already use for
+high-value typosquats. The names in a feed could be pre-registered (by the
+ecosystems, by the maintainers of the neighbouring real packages, or via a
+coordinated placeholder) to deny them to attackers.
+
+Treat a freshly generated feed as sensitive: share it through responsible
+channels with that defensive framing rather than publishing a raw list. The
+bundled feed in this repo is a small, curated set already verified unregistered;
+it exists so the feature works out of the box and has something to test against.
+
+## Deferred (org infrastructure)
+
+- **Signed CDN distribution.** Real Sigstore/cosign signing of feeds and a
+  hosted, mirrored distribution channel (à la the plugin registry) is
+  organization infrastructure. The format carries a digest and a signature seam
+  today; the pipeline that signs and serves feeds is out of scope for this
+  change.
+- **Live LLM emission priors.** The candidate priors model the generator from
+  documented hallucination modes. Real LLM logprobs / emission frequencies would
+  sharpen them and are the obvious next step.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -720,6 +720,31 @@ scan:
 
 This is useful for reducing noise from dependencies in `node_modules/` or test fixtures.
 
+### Predictive Slopsquat Feed (SLOP-002)
+
+The SLOP analyzer can consume a versioned, offline **predictive slopsquat
+blocklist** — a signed, content-addressed list of package names an LLM is likely
+to hallucinate that were verified *unregistered (squattable)* when the feed was
+generated. When an imported name matches a high-risk entry, `SLOP-002` fires with
+a severity derived from the entry's risk tier.
+
+It is **opt-in and off by default**: with no feed configured the analyzer's
+`SLOP-001` behavior is unchanged. Enabling a feed is purely additive.
+
+```yaml
+scan:
+  slop:
+    feed: bundled                 # ship-in-binary feed; or a path to a feed JSON
+    require_signature: false      # reject unsigned/bad-signature feeds
+    signature_key_path: keys/slopsquat.pub.pem   # PEM Ed25519 public key
+```
+
+No network is touched at scan time — only the out-of-band generator
+(`cmd/slopfeed`) queries registries. A malformed, tampered, or digest-mismatched
+feed fails closed (predictive dimension off, a visible `slop_feed` degradation
+recorded). See [docs/slopsquat-feed.md](slopsquat-feed.md) for the feed format,
+trust model, regeneration, and the responsible-disclosure note.
+
 ### Conditional Severity
 
 Override severity based on rule patterns and paths:


### PR DESCRIPTION
## Summary

Makes **Loop 2 — a learning feed — production-ready**, using the slopsquatting predictor as the concrete first feed. Intelligence accumulates centrally as a **signed, versioned, content-addressed data feed**; every device enforces it **deterministically and offline** — the same pattern proven by nox's OSV integration, but with the network removed from scan time entirely.

`SLOP-001` stays reactive (flags an import that resolves to nothing you declared). This adds a **predictive** dimension, `SLOP-002`: when an imported name matches a high-risk entry in a loaded feed — a name an LLM is likely to hallucinate that was verified *unregistered (squattable)* — it raises a distinct finding, even when the name is already declared (the "you may have installed the squat" case `SLOP-001` cannot see).

## Default-safe (the hard requirement)

The predictive dimension is **opt-in and off by default**. With no feed configured, the analyzer behaves exactly as today: `SLOP-001` only, zero `SLOP-002`, identical baseline, identical grade. Enabling a feed is purely **additive** — it never alters the `SLOP-001` baseline. Proven by `TestScanDefaultSafeNoFeed` and `TestScanWithFeedAddsPredictiveOnly` (SLOP-001 count identical feed-on vs feed-off).

Self-scan stays **grade A** (the bundled feed is off in nox's own `.nox.yaml`, and nox is a Go repo the SLOP analyzer's Python/JS scope never touches).

## What's here

- **Feed format** (`core/analyzers/slop/feed`) — schema `slopsquat-blocklist/v1`: per-ecosystem entries (name, pattern, tier, reason, `verified_at`) + metadata + a `sha256:` content digest over canonical entries + an optional Ed25519 signature seam. Loading **fails closed**: bad schema, digest mismatch, or an unmet signature requirement is rejected and never crashes the scan. Trust model mirrors `registry/trust`.
- **Consumer** (`SLOP-002`) — severity mapped from tier (critical→High, high→Medium, medium→Low), feed provenance in metadata.
- **Config** (`.nox.yaml` `scan.slop`): `feed` (path or `bundled`), `require_signature`, `signature_key_path`. A tampered/misconfigured feed disables the dimension and records a visible `slop_feed` degradation.
- **Generator** (`cmd/slopfeed`) — maintained Go port of the research prototype. Models LLM hallucination patterns, checks registries read-only (polite User-Agent, rate-limit, exponential backoff), **re-verifies every 404 twice**, and writes only unregistered high-likelihood names — **never accusing a registered package**.
- **Bundled feed** — 62 names re-verified **unregistered on 2026-07-25** (e.g. `openai-utils`, `anthropic-async`, `axios-retry-async`, `numpys`), so the feature works out of the box.
- **Docs** — `docs/slopsquat-feed.md` (format, trust model, regeneration, responsible-disclosure note) + `usage.md` pointer.

## Tests (red→green)

Feed round-trip + digest verify; tampered/malformed rejection (fail closed, no panic); signature hook (valid/wrong-key/required-but-absent). `SLOP-002` fires on feed match, silent with no feed. Scan-level: default-safe, additive-only, tampered-fails-closed, bundled-loads. Generator: determinism, never-emits-real-seed, checker re-verification, never-accuse-registered.

`go build ./...`, `go test ./...`, `golangci-lint run` all green.

## Deferred (org infrastructure)

Real Sigstore/cosign **signed CDN distribution** of feeds (à la the plugin registry) is org infra — the format carries a digest and a signature verification seam today, but the sign-and-serve pipeline is out of scope. Live-LLM emission priors would sharpen the generator and are the obvious next step.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj