### PR TITLE
fix(plugins): bind plugin findings to the scan's own boundaries

### DIFF
--- a/cli/plugin_register_test.go
+++ b/cli/plugin_register_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/degrade"
+	"github.com/nox-hq/nox/registry"
+)
+
+// Plugin registration used to be all-or-nothing per phase: runPluginBinaries
+// registered every binary up front and returned an error the moment one was
+// rejected, so a single gated plugin took the whole batch down with it.
+//
+// Requiring all ~20 installed plugins on nox's own repo hit exactly that —
+// nox/api-abuse declares needs_confirmation, the default policy does not allow
+// it, and the rejection aborted registration for all 20. The scan then fell
+// back to built-in findings only, having silently run none of the plugins the
+// project declared as required. One plugin's policy gate must not disable
+// every other plugin's detection.
+//
+// A rejected plugin is now degraded individually (the same treatment an
+// uninstalled or integrity-failed plugin already gets) and the rest still run.
+func TestRunPluginBinaries_OneBadPluginDegradesRatherThanAbortingTheBatch(t *testing.T) {
+	// /bin/echo is executable but is not a plugin: it exits immediately without
+	// completing the handshake, so registering it fails the same way a policy
+	// rejection does — from the caller's side, a registration error.
+	bins := []installedPlugin{
+		{name: "nox/not-a-plugin", path: "/bin/echo", track: registry.Track("core-analysis")},
+	}
+
+	out, err := runPluginBinaries(context.Background(), t.TempDir(), bins, nil, nil, false)
+	if err != nil {
+		t.Fatalf("a plugin that fails to register must not abort the scan, got error: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected output carrying a degradation, got nil")
+	}
+
+	var reported bool
+	for _, d := range out.Degradations {
+		if d.Kind == degrade.Plugin && strings.Contains(d.Detail, "not-a-plugin") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("a plugin that failed to register was not reported as a degradation: %+v", out.Degradations)
+	}
+}

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -25,6 +25,10 @@ func init() {
 // installed under. The track selects the safety profile the host enforces, so
 // it travels with the path rather than being looked up again later.
 type installedPlugin struct {
+	// name is the registry name (e.g. "nox/taint-analysis"), carried so a
+	// registration failure can name the plugin it degraded rather than only
+	// its cache path.
+	name  string
 	path  string
 	track registry.Track
 }
@@ -91,6 +95,7 @@ func installedPluginBinaries(required []string) ([]installedPlugin, []core.Degra
 		}
 
 		binaries = append(binaries, installedPlugin{
+			name:  name,
 			path:  ip.BinaryPath,
 			track: registry.Track(ip.Track),
 		})
@@ -137,10 +142,22 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 		plugin.WithIgnoreTrackProfiles(ignoreTrackProfiles),
 	)
 	defer func() { _ = host.Close() }()
+	// Per-plugin registration, for the same reason as the scan phase: one
+	// rejected plugin must not stop the others from annotating the findings.
+	registered := 0
 	for _, bin := range binaries {
 		if regErr := host.RegisterBinaryWithTrack(ctx, bin.path, nil, bin.track); regErr != nil {
-			return fmt.Errorf("registering plugin %q: %w", bin.path, regErr)
+			label := bin.name
+			if label == "" {
+				label = bin.path
+			}
+			fmt.Fprintf(os.Stderr, "[plugin warn] %s: not registered for post-scan: %v\n", label, regErr)
+			continue
 		}
+		registered++
+	}
+	if registered == 0 {
+		return nil
 	}
 
 	if invErr := host.InvokePostScan(ctx, result, absTarget); invErr != nil {
@@ -222,10 +239,33 @@ func runPluginBinaries(ctx context.Context, target string, binaries []installedP
 	)
 	defer func() { _ = host.Close() }()
 
+	// Register each plugin independently. A plugin the host rejects — a policy
+	// gate such as needs_confirmation, a failed handshake, a binary that is not
+	// a plugin at all — is degraded on its own and the rest still run.
+	// Aborting the batch here meant one gated plugin silently disabled every
+	// other required detector, which is the failure mode degradations exist to
+	// prevent: the scan looked clean because nothing ran.
+	var regDegradations []core.Degradation
+	registered := 0
 	for _, bin := range binaries {
 		if regErr := host.RegisterBinaryWithTrack(ctx, bin.path, nil, bin.track); regErr != nil {
-			return nil, fmt.Errorf("registering plugin %q: %w", bin.path, regErr)
+			label := bin.name
+			if label == "" {
+				label = bin.path
+			}
+			regDegradations = append(regDegradations, core.Degradation{
+				Kind:   degrade.Plugin,
+				Detail: fmt.Sprintf("required plugin %q was not registered: %v", label, regErr),
+				Impact: "findings this plugin would have produced are missing from this scan; other plugins still ran",
+			})
+			continue
 		}
+		registered++
+	}
+	if registered == 0 {
+		// Nothing registered: return the degradations so the operator learns
+		// why, rather than an empty success.
+		return &core.PluginScanOutput{Degradations: regDegradations}, nil
 	}
 
 	// Run the analysis `scan` tool across every plugin that declares it.
@@ -237,7 +277,7 @@ func runPluginBinaries(ctx context.Context, target string, binaries []installedP
 		return nil, fmt.Errorf("invoking analysis plugins: %w", err)
 	}
 
-	out := &core.PluginScanOutput{}
+	out := &core.PluginScanOutput{Degradations: regDegradations}
 	for _, r := range responses {
 		if r.Response == nil {
 			continue

--- a/core/plugin_exclude_test.go
+++ b/core/plugin_exclude_test.go
@@ -1,0 +1,223 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// writeNoxConfigRequiringWithExclude writes a .nox.yaml declaring both
+// scan.exclude patterns and plugins.required.
+func writeNoxConfigRequiringWithExclude(t *testing.T, dir string, excludes []string, required ...string) {
+	t.Helper()
+	body := "scan:\n  exclude:\n"
+	for _, e := range excludes {
+		body += "    - \"" + e + "\"\n"
+	}
+	body += "plugins:\n  required:\n"
+	for _, r := range required {
+		body += "    - " + r + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write .nox.yaml: %v", err)
+	}
+}
+
+// A plugin's `scan` tool walks the workspace root itself and is handed only
+// workspace_root — it never sees `scan.exclude`. So a repo that excludes its
+// intentionally-vulnerable fixture corpus (nox's own testdata/precision-suite,
+// testdata/metamorphic-corpus, …) had those deliberately-planted findings
+// re-surfaced the moment any analysis plugin was required: nox's self-scan went
+// from grade A / 3 findings to grade F / 47, and 38 of those 47 were on paths
+// .nox.yaml explicitly excludes.
+//
+// A third-party plugin cannot be trusted to honour an exclusion it is merely
+// told about, so the boundary is enforced host-side: plugin findings are
+// filtered through the same discovery.IsIgnored matcher the core scan uses, so
+// "excluded" means exactly the same thing no matter which analyzer produced
+// the finding.
+func TestRunScan_PluginFindingsHonourScanExclude(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiringWithExclude(t, dir,
+		[]string{"testdata/", "*.tmpl"}, "nox/taint-analysis")
+
+	setHook(t, func(_ context.Context, target string, _ []string) (*PluginScanOutput, error) {
+		mk := func(rule, path string) findings.Finding {
+			return findings.NewFinding(
+				rule, findings.SeverityHigh, findings.ConfidenceHigh,
+				findings.Location{FilePath: path, StartLine: 1, EndLine: 1},
+				"plugin finding",
+			)
+		}
+		// Plugins are handed an absolute workspace_root and report absolute
+		// paths, so that is what this asserts. (Relative paths are covered
+		// too — a plugin may report either.)
+		abs := func(rel string) string { return filepath.Join(target, rel) }
+		return &PluginScanOutput{Findings: []findings.Finding{
+			// Excluded by "testdata/" — an intentionally-vulnerable fixture.
+			mk("TAINT-002", abs("testdata/precision-suite/tp_injection.py")),
+			// Same, reported relatively.
+			mk("TAINT-005", "testdata/metamorphic-corpus/python/ops_cmdi.py"),
+			// Excluded by "*.tmpl".
+			mk("CONTAINER-001", abs("cli/templates/Dockerfile.tmpl")),
+			// Real source — must survive.
+			mk("TAINT-004", abs("cli/main.go")),
+		}}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+
+	byRule := map[string]bool{}
+	for _, f := range result.Findings.ActiveFindings() {
+		byRule[f.RuleID] = true
+	}
+
+	if byRule["TAINT-002"] {
+		t.Error("plugin finding on an excluded path (testdata/) was merged; scan.exclude must bind plugins too")
+	}
+	if byRule["CONTAINER-001"] {
+		t.Error("plugin finding on an excluded path (*.tmpl) was merged; scan.exclude must bind plugins too")
+	}
+	if !byRule["TAINT-004"] {
+		t.Error("plugin finding on real source was dropped; only excluded paths may be filtered")
+	}
+}
+
+// Plugins are handed an absolute workspace_root and report absolute paths,
+// while core findings are recorded relative to the scan root. Merging them
+// verbatim recorded the same physical file under two different spellings, with
+// three consequences:
+//
+//   - the unused-waiver check groups findings by path, so a file that had both
+//     core and plugin findings was evaluated twice, and each group tested ALL
+//     the file's waivers against only its own subset — reporting live waivers
+//     as "waives X but matched no finding". nox's own Dockerfile produced 4
+//     such false degradations the moment the container plugin was enabled.
+//   - the v2 fingerprint hashes the path, so a plugin finding's identity
+//     embedded an absolute machine path (/Users/<someone>/...) and no baseline
+//     could match across machines or in CI.
+//   - reports showed local absolute paths next to repo-relative ones.
+//
+// fingerprint.go's normaliseFilePath says the scanner is the right place to
+// make paths repo-relative before they reach the hash; this is that place.
+func TestRunScan_PluginFindingPathsAreMadeRootRelative(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/container")
+
+	setHook(t, func(_ context.Context, target string, _ []string) (*PluginScanOutput, error) {
+		return &PluginScanOutput{Findings: []findings.Finding{
+			findings.NewFinding(
+				"CONTAINER-011", findings.SeverityLow, findings.ConfidenceHigh,
+				findings.Location{FilePath: filepath.Join(target, "Dockerfile"), StartLine: 1, EndLine: 1},
+				"plugin finding with an absolute path",
+			),
+		}}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+
+	for _, f := range result.Findings.ActiveFindings() {
+		if f.RuleID != "CONTAINER-011" {
+			continue
+		}
+		if filepath.IsAbs(f.Location.FilePath) {
+			t.Errorf("plugin finding kept an absolute path %q; it must be recorded relative to the scan root like core findings",
+				f.Location.FilePath)
+		}
+		if f.Location.FilePath != "Dockerfile" {
+			t.Errorf("plugin finding path = %q, want %q", f.Location.FilePath, "Dockerfile")
+		}
+		return
+	}
+	t.Fatal("plugin finding CONTAINER-011 not present in results")
+}
+
+// Absent any scan.exclude patterns, every plugin finding must survive — the
+// filter must not become a silent finding-eater on the common config.
+func TestRunScan_PluginFindingsSurviveWithoutExclude(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/taint-analysis")
+
+	setHook(t, func(_ context.Context, _ string, _ []string) (*PluginScanOutput, error) {
+		return &PluginScanOutput{Findings: []findings.Finding{
+			findings.NewFinding(
+				"TAINT-004", findings.SeverityHigh, findings.ConfidenceHigh,
+				findings.Location{FilePath: "testdata/x.py", StartLine: 1, EndLine: 1},
+				"plugin finding",
+			),
+		}}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+	for _, f := range result.Findings.ActiveFindings() {
+		if f.RuleID == "TAINT-004" {
+			return
+		}
+	}
+	t.Error("plugin finding dropped even though no scan.exclude patterns are configured")
+}
+
+// A repository-scoped plugin finding (nox/depconfusion's DEPCONF-002, "no
+// private registry config for npm") has no single file to point at, so it
+// carries the workspace root as its path. The inline-suppression re-reader
+// then tried to os.ReadFile a directory and reported
+//
+//	[degraded] <repo> could not be re-read to apply inline suppressions: is a directory
+//
+// on an otherwise healthy scan. The empty-path case was already skipped for
+// exactly this reason; a directory is the same thing one step further — there
+// are no nox:ignore comments in a directory, so nothing was missed and nothing
+// should be reported.
+func TestRunScan_RepoScopedFindingDoesNotDegradeSuppressions(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/depconfusion")
+
+	setHook(t, func(_ context.Context, target string, _ []string) (*PluginScanOutput, error) {
+		return &PluginScanOutput{Findings: []findings.Finding{
+			findings.NewFinding(
+				"DEPCONF-002", findings.SeverityMedium, findings.ConfidenceMedium,
+				// The plugin reports the workspace root itself.
+				findings.Location{FilePath: target, StartLine: 0, EndLine: 0},
+				"No private registry configuration found for npm ecosystem",
+			),
+		}}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+
+	for _, d := range result.Degradations {
+		if d.Kind == "suppression" {
+			t.Errorf("repo-scoped finding produced a suppression degradation: %s", d.Detail)
+		}
+	}
+
+	// And it is recorded with the canonical repository-scoped path (empty),
+	// not the absolute machine path — otherwise the v2 fingerprint hashes
+	// /Users/<someone>/... and the finding cannot be baselined anywhere else.
+	for _, f := range result.Findings.ActiveFindings() {
+		if f.RuleID != "DEPCONF-002" {
+			continue
+		}
+		if f.Location.FilePath != "" {
+			t.Errorf("repo-scoped finding path = %q, want \"\" (repository-scoped); an absolute path makes its fingerprint machine-specific",
+				f.Location.FilePath)
+		}
+		return
+	}
+	t.Fatal("DEPCONF-002 not present in results")
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -521,8 +521,13 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 				"findings these plugins would have produced are missing from this scan")
 		}
 		if out != nil {
-			for i := range out.Findings {
-				allFindings.Add(out.Findings[i])
+			kept, dropped := filterPluginFindingsByExclude(out.Findings, target, cfg.Scan.Exclude)
+			for i := range kept {
+				allFindings.Add(kept[i])
+			}
+			if dropped > 0 {
+				slog.DebugContext(ctx, "plugin findings dropped by scan.exclude",
+					"dropped", dropped, "kept", len(kept))
 			}
 			pluginEnrichments = out.Enrichments
 			pluginGraphs = out.Graphs
@@ -1235,6 +1240,94 @@ func ConfidenceMeetsThreshold(confidence, threshold findings.Confidence) bool {
 	return cr <= tr
 }
 
+// filterPluginFindingsByExclude drops plugin findings whose path matches the
+// scan's `scan.exclude` patterns, returning the survivors and the drop count.
+//
+// A plugin's `scan` tool walks the workspace root itself and is handed only
+// workspace_root, so it never sees `scan.exclude`. That made any required
+// analysis plugin re-surface exactly the files the operator excluded: on nox's
+// own repo, requiring the code-analysis plugins took a clean grade-A self-scan
+// (3 findings) to grade F (47), and 38 of those 47 were on excluded paths —
+// principally the intentionally-vulnerable fixture corpora
+// (testdata/precision-suite, testdata/metamorphic-corpus) that exist to be
+// found by the precision and metamorphic harnesses, not by the self-scan.
+//
+// The boundary is enforced here, host-side, rather than by passing the patterns
+// down: a plugin is third-party code and cannot be relied on to honour an
+// exclusion it is merely told about. Filtering through the same
+// discovery.IsIgnored matcher the walker uses means "excluded" means the same
+// thing no matter which analyzer produced the finding.
+//
+// Paths are made relative to the scan root before matching, since patterns like
+// "testdata/" are written relative to the repository while plugins commonly
+// report absolute paths. A finding with no path is repository-scoped and is
+// never excluded — there is no path for a pattern to match.
+func filterPluginFindingsByExclude(in []findings.Finding, target string, patterns []string) (kept []findings.Finding, dropped int) {
+	if len(in) == 0 {
+		return in, 0
+	}
+
+	// The root must be absolute to be comparable: plugins report absolute
+	// paths (they are handed an absolute workspace_root), while the target is
+	// commonly ".". filepath.Rel refuses to relate a relative base to an
+	// absolute path, so a relative root left every plugin path absolute and no
+	// root-relative pattern could ever match it.
+	root := ConfigRoot(target)
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	kept = make([]findings.Finding, 0, len(in))
+	for i := range in {
+		p := in[i].Location.FilePath
+		if p == "" {
+			kept = append(kept, in[i])
+			continue
+		}
+		rel := p
+		if filepath.IsAbs(rel) {
+			if r, err := filepath.Rel(root, rel); err == nil {
+				rel = r
+			}
+		}
+		rel = filepath.ToSlash(rel)
+		// The finding names the scan root itself: it is repository-scoped, not
+		// located in a file (nox/depconfusion's DEPCONF-002, "no private
+		// registry config for this ecosystem", is a property of the repo). The
+		// empty path is the canonical spelling for that — the suppression pass
+		// already reads it as "repository-scoped rather than located" — and it
+		// keeps the absolute machine path out of the v2 fingerprint, which
+		// otherwise made such a finding unbaselineable anywhere but the machine
+		// that produced it.
+		if rel == "." {
+			f := in[i]
+			f.Location.FilePath = ""
+			kept = append(kept, f)
+			continue
+		}
+		// A path outside the scan root cannot be described by a root-relative
+		// pattern, and is not ours to rewrite; keep it as reported.
+		if strings.HasPrefix(rel, "../") {
+			kept = append(kept, in[i])
+			continue
+		}
+		if len(patterns) > 0 && discovery.IsIgnored(rel, patterns) {
+			dropped++
+			continue
+		}
+		// Record the finding against the same root-relative path convention
+		// core findings use. Left absolute, the same physical file appeared
+		// under two spellings: the unused-waiver check (which groups by path)
+		// then tested every waiver in the file against only one group's
+		// findings and reported live waivers as dead, and the v2 fingerprint
+		// hashed a machine-specific absolute path so no baseline could match
+		// across machines.
+		f := in[i]
+		f.Location.FilePath = rel
+		kept = append(kept, f)
+	}
+	return kept, dropped
+}
+
 // ConfigRoot returns the directory that paths relative to a scan target
 // resolve against — the baseline, the VEX document, custom rules, a Terraform
 // plan, and the source files findings point at.
@@ -1279,6 +1372,17 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 		fullPath := filePath
 		if !filepath.IsAbs(fullPath) {
 			fullPath = filepath.Join(ConfigRoot(target), fullPath)
+		}
+
+		// The same reasoning as the empty path above, one step further: a
+		// repository-scoped finding may name the workspace root itself rather
+		// than a file. nox/depconfusion's DEPCONF-002 ("no private registry
+		// config for the npm ecosystem") is a property of the repository, not
+		// of any one file, so it reports the root — and reading a directory
+		// failed, degrading a perfectly healthy scan. A directory holds no
+		// nox:ignore comments, so nothing was missed and nothing is reported.
+		if fi, statErr := os.Stat(fullPath); statErr == nil && fi.IsDir() {
+			continue
 		}
 
 		content, err := os.ReadFile(fullPath)


### PR DESCRIPTION
A plugin-augmented self-scan of this repo went from **grade A / 3 findings** to **grade F / 47**. Four defects, all in how plugin output crosses back into the core scan.

### 1. `scan.exclude` did not bind plugins
A plugin's `scan` tool is handed only `workspace_root` and walks the tree itself, so **38 of the 47** findings were on paths `.nox.yaml` explicitly excludes — principally the intentionally-vulnerable fixture corpora (`testdata/precision-suite`, `testdata/metamorphic-corpus`) that exist to be found by the precision and metamorphic harnesses, not by the self-scan. All 9 "high" findings were there.

Filtered **host-side** through the same `discovery.IsIgnored` matcher the walker uses, rather than passing the patterns down: a plugin is third-party code and cannot be relied on to honour an exclusion it is merely told about.

### 2. Plugin paths were absolute; core paths are root-relative
The same physical file appeared under two spellings, with three consequences:
- the unused-waiver check groups by path, so a file with both core and plugin findings was evaluated twice and each group tested **all** the file's waivers against only its own subset — reporting **four live waivers on this repo's Dockerfile as dead** once the container plugin was enabled. That is the instrumentation lying about itself.
- the v2 fingerprint hashes the path, so a plugin finding's identity embedded an absolute machine path (`/Users/<someone>/…`) and **no baseline could match on another machine or in CI**.
- reports mixed absolute and relative paths.

Now recorded root-relative — which is what `fingerprint.go`'s `normaliseFilePath` doc says the scanner should do.

### 3. A repository-scoped finding named the scan root
`DEPCONF-002` ("no private registry config for this ecosystem") is a property of the repo, not a file, so it reported the root — and reading a directory degraded a healthy scan. Canonicalised to the empty path the suppression pass already reads as "repository-scoped rather than located"; the directory case is skipped for the same reason the empty case already was.

### 4. Registration was all-or-nothing per phase
Requiring all ~20 installed plugins hit `nox/api-abuse`, which declares `needs_confirmation`; the rejection **aborted registration for every other plugin**, and the scan fell back to built-in findings having silently run none of them — the exact failure degradations exist to prevent. Each plugin now registers independently; a rejected one is degraded on its own.

### Result
On this repo with the code-analysis plugins required: **47 findings / 13 degradations → 11 / 0**, and the remaining 11 are real. The plain self-scan is unchanged at grade A.

Tests added for each defect (all red first). Full suite green; lint count identical to main.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj