### PR TITLE
fix(suppress): prose and string literals are no longer parsed as waivers

### DIFF
--- a/core/suppress/suppress.go
+++ b/core/suppress/suppress.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/nox-hq/nox/core/lexctx"
 )
 
 // Suppression represents a single inline suppression directive found in source.
@@ -72,6 +74,52 @@ var suppressionRE = regexp.MustCompile(
 // expiresRE extracts an expires:YYYY-MM-DD from the reason text.
 var expiresRE = regexp.MustCompile(`expires:(\d{4}-\d{2}-\d{2})`)
 
+// stringSubmatches rebuilds FindStringSubmatch's []string result from the
+// index pairs FindStringSubmatchIndex returns, so the match position is
+// available (for the string-literal test) without scanning the line twice.
+// A group that did not participate yields "".
+func stringSubmatches(s string, loc []int) []string {
+	out := make([]string, len(loc)/2)
+	for i := range out {
+		if loc[2*i] >= 0 {
+			out[i] = s[loc[2*i]:loc[2*i+1]]
+		}
+	}
+	return out
+}
+
+// ruleIDToken matches a single rule identifier in the space-separated form
+// (`nox:ignore SEC-161 SEC-162 -- reason`). A hyphen is required so a prose
+// word cannot be mistaken for another rule ID; every catalog rule is
+// PREFIX-NUMBER, and the comma-separated form — which needs no such guard
+// because its shape is unambiguous — remains the documented spelling.
+var ruleIDToken = regexp.MustCompile(`^\w+-[\w-]+`)
+
+// directiveTailOK reports whether what follows a directive's rule IDs is
+// consistent with a directive rather than prose.
+//
+// Accepted: nothing, a comment terminator, a `--` reason, or further
+// space-separated rule IDs before either of those. Anything else means the
+// line is describing the syntax, not using it.
+func directiveTailOK(rest string) bool {
+	rest = strings.TrimSpace(rest)
+	for {
+		rest = strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(rest, "*/"), "-->"))
+		if rest == "" {
+			return true
+		}
+		if strings.HasPrefix(rest, "--") {
+			// The reason separator (and `-->`, already trimmed above).
+			return true
+		}
+		tok := ruleIDToken.FindString(rest)
+		if tok == "" {
+			return false
+		}
+		rest = strings.TrimSpace(rest[len(tok):])
+	}
+}
+
 // ScanForSuppressions scans file content for nox:ignore directives and returns
 // all suppressions found. Each suppression targets either the same line
 // (trailing comment) or the next non-blank, non-comment line.
@@ -89,13 +137,43 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 	isMarkdown := markdownExts[strings.ToLower(filepath.Ext(filePath))]
 	inFence := false
 
+	// A directive written inside a string literal is a program printing the
+	// syntax, not a waiver on that line — nox's own pre-commit hook installer
+	// contains `echo "nox: use '// nox:ignore RULE-ID -- reason'"`, which was
+	// read as waiving a rule called RULE-ID.
+	//
+	// Deliberately classified one line at a time rather than over the whole
+	// file: a string that opens and closes on the directive's own line is
+	// unambiguous, while a region spanning many lines is usually an artifact
+	// (an unterminated or raw string) and treating a directive inside one as
+	// prose would silently drop a real waiver. Only a positive, single-line
+	// string identification suppresses the directive.
+	lang := lexctx.LangFromPath(filePath)
+
 	for i, line := range lines {
 		lineNum := i + 1
 		if isMarkdown && isFence(strings.TrimSpace(line)) {
 			inFence = !inFence
 		}
-		match := suppressionRE.FindStringSubmatch(line)
-		if match == nil {
+		loc := suppressionRE.FindStringSubmatchIndex(line)
+		if loc == nil {
+			continue
+		}
+		match := stringSubmatches(line, loc)
+
+		if lexctx.KindAt(lexctx.Classify(lang, []byte(line)), loc[0]) == lexctx.KindString {
+			continue
+		}
+
+		// A directive's grammar is `nox:ignore <IDs> [-- reason]`: after the
+		// rule IDs the line must end, close the comment, or introduce a reason
+		// with `--`. Free prose after the IDs means the text is *describing* a
+		// directive rather than issuing one — a doc comment that wrapped so
+		// that "…holds no nox:ignore comments, so nothing was missed" began a
+		// line was read as waiving a rule named "comments". Because a waiver
+		// that matches nothing is reported, that produced a false "dead waiver"
+		// degradation against correct code.
+		if !directiveTailOK(line[loc[1]:]) {
 			continue
 		}
 

--- a/core/suppress/suppress_test.go
+++ b/core/suppress/suppress_test.go
@@ -341,3 +341,82 @@ func TestScanForSuppressions_FenceOnlyAppliesToMarkdown(t *testing.T) {
 		t.Error("backticks in a .go file must not mark a directive as a doc example")
 	}
 }
+
+// `nox:ignore` appearing in PROSE or in a STRING LITERAL is documentation
+// about the syntax, not a waiver. Both forms were parsed as real directives,
+// and because a waiver that matches nothing is reported, nox produced false
+// "waives X but matched no finding" degradations against its own source —
+// the instrumentation accusing correct code of carrying dead waivers.
+//
+// The two real instances, both from nox's own tree:
+//
+//   - a doc comment that wrapped so the phrase "…holds no nox:ignore comments,
+//     so nothing was missed" began a line, parsed as waiving rule "comments";
+//   - pre-commit help text, `echo "nox: use '// nox:ignore RULE-ID -- reason'"`,
+//     parsed as waiving rule "RULE-ID".
+//
+// A directive's grammar is `nox:ignore <IDs> [-- reason]`: after the rule IDs
+// the line must end, close the comment, or introduce a reason with `--`.
+// Free prose after the IDs means the text is describing a directive, not
+// issuing one. And a directive inside a string literal is a program printing
+// the syntax, never a waiver on the string's own line.
+func TestScanForSuppressions_ProseAndStringsAreNotDirectives(t *testing.T) {
+	cases := []struct {
+		name, path, line string
+		want             bool // true = a real directive
+	}{
+		{
+			name: "prose: wrapped doc comment mentioning the directive",
+			path: "scan.go",
+			line: "\t\t// nox:ignore comments, so nothing was missed and nothing is reported.",
+			want: false,
+		},
+		{
+			name: "string literal: help text teaching the syntax",
+			path: "protect_cmd.go",
+			line: `    echo "nox: use '// nox:ignore RULE-ID -- reason' to suppress false positives"`,
+			want: false,
+		},
+		// Everything below is a real waiver and must keep working.
+		{
+			name: "real: rule id with reason",
+			path: "scan.go",
+			line: "\tfoo() // nox:ignore SEC-163 -- em dash in string not hex",
+			want: true,
+		},
+		{
+			name: "real: bare rule id, end of line",
+			path: "scan.go",
+			line: "\t// nox:ignore IAC-123",
+			want: true,
+		},
+		{
+			name: "real: comma-separated list",
+			path: "server.go",
+			line: "\t// nox:ignore SEC-659,SEC-506,SEC-574,SEC-664 -- reviewed",
+			want: true,
+		},
+		{
+			name: "real: space-separated list with reason",
+			path: "corpus.go",
+			line: "\tX = \"y\" // nox:ignore SEC-161 SEC-162 SEC-163 -- test canary, not a live secret",
+			want: true,
+		},
+		{
+			name: "real: yaml hash comment",
+			path: "ci.yml",
+			line: "  contents: write # nox:ignore IAC-314 -- needed for releases",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScanForSuppressions([]byte(tc.line+"\n"), tc.path)
+			isDirective := len(got) > 0 && !got[0].DocExample
+			if isDirective != tc.want {
+				t.Errorf("directive=%v, want %v\n  line: %s\n  parsed: %+v", isDirective, tc.want, tc.line, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`nox:ignore` written in **documentation** was read as a directive. Because a waiver that matches nothing is reported, nox produced false "waives X but matched no finding" degradations **against its own correct source** — the instrumentation accusing the code of carrying dead waivers. That signal is the one used to find genuinely dead waivers (it caught a real one in #328), so its false positives cost more than the noise.

Two forms, both from this tree:
- a doc comment that wrapped so "…holds no `nox:ignore` comments, so nothing was missed" began a line → parsed as waiving a rule named **`comments`**;
- the pre-commit installer's help text, `echo "nox: use '// nox:ignore RULE-ID -- reason'"` → parsed as waiving **`RULE-ID`**.

### The two guards
**Grammar.** A directive is `nox:ignore <IDs> [-- reason]`: after the rule IDs the line must end, close the comment, or introduce a reason with `--`. Free prose after the IDs means the text *describes* a directive rather than issues one. Space-separated IDs still work, so existing waivers written that way keep working; a continuation token must contain a hyphen so a prose word cannot pose as a rule ID.

**String literals.** A directive inside a string is a program printing the syntax. Classified **one line at a time** rather than over the whole file: a string opening and closing on the directive's own line is unambiguous, while a multi-line region is usually an artifact (unterminated or raw string) and treating a directive inside one as prose would *silently drop a real waiver*.

Both guards **fail toward keeping the directive**, so an unrecognised language or odd comment style behaves exactly as before.

### Verified
Table test covers both false positives plus five real waiver spellings that must keep working (reason, bare ID, comma list, space-separated list, YAML `#`). On this repo with plugins enabled the false reports drop **7 → 5**; the remaining 5 are genuine dead waivers. Full suite green; lint count identical to main.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj