### PR TITLE
feat(slop): remote signature-verified slopsquat feed + signed publish pipeline

### DIFF
--- a/.github/workflows/slopfeed-publish.yml
+++ b/.github/workflows/slopfeed-publish.yml
@@ -1,0 +1,130 @@
+name: Publish slopsquat feed
+
+# Regenerates the predictive slopsquat blocklist, signs it with the project's
+# Ed25519 feed-signing key, and publishes it as a downloadable, versioned
+# release asset. This is the "learning accumulates centrally, every device pulls
+# and verifies" half of the OSV pattern for nox's own feed.
+#
+# Trust chain: this job is the ONLY place that touches package registries (the
+# generator re-verifies every unregistered name, read-only and rate-limited). It
+# signs the frozen artifact with a private key held only as a repository secret;
+# nox clients verify the signature offline against the published public key. See
+# docs/slopsquat-feed.md.
+#
+# What a maintainer MUST configure before this workflow can publish:
+#   - Secret SLOPFEED_SIGNING_KEY: a PEM-encoded Ed25519 PRIVATE key
+#       openssl genpkey -algorithm ed25519 -out slopfeed.key
+#     Store the file's contents as the secret; never commit the private key.
+#   - (optional) Variable SLOPFEED_KEY_ID: a label recorded in the signature for
+#     rotation/audit (defaults to "slopfeed-key-v1").
+# The matching PUBLIC key is published as a release asset each run so operators
+# can pin it via scan.slop.signature_key_path.
+
+on:
+  schedule:
+    # Weekly. Registries drift: a name unregistered today can be claimed
+    # tomorrow, so each entry is re-verified and re-stamped on this cadence.
+    - cron: '17 6 * * 1'
+  workflow_dispatch: # nox:ignore IAC-308 -- manual re-publish is a deliberate maintainer control for this feed
+    inputs:
+      limit:
+        description: 'Max candidates to check against registries'
+        required: false
+        default: '180'
+
+# Least privilege at the top level: read only. The publishing job alone elevates
+# its release-write scope, and nothing here needs id-token (Ed25519 signing uses
+# a repository secret, not Sigstore keyless OIDC).
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # nox:ignore IAC-314 -- creating the feed release and uploading the signed feed + public key requires write to releases
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.25'
+
+      - name: Ensure signing key is configured
+        env:
+          SLOPFEED_SIGNING_KEY: ${{ secrets.SLOPFEED_SIGNING_KEY }}
+        run: |
+          if [ -z "$SLOPFEED_SIGNING_KEY" ]; then
+            echo "::error title=Missing signing key::Set the SLOPFEED_SIGNING_KEY secret to a PEM Ed25519 private key. See docs/slopsquat-feed.md."
+            exit 1
+          fi
+
+      - name: Materialize signing key
+        env:
+          SLOPFEED_SIGNING_KEY: ${{ secrets.SLOPFEED_SIGNING_KEY }}
+        run: |
+          umask 077
+          printf '%s\n' "$SLOPFEED_SIGNING_KEY" > "$RUNNER_TEMP/slopfeed.key"
+
+      - name: Regenerate and sign feed
+        env:
+          # Default resolved by the Actions expression so the run script carries
+          # no inline default literal.
+          KEY_ID: ${{ vars.SLOPFEED_KEY_ID || 'slopfeed-key-v1' }}
+          LIMIT: ${{ github.event.inputs.limit || '180' }}
+        run: |
+          set -euo pipefail
+          VERSION="$(date -u +%Y.%m.%d)"
+          echo "feed_version=$VERSION" >> "$GITHUB_ENV"
+          go run ./cmd/slopfeed \
+            --out "$RUNNER_TEMP/slopsquat-blocklist.v1.json" \
+            --sign-key "$RUNNER_TEMP/slopfeed.key" \
+            --key-id "$KEY_ID" \
+            --pubkey-out "$RUNNER_TEMP/slopfeed.pub.pem" \
+            --limit "$LIMIT" \
+            --version "$VERSION"
+
+      - name: Publish versioned release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="slopfeed/${feed_version}"
+          NOTES="Predictive slopsquat blocklist ${feed_version}. Signed Ed25519; verify against slopfeed.pub.pem. See docs/slopsquat-feed.md."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" \
+              "$RUNNER_TEMP/slopsquat-blocklist.v1.json" \
+              "$RUNNER_TEMP/slopfeed.pub.pem" --clobber
+          else
+            gh release create "$TAG" \
+              "$RUNNER_TEMP/slopsquat-blocklist.v1.json" \
+              "$RUNNER_TEMP/slopfeed.pub.pem" \
+              --title "Slopsquat feed ${feed_version}" \
+              --notes "$NOTES"
+          fi
+
+      - name: Update floating slopfeed-latest pointer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # A stable tag gives operators a constant fetch URL to point .nox.yaml
+          # at; its assets are replaced each run. Provenance/history lives in the
+          # dated slopfeed/<version> releases above.
+          NOTES="Rolling latest predictive slopsquat blocklist (currently ${feed_version}). Signed Ed25519; verify against slopfeed.pub.pem."
+          if gh release view slopfeed-latest >/dev/null 2>&1; then
+            gh release upload slopfeed-latest \
+              "$RUNNER_TEMP/slopsquat-blocklist.v1.json" \
+              "$RUNNER_TEMP/slopfeed.pub.pem" --clobber
+            gh release edit slopfeed-latest --notes "$NOTES"
+          else
+            gh release create slopfeed-latest \
+              "$RUNNER_TEMP/slopsquat-blocklist.v1.json" \
+              "$RUNNER_TEMP/slopfeed.pub.pem" \
+              --title "Slopsquat feed (latest)" \
+              --notes "$NOTES"
+          fi
+
+      - name: Shred signing key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/slopfeed.key"

--- a/cmd/slopfeed/main.go
+++ b/cmd/slopfeed/main.go
@@ -39,29 +39,49 @@ func main() {
 		dryRun   = flag.Bool("dry-run", false, "generate + select candidates but make no network calls; print a summary")
 		timeout  = flag.Duration("timeout", 20*time.Second, "per-request HTTP timeout")
 		printTop = flag.Int("print", 20, "print the top-N produced entries to stderr")
+		signKey  = flag.String("sign-key", "", "PEM Ed25519 private key (PKCS#8 or raw) used to sign the feed; when set, the written feed carries an Ed25519 signature over its canonical bytes")
+		keyID    = flag.String("key-id", "", "free-form identifier recorded in the signature (key rotation / audit)")
+		pubOut   = flag.String("pubkey-out", "", "path to write the signer's public key PEM; defaults to <out>.pub.pem when --sign-key is set")
 	)
 	flag.Parse()
 
-	if err := run(*out, *limit, *sleep, *timeout, *version, *dryRun, *printTop); err != nil {
+	opts := runOptions{
+		out: *out, limit: *limit, sleep: *sleep, timeout: *timeout, version: *version,
+		dryRun: *dryRun, printTop: *printTop, signKey: *signKey, keyID: *keyID, pubOut: *pubOut,
+	}
+	if err := run(opts); err != nil {
 		fmt.Fprintln(os.Stderr, "slopfeed:", err)
 		os.Exit(1)
 	}
 }
 
-func run(out string, limit int, sleep, timeout time.Duration, version string, dryRun bool, printTop int) error {
+// runOptions bundles the generator's parameters. It grew past a comfortable
+// positional-argument count once signing was added.
+type runOptions struct {
+	out            string
+	limit          int
+	sleep, timeout time.Duration
+	version        string
+	dryRun         bool
+	printTop       int
+	signKey, keyID string
+	pubOut         string
+}
+
+func run(o runOptions) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
 	cands := generateCandidates()
-	selected := stratifiedSelect(cands, limit)
+	selected := stratifiedSelect(cands, o.limit)
 	fmt.Fprintf(os.Stderr, "generated %d candidates; checking %d (stratified)\n", len(cands), len(selected))
 
-	if dryRun {
+	if o.dryRun {
 		summarize(selected)
 		return nil
 	}
 
-	chk := newChecker(&http.Client{Timeout: timeout}, sleep)
+	chk := newChecker(&http.Client{Timeout: o.timeout}, o.sleep)
 	today := time.Now().UTC().Format("2006-01-02")
 
 	var (
@@ -104,27 +124,42 @@ func run(out string, limit int, sleep, timeout time.Duration, version string, dr
 
 	f := &feed.Feed{
 		SchemaVersion: feed.SchemaVersion,
-		Version:       version,
+		Version:       o.version,
 		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
 		Source:        "cmd/slopfeed",
 		Entries:       entries,
 	}
 	f.SetDigest()
 
+	// Sign the feed when a signing key is provided. Sign re-derives the digest
+	// over the canonical entry bytes and attaches the Ed25519 signature nox
+	// verifies against a pinned public key. The public key is written next to the
+	// feed so the publish pipeline can attach it as a downloadable trust anchor.
+	if o.signKey != "" {
+		pubOut := o.pubOut
+		if pubOut == "" {
+			pubOut = o.out + ".pub.pem"
+		}
+		if _, err := signFeed(f, o.signKey, o.keyID, pubOut); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "signed feed with key %q (public key -> %s)\n", o.keyID, pubOut)
+	}
+
 	data, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshalling feed: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(out, data, 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", out, err)
+	if err := os.WriteFile(o.out, data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", o.out, err)
 	}
 
 	fmt.Fprintf(os.Stderr,
 		"\nwrote %s\n  entries: %d  (unregistered %d / registered %d / inconclusive %d)\n  requests: %d  digest: %s\n",
-		out, len(entries), nUnreg, nReg, nInconc, chk.requests, f.Digest)
-	if printTop > 0 {
-		n := printTop
+		o.out, len(entries), nUnreg, nReg, nInconc, chk.requests, f.Digest)
+	if o.printTop > 0 {
+		n := o.printTop
 		if n > len(entries) {
 			n = len(entries)
 		}

--- a/cmd/slopfeed/sign.go
+++ b/cmd/slopfeed/sign.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+)
+
+// loadEd25519PrivateKey reads a PEM-encoded Ed25519 private key from path. It
+// accepts the two forms a maintainer or CI is likely to hold:
+//
+//   - PKCS#8 ("PRIVATE KEY"), the default `openssl genpkey -algorithm ed25519`
+//     output and what most secret stores round-trip cleanly.
+//   - A raw key ("ED25519 PRIVATE KEY") whose body is either the 64-byte full
+//     private key or the 32-byte seed.
+//
+// It fails closed on anything else rather than guessing.
+func loadEd25519PrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading signing key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in signing key %s", path)
+	}
+
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing PKCS#8 signing key: %w", err)
+		}
+		priv, ok := key.(ed25519.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("signing key is not Ed25519 (got %T)", key)
+		}
+		return priv, nil
+	case "ED25519 PRIVATE KEY":
+		switch len(block.Bytes) {
+		case ed25519.PrivateKeySize:
+			return ed25519.PrivateKey(block.Bytes), nil
+		case ed25519.SeedSize:
+			return ed25519.NewKeyFromSeed(block.Bytes), nil
+		default:
+			return nil, fmt.Errorf("raw Ed25519 key has unexpected length %d", len(block.Bytes))
+		}
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q for a signing key", block.Type)
+	}
+}
+
+// signFeed signs f in place with the key at keyPath and, when pubkeyOut is set,
+// writes the corresponding public key PEM so the publish pipeline can attach it
+// as a downloadable trust anchor. It returns the public key PEM regardless.
+func signFeed(f *feed.Feed, keyPath, keyID, pubkeyOut string) (string, error) {
+	priv, err := loadEd25519PrivateKey(keyPath)
+	if err != nil {
+		return "", err
+	}
+	if err := f.Sign(priv, keyID); err != nil {
+		return "", fmt.Errorf("signing feed: %w", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", fmt.Errorf("deriving public key")
+	}
+	pubPEM := feed.EncodePublicKeyPEM(pub)
+	if pubkeyOut != "" {
+		if err := os.WriteFile(pubkeyOut, []byte(pubPEM), 0o644); err != nil {
+			return "", fmt.Errorf("writing public key %s: %w", pubkeyOut, err)
+		}
+	}
+	return pubPEM, nil
+}

--- a/cmd/slopfeed/sign_test.go
+++ b/cmd/slopfeed/sign_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+)
+
+func writePKCS8Key(t *testing.T, dir string, priv ed25519.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "key.pem")
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeRawKey(t *testing.T, dir string, priv ed25519.PrivateKey) string {
+	t.Helper()
+	path := filepath.Join(dir, "raw.pem")
+	block := &pem.Block{Type: "ED25519 PRIVATE KEY", Bytes: priv}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestSignFeedProducesVerifiableSignature proves the generator signs with both
+// key encodings and that nox's verifier accepts the result under the matching
+// public key and rejects it under a different one.
+func TestSignFeedProducesVerifiableSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		keyPath string
+	}{
+		{"pkcs8", writePKCS8Key(t, dir, priv)},
+		{"raw", writeRawKey(t, dir, priv)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &feed.Feed{
+				SchemaVersion: feed.SchemaVersion,
+				Version:       "test",
+				Source:        "test",
+				Entries: []feed.Entry{{
+					Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+					Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+				}},
+			}
+			pubOut := filepath.Join(dir, tc.name+".pub.pem")
+			if _, err := signFeed(f, tc.keyPath, "kid", pubOut); err != nil {
+				t.Fatalf("signFeed: %v", err)
+			}
+			raw := mustMarshal(t, f)
+
+			// Accepts under the correct key.
+			if _, err := feed.Parse(raw, feed.VerifyOptions{
+				RequireSignature: true, Verifier: feed.Ed25519Verifier(pub),
+			}); err != nil {
+				t.Fatalf("signed feed must verify: %v", err)
+			}
+			// Rejects under a different key.
+			otherPub, _, _ := ed25519.GenerateKey(nil)
+			if _, err := feed.Parse(raw, feed.VerifyOptions{
+				RequireSignature: true, Verifier: feed.Ed25519Verifier(otherPub),
+			}); err == nil {
+				t.Fatalf("signature must not verify under a different key")
+			}
+			// The written public key file must be usable as a pinned verifier.
+			pemBytes, err := os.ReadFile(pubOut)
+			if err != nil {
+				t.Fatal(err)
+			}
+			v, err := feed.PEMEd25519Verifier(pemBytes)
+			if err != nil {
+				t.Fatalf("PEMEd25519Verifier from emitted pubkey: %v", err)
+			}
+			if _, err := feed.Parse(raw, feed.VerifyOptions{RequireSignature: true, Verifier: v}); err != nil {
+				t.Fatalf("emitted public key must verify the feed: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadEd25519PrivateKeyRejectsGarbage(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(bad, []byte("not a pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadEd25519PrivateKey(bad); err == nil {
+		t.Fatalf("garbage key must be rejected")
+	}
+	if _, err := loadEd25519PrivateKey(filepath.Join(dir, "missing.pem")); err == nil {
+		t.Fatalf("missing key must be rejected")
+	}
+}
+
+func mustMarshal(t *testing.T, f *feed.Feed) []byte {
+	t.Helper()
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/core/analyzers/slop/feed/feed.go
+++ b/core/analyzers/slop/feed/feed.go
@@ -19,14 +19,18 @@
 //     and rejects any feed whose bytes do not match — this catches truncation,
 //     tampering, and accidental corruption. Verification fails closed: a feed
 //     that does not verify is never trusted, and never crashes the scanner.
-//   - The format reserves an Ed25519 signature over the same canonical bytes,
-//     so a feed can later be Sigstore/cosign-signed exactly like a plugin
-//     artifact. Signature verification is a pluggable hook (SignatureVerifier);
-//     nothing here stands up real signing infrastructure, but the consumer has
-//     a verification seam and can be configured to require a valid signature.
+//   - The format carries an Ed25519 signature over the same canonical bytes, so
+//     a feed is authenticated exactly like a plugin artifact. Signing is done
+//     out of band by the publish pipeline (see Sign and cmd/slopfeed); nox
+//     verifies against a pinned public key via a pluggable hook
+//     (SignatureVerifier) and can be configured to require a valid signature.
 //
-// The package has no network access and no side effects. It depends only on
-// the standard library, so it does not couple core to the registry package.
+// A local feed (Load/Bundled) touches no network. A remote feed (LoadRemote)
+// fetches over HTTP(S), verifies digest AND signature before use, and caches the
+// verified bytes content-addressed on disk so subsequent scans are offline and
+// deterministic. Verification always gates use: only bytes that verify are
+// cached or returned. The package depends only on the standard library, so it
+// does not couple core to the registry package.
 package feed
 
 import (

--- a/core/analyzers/slop/feed/remote.go
+++ b/core/analyzers/slop/feed/remote.go
@@ -1,0 +1,221 @@
+package feed
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// maxFeedSize bounds a fetched feed so a hostile or misbehaving server
+	// cannot exhaust memory. A real feed is a few hundred entries — kilobytes;
+	// 8 MiB is generous headroom.
+	maxFeedSize = 8 * 1024 * 1024
+	// defaultFeedHTTPTimeout bounds a single feed fetch.
+	defaultFeedHTTPTimeout = 30 * time.Second
+	// DefaultRefreshInterval is how long a cached remote feed is treated as
+	// fresh before a refetch is attempted. A signed feed changes on the
+	// generator's cadence (days), so a day is a safe default that keeps scans
+	// offline between refreshes.
+	DefaultRefreshInterval = 24 * time.Hour
+)
+
+// RemoteOptions configures fetching, caching, and verifying a feed served over
+// HTTP(S).
+type RemoteOptions struct {
+	// URL is the feed location. Must be http or https.
+	URL string
+	// CacheDir is where verified feed bytes are cached, content-addressed by
+	// URL. Empty defaults to $HOME/.nox/cache/slopfeed.
+	CacheDir string
+	// TTL is how long a cached copy is considered fresh; within it, no network
+	// call is made. Zero forces a refetch attempt (still falling back to cache
+	// on a network error). See DefaultRefreshInterval.
+	TTL time.Duration
+	// Offline forbids all network access: the feed is served from cache or the
+	// load fails closed. Mirrors the scan-wide Offline guarantee.
+	Offline bool
+	// HTTPClient overrides the default client (used by tests). Nil uses a client
+	// with defaultFeedHTTPTimeout.
+	HTTPClient *http.Client
+	// Verify is applied to both freshly fetched and cached bytes. Only bytes
+	// that pass verification are ever cached or returned.
+	Verify VerifyOptions
+}
+
+// LoadRemote fetches, verifies, and caches a feed from a URL, then returns it
+// indexed for lookup. It is the remote analogue of Load, and it fails closed on
+// every error path: a fetch failure, a non-2xx status, an oversized body, a
+// digest mismatch, or an unmet signature requirement never yields a trusted
+// feed and never panics.
+//
+// Determinism and offline behavior:
+//   - A cached copy that is still fresh (within TTL) and that re-verifies is
+//     used WITHOUT any network call, so repeated scans are deterministic and a
+//     disconnected machine keeps working.
+//   - Offline forbids the network entirely: only a verified cache is accepted.
+//   - When a refetch is attempted but the network fails, a previously cached and
+//     re-verified copy is used as a fallback rather than losing coverage.
+//
+// Critically, verification gates USE: bytes are cached only after they verify,
+// and cached bytes are re-verified on every read. An attacker who MITMs the feed
+// cannot inject a name nox would then flag, nor suppress an existing one,
+// without a signature that verifies under the pinned key.
+func LoadRemote(ctx context.Context, opts RemoteOptions) (*Loaded, error) {
+	if err := validateFeedURL(opts.URL); err != nil {
+		return nil, err
+	}
+	cacheDir := opts.CacheDir
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.Getenv("HOME"), ".nox", "cache", "slopfeed")
+	}
+	cachePath := feedCachePath(cacheDir, opts.URL)
+
+	// Offline: cache-only, fail closed if absent or unverifiable.
+	if opts.Offline {
+		loaded, err := loadCachedFeed(cachePath, opts.Verify)
+		if err != nil {
+			return nil, fmt.Errorf("offline: no usable cached feed for %s: %w", opts.URL, err)
+		}
+		return loaded, nil
+	}
+
+	// Fresh cache within TTL: serve without touching the network.
+	if opts.TTL > 0 && !cacheStale(cachePath, opts.TTL) {
+		if loaded, err := loadCachedFeed(cachePath, opts.Verify); err == nil {
+			return loaded, nil
+		}
+		// A corrupt/unverifiable cache is not fatal here: fall through to fetch a
+		// fresh copy.
+	}
+
+	// Fetch, verify, and cache.
+	loaded, fetchErr := fetchAndCacheFeed(ctx, opts, cachePath)
+	if fetchErr == nil {
+		return loaded, nil
+	}
+
+	// Network failure: fall back to a cached, re-verified copy (even if stale)
+	// rather than losing predictive coverage. A verification failure on the
+	// FETCHED bytes is not eligible for fallback here — fetchAndCacheFeed only
+	// returns a non-nil loaded on success, and a tampered/bad-signature fetch
+	// returns an error we surface, never a cached impersonation of it.
+	if loaded, err := loadCachedFeed(cachePath, opts.Verify); err == nil {
+		return loaded, nil
+	}
+	return nil, fetchErr
+}
+
+// validateFeedURL rejects anything that is not an absolute http(s) URL. This
+// keeps LoadRemote from being coerced into reading local files or other schemes.
+func validateFeedURL(raw string) error {
+	if raw == "" {
+		return errors.New("feed URL is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid feed URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("feed URL must use http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("feed URL has no host: %q", raw)
+	}
+	return nil
+}
+
+// feedCachePath derives a deterministic, content-addressed cache path from the
+// feed URL, mirroring the registry cache's scheme.
+func feedCachePath(dir, feedURL string) string {
+	h := sha256.Sum256([]byte(feedURL))
+	return filepath.Join(dir, hex.EncodeToString(h[:8])+".json")
+}
+
+// cacheStale reports whether the cache file is missing or older than ttl.
+func cacheStale(path string, ttl time.Duration) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return time.Since(info.ModTime()) > ttl
+}
+
+// loadCachedFeed reads and re-verifies cached feed bytes. A missing file or a
+// verification failure returns an error (fail closed) so the caller never trusts
+// an unverifiable cache.
+func loadCachedFeed(path string, verify VerifyOptions) (*Loaded, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data, verify)
+}
+
+// fetchAndCacheFeed performs the network fetch, verifies the response, and — only
+// on success — atomically writes the verified bytes to the cache.
+func fetchAndCacheFeed(ctx context.Context, opts RemoteOptions, cachePath string) (*Loaded, error) {
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultFeedHTTPTimeout}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, opts.URL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("building feed request: %w", err)
+	}
+	req.Header.Set("User-Agent", "nox-slopfeed-client")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching feed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("feed server returned HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading feed body: %w", err)
+	}
+	if len(body) > maxFeedSize {
+		return nil, fmt.Errorf("feed exceeds maximum size of %d bytes", maxFeedSize)
+	}
+
+	// Verify BEFORE caching: only verified bytes are ever persisted or trusted.
+	loaded, err := Parse(body, opts.Verify)
+	if err != nil {
+		return nil, fmt.Errorf("verifying fetched feed: %w", err)
+	}
+	if err := writeFeedCache(cachePath, body); err != nil {
+		// A cache-write failure must not fail the load — we already have a
+		// verified feed in hand; we just lose the offline copy this round.
+		return loaded, nil //nolint:nilerr // verified feed is usable; cache is best-effort
+	}
+	return loaded, nil
+}
+
+// writeFeedCache atomically writes verified feed bytes to the cache (temp file +
+// rename), creating the cache directory as needed.
+func writeFeedCache(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating feed cache dir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("writing feed cache: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming feed cache: %w", err)
+	}
+	return nil
+}

--- a/core/analyzers/slop/feed/remote_test.go
+++ b/core/analyzers/slop/feed/remote_test.go
@@ -1,0 +1,273 @@
+package feed
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// signedFeedBytes builds a feed over sampleEntries, signs it with priv, and
+// returns the JSON bytes a server would serve.
+func signedFeedBytes(t *testing.T, priv ed25519.PrivateKey) []byte {
+	t.Helper()
+	f := &Feed{
+		SchemaVersion: SchemaVersion,
+		Version:       "2026.07.25",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries:       sampleEntries(),
+	}
+	if err := f.Sign(priv, "test-key"); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return mustJSON(t, f)
+}
+
+// countingServer serves body and records how many requests it received.
+func countingServer(body []byte, hits *int64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(hits, 1)
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestLoadRemoteValidSignatureLoads(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	var hits int64
+	srv := countingServer(signedFeedBytes(t, priv), &hits)
+	defer srv.Close()
+
+	loaded, err := LoadRemote(context.Background(), RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: t.TempDir(),
+		TTL:      time.Hour,
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	})
+	if err != nil {
+		t.Fatalf("valid signed remote feed must load: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", loaded.Len())
+	}
+	if _, ok := loaded.Lookup("pypi", "openai-utils"); !ok {
+		t.Fatalf("expected openai-utils in the loaded feed")
+	}
+}
+
+func TestLoadRemoteWrongKeyRejected(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	var hits int64
+	srv := countingServer(signedFeedBytes(t, priv), &hits)
+	defer srv.Close()
+
+	loaded, err := LoadRemote(context.Background(), RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: t.TempDir(),
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(otherPub)},
+	})
+	if err == nil {
+		t.Fatalf("feed signed by a different key must be rejected")
+	}
+	if loaded != nil {
+		t.Fatalf("expected nil loaded feed on rejection")
+	}
+}
+
+func TestLoadRemoteTamperedDigestRejected(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	body := signedFeedBytes(t, priv)
+	// Tamper: mutate an entry after signing so the digest no longer matches.
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["entries"].([]any)[0].(map[string]any)["name"] = "evil-injected"
+	tampered := mustJSON(t, m)
+	var hits int64
+	srv := countingServer(tampered, &hits)
+	defer srv.Close()
+
+	loaded, err := LoadRemote(context.Background(), RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: t.TempDir(),
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	})
+	if err == nil {
+		t.Fatalf("tampered feed must be rejected (digest mismatch)")
+	}
+	if loaded != nil {
+		t.Fatalf("expected nil loaded feed on tamper")
+	}
+}
+
+func TestLoadRemoteRequireSignatureUnsignedRejected(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	// Serve an UNSIGNED (but digest-valid) feed.
+	f := buildFeed(t)
+	var hits int64
+	srv := countingServer(mustJSON(t, f), &hits)
+	defer srv.Close()
+
+	_, err := LoadRemote(context.Background(), RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: t.TempDir(),
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	})
+	if err == nil {
+		t.Fatalf("require_signature must reject an unsigned remote feed")
+	}
+}
+
+func TestLoadRemoteFreshCacheAvoidsNetwork(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	var hits int64
+	srv := countingServer(signedFeedBytes(t, priv), &hits)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	opts := RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: dir,
+		TTL:      time.Hour,
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	}
+	if _, err := LoadRemote(context.Background(), opts); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Fatalf("expected exactly 1 network hit on first load, got %d", got)
+	}
+	// Second load within TTL must be served from the verified cache: no network.
+	if _, err := LoadRemote(context.Background(), opts); err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Fatalf("fresh cache must avoid the network: expected 1 hit total, got %d", got)
+	}
+}
+
+func TestLoadRemoteOfflineUsesCacheNeverNetwork(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	var hits int64
+	srv := countingServer(signedFeedBytes(t, priv), &hits)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	base := RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: dir,
+		TTL:      time.Hour,
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	}
+	// Prime the cache once online.
+	if _, err := LoadRemote(context.Background(), base); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	primed := atomic.LoadInt64(&hits)
+
+	// Now go offline with TTL=0 (would normally force a refetch): must still be
+	// served from cache and must not touch the network.
+	offline := base
+	offline.Offline = true
+	offline.TTL = 0
+	loaded, err := LoadRemote(context.Background(), offline)
+	if err != nil {
+		t.Fatalf("offline load from cache must succeed: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("expected cached feed with 2 entries, got %d", loaded.Len())
+	}
+	if got := atomic.LoadInt64(&hits); got != primed {
+		t.Fatalf("offline mode must not touch the network: hits went %d -> %d", primed, got)
+	}
+}
+
+func TestLoadRemoteOfflineWithNoCacheFailsClosed(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	_, err := LoadRemote(context.Background(), RemoteOptions{
+		URL:      "https://feeds.example.com/slopfeed.json",
+		CacheDir: t.TempDir(),
+		Offline:  true,
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	})
+	if err == nil {
+		t.Fatalf("offline with no cache must fail closed")
+	}
+}
+
+func TestLoadRemoteFetchErrorFallsBackToCache(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	good := signedFeedBytes(t, priv)
+	var serverDown atomic.Bool
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		if serverDown.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(good)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	base := RemoteOptions{
+		URL:      srv.URL,
+		CacheDir: dir,
+		TTL:      time.Hour,
+		Verify:   VerifyOptions{RequireSignature: true, Verifier: Ed25519Verifier(pub)},
+	}
+	if _, err := LoadRemote(context.Background(), base); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	// Server now fails; force a refetch (TTL=0). Must fall back to the verified
+	// cache rather than failing the load.
+	serverDown.Store(true)
+	stale := base
+	stale.TTL = 0
+	loaded, err := LoadRemote(context.Background(), stale)
+	if err != nil {
+		t.Fatalf("fetch error must fall back to cache: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("expected cached feed, got %d entries", loaded.Len())
+	}
+}
+
+func TestLoadRemoteRejectsNonHTTPScheme(t *testing.T) {
+	for _, u := range []string{"file:///etc/passwd", "ftp://x/y", "/local/path", ""} {
+		if _, err := LoadRemote(context.Background(), RemoteOptions{URL: u, CacheDir: t.TempDir()}); err == nil {
+			t.Fatalf("scheme %q must be rejected", u)
+		}
+	}
+}
+
+func TestSignRoundTripsThroughPEMVerifier(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	f := buildFeed(t)
+	if err := f.Sign(priv, "kid-1"); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	data := mustJSON(t, f)
+
+	// The public key the signer embedded must be usable to build a verifier that
+	// accepts the feed — and it must be the SAME key material as pub.
+	verifier := Ed25519Verifier(pub)
+	if _, err := Parse(data, VerifyOptions{RequireSignature: true, Verifier: verifier}); err != nil {
+		t.Fatalf("signed feed must verify under the signer's public key: %v", err)
+	}
+	// A PEM verifier built from the embedded public key must also accept it.
+	pemVerifier, err := PEMEd25519Verifier([]byte(f.Signature.PublicKeyPEM))
+	if err != nil {
+		t.Fatalf("PEMEd25519Verifier from embedded key: %v", err)
+	}
+	if _, err := Parse(data, VerifyOptions{RequireSignature: true, Verifier: pemVerifier}); err != nil {
+		t.Fatalf("signed feed must verify under a PEM verifier from its embedded key: %v", err)
+	}
+}

--- a/core/analyzers/slop/feed/sign.go
+++ b/core/analyzers/slop/feed/sign.go
@@ -1,0 +1,53 @@
+package feed
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+)
+
+// Sign computes the feed's content digest and attaches an Ed25519 signature over
+// the canonical entry bytes — the same bytes the digest covers. It is the
+// signing side of the format's verification seam (see Ed25519Verifier), used by
+// the out-of-band publish pipeline (cmd/slopfeed): a maintainer holds the
+// private half; nox verifies against the published public half.
+//
+// The signer's public key is recorded in Signature.PublicKeyPEM for
+// transparency and offline diagnosis only. A verifier NEVER trusts that
+// self-described key — Ed25519Verifier checks against a key the operator pinned
+// out of band, so embedding the public key cannot be used to forge trust.
+//
+// keyID is a free-form label identifying which signing key was used (rotation,
+// audit). Sign always (re)computes the digest first, so an entry mutation after
+// SetDigest cannot slip past unsigned.
+func (f *Feed) Sign(priv ed25519.PrivateKey, keyID string) error {
+	if len(priv) != ed25519.PrivateKeySize {
+		return fmt.Errorf("ed25519 private key has wrong size: got %d, want %d", len(priv), ed25519.PrivateKeySize)
+	}
+	f.SetDigest()
+	content := CanonicalEntries(f.Entries)
+	sig := ed25519.Sign(priv, content)
+
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("deriving public key from private key")
+	}
+	f.Signature = &Signature{
+		Algorithm:    "ed25519",
+		KeyID:        keyID,
+		PublicKeyPEM: EncodePublicKeyPEM(pub),
+		Value:        base64.StdEncoding.EncodeToString(sig),
+	}
+	return nil
+}
+
+// EncodePublicKeyPEM encodes a raw Ed25519 public key as a PEM block of type
+// "ED25519 PUBLIC KEY" (raw 32-byte body). This is the exact form
+// PEMEd25519Verifier accepts, so a key emitted here round-trips into a verifier
+// without crypto/x509. The publish pipeline writes this alongside the feed so
+// operators can pin it via scan.slop.signature_key_path.
+func EncodePublicKeyPEM(pub ed25519.PublicKey) string {
+	block := &pem.Block{Type: "ED25519 PUBLIC KEY", Bytes: pub}
+	return string(pem.EncodeToMemory(block))
+}

--- a/core/config.go
+++ b/core/config.go
@@ -375,10 +375,21 @@ type OSVConfig struct {
 // docs/slopsquat-feed.md.
 type SlopConfig struct {
 	// Feed selects the predictive blocklist. Empty (default) disables the
-	// predictive dimension entirely. The special value "bundled" uses the feed
-	// shipped in the nox binary; any other value is a path to a feed JSON file
-	// (relative to the scan root or absolute).
+	// predictive dimension entirely. Accepted values:
+	//   - "bundled"          — the feed shipped in the nox binary
+	//   - an http(s):// URL  — a remotely published, signature-verified feed
+	//                          (fetched, verified, and cached locally; offline
+	//                          after the first successful fetch)
+	//   - any other value    — a path to a feed JSON file (relative to the scan
+	//                          root or absolute)
 	Feed string `yaml:"feed"`
+	// CacheDir overrides where a remote feed's verified bytes are cached. Empty
+	// defaults to $HOME/.nox/cache/slopfeed. Only used for http(s) feeds.
+	CacheDir string `yaml:"cache_dir"`
+	// Refresh sets how long a cached remote feed is treated as fresh before a
+	// refetch is attempted (a Go duration such as "24h" or "7d"). Within it, no
+	// network call is made. Empty defaults to 24h. Only used for http(s) feeds.
+	Refresh string `yaml:"refresh"`
 	// RequireSignature, when true, rejects a feed that is unsigned or whose
 	// signature does not verify — the predictive dimension then stays off rather
 	// than trusting an unverified feed. Digest integrity is always enforced

--- a/core/scan.go
+++ b/core/scan.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -256,7 +257,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// stays off and the failure is recorded as a visible degradation.
 	var slopOpts []slop.Option
 	if fp := cfg.Scan.Slop.Feed; fp != "" {
-		if loaded, ferr := loadSlopFeed(target, cfg.Scan.Slop); ferr != nil {
+		if loaded, ferr := loadSlopFeed(ctx, target, cfg.Scan.Slop, opts.Offline); ferr != nil {
 			degradations.Add(degrade.SlopFeed,
 				fmt.Sprintf("predictive slopsquat feed %q could not be loaded: %v", fp, ferr),
 				"the SLOP-002 predictive dimension is disabled; high-risk slopsquat targets are not being flagged from the feed")
@@ -581,12 +582,20 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 }
 
 // loadSlopFeed resolves and verifies the predictive slopsquat feed named in the
-// config. The special value "bundled" loads the feed embedded in the binary;
-// any other value is a file path resolved relative to the scan root (unless
-// absolute). Verification is offline and fails closed: a digest mismatch,
-// decode error, or an unmet signature requirement returns an error and the
-// caller disables the predictive dimension rather than trusting the feed.
-func loadSlopFeed(target string, cfg SlopConfig) (*feed.Loaded, error) {
+// config. The value selects the source:
+//   - "bundled"         — the feed embedded in the binary
+//   - an http(s):// URL — a remotely published feed, fetched over the network,
+//     verified (digest + signature), and cached locally so later scans are
+//     offline and deterministic
+//   - any other value   — a file path resolved relative to the scan root
+//
+// Verification fails closed everywhere: a digest mismatch, decode error, unmet
+// signature requirement, fetch failure with no usable cache, or (offline) a
+// missing cache returns an error, and the caller disables the predictive
+// dimension and records a degradation rather than trusting the feed. When
+// offline is set, a URL feed never touches the network — it is served from the
+// verified cache or the load fails closed.
+func loadSlopFeed(ctx context.Context, target string, cfg SlopConfig, offline bool) (*feed.Loaded, error) {
 	opts := feed.VerifyOptions{RequireSignature: cfg.RequireSignature}
 	if cfg.SignatureKeyPath != "" {
 		keyPath := cfg.SignatureKeyPath
@@ -617,11 +626,57 @@ func loadSlopFeed(target string, cfg SlopConfig) (*feed.Loaded, error) {
 		return loaded, nil
 	}
 
+	if isRemoteFeed(cfg.Feed) {
+		ttl := feed.DefaultRefreshInterval
+		if cfg.Refresh != "" {
+			parsed, err := parseFeedRefresh(cfg.Refresh)
+			if err != nil {
+				return nil, fmt.Errorf("parsing slop.refresh %q: %w", cfg.Refresh, err)
+			}
+			ttl = parsed
+		}
+		cacheDir := cfg.CacheDir
+		if cacheDir != "" && !filepath.IsAbs(cacheDir) {
+			cacheDir = filepath.Join(scanRootDir(target), cacheDir)
+		}
+		return feed.LoadRemote(ctx, feed.RemoteOptions{
+			URL:      cfg.Feed,
+			CacheDir: cacheDir,
+			TTL:      ttl,
+			Offline:  offline,
+			Verify:   opts,
+		})
+	}
+
 	path := cfg.Feed
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(scanRootDir(target), path)
 	}
 	return feed.Load(path, opts)
+}
+
+// isRemoteFeed reports whether a feed value names a remotely fetched feed rather
+// than a local path or the bundled feed.
+func isRemoteFeed(v string) bool {
+	return strings.HasPrefix(v, "https://") || strings.HasPrefix(v, "http://")
+}
+
+// parseFeedRefresh parses a refresh interval: a standard Go duration, or a
+// bare "<n>d" days form (which time.ParseDuration does not accept). It matches
+// the "7d"/"24h" style used elsewhere in .nox.yaml.
+func parseFeedRefresh(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if rest, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.Atoi(strings.TrimSpace(rest))
+		if err != nil {
+			return 0, fmt.Errorf("invalid days value %q", s)
+		}
+		if days < 0 {
+			return 0, fmt.Errorf("negative refresh interval %q", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
 }
 
 // scanRootDir returns the directory a relative config path is resolved against:

--- a/core/scan_slop_remote_feed_test.go
+++ b/core/scan_slop_remote_feed_test.go
@@ -1,0 +1,263 @@
+package core
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/analyzers/slop/feed"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// signedFeedJSON builds and signs a feed flagging the given entries.
+func signedFeedJSON(t *testing.T, priv ed25519.PrivateKey, entries ...feed.Entry) []byte {
+	t.Helper()
+	f := &feed.Feed{
+		SchemaVersion: feed.SchemaVersion,
+		Version:       "remote-2026.07.25",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries:       entries,
+	}
+	if err := f.Sign(priv, "test-key"); err != nil {
+		t.Fatalf("sign feed: %v", err)
+	}
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// TestScanRemoteSignedFeedFiresSLOP002 proves the full remote trust chain from
+// the consumer's side: nox fetches a signed feed over HTTP, verifies its
+// signature against a pinned public key, and fires SLOP-002 — all without
+// altering the SLOP-001 baseline.
+func TestScanRemoteSignedFeedFiresSLOP002(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	body := signedFeedJSON(t, priv, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "unregistered high-risk", VerifiedAt: "2026-07-25",
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	root := writeProject(t, map[string]string{
+		"requirements.txt": "flask\n",
+		"app.py":           "import flask\nimport openai_utils\n",
+	})
+	// Pin the publisher's public key on disk and require a signature.
+	writeProjFile(t, root, "keys/slopfeed.pub.pem", feed.EncodePublicKeyPEM(pub))
+	writeProjFile(t, root, ".nox.yaml",
+		"scan:\n  slop:\n    feed: "+srv.URL+"\n    require_signature: true\n"+
+			"    signature_key_path: keys/slopfeed.pub.pem\n"+
+			"    cache_dir: .nox/slopfeed-cache\n")
+
+	res, err := RunScanContext(context.Background(), root, ScanOptions{})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := countRule(res, "SLOP-001"); got != 1 {
+		t.Fatalf("expected 1 SLOP-001, got %d", got)
+	}
+	if got := countRule(res, "SLOP-002"); got != 1 {
+		t.Fatalf("expected 1 SLOP-002 from the signed remote feed, got %d", got)
+	}
+	for _, f := range res.Findings.Findings() {
+		if f.RuleID == "SLOP-002" && f.Severity != findings.SeverityHigh {
+			t.Errorf("critical-tier predictive finding should be High, got %q", f.Severity)
+		}
+	}
+	// No degradation: the feed verified cleanly.
+	for _, d := range res.Degradations {
+		if d.Kind == "slop_feed" {
+			t.Fatalf("unexpected slop_feed degradation on a valid signed feed: %+v", d)
+		}
+	}
+}
+
+// TestScanRemoteFeedCachedServesOffline proves that after one successful fetch,
+// a subsequent offline scan is served from the verified cache with no network.
+func TestScanRemoteFeedCachedServesOffline(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	body := signedFeedJSON(t, priv, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	var down bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if down {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	root := writeProject(t, map[string]string{"app.py": "import openai_utils\n"})
+	writeProjFile(t, root, "keys/slopfeed.pub.pem", feed.EncodePublicKeyPEM(pub))
+	writeProjFile(t, root, ".nox.yaml",
+		"scan:\n  slop:\n    feed: "+srv.URL+"\n    require_signature: true\n"+
+			"    signature_key_path: keys/slopfeed.pub.pem\n"+
+			"    cache_dir: .nox/slopfeed-cache\n")
+
+	// Prime the cache online.
+	if _, err := RunScanContext(context.Background(), root, ScanOptions{}); err != nil {
+		t.Fatalf("prime scan: %v", err)
+	}
+	// Take the server down AND scan offline: must be served from cache.
+	down = true
+	res, err := RunScanContext(context.Background(), root, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("offline scan: %v", err)
+	}
+	if got := countRule(res, "SLOP-002"); got != 1 {
+		t.Fatalf("offline cached feed should still fire SLOP-002, got %d", got)
+	}
+}
+
+// TestScanRemoteTamperedFeedFailsClosed proves a MITM-tampered remote feed is
+// rejected: no SLOP-002, a visible degradation, SLOP-001 intact, no crash.
+func TestScanRemoteTamperedFeedFailsClosed(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	body := signedFeedJSON(t, priv, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	// Attacker mutates an entry to inject a name, invalidating the digest.
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["entries"].([]any)[0].(map[string]any)["name"] = "attacker-injected"
+	tampered, _ := json.Marshal(m)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tampered)
+	}))
+	defer srv.Close()
+
+	root := writeProject(t, map[string]string{"app.py": "import openai_utils\n"})
+	writeProjFile(t, root, "keys/slopfeed.pub.pem", feed.EncodePublicKeyPEM(pub))
+	writeProjFile(t, root, ".nox.yaml",
+		"scan:\n  slop:\n    feed: "+srv.URL+"\n    require_signature: true\n"+
+			"    signature_key_path: keys/slopfeed.pub.pem\n"+
+			"    cache_dir: .nox/slopfeed-cache\n")
+
+	res, err := RunScanContext(context.Background(), root, ScanOptions{})
+	if err != nil {
+		t.Fatalf("scan must not crash on a tampered feed: %v", err)
+	}
+	if got := countRule(res, "SLOP-002"); got != 0 {
+		t.Fatalf("tampered feed must yield no SLOP-002, got %d", got)
+	}
+	if got := countRule(res, "SLOP-001"); got != 1 {
+		t.Fatalf("SLOP-001 baseline must be intact, got %d", got)
+	}
+	var degraded bool
+	for _, d := range res.Degradations {
+		if d.Kind == "slop_feed" {
+			degraded = true
+		}
+	}
+	if !degraded {
+		t.Fatalf("a tampered remote feed must record a slop_feed degradation")
+	}
+}
+
+// TestScanRemoteWrongIdentityFeedRejected proves a feed signed by a DIFFERENT
+// key (a forged identity) is rejected even though it is internally consistent.
+func TestScanRemoteWrongIdentityFeedRejected(t *testing.T) {
+	// The publisher we pin.
+	pinnedPub, _, _ := ed25519.GenerateKey(nil)
+	// The attacker signs with their own key over a valid digest.
+	_, attackerPriv, _ := ed25519.GenerateKey(nil)
+	body := signedFeedJSON(t, attackerPriv, feed.Entry{
+		Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+		Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	root := writeProject(t, map[string]string{"app.py": "import openai_utils\n"})
+	writeProjFile(t, root, "keys/slopfeed.pub.pem", feed.EncodePublicKeyPEM(pinnedPub))
+	writeProjFile(t, root, ".nox.yaml",
+		"scan:\n  slop:\n    feed: "+srv.URL+"\n    require_signature: true\n"+
+			"    signature_key_path: keys/slopfeed.pub.pem\n"+
+			"    cache_dir: .nox/slopfeed-cache\n")
+
+	res, err := RunScanContext(context.Background(), root, ScanOptions{})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := countRule(res, "SLOP-002"); got != 0 {
+		t.Fatalf("feed signed by a non-pinned identity must be rejected, got %d SLOP-002", got)
+	}
+	var degraded bool
+	for _, d := range res.Degradations {
+		if d.Kind == "slop_feed" {
+			degraded = true
+		}
+	}
+	if !degraded {
+		t.Fatalf("wrong-identity feed must record a slop_feed degradation")
+	}
+}
+
+// TestScanRemoteUnsignedFeedWithRequireSignatureRejected proves an unsigned feed
+// is rejected when require_signature is set.
+func TestScanRemoteUnsignedFeedWithRequireSignatureRejected(t *testing.T) {
+	// Build an UNSIGNED but digest-valid feed.
+	f := &feed.Feed{
+		SchemaVersion: feed.SchemaVersion,
+		Version:       "unsigned",
+		GeneratedAt:   "2026-07-25T00:00:00Z",
+		Source:        "test",
+		Entries: []feed.Entry{{
+			Name: "openai-utils", Ecosystem: "pypi", Pattern: "obvious",
+			Risk: 0.82, Tier: "critical", Reason: "x", VerifiedAt: "2026-07-25",
+		}},
+	}
+	f.SetDigest()
+	body, _ := json.Marshal(f)
+	pub, _, _ := ed25519.GenerateKey(nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	root := writeProject(t, map[string]string{"app.py": "import openai_utils\n"})
+	writeProjFile(t, root, "keys/slopfeed.pub.pem", feed.EncodePublicKeyPEM(pub))
+	writeProjFile(t, root, ".nox.yaml",
+		"scan:\n  slop:\n    feed: "+srv.URL+"\n    require_signature: true\n"+
+			"    signature_key_path: keys/slopfeed.pub.pem\n"+
+			"    cache_dir: .nox/slopfeed-cache\n")
+
+	res, err := RunScanContext(context.Background(), root, ScanOptions{})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := countRule(res, "SLOP-002"); got != 0 {
+		t.Fatalf("unsigned feed under require_signature must be rejected, got %d", got)
+	}
+}
+
+// writeFile writes a single file under root, creating parent dirs.
+func writeProjFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/slopsquat-feed.md
+++ b/docs/slopsquat-feed.md
@@ -29,13 +29,14 @@ no `SLOP-002`, identical findings, identical grade. Enabling a feed is purely
 
 ## Enabling it
 
-In `.nox.yaml`:
+In `.nox.yaml`, `scan.slop.feed` accepts three kinds of value:
 
 ```yaml
 scan:
   slop:
-    # "bundled" uses the feed shipped inside the nox binary. Any other value is
-    # a path to a feed JSON file (relative to the scan root, or absolute).
+    # "bundled" uses the feed shipped inside the nox binary. A local path
+    # (relative to the scan root, or absolute) uses a feed JSON file. An
+    # https:// URL uses a remotely published, signature-verified feed.
     feed: bundled
 
     # Optional signature enforcement (see "Trust model"). Digest integrity is
@@ -44,13 +45,33 @@ scan:
     signature_key_path: keys/slopsquat.pub.pem  # PEM Ed25519 public key
 ```
 
-To point at your own regenerated feed instead of the bundled one:
+To point at your own regenerated feed file instead of the bundled one:
 
 ```yaml
 scan:
   slop:
     feed: security/slopsquat-blocklist.v1.json
 ```
+
+To consume the **remotely published, signed** feed (recommended — the feed
+accumulates centrally and every device pulls and verifies it, the OSV pattern):
+
+```yaml
+scan:
+  slop:
+    feed: https://github.com/nox-hq/nox/releases/download/slopfeed-latest/slopsquat-blocklist.v1.json
+    require_signature: true                         # fail closed on a bad/absent signature
+    signature_key_path: security/slopfeed.pub.pem   # the pinned publisher key
+    cache_dir: .nox/cache/slopfeed                  # optional; defaults to ~/.nox/cache/slopfeed
+    refresh: 24h                                    # optional; how long a cached copy is fresh (default 24h)
+```
+
+nox fetches the feed once, verifies its digest **and** its Ed25519 signature
+against the pinned public key, and caches the verified bytes content-addressed on
+disk. Subsequent scans within `refresh` use the cache with **no network call**,
+so scans stay offline and deterministic. `nox scan --offline` never touches the
+network at all: a URL feed is served from the verified cache, or the predictive
+dimension fails closed with a visible degradation.
 
 ## What `SLOP-002` reports
 
@@ -117,15 +138,83 @@ The format mirrors the plugin registry's trust model (`registry/trust`):
   *degradation* (`slop_feed`) is recorded so the missing coverage is never
   mistaken for "nothing high-risk found". A malformed feed never crashes the
   scan.
-- **Signature (optional).** The format reserves an Ed25519 signature over the
-  same canonical bytes, so a feed can be Sigstore/cosign-signed exactly like a
-  plugin artifact. Verification is a pluggable hook; set `require_signature:
-  true` with a `signature_key_path` to enforce it. A present-but-invalid
-  signature is always a hard failure, even when `require_signature` is false.
+- **Signature.** The format carries an Ed25519 signature over the same canonical
+  bytes. Verification is a pluggable hook; set `require_signature: true` with a
+  `signature_key_path` to enforce it. A present-but-invalid signature is always a
+  hard failure, even when `require_signature` is false. nox verifies against the
+  key **you pin** — it never trusts a key embedded in the feed itself, so a
+  self-described key cannot forge trust.
+- **Remote feeds fail closed on every path.** For an `https://` feed, a fetch
+  error, a non-200 status, an oversized body, a digest mismatch, a
+  wrong-identity or absent-but-required signature, or (offline) a missing cache
+  all disable the predictive dimension and record a `slop_feed` degradation. An
+  attacker who MITMs the feed cannot inject a name nox would then flag, nor
+  suppress an existing one, without a signature that verifies under the pinned
+  key — verification gates *use*, and only verified bytes are ever cached.
 
-Only this repository ships a real feed today; **standing up a signed CDN
-distribution channel is org infrastructure and is intentionally deferred** (see
-"Deferred"). The consumer already has the verification seam.
+### Why Ed25519 (published key) rather than cosign keyless
+
+Plugins are signed with cosign keyless (Sigstore). The feed uses **Ed25519 with a
+published public key** instead, for one reason: **offline, deterministic
+verification.** cosign keyless verification needs the `cosign` binary on PATH and
+a network round-trip (Rekor / OIDC trust root) at *verify* time — which would
+reintroduce the network into scan time, breaking the offline-first and
+determinism guarantees this feature exists to keep. Ed25519 verification is a few
+lines of the standard library, fully offline, and reuses the exact primitives in
+`registry/trust` (`ParsePublicKey`, `VerifySignature`) and the feed's own
+`Ed25519Verifier`. The trade-off is key management (below) instead of an OIDC
+identity.
+
+## Remote signed distribution (the full trust chain)
+
+Intelligence accumulates centrally as a signed, versioned artifact; every device
+pulls and verifies it. End to end:
+
+1. **Generate** — the `slopfeed-publish` workflow runs `cmd/slopfeed`, which
+   models hallucinated names and re-verifies each one **unregistered** against
+   public registries (read-only, rate-limited). This is the *only* network step,
+   and it runs out of band in CI, never at scan time.
+2. **Sign** — the same run signs the feed with `--sign-key`, an Ed25519 private
+   key held **only** as the `SLOPFEED_SIGNING_KEY` repository secret. `Sign`
+   re-derives the content digest and signs the canonical entry bytes, so no entry
+   can change without invalidating the signature.
+3. **Publish** — the workflow uploads the signed `slopsquat-blocklist.v1.json`
+   and the matching `slopfeed.pub.pem` public key as release assets: a dated,
+   immutable `slopfeed/<version>` release for provenance, and a rolling
+   `slopfeed-latest` release that gives operators a **stable HTTPS URL**.
+4. **Fetch** — a client with an `https://` feed configured downloads it once,
+   bounded in size and time, and caches the verified bytes content-addressed
+   under `cache_dir`.
+5. **Verify** — nox recomputes the digest and checks the Ed25519 signature
+   against the operator's pinned `signature_key_path`. Only bytes that verify are
+   cached or trusted.
+6. **Enforce** — a verified feed drives `SLOP-002`. Any failure fails closed with
+   a `slop_feed` degradation; a fresh verified cache serves later scans offline.
+
+### What a maintainer must configure
+
+The publish pipeline assumes a signing identity. Before it can publish:
+
+```bash
+# 1. Generate the feed-signing keypair (once).
+openssl genpkey -algorithm ed25519 -out slopfeed.key
+openssl pkey -in slopfeed.key -pubout -out slopfeed.pub.pem
+
+# 2. Store the PRIVATE key as the repository secret SLOPFEED_SIGNING_KEY
+#    (paste the contents of slopfeed.key). NEVER commit the private key.
+#    Optionally set the SLOPFEED_KEY_ID variable for signature labelling.
+
+# 3. Distribute the PUBLIC key (slopfeed.pub.pem) to operators out of band:
+#    commit it to consuming repos and point signature_key_path at it. It is also
+#    attached to every release for convenience, but pin it from a channel you
+#    trust (trust-on-first-use or a reviewed commit), not from the same URL you
+#    fetch the feed from.
+```
+
+The workflow (`.github/workflows/slopfeed-publish.yml`, `schedule` +
+`workflow_dispatch`) fails loudly if `SLOPFEED_SIGNING_KEY` is unset rather than
+publishing an unsigned feed. It requests only `contents: write` on the publishing
+job and needs no `id-token` (Ed25519 signing is secret-based, not keyless OIDC).
 
 ## Regenerating the feed
 
@@ -176,13 +265,16 @@ channels with that defensive framing rather than publishing a raw list. The
 bundled feed in this repo is a small, curated set already verified unregistered;
 it exists so the feature works out of the box and has something to test against.
 
-## Deferred (org infrastructure)
+## Deferred / next steps
 
-- **Signed CDN distribution.** Real Sigstore/cosign signing of feeds and a
-  hosted, mirrored distribution channel (à la the plugin registry) is
-  organization infrastructure. The format carries a digest and a signature seam
-  today; the pipeline that signs and serves feeds is out of scope for this
-  change.
 - **Live LLM emission priors.** The candidate priors model the generator from
   documented hallucination modes. Real LLM logprobs / emission frequencies would
   sharpen them and are the obvious next step.
+- **Key rotation & transparency.** Rotating the Ed25519 signing key today means
+  re-distributing the pinned public key to operators. A published key history (or
+  a small transparency log) would let clients rotate without a manual re-pin. The
+  signature already records a `key_id` to make this tractable.
+- **Mirrored distribution.** The feed is served from GitHub release assets over
+  HTTPS. A mirrored/CDN channel would add availability, but is not required for
+  correctness — a signed feed is safe to fetch from any mirror because
+  verification, not transport, is the trust boundary.


### PR DESCRIPTION
## What & why

Completes the **signed-feed distribution** left as documented org-infra in Loop 2. nox now consumes a **remote, signature-verified** predictive slopsquat feed, and a CI pipeline **regenerates, signs, and publishes** it. This is the OSV pattern made real for nox's own feed: the learning (the feed) accumulates centrally, is signed, and every device pulls and verifies it deterministically and offline.

## The remote trust chain

`generate → sign → publish → fetch → verify → enforce`

1. **Generate** — `slopfeed-publish` runs `cmd/slopfeed`, re-verifying each name **unregistered** against registries (read-only, rate-limited). The only network step, out of band in CI.
2. **Sign** — the run signs with `--sign-key` (Ed25519 private key held only as the `SLOPFEED_SIGNING_KEY` secret). `Sign` re-derives the digest and signs the canonical entry bytes.
3. **Publish** — uploads the signed feed + public key as release assets: a dated `slopfeed/<version>` release and a rolling `slopfeed-latest` release (stable HTTPS URL).
4. **Fetch** — a client with an `https://` feed downloads it once (size/time bounded) and caches the verified bytes content-addressed.
5. **Verify** — nox recomputes the digest and checks the Ed25519 signature against the operator's **pinned** `signature_key_path` (never a key embedded in the feed).
6. **Enforce** — a verified feed drives `SLOP-002`; any failure fails closed with a `slop_feed` degradation; a fresh verified cache serves later scans offline.

### Why Ed25519 (published key) rather than cosign keyless
Offline, deterministic verification. cosign keyless verify needs the `cosign` binary + a network round-trip (Rekor/OIDC) at *verify* time — reintroducing the network into scan time. Ed25519 verification is stdlib-only, offline, and reuses `registry/trust`'s primitives and the feed's existing `Ed25519Verifier` seam.

## Fail-closed / default-safe
- Remote fetch error, non-200, oversized body, digest mismatch, wrong-identity/absent-required signature, or (offline) missing cache → **SLOP-002 disabled + `slop_feed` degradation**, never a crash, never trusting unverified data. An attacker who MITMs the feed cannot inject a flagged name nor suppress one without a signature that verifies under the pinned key.
- **Default off**: no feed configured → byte-identical baseline (proved by test).
- `--offline` never touches the network — a URL feed is served from the verified cache or fails closed.

## What a maintainer must configure
The pipeline assumes a signing identity:
- Secret `SLOPFEED_SIGNING_KEY` — a PEM Ed25519 private key (`openssl genpkey -algorithm ed25519`). The workflow fails loudly if unset rather than publishing unsigned.
- (optional) Variable `SLOPFEED_KEY_ID` for signature labelling.
- The **public** key is published each run; operators pin it via `signature_key_path` from a channel they trust.

Workflow uses SHA-pinned actions, `contents: write` on the publish job only, **no `id-token`**, and inline-suppresses its two deliberate findings — it self-scans clean.

## Tests (test-first, no real network — httptest + test keypairs)
- URL feed with a valid signature loads and **SLOP-002 fires**.
- Tampered digest / wrong identity / `require_signature` + unsigned → **rejected** (fail closed, degradation, no crash).
- Cached feed serves **offline with no network**; fetch error falls back to last-known-good cache.
- No feed → baseline unchanged.
- Generator signing round-trips through nox's verifier (PKCS#8 and raw keys).

## Gates
`go build ./...`, `go test ./...`, `golangci-lint run` all pass. Self-scan: new files produce zero findings; the workflow reports 0 unsuppressed (2 deliberate, inline-suppressed). Zero degradations.

## Scope
Touches only `core/analyzers/slop/feed/`, config wiring (`core/config.go`, `core/scan.go`), `cmd/slopfeed`, the publish workflow, and docs. Does not touch CHANGELOG, confirm/AI-taint, the metamorphic harness, or unrelated analyzers.

## Deferred (honest)
- Key rotation/transparency (a published key history to rotate without a manual re-pin; `key_id` already recorded).
- Mirrored/CDN distribution (correctness rides on the signature, not transport, so any mirror is safe).
- Live LLM emission priors for the generator.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj