### PR TITLE
feat(metamorphic): corpus-wide rule-bug oracle (sweep + scheduled audit)

### DIFF
--- a/.github/workflows/metamorphic-audit.yml
+++ b/.github/workflows/metamorphic-audit.yml
@@ -1,0 +1,92 @@
+name: Metamorphic corpus audit
+
+# Scheduled, corpus-wide companion to the per-PR metamorphic gate
+# (.github/workflows/metamorphic.yml).
+#
+# The per-PR gate asks "does THIS change break the metamorphic relation on the
+# PR's own testdata?". This audit is the standing oracle: once a week it runs the
+# metamorphic invariance check across the whole curated corpus
+# (testdata/metamorphic-corpus/), hunting the NEXT rule bug and ranking
+# suspicious rules. It uploads a triage report every run and fails / files an
+# issue only on a NEW (un-baselined) verified violation — pre-existing defects
+# recorded in scripts/metamorphic/known_issues.json do not re-alert.
+#
+# Deterministic: sorted seeds, fixed mutation order, no randomness, no wall-clock
+# in the report, nox run with --offline. The positive-control self-test proves
+# the sweep can go red before we trust a green run.
+
+on:
+  schedule:
+    # Mondays 07:17 UTC. Off the hour to avoid the top-of-hour scheduler surge.
+    - cron: "17 7 * * 1"
+  workflow_dispatch: # nox:ignore IAC-308 -- on-demand re-run of the corpus audit after a rule change
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Corpus-wide metamorphic sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build nox
+        run: make build
+
+      - name: Positive-control self-test
+        # A gate that cannot go red is worthless. This proves the harness AND the
+        # sweep flag a real finding-removing edit, ignore pure line shifts, rank
+        # a planted violation high-risk, and honour the known-issues baseline.
+        run: python3 scripts/metamorphic/selftest.py --bin ./nox
+
+      - name: Corpus-wide metamorphic sweep
+        id: sweep
+        # Exits non-zero only on a NEW verified violation. Capture the code so the
+        # triage report is still uploaded and an issue can be filed.
+        run: |
+          set +e
+          python3 scripts/metamorphic/sweep.py --bin ./nox --results sweep-out
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload triage report
+        # Always keep the report + repros, green or red, as the maintainer's
+        # worklist and an audit trail.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 # nox:ignore IAC-153 -- CI diagnostic triage bundle, not a released binary; release artifacts are signed and attested in release.yml
+        with:
+          name: metamorphic-triage
+          path: sweep-out/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: File issue on new verified violation
+        if: steps.sweep.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="Metamorphic sweep: new rule-robustness violation"
+          existing="$(gh issue list --state open --search "$title in:title" \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file sweep-out/triage_summary.md
+          else
+            gh issue create --title "$title" --body-file sweep-out/triage_summary.md
+          fi
+
+      - name: Fail on new verified violation
+        if: steps.sweep.outputs.exit_code != '0'
+        run: |
+          echo "New (un-baselined) metamorphic violation(s) found. See the" >&2
+          echo "metamorphic-triage artifact and the filed issue." >&2
+          exit 1

--- a/.nox.yaml
+++ b/.nox.yaml
@@ -14,6 +14,11 @@ scan:
     - "core/analyzers/deps/testdata/lockfiles/"
     - "testdata/precision-corpus/"
     - "testdata/precision-suite/"
+    # Intentionally finding-bearing inputs for the metamorphic corpus oracle
+    # (scripts/metamorphic/sweep.py). Same rationale as the precision corpora:
+    # the sweep scans them explicitly in isolated temp dirs; the self-scan must
+    # not flag them. See scripts/metamorphic/README.md.
+    - "testdata/metamorphic-corpus/"
     - "testdata/precision-suite-php/"
     - "testdata/precision-suite-java/"
     - "testdata/precision-suite-ruby/"

--- a/scripts/metamorphic/.gitignore
+++ b/scripts/metamorphic/.gitignore
@@ -1,2 +1,7 @@
 __pycache__/
 *.pyc
+# Local sweep / harness output (reports + repros). CI uploads these as
+# artifacts; they are never committed.
+.sweep-out/
+.harness-out/
+metamorphic-out/

--- a/scripts/metamorphic/README.md
+++ b/scripts/metamorphic/README.md
@@ -1,4 +1,4 @@
-# Metamorphic rule-robustness gate
+# Metamorphic rule-robustness tooling
 
 CI tooling that finds bugs in nox's own detection rules by enforcing a
 **metamorphic relation**:
@@ -9,21 +9,41 @@ CI tooling that finds bugs in nox's own detection rules by enforcing a
 
 This is the same technique that found three nox rule bugs by hand (a blank
 line before a Dockerfile `COPY` → false positive; a comment mentioning
-`HEALTHCHECK` → false negative). The harness automates and scales it, and runs
-as a `pull_request` gate (`.github/workflows/metamorphic.yml`).
+`HEALTHCHECK` → false negative).
+
+There are **two modes**, sharing one engine:
+
+| | Per-PR gate | Corpus audit (oracle) |
+|---|---|---|
+| Script | `harness.py` | `sweep.py` |
+| Workflow | `.github/workflows/metamorphic.yml` (`pull_request`) | `.github/workflows/metamorphic-audit.yml` (`schedule` weekly + `workflow_dispatch`) |
+| Inputs | the PR's own testdata (`testdata/precision-suite/`) + synthetic seeds (`seeds/`) | the curated `testdata/metamorphic-corpus/` |
+| Question | "does *this change* break the relation?" | "what is the *next* rule bug across many samples?" |
+| Output | `invariance_report.json` + repros | `triage_report.json` + `triage_summary.md` + repros |
+| Extras | — | per-rule coverage, suspicious-rule ranking, known-issues baseline |
+| Fails on | any verified violation | any *new* (un-baselined) verified violation |
+
+The gate keeps a change from regressing what the PR touches; the audit is the
+standing oracle that hunts new bugs corpus-wide and ranks fragile rules.
 
 ## Run it locally
 
 ```bash
-make build                                        # produces ./nox
-python3 scripts/metamorphic/selftest.py --bin ./nox   # positive controls (must pass)
-python3 scripts/metamorphic/harness.py --bin ./nox    # the sweep (exit non-zero on any violation)
+make build                                             # produces ./nox
+python3 scripts/metamorphic/selftest.py --bin ./nox    # positive controls (must pass)
+python3 scripts/metamorphic/harness.py --bin ./nox     # per-PR gate (exit non-zero on any violation)
+python3 scripts/metamorphic/sweep.py   --bin ./nox --results out   # corpus audit
 ```
 
 `harness.py` flags: `--bin <nox>` (default repo `./nox`), `--seeds <dir>`
 (repeatable; default = precision corpus + committed synthetic seeds),
 `--results <dir>` (report + repros; default a temp dir), `--limit N` (first N
 seed files, for a quick run).
+
+`sweep.py` flags: `--bin`, `--seeds` (default `testdata/metamorphic-corpus/`),
+`--results`, `--limit`, `--known-issues <json>` (default
+`known_issues.json`), and `--no-known-issues` (report every verified violation
+as new — use to confirm a baselined bug still reproduces).
 
 ## What it does (pipeline)
 
@@ -46,6 +66,55 @@ seed files, for a quick run).
 6. **Report** — writes `invariance_report.json` plus, for each survivor, a
    `repros/<id>/` directory with `before/`, `after/`, and `REPRO.md`; **exits
    non-zero** if any survive.
+
+## The corpus audit (`sweep.py`) — the production oracle
+
+`sweep.py` reuses the whole engine above (mutations, equivalence, adversarial
+re-verify, ddmin) and runs it across `testdata/metamorphic-corpus/` — a curated,
+diverse set of Dockerfiles, GitHub workflows, Terraform, and Python/JS/Go
+secrets/taint samples (see that directory's `README.md` for the coverage
+breakdown). Beyond the pass/fail gate it produces a **triage report** with three
+extra products:
+
+1. **Per-rule coverage.** Every corpus file is scanned once and each rule is
+   tallied by the distinct *constructs* (line-shift-invariant anchors) it fires
+   on. `rules_exercised` and the full `coverage` map land in the report.
+2. **Suspicious-rule ranking.** Rules are ranked for a maintainer to review:
+   - `flips_under_edit` (**risk high**) — a rule with a *new* verified violation
+     (its finding appeared/disappeared under a trivial edit). A confirmed bug.
+   - `single_construct` (**risk medium**) — a rule that fired on exactly one
+     distinct construct across the whole corpus, so the sweep could not
+     cross-check its robustness. Not a bug: a coverage/fragility signal that says
+     "add a second construct for this rule or review it for over-fitting."
+3. **Known-issues baseline** (`known_issues.json`). A verified violation that
+   matches a documented, already-triaged pre-existing nox defect is reported but
+   does **not** fail the sweep — exactly like nox's own `baseline`. This keeps the
+   weekly audit green on today's known state so it only alerts on something
+   *new*, while the corpus keeps the tripping construct so the oracle keeps
+   watching it (a new rule with the same shape, or a regression, still fails).
+   Each entry must name specific `ruleids` **and** `seeds`, so a baseline can
+   never blanket-suppress a class of future bugs. Run `--no-known-issues` to see
+   the raw, unsuppressed set.
+
+The report is deterministic: sorted throughout, **no wall-clock, no absolute
+paths**, so two runs on the same repo state produce byte-identical output that
+diffs cleanly in review.
+
+### Triaging a reported violation
+
+1. Open the `metamorphic-triage` artifact from the failed audit run (or run
+   `sweep.py --results out` locally). Read `triage_summary.md`.
+2. For each row under **NEW verified violations**, open its
+   `repros/<id>/` directory: `before/` and `after/` are the minimal one-file
+   inputs, `REPRO.md` has the exact `nox scan` commands. The edit between them is
+   semantics-preserving by construction, so a finding that differs is a real
+   false positive (`appeared`) or false negative (`disappeared`).
+3. Confirm by hand: `nox scan repros/<id>/before` vs `.../after`. If it
+   reproduces, it is a detection-logic (`core/rules`/analyzer) bug — fix the rule.
+4. If it is a genuine pre-existing defect that must be deferred, add a scoped
+   entry to `known_issues.json` with a repro note; the audit then only re-alerts
+   if the shape spreads to a new rule/seed. Remove the entry once fixed — the
+   sweep goes green on its own, and a re-introduction fails again.
 
 ## The equivalence (line-shift vs. real bug)
 
@@ -109,6 +178,17 @@ go red is worthless), and it runs in CI alongside the sweep:
   disappeared`, demonstrating the harness *would* catch that historical bug were
   it still present.
 
+The sweep mode adds four more controls, so a green audit is trustworthy too:
+
+- **PC5 sweep coverage** — `collect_coverage` tallies real rules from a real scan.
+- **PC6 sweep triage goes red** — a planted verified violation is ranked
+  **high** (`flips_under_edit`) at the top of the triage, never silently dropped.
+- **PC7 sweep line-shift invariance** — an end-to-end sweep over a clean corpus
+  file yields **zero** new verified violations.
+- **PC8 known-issues baseline** — the baseline suppresses exactly the violation
+  it names and nothing more; a same-rule violation on a *different* seed stays
+  new (so a regression elsewhere still fails).
+
 ## Determinism
 
 Seed files are sorted, mutation order is fixed, there is no randomness, and nox
@@ -121,7 +201,27 @@ isolated temp dirs.
 
 ## Files
 
-- `harness.py` — the harness (mutations, equivalence, diff, verify, ddmin, report).
-- `selftest.py` — positive controls (run to trust a green result).
-- `seeds/` — committed synthetic Dockerfiles + GitHub workflows (the acute
-  Dockerfile/YAML absence-rule bug class).
+- `harness.py` — the per-PR engine (mutations, equivalence, diff, verify, ddmin,
+  report).
+- `sweep.py` — the corpus audit / oracle (reuses the engine; adds coverage,
+  suspicious-rule ranking, known-issues baseline, triage report).
+- `selftest.py` — positive controls for both modes (run to trust a green result).
+- `known_issues.json` — the sweep's baseline of already-triaged, pre-existing
+  verified violations (scoped by rule + seed).
+- `seeds/` — committed synthetic Dockerfiles + GitHub workflows for the per-PR
+  gate (the acute Dockerfile/YAML absence-rule bug class).
+- `../../testdata/metamorphic-corpus/` — the curated multi-sample corpus the
+  audit sweeps (see its `README.md` for coverage).
+
+## Deferred / out of scope
+
+- **Running against *external* repositories.** The oracle sweeps a committed,
+  in-repo corpus so CI is deterministic and self-contained. Pointing it at a
+  fleet of external real-world repos (more constructs, more rules) is valuable
+  but is org-infrastructure — it needs checkout credentials, a scheduling budget,
+  and non-deterministic inputs — so it is intentionally not wired here. `sweep.py`
+  already accepts extra `--seeds <root>` arguments, so such a job can reuse this
+  engine unchanged.
+- **Fixing the rule bugs the oracle finds.** The oracle is built *around* the
+  rules, not in them. Detection-logic fixes (`core/rules`, analyzers, taint) are a
+  separate change; found defects are recorded in `known_issues.json`.

--- a/scripts/metamorphic/harness.py
+++ b/scripts/metamorphic/harness.py
@@ -581,14 +581,20 @@ def main():
         c["repro_dir"] = os.path.relpath(write_repro(results_dir, c, i),
                                          results_dir)
 
+    # The JSON report is a committed/uploaded artifact people diff, so it is kept
+    # deterministic: no wall-clock (elapsed is printed to stdout only) and no
+    # absolute paths (binary is shown relative to the repo when possible).
+    try:
+        binary_display = os.path.relpath(nox.binary, REPO_ROOT)
+    except ValueError:
+        binary_display = os.path.basename(nox.binary)
     report = {
-        "nox_binary": nox.binary,
+        "nox_binary": binary_display,
         "seed_roots": [os.path.relpath(r, REPO_ROOT) for r in seed_roots
                        if os.path.isdir(r)],
         "seed_file_count": len(seeds),
         "mutations_applied": stats["mutations_applied"],
         "total_nox_scans": nox.scans,
-        "elapsed_seconds": round(elapsed, 1),
         "candidate_violations": stats["candidates"],
         "verified_violations": len(survivors),
         "unique_verified_violations": len(unique),
@@ -606,7 +612,7 @@ def main():
     print(f"seed files:            {report['seed_file_count']}")
     print(f"mutations applied:     {report['mutations_applied']}")
     print(f"total nox scans:       {report['total_nox_scans']}")
-    print(f"elapsed:               {report['elapsed_seconds']}s")
+    print(f"elapsed:               {round(elapsed, 1)}s")
     print(f"candidate violations:  {report['candidate_violations']}")
     print(f"verified violations:   {report['verified_violations']}")
     print(f"unique verified:       {report['unique_verified_violations']}")

--- a/scripts/metamorphic/known_issues.json
+++ b/scripts/metamorphic/known_issues.json
@@ -1,0 +1,15 @@
+{
+  "schema": "nox-metamorphic-known-issues/v1",
+  "description": "Verified metamorphic violations that are pre-existing, separately-tracked nox defects. The corpus deliberately keeps the constructs that trip them so the oracle keeps watching (it will catch a NEW rule with the same shape, or a regression), but these specific (rule, seed, mutation) combinations do not fail the weekly sweep. Each entry must scope itself with non-empty ruleids AND seeds so a baseline can never blanket-suppress a class of future bugs. Remove an entry once the underlying rule is fixed; the sweep will then go green on its own and a re-introduction will fail.",
+  "known_issues": [
+    {
+      "id": "IAC-DOCKERFILE-INTERLEAVED-BLANK-LINESHIFT",
+      "ruleids": ["IAC-001", "IAC-003", "IAC-024"],
+      "seeds": ["testdata/metamorphic-corpus/docker/Dockerfile.root-installer"],
+      "mutation_classes": ["blank_line_before_each", "blank_line_after_each"],
+      "directions": ["appeared", "disappeared"],
+      "found_by": "scripts/metamorphic/sweep.py (metamorphic corpus oracle)",
+      "note": "Dockerfile IAC rules that anchor to an explicit instruction (IAC-001 `USER root`, IAC-003 `ADD`, IAC-024 `sudo`) mis-locate and re-fingerprint under an INTERLEAVED blank line. A pure leading shift (blank lines at the top) is handled correctly — the finding's line tracks and the fingerprint is stable — but a blank line inserted *before* the flagged instruction leaves nox reporting the stale (pre-shift) line number, which now points at the blank line, and perturbs the v2 fingerprint. Blank lines between Dockerfile instructions are semantics-preserving, so this is a false-negative/false-positive pair under a no-op edit. Confirmed with a minimal one-blank-line repro on a canonical Dockerfile (FROM/RUN/ADD/RUN/COPY/USER root/ENTRYPOINT). Root cause is in nox's Dockerfile IAC location/fingerprint mapping (detection logic), which is out of scope for the oracle workstream. Re-verify at any time with: python3 scripts/metamorphic/sweep.py --bin ./nox --no-known-issues"
+    }
+  ]
+}

--- a/scripts/metamorphic/selftest.py
+++ b/scripts/metamorphic/selftest.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Positive controls for the metamorphic harness.
+"""Positive controls for the metamorphic harness AND the corpus sweep.
 
-A green run of harness.py is only trustworthy if we can show the harness would
-have gone red on a real bug. These controls exercise the three pieces that a
-false "no violations" could hide:
+A green run is only trustworthy if we can show the tooling would have gone red on
+a real bug. These controls exercise every piece a false "no violations" could
+hide, for both the per-PR gate (harness.py) and the corpus oracle (sweep.py):
 
   PC1  detection      — a genuinely finding-removing edit MUST be reported.
   PC2  line-shift      — a pure blank-line shift MUST NOT be reported.
@@ -12,6 +12,13 @@ false "no violations" could hide:
   PC4  synthetic FN bug — emulates the historical "comment mentioning
                           HEALTHCHECK hides IAC-121" bug by hand and shows the
                           diff logic flags it as a disappeared finding.
+  PC5  sweep coverage  — collect_coverage tallies real rules from a real scan.
+  PC6  sweep triage red — a planted verified violation is ranked high-risk
+                          (flips_under_edit); the sweep provably goes red.
+  PC7  sweep line-shift — an end-to-end sweep over a clean file yields ZERO new
+                          verified violations (the core invariance, at sweep scope).
+  PC8  known-issues    — the baseline suppresses a matching violation but a
+                         NON-matching (new) violation survives to fail.
 
 A gate that cannot go red is worthless — this is mandatory and runs in CI.
 
@@ -19,9 +26,12 @@ Run:  python3 scripts/metamorphic/selftest.py --bin ./nox   (exit 0 = all pass)
 """
 import argparse
 import os
+import shutil
 import sys
+import tempfile
 
 import harness as H
+import sweep as S
 
 ap = argparse.ArgumentParser()
 ap.add_argument("--bin", default=H.DEFAULT_BIN)
@@ -80,6 +90,65 @@ atext = "FROM alpine:3.19\n# HEALTHCHECK\nCOPY app /app\n"
 v4 = H.diff_findings(before_fp, btext, after_fp, atext)
 check("PC4 synthetic HEALTHCHECK FN caught",
       any(x["direction"] == "disappeared" and x["ruleid"] == "IAC-121" for x in v4))
+
+# ---------------------------------------------------------------------------
+# Sweep-mode controls (the corpus oracle).
+# ---------------------------------------------------------------------------
+
+# PC5 — coverage collection tallies real rules off a real scan. TAINT-002 is the
+# os.system sink in the corpus seed; it must appear with a real construct count.
+cov = S.collect_coverage([(SEED, "tp_injection.py")], nox)
+check("PC5 sweep coverage",
+      "TAINT-002" in cov and cov["TAINT-002"]["fires"] >= 1,
+      f"(rules={sorted(cov)})")
+
+# PC6 — a planted verified violation MUST rank as high-risk (flips_under_edit).
+# This is the sweep's own "goes red": a rule whose finding flips under a trivial
+# edit is surfaced at the top of the triage, not silently dropped.
+planted = [{"ruleid": "IAC-121", "direction": "disappeared"}]
+suspects = S.rank_suspicious({"IAC-121": {"seeds": {"x"}, "constructs": {"a"},
+                                          "fires": 1}}, planted)
+top = suspects[0] if suspects else {}
+check("PC6 sweep triage flags planted FN as high-risk",
+      top.get("ruleid") == "IAC-121" and top.get("risk") == "high"
+      and "flips_under_edit" in top.get("signals", []),
+      str(suspects[:1]))
+
+# PC7 — an end-to-end sweep over a single CLEAN corpus file must yield zero NEW
+# verified violations (pure line-shift invariance holds at sweep scope). Uses a
+# secrets file that fires findings but has no line-shift bug.
+clean = os.path.join(H.REPO_ROOT, "testdata", "metamorphic-corpus",
+                     "python", "config_secrets.py")
+_tmp_root = tempfile.mkdtemp(prefix="nox-sweep-selftest-")
+_results = tempfile.mkdtemp(prefix="nox-sweep-selftest-out-")
+try:
+    shutil.copy(clean, os.path.join(_tmp_root, "config_secrets.py"))
+    rep = S.sweep([_tmp_root], nox, _results, known_issues=[])
+    check("PC7 sweep line-shift invariance (clean file, 0 new violations)",
+          rep["verified_violation_count"] == 0 and rep["rules_exercised"] > 0,
+          f"(rules_exercised={rep['rules_exercised']}, "
+          f"new={rep['verified_violation_count']})")
+finally:
+    shutil.rmtree(_tmp_root, ignore_errors=True)
+    shutil.rmtree(_results, ignore_errors=True)
+
+# PC8 — the known-issues baseline suppresses exactly what it names and nothing
+# more. A matching violation is moved to `known`; a violation of the SAME rule on
+# a DIFFERENT seed stays `new` (so a regression elsewhere still fails).
+known = [{
+    "id": "TEST-ENTRY", "ruleids": ["IAC-001"],
+    "seeds": ["seed/known.Dockerfile"],
+    "mutation_classes": ["blank_line_before_each"],
+}]
+viol_known = {"ruleid": "IAC-001", "seed": "seed/known.Dockerfile",
+              "direction": "disappeared", "mutation": "blank_line_before_each"}
+viol_new = {"ruleid": "IAC-001", "seed": "seed/other.Dockerfile",
+            "direction": "disappeared", "mutation": "blank_line_before_each"}
+new_v, known_v = S.partition_known([dict(viol_known), dict(viol_new)], known)
+check("PC8 known-issues baseline suppresses only the named violation",
+      len(known_v) == 1 and known_v[0]["seed"] == "seed/known.Dockerfile"
+      and len(new_v) == 1 and new_v[0]["seed"] == "seed/other.Dockerfile",
+      f"(new={[x['seed'] for x in new_v]}, known={[x['seed'] for x in known_v]})")
 
 print()
 if fails:

--- a/scripts/metamorphic/sweep.py
+++ b/scripts/metamorphic/sweep.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Corpus-wide metamorphic sweep — the production rule-bug oracle for `nox`.
+
+Where `harness.py` is the per-PR gate (does *this change* break the metamorphic
+relation on the PR's own testdata + the synthetic seeds), `sweep.py` is the
+standing corpus-wide oracle: it hunts the *next* rule bug across a curated,
+diverse corpus of real-world-shaped inputs, and it ranks *suspicious* rules even
+when nothing has hard-failed yet.
+
+Metamorphic relation under test (identical to harness.py):
+    A *semantics-preserving* edit to a source file must not change nox's finding
+    set. Any finding that appears or disappears under such an edit is a rule bug.
+
+The sweep does three things beyond the gate:
+
+  1. VIOLATIONS (hard). It reuses the harness engine — the same mutation set,
+     line-shift-invariant equivalence, adversarial re-verification, and ddmin
+     minimisation — across the whole corpus. A verified violation is a bug.
+
+  2. KNOWN-ISSUES BASELINE. A verified violation that matches a documented entry
+     in `known_issues.json` (a specific rule + seed + mutation class we have
+     already triaged and accepted as a pre-existing, separately-tracked nox
+     defect) is reported but does NOT fail the sweep. This mirrors nox's own
+     `baseline` concept: the gate stays green on today's known state and goes
+     red only on a NEW, un-triaged violation. Run `--no-known-issues` to see the
+     raw, unsuppressed set (used to confirm a baselined bug still reproduces).
+
+  3. TRIAGE (soft, informational). It scans every corpus file once to build a
+     per-rule coverage map, then ranks SUSPICIOUS rules the maintainer should
+     look at next:
+        * flips_under_edit — a rule with a NEW (un-baselined) verified violation
+          (a confirmed bug shape; risk high).
+        * single_construct — a rule that fires on exactly ONE distinct construct
+          across the entire corpus, so the metamorphic check only ever exercised
+          it in one place. Not a bug: a fragility / under-coverage signal that
+          says "we cannot yet tell if this rule is precise or merely overfit —
+          add a construct or review it" (risk medium).
+
+Only a NEW verified violation fails the sweep (exit non-zero). The triage report
+is uploaded as an audit artifact and is the maintainer's worklist.
+
+Determinism: seeds are sorted, mutation order is fixed, there is no randomness,
+nox runs with --offline, and the report contains NO wall-clock and NO absolute
+paths. Same repo state => byte-identical report.
+
+Run:  python3 scripts/metamorphic/sweep.py --bin ./nox --results sweep-out
+See scripts/metamorphic/README.md for the full write-up.
+"""
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+import harness as H
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# The curated multi-sample corpus is the default sweep target. Operators can add
+# more roots with --seeds (e.g. the per-PR synthetic seeds) for a wider hunt.
+DEFAULT_CORPUS_ROOTS = [
+    os.path.join(H.REPO_ROOT, "testdata", "metamorphic-corpus"),
+]
+DEFAULT_KNOWN_ISSUES = os.path.join(HERE, "known_issues.json")
+
+TRIAGE_SCHEMA = "nox-metamorphic-triage/v1"
+RISK_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+# ---------------------------------------------------------------------------
+# Known-issues baseline
+# ---------------------------------------------------------------------------
+
+
+def load_known_issues(path):
+    """Load and validate the known-issues baseline. Returns a list of entries.
+
+    Each entry MUST scope itself with non-empty `ruleids` and `seeds` so a
+    baseline can never blanket-suppress a whole class of future bugs. Optional
+    `mutation_classes` and `directions` narrow it further (default: match any).
+    """
+    if not path or not os.path.exists(path):
+        return []
+    with open(path) as f:
+        data = json.load(f)
+    issues = data.get("known_issues", [])
+    for it in issues:
+        if not it.get("ruleids") or not it.get("seeds"):
+            sys.exit(f"known_issues entry {it.get('id')!r} must set non-empty "
+                     f"'ruleids' and 'seeds'")
+    return issues
+
+
+def match_known(violation, known_issues):
+    """Return the id of the first known-issue entry matching `violation`, else None."""
+    mclass = violation["mutation"].split("[")[0]
+    for it in known_issues:
+        if violation["ruleid"] not in it["ruleids"]:
+            continue
+        if violation["seed"] not in it["seeds"]:
+            continue
+        mcs = it.get("mutation_classes")
+        if mcs and mclass not in mcs:
+            continue
+        dirs = it.get("directions")
+        if dirs and violation["direction"] not in dirs:
+            continue
+        return it.get("id", "unknown")
+    return None
+
+
+def partition_known(violations, known_issues):
+    """Split verified violations into (new, known). Tags known ones with their id."""
+    new, known = [], []
+    for c in violations:
+        kid = match_known(c, known_issues)
+        if kid:
+            c["known_issue_id"] = kid
+            known.append(c)
+        else:
+            new.append(c)
+    return new, known
+
+
+# ---------------------------------------------------------------------------
+# Coverage — one scan per corpus file, tally what each rule reacts to
+# ---------------------------------------------------------------------------
+
+
+def collect_coverage(seeds, nox):
+    """Scan each seed original once; return per-rule coverage.
+
+    Returns: {ruleid: {"seeds": set(display), "constructs": set(anchor),
+                       "fires": int}}. A "construct" is the whitespace-normalised
+    anchor text the finding points at (the same line-shift-invariant identity the
+    diff uses), so two findings on identically-shaped lines count as one
+    construct even across files.
+    """
+    coverage = {}
+    for path, display in seeds:
+        filename = os.path.basename(path)
+        lines, tnl = H.read_seed(path)
+        text = H.join_lines(lines, tnl)
+        findings = nox.scan_one_file(filename, text.encode("utf-8"))
+        flines = text.split("\n")
+        for fi in findings:
+            rid = fi.get("RuleID")
+            if not rid:
+                continue
+            entry = coverage.setdefault(
+                rid, {"seeds": set(), "constructs": set(), "fires": 0})
+            entry["seeds"].add(display)
+            entry["constructs"].add(H.anchor_for(fi, flines)[1])
+            entry["fires"] += 1
+    return coverage
+
+
+# ---------------------------------------------------------------------------
+# Triage ranking — pure function of (coverage, new violations)
+# ---------------------------------------------------------------------------
+
+
+def rank_suspicious(coverage, new_violations):
+    """Rank suspicious rules. Pure + deterministic (sorted output).
+
+    A rule is listed if it has at least one signal:
+      * flips_under_edit  (=> risk high)   — has a NEW verified violation.
+      * single_construct  (=> risk medium) — fires on exactly one distinct
+                                             construct across the whole corpus.
+    seed_count is reported as context but is not, by itself, a listing trigger.
+    """
+    violating = {}  # ruleid -> set(direction)
+    for v in new_violations:
+        violating.setdefault(v["ruleid"], set()).add(v["direction"])
+
+    suspects = []
+    for rid in sorted(set(coverage) | set(violating)):
+        entry = coverage.get(
+            rid, {"seeds": set(), "constructs": set(), "fires": 0})
+        constructs = len(entry["constructs"])
+        signals = []
+        if rid in violating:
+            signals.append("flips_under_edit")
+        if constructs == 1:
+            signals.append("single_construct")
+        if not signals:
+            continue
+        risk = "high" if "flips_under_edit" in signals else "medium"
+        suspects.append({
+            "ruleid": rid,
+            "risk": risk,
+            "signals": signals,
+            "fire_count": entry["fires"],
+            "distinct_constructs": constructs,
+            "seed_count": len(entry["seeds"]),
+            "seeds": sorted(entry["seeds"]),
+            "violation_directions": sorted(violating.get(rid, set())),
+        })
+    suspects.sort(key=lambda s: (RISK_ORDER[s["risk"]], s["ruleid"]))
+    return suspects
+
+
+# ---------------------------------------------------------------------------
+# Violation collection (reuses the harness engine verbatim)
+# ---------------------------------------------------------------------------
+
+
+def _violation_sort_key(c):
+    return (c["ruleid"], c["direction"], c["seed"], c["mutation"])
+
+
+def collect_violations(seeds, nox, results_dir):
+    """Run the harness invariance engine over `seeds`; return sorted unique list.
+
+    Identical pipeline to harness.main: run -> adversarial verify + ddmin ->
+    de-duplicate -> write minimal repros.
+    """
+    candidates, stats = H.run(seeds, nox)
+    survivors = H.verify_and_minimize(candidates, nox)
+
+    seen = set()
+    unique = []
+    for c in survivors:
+        key = (c["seed"], c["ruleid"], c["direction"],
+               c["mutation"].split("[")[0])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(c)
+
+    unique.sort(key=_violation_sort_key)
+    for i, c in enumerate(unique):
+        c["repro_dir"] = os.path.relpath(
+            H.write_repro(results_dir, c, i), results_dir)
+    return unique, stats
+
+
+# ---------------------------------------------------------------------------
+# Report building (deterministic — no wall-clock, no absolute paths)
+# ---------------------------------------------------------------------------
+
+
+def _violation_view(c, extra_keys=()):
+    keys = ("seed", "filename", "mutation", "direction",
+            "ruleid", "anchor", "message", "repro_dir") + tuple(extra_keys)
+    view = {k: c[k] for k in keys if k in c}
+    view["minimal_edit_count"] = len(c["minimal_edits"])
+    return view
+
+
+def build_triage(corpus_roots, seed_count, stats, total_scans,
+                 coverage, new_violations, known_violations):
+    suspects = rank_suspicious(coverage, new_violations)
+    return {
+        "schema": TRIAGE_SCHEMA,
+        "corpus_roots": sorted(
+            os.path.relpath(r, H.REPO_ROOT)
+            for r in corpus_roots if os.path.isdir(r)),
+        "seed_file_count": seed_count,
+        "mutations_applied": stats.get("mutations_applied", 0),
+        "total_nox_scans": total_scans,
+        "rules_exercised": len(coverage),
+        "verified_violation_count": len(new_violations),
+        "verified_violations": [_violation_view(c) for c in new_violations],
+        "known_violation_count": len(known_violations),
+        "known_violations": [
+            _violation_view(c, ("known_issue_id",)) for c in known_violations],
+        "suspicious_rule_count": len(suspects),
+        "high_risk_count": sum(1 for s in suspects if s["risk"] == "high"),
+        "medium_risk_count": sum(1 for s in suspects if s["risk"] == "medium"),
+        "suspicious_rules": suspects,
+        "coverage": {
+            rid: {
+                "seeds": sorted(entry["seeds"]),
+                "distinct_constructs": len(entry["constructs"]),
+                "fires": entry["fires"],
+            }
+            for rid, entry in sorted(coverage.items())
+        },
+    }
+
+
+def render_summary(report):
+    """Deterministic human-readable Markdown summary (no timestamps)."""
+    out = []
+    out.append("# Metamorphic corpus sweep — triage summary\n")
+    out.append(f"- corpus roots: {', '.join(report['corpus_roots'])}")
+    out.append(f"- seed files: {report['seed_file_count']}")
+    out.append(f"- rules exercised: {report['rules_exercised']}")
+    out.append(f"- mutations applied: {report['mutations_applied']}")
+    out.append(f"- total nox scans: {report['total_nox_scans']}")
+    out.append(f"- new verified violations: {report['verified_violation_count']}")
+    out.append(f"- known (baselined) violations: {report['known_violation_count']}")
+    out.append(
+        f"- suspicious rules: {report['suspicious_rule_count']} "
+        f"(high {report['high_risk_count']}, medium {report['medium_risk_count']})\n")
+
+    if report["verified_violations"]:
+        out.append("## NEW verified violations (BUGS — sweep fails)\n")
+        out.append("| rule | direction | seed | mutation | repro |")
+        out.append("|---|---|---|---|---|")
+        for v in report["verified_violations"]:
+            kind = ("false negative" if v["direction"] == "disappeared"
+                    else "false positive")
+            out.append(
+                f"| `{v['ruleid']}` | {v['direction']} ({kind}) | "
+                f"`{v['seed']}` | `{v['mutation']}` | `{v['repro_dir']}` |")
+        out.append("")
+    else:
+        out.append("## NEW verified violations\n\nNone. No un-baselined "
+                   "metamorphic violation across the corpus.\n")
+
+    if report["known_violations"]:
+        out.append("## Known (baselined) violations — see known_issues.json\n")
+        out.append("| rule | direction | seed | mutation | known-issue id |")
+        out.append("|---|---|---|---|---|")
+        for v in report["known_violations"]:
+            out.append(
+                f"| `{v['ruleid']}` | {v['direction']} | `{v['seed']}` | "
+                f"`{v['mutation']}` | `{v.get('known_issue_id','')}` |")
+        out.append("")
+
+    if report["suspicious_rules"]:
+        out.append("## Suspicious rules (review — does not fail CI)\n")
+        out.append("| risk | rule | signals | fires | constructs | seeds |")
+        out.append("|---|---|---|---|---|---|")
+        for s in report["suspicious_rules"]:
+            out.append(
+                f"| {s['risk']} | `{s['ruleid']}` | {', '.join(s['signals'])} | "
+                f"{s['fire_count']} | {s['distinct_constructs']} | "
+                f"{s['seed_count']} |")
+        out.append("")
+        out.append(
+            "`single_construct` = the rule only ever fired on one distinct "
+            "construct across the corpus, so the sweep could not cross-check its "
+            "robustness. It is a coverage/fragility signal, not a bug: add a "
+            "second construct to the corpus for that rule, or review the rule "
+            "for over-fitting.\n")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def sweep(seed_roots, nox, results_dir, known_issues=None):
+    """End-to-end sweep. Returns the triage report dict."""
+    known_issues = known_issues or []
+    seeds = H.discover_seeds(seed_roots)
+    if not seeds:
+        sys.exit(f"no corpus files found under: {seed_roots}")
+    coverage = collect_coverage(seeds, nox)
+    violations, stats = collect_violations(seeds, nox, results_dir)
+    new_v, known_v = partition_known(violations, known_issues)
+    return build_triage(seed_roots, len(seeds), stats, nox.scans,
+                        coverage, new_v, known_v)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bin", default=H.DEFAULT_BIN,
+                    help="path to the nox binary (default: repo ./nox)")
+    ap.add_argument("--seeds", action="append", default=None,
+                    help="corpus root to walk (repeatable; default: "
+                         "testdata/metamorphic-corpus)")
+    ap.add_argument("--results", default=None,
+                    help="directory for the triage report + repros "
+                         "(default: a temp dir)")
+    ap.add_argument("--known-issues", default=DEFAULT_KNOWN_ISSUES,
+                    help="path to the known-issues baseline JSON "
+                         "(default: scripts/metamorphic/known_issues.json)")
+    ap.add_argument("--no-known-issues", action="store_true",
+                    help="ignore the baseline; report every verified violation "
+                         "as new (use to confirm a baselined bug still repros)")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="limit number of corpus files (for a quick run)")
+    args = ap.parse_args()
+
+    seed_roots = args.seeds if args.seeds else DEFAULT_CORPUS_ROOTS
+    seeds = H.discover_seeds(seed_roots)
+    if not seeds:
+        sys.exit(f"no corpus files found under: {seed_roots}")
+    if args.limit:
+        seeds = seeds[:args.limit]
+
+    known_issues = [] if args.no_known_issues else load_known_issues(
+        args.known_issues)
+
+    nox = H.Nox(args.bin)
+    results_dir = args.results or tempfile.mkdtemp(prefix="nox-metamorphic-sweep-")
+    os.makedirs(results_dir, exist_ok=True)
+
+    coverage = collect_coverage(seeds, nox)
+    violations, stats = collect_violations(seeds, nox, results_dir)
+    new_v, known_v = partition_known(violations, known_issues)
+    report = build_triage(seed_roots, len(seeds), stats, nox.scans,
+                         coverage, new_v, known_v)
+
+    report_path = os.path.join(results_dir, "triage_report.json")
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+        f.write("\n")
+    summary = render_summary(report)
+    summary_path = os.path.join(results_dir, "triage_summary.md")
+    with open(summary_path, "w") as f:
+        f.write(summary)
+        f.write("\n")
+
+    print(summary)
+    print(f"\ntriage report:  {report_path}")
+    print(f"triage summary: {summary_path}")
+
+    if report["verified_violation_count"]:
+        print(f"\nFAIL: {report['verified_violation_count']} NEW verified "
+              f"metamorphic violation(s). See repros under "
+              f"{results_dir}/repros/.", file=sys.stderr)
+        sys.exit(1)
+    print(f"\nOK: no NEW metamorphic violations "
+          f"({report['known_violation_count']} known/baselined).")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/testdata/metamorphic-corpus/README.md
+++ b/testdata/metamorphic-corpus/README.md
@@ -1,0 +1,65 @@
+# Metamorphic corpus
+
+A curated, deterministic set of real-world-shaped inputs for the corpus-wide
+metamorphic sweep (`scripts/metamorphic/sweep.py`). The sweep applies
+semantics-preserving edits (blank lines, whitespace reflow, CRLF, inert
+keyword-comments) to each file and asserts nox's finding set does not change; any
+finding that appears or disappears under such an edit is a rule bug. This corpus
+gives the oracle many rules to exercise across the languages and rule-families
+where context-confusion bugs live.
+
+**These files are intentionally finding-bearing** (unpinned base images, public
+S3 buckets, hardcoded credentials, taint flows, script injection). They are
+excluded from nox's own self-scan in `.nox.yaml`, the same way the precision
+corpora are; the sweep scans them explicitly in isolated temp dirs. Do not "fix"
+them — their findings are the point.
+
+## Layout
+
+| Directory | Files | Families exercised |
+|---|---|---|
+| `docker/` | 4 Dockerfiles (python service, node multistage, root installer, hardened distroless) | `IAC-0xx`/`IAC-1xx` Dockerfile rules, `CONT-001` base-image pinning |
+| `workflows/` | 3 GitHub Actions workflows (mutable tags, `pull_request_target` injection, SHA-pinned release) | `IAC-012`/`IAC-013` action pinning, workflow-permission and injection rules |
+| `terraform/` | 3 `.tf` files (public S3, open security groups, wildcard IAM + unencrypted RDS) | `IAC-004`/`IAC-040`/`IAC-1xx`/`IAC-3xx` Terraform rules, `SEC-2xx` field secrets |
+| `python/` | 5 files (cloud secrets, SQLi, command injection, SSRF, LLM agent) | `SEC-0xx` secrets, `TAINT-0xx` taint, `AI-0xx` prompt/logging |
+| `javascript/` | 2 files (cloud/Slack/Stripe secrets, XSS + command + eval sinks) | `SEC-0xx` secrets, `TAINT-0xx` taint |
+| `go/` | 2 files (cloud secrets, SQLi + command injection handlers) | `SEC-0xx` secrets, `TAINT-0xx` taint |
+
+19 files total. The `hardened` Dockerfile and the `deploy-pinned` workflow are
+deliberately *clean* variants of a construct — a metamorphic oracle needs both
+the vulnerable and the safe shape of a pattern to tell "precise" from "overfit".
+
+## Coverage (rules exercised on current `main`)
+
+The sweep reports `rules_exercised` and a full per-rule coverage map in
+`triage_report.json`. As of the current corpus it exercises **38 distinct
+rules** across six families:
+
+```
+AI-002, AI-006,
+CONT-001,
+IAC-001, IAC-003, IAC-004, IAC-005, IAC-006, IAC-012, IAC-013, IAC-014,
+IAC-024, IAC-036, IAC-037, IAC-040, IAC-121, IAC-122, IAC-123, IAC-124,
+IAC-126, IAC-127, IAC-167, IAC-282, IAC-283, IAC-315, IAC-317, IAC-318,
+SEC-001, SEC-003, SEC-023, SEC-030, SEC-080, SEC-086, SEC-508,
+SLOP-001,
+TAINT-001, TAINT-002, TAINT-006
+```
+
+The triage report also ranks rules that fire on exactly one distinct construct
+(`single_construct`) — these are under-exercised and are the worklist for
+growing the corpus: give such a rule a second, differently-shaped construct so
+the sweep can cross-check its robustness.
+
+## How to extend
+
+1. Add a realistic file under the right family directory (small, deterministic,
+   no secrets that are *real* — use well-known example/placeholder values).
+2. Re-run `python3 scripts/metamorphic/sweep.py --bin ./nox --results out` and
+   check `out/triage_summary.md`: confirm your file adds coverage and introduces
+   no *new* verified violation.
+3. If it surfaces a genuine, pre-existing rule bug (a verified violation), keep
+   the file and record the violation in `scripts/metamorphic/known_issues.json`
+   with a repro note, rather than deleting the construct.
+
+Keep the corpus small enough that the full sweep stays a few minutes in CI.

--- a/testdata/metamorphic-corpus/docker/Dockerfile.hardened
+++ b/testdata/metamorphic-corpus/docker/Dockerfile.hardened
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static-debian12:nonroot
+WORKDIR /app
+COPY --chown=nonroot:nonroot app /app/app
+USER nonroot
+HEALTHCHECK CMD ["/app/app", "healthcheck"]
+ENTRYPOINT ["/app/app"]

--- a/testdata/metamorphic-corpus/docker/Dockerfile.node-multistage
+++ b/testdata/metamorphic-corpus/docker/Dockerfile.node-multistage
@@ -1,0 +1,13 @@
+FROM node:20 AS build
+WORKDIR /src
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-slim
+WORKDIR /srv
+COPY --from=build /src/dist ./dist
+COPY --from=build /src/node_modules ./node_modules
+EXPOSE 3000
+CMD ["node", "dist/server.js"]

--- a/testdata/metamorphic-corpus/docker/Dockerfile.python-service
+++ b/testdata/metamorphic-corpus/docker/Dockerfile.python-service
@@ -1,0 +1,7 @@
+FROM python:3.11
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["python", "app.py"]

--- a/testdata/metamorphic-corpus/docker/Dockerfile.root-installer
+++ b/testdata/metamorphic-corpus/docker/Dockerfile.root-installer
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl sudo ca-certificates
+ADD https://example.com/install.sh /tmp/install.sh
+RUN chmod +x /tmp/install.sh && /tmp/install.sh
+COPY entrypoint.sh /entrypoint.sh
+USER root
+ENTRYPOINT ["/entrypoint.sh"]

--- a/testdata/metamorphic-corpus/go/config.go
+++ b/testdata/metamorphic-corpus/go/config.go
@@ -1,0 +1,19 @@
+package config
+
+// Credentials for the payments service. Loaded at startup.
+
+const (
+	AWSAccessKeyID     = "AKIAIOSFODNN7EXAMPLE"
+	AWSSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	StripeSecretKey    = "sk_live_4eC39HqLyjWDarjtT1zdp7dcABCDEFGHIJ"
+	DatabasePassword   = "prod-db-pa55word-do-not-share"
+)
+
+// Config returns the static service configuration.
+func Config() map[string]string {
+	return map[string]string{
+		"region":     "us-east-1",
+		"access_key": AWSAccessKeyID,
+		"secret_key": AWSSecretAccessKey,
+	}
+}

--- a/testdata/metamorphic-corpus/go/handlers.go
+++ b/testdata/metamorphic-corpus/go/handlers.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"os/exec"
+)
+
+var db *sql.DB
+
+// GetUser looks up a user by the id query parameter.
+func GetUser(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	query := fmt.Sprintf("SELECT * FROM users WHERE id = '%s'", id)
+	rows, err := db.Query(query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+}
+
+// Lookup runs a DNS lookup for the host query parameter.
+func Lookup(w http.ResponseWriter, r *http.Request) {
+	host := r.URL.Query().Get("host")
+	out, _ := exec.Command("nslookup", host).Output()
+	w.Write(out)
+}

--- a/testdata/metamorphic-corpus/javascript/config.js
+++ b/testdata/metamorphic-corpus/javascript/config.js
@@ -1,0 +1,11 @@
+// Service configuration for the notifications worker.
+
+const config = {
+  region: "us-east-1",
+  awsAccessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  awsSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  slackToken: "xoxb-123456789012-1234567890123-abcdEFGHijklMNOPqrstUVwx",
+  stripeKey: "sk_live_4eC39HqLyjWDarjtT1zdp7dcABCDEFGHIJ",
+};
+
+module.exports = config;

--- a/testdata/metamorphic-corpus/javascript/routes.js
+++ b/testdata/metamorphic-corpus/javascript/routes.js
@@ -1,0 +1,24 @@
+const express = require("express");
+const { exec } = require("child_process");
+
+const app = express();
+
+app.get("/render", (req, res) => {
+  const name = req.query.name;
+  res.send("<h1>Hello " + name + "</h1>");
+});
+
+app.get("/lookup", (req, res) => {
+  const domain = req.query.domain;
+  exec("nslookup " + domain, (err, stdout) => {
+    res.send(stdout);
+  });
+});
+
+app.get("/eval", (req, res) => {
+  const expr = req.query.expr;
+  const result = eval(expr);
+  res.json({ result });
+});
+
+module.exports = app;

--- a/testdata/metamorphic-corpus/python/config_secrets.py
+++ b/testdata/metamorphic-corpus/python/config_secrets.py
@@ -1,0 +1,19 @@
+"""Application configuration.
+
+Loads service credentials for the billing integration.
+"""
+
+AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+STRIPE_SECRET_KEY = "sk_live_4eC39HqLyjWDarjtT1zdp7dcABCDEFGHIJ"
+GITHUB_TOKEN = "ghp_016C7dEfGhIjKlMnOpQrStUvWxYz0123abcd"
+
+DATABASE_PASSWORD = "prod-db-pa55word-do-not-share"
+
+
+def client_config():
+    return {
+        "region": "us-east-1",
+        "access_key": AWS_ACCESS_KEY_ID,
+        "secret_key": AWS_SECRET_ACCESS_KEY,
+    }

--- a/testdata/metamorphic-corpus/python/fetch_ssrf.py
+++ b/testdata/metamorphic-corpus/python/fetch_ssrf.py
@@ -1,0 +1,19 @@
+import requests
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/proxy")
+def proxy():
+    url = request.args.get("url")
+    resp = requests.get(url, timeout=5)
+    return resp.text
+
+
+@app.route("/webhook")
+def webhook():
+    callback = request.args.get("callback")
+    requests.post(callback, json={"event": "ping"}, timeout=5)
+    return "sent"

--- a/testdata/metamorphic-corpus/python/llm_agent.py
+++ b/testdata/metamorphic-corpus/python/llm_agent.py
@@ -1,0 +1,32 @@
+"""A minimal LLM agent that answers support questions over user data."""
+
+import logging
+
+from flask import Flask, request
+
+app = Flask(__name__)
+logger = logging.getLogger("agent")
+
+
+def build_prompt(user_input, context):
+    system = "You are a support agent. Answer using the context below."
+    return f"{system}\n\nContext:\n{context}\n\nUser: {user_input}\nAnswer:"
+
+
+@app.route("/ask")
+def ask():
+    question = request.args.get("q")
+    context = load_docs()
+    prompt = build_prompt(question, context)
+    logger.info("prompt sent to model: %s", prompt)
+    answer = call_model(prompt)
+    logger.info("model response: %s", answer)
+    return {"answer": answer}
+
+
+def load_docs():
+    return "internal knowledge base contents"
+
+
+def call_model(prompt):
+    return "stubbed response"

--- a/testdata/metamorphic-corpus/python/ops_cmdi.py
+++ b/testdata/metamorphic-corpus/python/ops_cmdi.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/ping")
+def ping():
+    host = request.args.get("host")
+    os.system("ping -c 1 " + host)
+    return "ok"
+
+
+@app.route("/backup")
+def backup():
+    target = request.args.get("path")
+    subprocess.call("tar czf backup.tgz " + target, shell=True)
+    return "queued"

--- a/testdata/metamorphic-corpus/python/views_sqli.py
+++ b/testdata/metamorphic-corpus/python/views_sqli.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/user")
+def get_user():
+    user_id = request.args.get("id")
+    conn = sqlite3.connect("app.db")
+    cursor = conn.cursor()
+    query = "SELECT * FROM users WHERE id = '" + user_id + "'"
+    cursor.execute(query)
+    return {"rows": cursor.fetchall()}
+
+
+@app.route("/search")
+def search():
+    term = request.args.get("q")
+    conn = sqlite3.connect("app.db")
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM items WHERE name LIKE '%%%s%%'" % term)
+    return {"rows": cursor.fetchall()}

--- a/testdata/metamorphic-corpus/terraform/iam.tf
+++ b/testdata/metamorphic-corpus/terraform/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_policy" "admin" {
+  name = "app-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_db_instance" "primary" {
+  engine              = "postgres"
+  instance_class      = "db.t3.medium"
+  allocated_storage   = 20
+  username            = "admin"
+  password            = "Sup3rSecretDbPass!"
+  publicly_accessible = true
+  storage_encrypted   = false
+  skip_final_snapshot = true
+}

--- a/testdata/metamorphic-corpus/terraform/network.tf
+++ b/testdata/metamorphic-corpus/terraform/network.tf
@@ -1,0 +1,27 @@
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Allow web traffic"
+
+  ingress {
+    description = "SSH from anywhere"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/testdata/metamorphic-corpus/terraform/s3.tf
+++ b/testdata/metamorphic-corpus/terraform/s3.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket" "assets" {
+  bucket = "example-assets"
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_public_access_block" "assets" {
+  bucket                  = aws_s3_bucket.assets.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/testdata/metamorphic-corpus/workflows/ci-mutable-tags.yml
+++ b/testdata/metamorphic-corpus/workflows/ci-mutable-tags.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - uses: some/third-party-action@main
+      - uses: another/tool@master
+      - run: make build
+      - run: make test

--- a/testdata/metamorphic-corpus/workflows/deploy-pinned.yml
+++ b/testdata/metamorphic-corpus/workflows/deploy-pinned.yml
@@ -1,0 +1,17 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/build-push-action@0788c444d8b4d67580213712e34a148cae3a6c4e # v6.18.0
+      - run: ./scripts/publish.sh

--- a/testdata/metamorphic-corpus/workflows/pr-target-injection.yml
+++ b/testdata/metamorphic-corpus/workflows/pr-target-injection.yml
@@ -1,0 +1,16 @@
+name: PR Title Check
+on: pull_request_target
+permissions: write-all
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Echo PR title
+        run: echo "Reviewing ${{ github.event.pull_request.title }}"
+      - name: Comment
+        run: |
+          BODY="${{ github.event.pull_request.body }}"
+          echo "$BODY" > body.txt


### PR DESCRIPTION
## What this adds

Promotes the per-PR metamorphic gate into a **standing, corpus-wide oracle** that hunts the *next* rule bug across many code samples, rather than only the PR's own testdata. Complements — does not replace — the existing `metamorphic.yml` gate.

### Two CI modes now

| | Per-PR gate (existing) | Corpus audit (new) |
|---|---|---|
| Script | `harness.py` | `sweep.py` |
| Workflow | `metamorphic.yml` (`pull_request`) | `metamorphic-audit.yml` (`schedule` weekly + `workflow_dispatch`) |
| Inputs | precision-suite + synthetic seeds | `testdata/metamorphic-corpus/` |
| Question | "does *this change* regress?" | "what is the *next* rule bug corpus-wide?" |
| Fails on | any verified violation | any *new* (un-baselined) verified violation |

### Corpus (`testdata/metamorphic-corpus/`, 19 files)
Dockerfiles, GitHub workflows, Terraform, and Python/JS/Go secrets+taint samples. Exercises **38 distinct rules** across AI/CONT/IAC/SEC/SLOP/TAINT. Excluded from the self-scan in `.nox.yaml`, exactly like the precision corpora. Coverage documented in the corpus README.

### Sweep (`sweep.py`)
Reuses the harness engine (mutation set, line-shift-invariant equivalence, adversarial re-verify, ddmin) and adds:
- **per-rule coverage** map,
- **suspicious-rule ranking**: `flips_under_edit` (high) and `single_construct` (medium — a fragility/under-coverage signal),
- **known-issues baseline** (`known_issues.json`) so the weekly audit stays green on today's known state and alerts only on something new. Mirrors nox's own `baseline`.

Output is a deterministic triage report (JSON + Markdown): sorted throughout, **no wall-clock, no absolute paths** — byte-identical across runs.

### Scheduled audit (`metamorphic-audit.yml`)
Weekly + `workflow_dispatch`. Runs the positive-control self-test, then the sweep; **always** uploads the triage artifact; files an issue and fails **only** on a new verified violation. SHA-pinned actions, minimal `permissions:`, inline `# nox:ignore` for the two deliberate workflow findings.

## The oracle already found a real bug
Detection logic left untouched (out of scope for this workstream); the bug is recorded in `known_issues.json` with a repro note: **Dockerfile IAC rules that anchor to an explicit instruction (IAC-001 `USER root`, IAC-003 `ADD`, IAC-024 `sudo`) mis-locate and re-fingerprint under an interleaved blank line** — a semantics-preserving edit — while a pure leading shift is handled correctly. Reproduce with `sweep.py --no-known-issues`.

## Proof the gate can go red
`selftest.py` PC5-PC8 extend the positive controls to the sweep: coverage collection, triage ranking a planted FN as high-risk, end-to-end line-shift invariance (0 violations), and baseline scoping (a same-rule violation on a different seed still fails). Additionally, `sweep.py --no-known-issues` exits non-zero on the real bug above.

## Gates
- `go build ./...`, `go test ./...` pass (no Go changed; corpus lives under `testdata/`, ignored by the go tool).
- `golangci-lint` unchanged from main (zero Go touched).
- Self-scan stays **grade A** with 0 net-new active findings; the new workflow is clean (all findings suppressed via SHA-pins + inline ignores).
- Full sweep against current `main`: 0 new violations (12 baselined), 38 rules exercised. Self-test: 8/8 controls pass. Reports verified byte-identical across runs.

## Deferred (documented in the harness README)
- Running against **external** repos is org-infrastructure (credentials, scheduling budget, non-deterministic inputs); `sweep.py` accepts extra `--seeds` roots so such a job can reuse this engine unchanged.
- Fixing the rule bugs the oracle finds is a separate, detection-logic change.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj
