### PR TITLE
ci: add the dependabot config the auto-merge workflow was waiting for

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# Dependabot configuration.
+#
+# This file was missing while .github/workflows/dependabot-auto-merge.yml was
+# present, so the auto-merge workflow sat there with nothing to merge:
+# Dependabot never opened a pull request against this repository at all.
+#
+# The cost was invisible and specific to what nox is. Every action here is
+# pinned to a commit SHA, because nox ships IAC-013 to flag actions pinned to a
+# mutable tag — but a SHA pin is frozen by definition, so without something
+# proposing new ones the pins silently age. This repository sat on
+# actions/setup-go v6.4.0 while the plugin repositories, which do have this
+# config, had already moved to v7.0.0. A security scanner whose own supply
+# chain quietly falls behind is the wrong advertisement.
+#
+# Dependabot understands SHA pins: it bumps the digest and rewrites the
+# trailing `# vX.Y.Z` comment, so IAC-013 stays satisfied after every update.
+#
+# Layout and cadence follow the plugin repositories so the fleet behaves the
+# same way everywhere.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+
+  # The VS Code extension. Its toolchain is where the brace-expansion ReDoS
+  # (GHSA-mh99-v99m-4gvg) reached this repository, which had to be caught by a
+  # self-scan and fixed by hand.
+  - package-ecosystem: npm
+    directory: /editors/vscode
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+
+  # Base image for the published container.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker


### PR DESCRIPTION
`.github/workflows/dependabot-auto-merge.yml` has been present **without a `.github/dependabot.yml`** — so it sat there with nothing to merge. Dependabot never opened a pull request against this repository at all.

### Why it matters here specifically
Every action in this repo is pinned to a commit SHA, because nox ships **IAC-013** to flag actions pinned to a mutable tag. But a SHA pin is frozen by definition, so with nothing proposing new ones the pins silently age: this repository sat on `actions/setup-go` **v6.4.0** while the plugin repositories — which all have this config — had already moved to **v7.0.0**. A security scanner whose own supply chain quietly falls behind is the wrong advertisement.

Dependabot understands SHA pins: it bumps the digest *and* rewrites the trailing `# vX.Y.Z` comment, so IAC-013 stays satisfied after an update. The existing auto-merge workflow only takes **patch and minor**, so a major bump like setup-go v6→v7 still gets a human.

### Scope
Covers the ecosystems this repo actually has **and whose paths are tracked**: root Go module, GitHub Actions, the VS Code extension's npm tree (where GHSA-mh99-v99m-4gvg reached us and had to be caught by a self-scan and fixed by hand), and the Dockerfile base image.

`plugins/` is deliberately **not** covered — it is gitignored with zero tracked files, so an entry for it would point at a path that does not exist upstream. I had included it initially and removed it after checking.

Layout and cadence follow the plugin repositories so the fleet behaves the same way everywhere.