### PR TITLE
fix(iac): blank line before a Dockerfile instruction no longer mis-locates it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A blank line before a Dockerfile instruction no longer mis-locates the
+  finding or changes its fingerprint.** 16 regex-pattern IaC rules anchored with
+  `(?im)^\s*KEYWORD`, and `\s` matches newlines — so under multiline matching a
+  blank line before the flagged instruction (e.g. `USER root`, `ADD`, a `sudo`
+  RUN) let `^\s*` begin the match on the *preceding blank line*. The finding was
+  reported on the blank line, and its matched content gained a leading newline
+  that perturbed the v2 fingerprint — a false-positive/false-negative pair under
+  a semantics-preserving edit that also broke baseline matching. Anchored with
+  `^[ \t]*`, which cannot cross a newline (the same correction the absence
+  anchors got). Found by nox's own metamorphic corpus oracle.
+
 ### Security
 
 - **`brace-expansion` in the VS Code extension is bumped past a newly-published

--- a/core/analyzers/iac/dockerfile_blankline_test.go
+++ b/core/analyzers/iac/dockerfile_blankline_test.go
@@ -1,0 +1,93 @@
+package iac
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// A blank line before a flagged Dockerfile instruction is semantics-preserving,
+// so a finding must land on the instruction and keep a stable fingerprint. The
+// pattern rules anchored with `(?im)^\s*KEYWORD`, and `\s` includes newlines, so
+// under multiline matching `^\s*` began the match on the *preceding blank line*:
+// the finding was reported on the blank line (a wrong location) and its matched
+// content gained a leading newline, which perturbed the v2 fingerprint — a
+// silent false-positive/false-negative pair under a no-op edit that also breaks
+// baseline matching.
+//
+// Found by the metamorphic corpus oracle (scripts/metamorphic/sweep.py) on
+// IAC-001 / IAC-003 / IAC-024. The fix anchors with `^[ \t]*`, which cannot
+// cross a newline — the same correction #311 applied to the absence anchors.
+func TestDockerfilePatternRule_BlankLineBeforeInstruction(t *testing.T) {
+	cases := []struct {
+		name, rule string
+		noBlank    string
+		withBlank  string
+		// The line the instruction sits on in withBlank (1-based).
+		wantLine int
+	}{
+		{
+			name:      "IAC-001 USER root",
+			rule:      "IAC-001",
+			noBlank:   "FROM alpine:3.20\nRUN true\nUSER root\nCMD [\"/a\"]\n",
+			withBlank: "FROM alpine:3.20\nRUN true\n\nUSER root\nCMD [\"/a\"]\n",
+			wantLine:  4,
+		},
+		{
+			name:      "IAC-003 ADD",
+			rule:      "IAC-003",
+			noBlank:   "FROM alpine:3.20\nADD x.tar /x\n",
+			withBlank: "FROM alpine:3.20\n\nADD x.tar /x\n",
+			wantLine:  3,
+		},
+		{
+			name:      "IAC-024 sudo",
+			rule:      "IAC-024",
+			noBlank:   "FROM alpine:3.20\nRUN sudo apk add curl\n",
+			withBlank: "FROM alpine:3.20\n\nRUN sudo apk add curl\n",
+			wantLine:  3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAnalyzer()
+
+			base, err := a.ScanFile("Dockerfile", []byte(tc.noBlank))
+			if err != nil {
+				t.Fatalf("scan noBlank: %v", err)
+			}
+			baseF := findRule(base, tc.rule)
+			if baseF == nil {
+				t.Fatalf("%s did not fire on the un-shifted Dockerfile", tc.rule)
+			}
+
+			got, err := a.ScanFile("Dockerfile", []byte(tc.withBlank))
+			if err != nil {
+				t.Fatalf("scan withBlank: %v", err)
+			}
+			f := findRule(got, tc.rule)
+			if f == nil {
+				t.Fatalf("%s disappeared when a blank line was inserted before it", tc.rule)
+			}
+
+			if f.Location.StartLine != tc.wantLine {
+				t.Errorf("%s located at line %d, want %d (the instruction line, not the blank line)",
+					tc.rule, f.Location.StartLine, tc.wantLine)
+			}
+			if f.Fingerprint != baseF.Fingerprint {
+				t.Errorf("%s fingerprint changed under a semantics-preserving blank-line insert\n  before=%s\n   after=%s\n(this breaks baseline matching)",
+					tc.rule, baseF.Fingerprint, f.Fingerprint)
+			}
+		})
+	}
+}
+
+func findRule(results []findings.Finding, ruleID string) *findings.Finding {
+	for i := range results {
+		if results[i].RuleID == ruleID {
+			return &results[i]
+		}
+	}
+	return nil
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -44,7 +44,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		// =================================================================
 		{
 			id: "IAC-001", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*USER\s+root\s*$`,
+			pattern:     `(?im)^[ \t]*USER\s+root\s*$`,
 			description: "Dockerfile runs as root user",
 			cwe:         "CWE-250", keywords: []string{"user root"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -54,7 +54,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-002", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*FROM\s+[a-zA-Z0-9._/-]+\s*$|(?im)^\s*FROM\s+\S+:latest\b`,
+			pattern:     `(?im)^[ \t]*FROM\s+[a-zA-Z0-9._/-]+\s*$|(?im)^[ \t]*FROM\s+\S+:latest\b`,
 			description: "Dockerfile uses unpinned base image (latest or no tag)",
 			cwe:         "CWE-829", keywords: []string{"from"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -64,7 +64,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-003", severity: findings.SeverityLow, confidence: findings.ConfidenceHigh,
-			pattern:     `(?im)^\s*ADD\s+`,
+			pattern:     `(?im)^[ \t]*ADD\s+`,
 			description: "Dockerfile uses ADD instead of COPY",
 			cwe:         "CWE-829", keywords: []string{"add"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -74,7 +74,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-022", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*ARG\s+(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|DB_PASS|MYSQL_PASSWORD|POSTGRES_PASSWORD)\b`,
+			pattern:     `(?im)^[ \t]*ARG\s+(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|DB_PASS|MYSQL_PASSWORD|POSTGRES_PASSWORD)\b`,
 			description: "Secret value passed as Docker build argument",
 			cwe:         "CWE-798", keywords: []string{"arg"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -94,7 +94,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-024", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*RUN\s+.*\bsudo\b`,
+			pattern:     `(?im)^[ \t]*RUN\s+.*\bsudo\b`,
 			description: "Dockerfile RUN uses sudo (unnecessary in Docker build)",
 			cwe:         "CWE-250", keywords: []string{"sudo"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -104,7 +104,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-025", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:     `(?im)^\s*(COPY|ADD)\s+--chmod=777\b`,
+			pattern:     `(?im)^[ \t]*(COPY|ADD)\s+--chmod=777\b`,
 			description: "Dockerfile COPY/ADD sets world-writable permissions",
 			cwe:         "CWE-732", keywords: []string{"chmod=777"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -312,7 +312,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-028", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:     `(?im)^\s*-\s*(SYS_ADMIN|SYS_PTRACE|NET_RAW|SYS_MODULE|DAC_OVERRIDE)\s*$`,
+			pattern:     `(?im)^[ \t]*-\s*(SYS_ADMIN|SYS_PTRACE|NET_RAW|SYS_MODULE|DAC_OVERRIDE)\s*$`,
 			description: "Container adds dangerous Linux capability",
 			cwe:         "CWE-250", keywords: []string{"sys_admin", "sys_ptrace", "net_raw"},
 			filePatterns: []string{"*.yaml", "*.yml"},
@@ -1428,7 +1428,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-128", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:     `(?im)^\s*EXPOSE\s+22\b`,
+			pattern:     `(?im)^[ \t]*EXPOSE\s+22\b`,
 			description: "Dockerfile exposes SSH port 22",
 			cwe:         "CWE-284", keywords: []string{"EXPOSE", "22"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -1450,7 +1450,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-130", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*ENV\s+(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|AWS_SECRET_ACCESS_KEY|DATABASE_PASSWORD|DB_PASSWORD)\s*=`,
+			pattern:     `(?im)^[ \t]*ENV\s+(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|AWS_SECRET_ACCESS_KEY|DATABASE_PASSWORD|DB_PASSWORD)\s*=`,
 			description: "Dockerfile ENV sets a variable with a secret-like name",
 			cwe:         "CWE-798", keywords: []string{"ENV", "PASSWORD", "SECRET", "TOKEN", "API_KEY"},
 			filePatterns: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"},
@@ -1706,7 +1706,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-152", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
-			pattern:     `(?im)^\s+steps\s*:\s*\n(\s+-\s+(uses|run)\s*:.*\n){15,}`,
+			pattern:     `(?im)^[ \t]+steps\s*:\s*\n(\s+-\s+(uses|run)\s*:.*\n){15,}`,
 			description: "GitHub Actions workflow has many steps - consider reusable workflows",
 			cwe:         "CWE-1059", keywords: []string{"steps", "uses"},
 			filePatterns: []string{"*.yml", "*.yaml"},
@@ -1802,7 +1802,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		// =================================================================
 		{
 			id: "IAC-161", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)^\s*provider\s+"[^"]+"\s*\{\s*$`,
+			pattern:     `(?im)^[ \t]*provider\s+"[^"]+"\s*\{\s*$`,
 			description: "Terraform provider without version constraints",
 			cwe:         "CWE-829", keywords: []string{"provider", "required_providers"},
 			filePatterns: []string{"*.tf"},

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -872,7 +872,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		// =================================================================
 		{
 			id: "IAC-341", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:      `(?im)^\s*HEALTHCHECK\s+NONE`,
+			pattern:      `(?im)^[ \t]*HEALTHCHECK\s+NONE`,
 			description:  "Dockerfile disables healthcheck",
 			cwe:          "CWE-693",
 			keywords:     []string{"HEALTHCHECK", "NONE"},
@@ -883,7 +883,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-342", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?im)^\s*EXPOSE\s+(?:22|3389|5900)\b`,
+			pattern:      `(?im)^[ \t]*EXPOSE\s+(?:22|3389|5900)\b`,
 			description:  "Dockerfile exposes remote access port",
 			cwe:          "CWE-284",
 			keywords:     []string{"EXPOSE", "22", "3389"},
@@ -894,7 +894,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-343", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?im)^\s*ENV\s+(?:PASSWORD|SECRET|TOKEN|API_KEY)\s*=`,
+			pattern:      `(?im)^[ \t]*ENV\s+(?:PASSWORD|SECRET|TOKEN|API_KEY)\s*=`,
 			description:  "Dockerfile sets secret in ENV instruction",
 			cwe:          "CWE-798",
 			keywords:     []string{"ENV", "PASSWORD", "SECRET"},
@@ -905,7 +905,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-344", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
-			pattern:      `(?im)^\s*COPY\s+--from=\S+\s+/etc/shadow`,
+			pattern:      `(?im)^[ \t]*COPY\s+--from=\S+\s+/etc/shadow`,
 			description:  "Dockerfile copies shadow file from build stage",
 			cwe:          "CWE-538",
 			keywords:     []string{"shadow"},
@@ -916,7 +916,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-345", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
-			pattern:      `(?im)^\s*RUN\s+.*apt-get\s+install\s+.*\*`,
+			pattern:      `(?im)^[ \t]*RUN\s+.*apt-get\s+install\s+.*\*`,
 			description:  "Dockerfile apt-get install using wildcard package names",
 			cwe:          "CWE-693",
 			keywords:     []string{"apt-get", "install"},
@@ -986,7 +986,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-351", severity: findings.SeverityCritical, confidence: findings.ConfidenceMedium,
-			pattern:      `(?im)^\s*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)\s*:\s*['"]?[A-Za-z0-9]`,
+			pattern:      `(?im)^[ \t]*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)\s*:\s*['"]?[A-Za-z0-9]`,
 			description:  "CI variable with hardcoded secret",
 			cwe:          "CWE-798",
 			keywords:     []string{"PASSWORD", "SECRET", "TOKEN"},

--- a/scripts/metamorphic/known_issues.json
+++ b/scripts/metamorphic/known_issues.json
@@ -1,15 +1,5 @@
 {
   "schema": "nox-metamorphic-known-issues/v1",
   "description": "Verified metamorphic violations that are pre-existing, separately-tracked nox defects. The corpus deliberately keeps the constructs that trip them so the oracle keeps watching (it will catch a NEW rule with the same shape, or a regression), but these specific (rule, seed, mutation) combinations do not fail the weekly sweep. Each entry must scope itself with non-empty ruleids AND seeds so a baseline can never blanket-suppress a class of future bugs. Remove an entry once the underlying rule is fixed; the sweep will then go green on its own and a re-introduction will fail.",
-  "known_issues": [
-    {
-      "id": "IAC-DOCKERFILE-INTERLEAVED-BLANK-LINESHIFT",
-      "ruleids": ["IAC-001", "IAC-003", "IAC-024"],
-      "seeds": ["testdata/metamorphic-corpus/docker/Dockerfile.root-installer"],
-      "mutation_classes": ["blank_line_before_each", "blank_line_after_each"],
-      "directions": ["appeared", "disappeared"],
-      "found_by": "scripts/metamorphic/sweep.py (metamorphic corpus oracle)",
-      "note": "Dockerfile IAC rules that anchor to an explicit instruction (IAC-001 `USER root`, IAC-003 `ADD`, IAC-024 `sudo`) mis-locate and re-fingerprint under an INTERLEAVED blank line. A pure leading shift (blank lines at the top) is handled correctly — the finding's line tracks and the fingerprint is stable — but a blank line inserted *before* the flagged instruction leaves nox reporting the stale (pre-shift) line number, which now points at the blank line, and perturbs the v2 fingerprint. Blank lines between Dockerfile instructions are semantics-preserving, so this is a false-negative/false-positive pair under a no-op edit. Confirmed with a minimal one-blank-line repro on a canonical Dockerfile (FROM/RUN/ADD/RUN/COPY/USER root/ENTRYPOINT). Root cause is in nox's Dockerfile IAC location/fingerprint mapping (detection logic), which is out of scope for the oracle workstream. Re-verify at any time with: python3 scripts/metamorphic/sweep.py --bin ./nox --no-known-issues"
-    }
-  ]
+  "known_issues": []
 }


### PR DESCRIPTION
**The metamorphic corpus oracle (#324) found this on its first run** — proof the oracle works. Independently reproduced and fixed here.

## The bug
16 regex-pattern IaC rules anchor with `(?im)^\s*KEYWORD`. `\s` includes newlines, so under multiline matching a blank line before the flagged instruction lets `^\s*` begin the match on the **preceding blank line**:

```dockerfile
FROM alpine:3.20
RUN true

USER root          # <- IAC-001 reported on the BLANK line above, fingerprint changed
```

A blank line between Dockerfile instructions is semantics-preserving, so this is a **false-positive/false-negative pair under a no-op edit** — and the fingerprint change silently **breaks baseline matching** for real users.

## The fix
`^\s*` → `^[ \t]*` (cannot cross a newline) across all 16 patterns. This is the *exact* correction #311 applied to the absence anchors — the same `\s`-crosses-newlines trap lived in the pattern rules too. Real instructions carry only spaces/tabs before the keyword, so every genuine match is preserved.

## Verified
- Test-first: `dockerfile_blankline_test.go` asserts location tracks + fingerprint stable across the blank-line insert (red → green), for IAC-001/003/024.
- **Finding-neutral**: nox self-scan stays grade A; precision harness unchanged; `go test ./...` + `golangci-lint` clean.
- **The oracle now passes with `--no-known-issues`** — all 12 recorded violations cleared by this one fix. Its `known_issues.json` entry is removed, so a re-introduction fails CI on its own.

The loop closes: oracle finds → human fixes → oracle goes green.