### PR TITLE
fix(iac): Ansible rules no longer fire on GitHub Actions files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        shell: bash # nox:ignore IAC-193 -- composite-style step, not Ansible
+        shell: bash
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Coverage summary

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
   steps:
     - name: Run Nox Security Scanner
       id: scan
-      shell: bash # nox:ignore IAC-193 -- composite GHA action, not Ansible
+      shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_FORMAT: ${{ inputs.format }}

--- a/actions/remediate/action.yml
+++ b/actions/remediate/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: Build remediation plan
       id: plan
-      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
+      shell: bash
       env:
         INPUT_OUTPUT: ${{ inputs.scan-output }}
         INPUT_INCLUDE_MAJOR: ${{ inputs.include-major }}
@@ -100,7 +100,7 @@ runs:
 
     - name: Apply remediation
       if: steps.plan.outputs.has-updates == 'true' && inputs.apply == 'true'
-      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
+      shell: bash
       env:
         INPUT_OUTPUT: ${{ inputs.scan-output }}
         INPUT_INCLUDE_MAJOR: ${{ inputs.include-major }}
@@ -109,7 +109,7 @@ runs:
 
     - name: Verify changes
       if: steps.plan.outputs.has-updates == 'true' && inputs.apply == 'true' && inputs.verify-cmd != ''
-      shell: bash  # nox:ignore IAC-193 -- composite GHA action, not Ansible
+      shell: bash
       working-directory: ${{ inputs.manifest-root }}
       run: ${{ inputs.verify-cmd }}
 

--- a/core/analyzers/iac/gha_ansible_test.go
+++ b/core/analyzers/iac/gha_ansible_test.go
@@ -1,0 +1,92 @@
+package iac
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Every Ansible rule is scoped to `*.yml`/`*.yaml`, which is every YAML file
+// in the repository — including GitHub Actions workflows and composite
+// actions. So `shell: bash`, which a composite action step is REQUIRED to
+// declare, matched IAC-193 "Ansible task uses shell module".
+//
+// This is the context-confusion class: a pattern firing where it cannot mean
+// what the rule assumes. A GitHub Actions file is not an Ansible playbook, so
+// the finding is categorically wrong rather than merely lower severity — the
+// existing GHA pass downgrades, which is the wrong remedy here. nox's own tree
+// carried five `nox:ignore IAC-193 -- composite-style step, not Ansible`
+// waivers papering over exactly this.
+//
+// Composite actions matter as much as workflows: four of those five waivers
+// were on `action.yml` files, which the workflows-only path prefix never
+// covered.
+func TestApplyGHAContext_AnsibleRulesDroppedOnGitHubActionsFiles(t *testing.T) {
+	workflow := []byte("name: CI\non: [push]\njobs:\n  b:\n    steps:\n      - shell: bash\n        run: go test ./...\n")
+	composite := []byte("name: act\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      run: echo hi\n")
+
+	cases := []struct {
+		name, path string
+		content    []byte
+	}{
+		{"workflow", ".github/workflows/ci.yml", workflow},
+		{"composite action at root", "action.yml", composite},
+		{"composite action nested", "actions/remediate/action.yml", composite},
+		{"composite action .yaml", "actions/x/action.yaml", composite},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := []findings.Finding{
+				mkFinding("IAC-193", tc.path),
+				// A non-Ansible IaC rule on the same file must survive: this
+				// pass may only remove findings that cannot apply, not quietly
+				// prune the workflow's real findings.
+				mkFinding("IAC-314", tc.path),
+			}
+			out := ApplyGHAContext(in, map[string][]byte{tc.path: tc.content})
+
+			for _, f := range out {
+				if f.RuleID == "IAC-193" {
+					t.Errorf("IAC-193 (Ansible shell module) survived on GitHub Actions file %s", tc.path)
+				}
+			}
+			var keptOther bool
+			for _, f := range out {
+				if f.RuleID == "IAC-314" {
+					keptOther = true
+				}
+			}
+			if !keptOther {
+				t.Errorf("a non-Ansible finding was dropped from %s; only Ansible rules may be removed", tc.path)
+			}
+		})
+	}
+}
+
+// The converse, and the reason this is a targeted drop rather than a blanket
+// one: a real Ansible playbook must still be flagged. A playbook is an
+// ordinary .yml file with no GitHub Actions shape, so nothing about it should
+// reach the GHA pass.
+func TestApplyGHAContext_AnsibleRulesSurviveOnPlaybooks(t *testing.T) {
+	playbook := []byte("- hosts: all\n  tasks:\n    - name: run it\n      shell: /usr/bin/thing --flag\n")
+	paths := []string{"playbook.yml", "ansible/site.yaml", "roles/web/tasks/main.yml"}
+
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			in := []findings.Finding{mkFinding("IAC-193", p)}
+			out := ApplyGHAContext(in, map[string][]byte{p: playbook})
+			if len(out) != 1 || out[0].RuleID != "IAC-193" {
+				t.Errorf("IAC-193 was dropped from Ansible playbook %s: %+v", p, out)
+			}
+		})
+	}
+}
+
+func mkFinding(ruleID, path string) findings.Finding {
+	return findings.NewFinding(
+		ruleID, findings.SeverityMedium, findings.ConfidenceLow,
+		findings.Location{FilePath: path, StartLine: 1, EndLine: 1},
+		"test finding",
+	)
+}

