### PR TITLE
fix(bootstrap): re-point bundled plugins when the binary moves

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -114,29 +114,9 @@ func bootstrapBundledPlugins() {
 	}
 
 	if os.Getenv("NOX_NO_BUNDLED_PLUGINS") == "" {
-		for _, name := range bundledPlugins {
-			if st.FindPlugin(canonicalName(name)) != nil {
-				continue
-			}
-			path := filepath.Join(binDir, name)
-			if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
-				continue
-			}
-			bundledIP := &InstalledPlugin{
-				Name:        canonicalName(name),
-				Version:     "bundled",
-				BinaryPath:  path,
-				TrustLevel:  "bundled",
-				RiskClass:   "passive",
-				InstalledAt: time.Now().UTC(),
-				UpdatedAt:   time.Now().UTC(),
-			}
-			bundledIP.RecordBinaryDigest()
-			st.AddPlugin(bundledIP)
+		if bundledNotices := syncBundledPlugins(st, binDir); len(bundledNotices) > 0 {
+			notices = append(notices, bundledNotices...)
 			changed = true
-			notices = append(notices, fmt.Sprintf(
-				"registered bundled plugin %s -> %s (disable: export NOX_NO_BUNDLED_PLUGINS=1)",
-				canonicalName(name), path))
 		}
 	}
 
@@ -146,6 +126,62 @@ func bootstrapBundledPlugins() {
 			fmt.Fprintf(os.Stderr, "[nox bootstrap] %s\n", n)
 		}
 	}
+}
+
+// syncBundledPlugins registers the plugins shipped beside the nox binary
+// and keeps existing records pointing at them. It returns one notice per
+// change; an empty slice means state is already correct.
+//
+// Re-pointing is the part that is easy to leave out and expensive to
+// omit. The path recorded at registration names the install prefix of
+// that release — a Homebrew Cellar directory, say — and upgrading
+// deletes it. A record written once and never revisited therefore
+// dangles for the life of the install: `doctor` reports "binary missing"
+// while `scan` says nothing at all and silently falls back to whatever
+// else provides the plugin. That is how a repository ends up analysed by
+// a plugin build several versions behind the one the operator installed,
+// with no output anywhere saying so.
+//
+// Only records this function created (TrustLevel "bundled") are touched,
+// so a plugin the operator installed deliberately is never overwritten
+// by the shipped copy.
+func syncBundledPlugins(st *State, binDir string) []string {
+	var notices []string
+	for _, name := range bundledPlugins {
+		path := filepath.Join(binDir, name)
+		info, err := os.Stat(path)
+		usable := err == nil && info.Mode().IsRegular()
+
+		if existing := st.FindPlugin(canonicalName(name)); existing != nil {
+			if existing.TrustLevel == "bundled" && usable && existing.BinaryPath != path {
+				existing.BinaryPath = path
+				existing.RecordBinaryDigest()
+				existing.UpdatedAt = time.Now().UTC()
+				notices = append(notices, fmt.Sprintf(
+					"re-pointed bundled plugin %s -> %s (previous location is gone)",
+					canonicalName(name), path))
+			}
+			continue
+		}
+		if !usable {
+			continue
+		}
+		bundledIP := &InstalledPlugin{
+			Name:        canonicalName(name),
+			Version:     "bundled",
+			BinaryPath:  path,
+			TrustLevel:  "bundled",
+			RiskClass:   "passive",
+			InstalledAt: time.Now().UTC(),
+			UpdatedAt:   time.Now().UTC(),
+		}
+		bundledIP.RecordBinaryDigest()
+		st.AddPlugin(bundledIP)
+		notices = append(notices, fmt.Sprintf(
+			"registered bundled plugin %s -> %s (disable: export NOX_NO_BUNDLED_PLUGINS=1)",
+			canonicalName(name), path))
+	}
+	return notices
 }
 
 // canonicalName strips the nox-plugin- prefix so registry lookups by

--- a/cli/bootstrap_test.go
+++ b/cli/bootstrap_test.go
@@ -52,28 +52,101 @@ func TestBootstrap_RegistersExistingPlugin(t *testing.T) {
 // TestBootstrap_RegistersExistingPlugin. It mirrors the production
 // bootstrap logic but takes binDir as an argument so the test can
 // supply a temp directory without monkey-patching os.Executable.
+//
+// It calls the production syncBundledPlugins rather than restating its
+// logic: a seam that re-implements what it is meant to cover passes
+// while the real code is broken, which is exactly how the stale-path bug
+// below survived.
 func registerPluginsFromDir(binDir string) error {
 	st, err := LoadState(DefaultStatePath())
 	if err != nil {
 		return err
 	}
-	for _, name := range bundledPlugins {
-		if st.FindPlugin(canonicalName(name)) != nil {
-			continue
-		}
-		path := filepath.Join(binDir, name)
-		if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
-			continue
-		}
-		st.AddPlugin(&InstalledPlugin{
-			Name:       canonicalName(name),
-			Version:    "bundled",
-			BinaryPath: path,
-			TrustLevel: "bundled",
-			RiskClass:  "passive",
-		})
-	}
+	syncBundledPlugins(st, binDir)
 	return SaveState(DefaultStatePath(), st)
+}
+
+// An upgrade moves the shipped plugin: the release that registered it is
+// deleted, and the recorded path with it. The record must follow the
+// binary, or the plugin silently stops running while state still claims
+// it is installed.
+func TestBootstrap_RepointsMovedBundledPlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Executable + symlinks behave differently on Windows; covered in integration tests")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	oldDir := t.TempDir()
+	oldPath := filepath.Join(oldDir, "nox-plugin-reachability")
+	if err := os.WriteFile(oldPath, []byte("#!/bin/sh\n# v1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := registerPluginsFromDir(oldDir); err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+
+	// The upgrade: a new prefix holds the binary, the old one is gone.
+	newDir := t.TempDir()
+	newPath := filepath.Join(newDir, "nox-plugin-reachability")
+	if err := os.WriteFile(newPath, []byte("#!/bin/sh\n# v2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(oldDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := registerPluginsFromDir(newDir); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+
+	st, err := LoadState(DefaultStatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := st.FindPlugin("reachability")
+	if p == nil {
+		t.Fatal("reachability record disappeared")
+	}
+	if p.BinaryPath != newPath {
+		t.Errorf("BinaryPath = %q, want %q — the record still points at the deleted install", p.BinaryPath, newPath)
+	}
+	if _, err := os.Stat(p.BinaryPath); err != nil {
+		t.Errorf("recorded binary is not usable: %v", err)
+	}
+}
+
+// A plugin the operator installed deliberately outranks the shipped
+// copy; re-pointing must never reach across and overwrite it.
+func TestBootstrap_LeavesOperatorInstalledPluginAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Executable + symlinks behave differently on Windows; covered in integration tests")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	st, err := LoadState(DefaultStatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	chosen := "/opt/operator/nox-plugin-reachability"
+	st.AddPlugin(&InstalledPlugin{
+		Name:       "reachability",
+		Version:    "0.7.1",
+		BinaryPath: chosen,
+		TrustLevel: "community",
+		RiskClass:  "passive",
+	})
+
+	shipped := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shipped, "nox-plugin-reachability"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if n := syncBundledPlugins(st, shipped); len(n) != 0 {
+		t.Errorf("notices = %v, want none — the operator's choice was touched", n)
+	}
+	if got := st.FindPlugin("reachability"); got.BinaryPath != chosen || got.Version != "0.7.1" {
+		t.Errorf("record = %+v, want the operator's 0.7.1 at %q", got, chosen)
+	}
 }
 
 func TestCanonicalName(t *testing.T) {


### PR DESCRIPTION
A bundled plugin is registered once and never revisited — `cli/bootstrap.go` skipped any name already present in state. The path recorded at registration names the install prefix of *that* release, so an upgrade that relocates the binary leaves the record pointing into a directory the package manager has since deleted.

Nothing recovers from it. `doctor` reports `binary missing`; a scan says nothing at all and silently falls back to whatever else provides the plugin, or runs without it.

## Observed on a real install

```
$ nox --version
nox 1.16.1

$ nox doctor
  reachability@bundled  /opt/homebrew/Cellar/nox/0.8.1/bin/nox-plugin-reachability
    ! binary missing
```

Registered against **0.8.1** while running **1.16.1** — so every scan used a community reachability build several versions behind the shipped one, with no output anywhere saying so. Four releases went out the day I hit this; each one is another chance to strand the record.

## The fix

Bootstrap re-points a bundled record whose path no longer matches the shipped binary, recording the new digest with it. Only records it created itself (`TrustLevel: "bundled"`) are touched, so a plugin the operator installed deliberately still wins.

## Why it was invisible

The test seam `registerPluginsFromDir` **restated** the production loop instead of calling it — so it carried the same gap and passed. It now calls `syncBundledPlugins`, the same function bootstrap runs. Two tests cover the move and the operator-installed case; reverting the fix makes the move test fail.

Any package manager with a versioned install prefix hits this — Homebrew's Cellar, Nix store paths, versioned tarball directories.

## Verification

`gofmt` clean · `go build ./...` · `go test ./cli/ -count=1` passes.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3