### PR TITLE
fix(ci): the SLSA generator must be tag-referenced, not SHA-pinned

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -84,7 +84,21 @@ jobs:
       actions: read       # required by the reusable workflow
       id-token: write # nox:ignore IAC-306 -- OIDC is the keyless-signing mechanism for the attestation (OIDC token for sigstore keyless signing)
       contents: write # nox:ignore IAC-314 -- uploads the provenance attestation to the release (upload provenance to the release)
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0-rc.3
+    # MUST be referenced by tag, not by SHA. slsa-verifier resolves the
+    # trusted builder's identity from the ref, so a digest pin makes the
+    # generator unverifiable and the run fails in `upload-assets` with
+    # `final` exiting 27 — with every earlier job still reporting success,
+    # which is why this went unnoticed. Upstream states it explicitly:
+    # "the GitHub Actions provided in this repository as builders and
+    # generators MUST be referenced by tag ... contrary to the GitHub best
+    # practice for third-party actions ... but intentional due to limits in
+    # GitHub Actions." It must also be the full `@vX.Y.Z`; `@vX.Y` or `@vX`
+    # fail. See slsa-framework/slsa-verifier#12.
+    #
+    # No waiver is needed: IAC-013 flags MUTABLE tags (@v2, @v2.1), and a full
+    # @vX.Y.Z is what the rule already considers acceptable — which is exactly
+    # the form upstream requires. The rule and the constraint agree here.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.subjects.outputs.hashes }}
       upload-assets: true


### PR DESCRIPTION
**SLSA provenance has been silently absent from every release since v1.14.0**, while the project advertises SLSA Level 3 provenance.

| release | date | provenance |
|---|---|---|
| v1.13.0 / v1.13.5 / v1.13.6 | ≤ 07-21 | ✅ 1 attestation each |
| **v1.14.0 → v1.17.0** (6 releases) | 07-22 → 07-25 | ❌ **none** |

### Cause: a pin this project's own tooling applied
On 2026-07-22, `nox fix --actions` rewrote `generator_generic_slsa3.yml@v2.1.0` to a digest. `slsa-verifier` resolves the trusted builder's identity **from the ref**, so a digest pin makes the generator unverifiable. Upstream says so explicitly:

> the GitHub Actions provided in this repository as builders and generators **MUST** be referenced by tag … This is contrary to the GitHub best practice for third-party actions … but intentional due to limits in GitHub Actions.

It must also be the full `@vX.Y.Z` — `@vX.Y` and `@vX` fail. (slsa-framework/slsa-verifier#12)

### Why it was expensive to find
`subjects`, `generator` and `upload-assets` all report **success**; only `final` fails, exiting **27** — the code the workflow's own comment documents as *"no subjects supplied"*, which it is not (subjects resolved the tag, downloaded assets and set `hashes`). Nothing in the release path noticed, and six releases shipped without provenance.

### The pin was wrong on its own terms too
The digest chosen was **`v2.1.0-rc.3`** — a release candidate — in place of the v2.1.0 release. That is the `nox fix --actions` mis-resolution the audit backlog records. It was re-tested against seven ordinary actions earlier today and judged fixed; **this is a counterexample**, and the distinguishing shape is a reusable-workflow `uses:` **with a path**, in a repo carrying **20 prerelease tags**. Worth a follow-up in the resolver.

### No waiver
IAC-013 flags **mutable** tags; a full `@vX.Y.Z` is already acceptable to it, so the rule and upstream's constraint agree. A waiver written here first was reported as dead by nox's own unused-waiver check (added earlier today) and removed — 0 degradations, grade A.

Verified: reverting to `@v2.1.0` restores the exact reference that last produced provenance on 07-21.