--- a/core/analyzers/iac/gha_context.go
+++ b/core/analyzers/iac/gha_context.go
@@ -1,6 +1,7 @@
 package iac
 
 import (
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -70,9 +71,60 @@ func ApplyGHAContext(findingsList []findings.Finding, fileContent map[string][]b
 	return applyGHAContext(findingsList, fileContent)
 }
 
+// ansibleRuleIDs is the set of rule IDs belonging to the Ansible family,
+// derived from the rule table itself so a rule added there is covered here
+// without a second list to keep in sync.
+var ansibleRuleIDs = func() map[string]bool {
+	ids := make(map[string]bool)
+	for _, r := range builtinAnsibleRules() {
+		ids[r.ID] = true
+	}
+	return ids
+}()
+
+// isGitHubActionsFile reports whether a path is a GitHub Actions workflow or a
+// composite action definition.
+//
+// Composite actions are included deliberately. The workflows-only prefix left
+// `action.yml` uncovered, and a composite step is REQUIRED to declare `shell:`
+// — which is precisely the construct that was being misread as Ansible. Four
+// of the five IAC-193 waivers in nox's own tree were on action.yml files.
+func isGitHubActionsFile(path string) bool {
+	p := filepath.ToSlash(path)
+	if strings.HasPrefix(p, ghaWorkflowsPrefix) || strings.Contains(p, "/"+ghaWorkflowsPrefix) {
+		return true
+	}
+	switch filepath.Base(p) {
+	case "action.yml", "action.yaml":
+		return true
+	}
+	return false
+}
+
 // applyGHAContext is the unexported implementation called by ApplyGHAContext
 // and by the IaC analyzer's own post-pass.
 func applyGHAContext(findingsList []findings.Finding, fileContent map[string][]byte) []findings.Finding {
+	// An Ansible rule cannot mean what it says on a GitHub Actions file: a
+	// workflow is not a playbook. Every Ansible rule is scoped to `*.yml` /
+	// `*.yaml`, i.e. every YAML file in the repository, so `shell: bash` in a
+	// composite action — which the step is required to declare — matched
+	// IAC-193 "Ansible task uses shell module". These are dropped rather than
+	// downgraded, because the finding is categorically wrong rather than less
+	// severe; a downgrade would leave an operator triaging a rule that could
+	// never apply. nox's own tree carried five waivers papering over this.
+	//
+	// Detection is by path, not content: an Ansible playbook is an ordinary
+	// .yml file that never lives at .github/workflows/ or action.yml, so real
+	// playbooks are untouched.
+	kept := findingsList[:0]
+	for _, f := range findingsList {
+		if ansibleRuleIDs[f.RuleID] && isGitHubActionsFile(f.Location.FilePath) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	findingsList = kept
+
 	for i := range findingsList {
 		f := &findingsList[i]
 		path := f.Location.FilePath


### PR DESCRIPTION
Every Ansible rule is scoped to `*.yml` / `*.yaml` — which is **every YAML file in a repository**, GitHub Actions workflows and composite actions included. So `shell: bash`, which a composite action step is *required* to declare, matched **IAC-193 "Ansible task uses shell module"**.

This is the context-confusion class again: a pattern firing where it cannot mean what the rule assumes.

### Dropped, not downgraded
A GitHub Actions file is not an Ansible playbook, so the finding is **categorically wrong** rather than less severe — unlike the other GHA false positives this pass handles. A downgrade would still leave an operator triaging a rule that could never apply.

### Composite actions, not just workflows
The existing pass keyed off the `.github/workflows/` prefix alone, leaving `action.yml` uncovered — and that is exactly where `shell:` is mandatory. **Four of the five IAC-193 waivers in this tree were on action.yml files.**

### Kept honest
- The rule-ID set is derived from `builtinAnsibleRules()`, not hardcoded, so a rule added to the Ansible table is covered without a second list to keep in sync.
- Detection is by path, not content: a playbook is an ordinary `.yml` that never lives at `.github/workflows/` or `action.yml`. **Real playbooks still fire — asserted by test** (`playbook.yml`, `ansible/site.yaml`, `roles/web/tasks/main.yml`).
- A non-Ansible finding on the same workflow file must survive — also asserted, so this can't quietly prune real workflow findings.

### Result
All five `nox:ignore IAC-193` waivers removed from this tree; the rule now produces nothing to waive. Self-scan unchanged: 3 findings, 0 degradations, grade A. Full suite green, lint at baseline.

Closes the last of the confirmed false positives in the 2026-07 audit backlog.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj