### PR TITLE
fix(fix-actions): never SHA-pin a reusable workflow, never pick a prerelease

### DIFF
--- a/cli/fix_actions.go
+++ b/cli/fix_actions.go
@@ -22,6 +22,24 @@ import (
 // (a SHA or a tag), 4=trailing comment (optional, e.g. " # v4").
 var usesRe = regexp.MustCompile(`^(\s*(?:-\s+)?uses:\s*)([A-Za-z0-9._-]+/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._/-]+)?)@([A-Za-z0-9._-]+)(\s*#.*)?$`)
 
+// isReusableWorkflowRef reports whether a `uses:` target is a reusable
+// WORKFLOW rather than an action.
+//
+// These must keep their tag. slsa-verifier resolves a trusted builder's
+// identity from the ref, so pinning slsa-github-generator by digest makes it
+// unverifiable; upstream is explicit that its builders "MUST be referenced by
+// tag ... contrary to the GitHub best practice for third-party actions ... but
+// intentional due to limits in GitHub Actions". Pinning it anyway removed SLSA
+// provenance from six nox releases, and did so quietly: every job except
+// `final` still reported success.
+//
+// GitHub requires reusable workflows to live in .github/workflows/, which is
+// what distinguishes them from an action published in a subdirectory such as
+// anchore/sbom-action/download-syft — that one is an action and stays pinned.
+func isReusableWorkflowRef(full string) bool {
+	return strings.Contains(full, "/.github/workflows/")
+}
+
 // actionPin is one `uses:` occurrence found in a workflow file.
 type actionPin struct {
 	file    string
@@ -47,6 +65,21 @@ func (p *actionPin) currentVersion() string {
 }
 
 var commentVerRe = regexp.MustCompile(`v?\d+(?:\.\d+){0,2}`)
+
+// releaseTagRe matches a tag that denotes a RELEASE — the whole tag, not a
+// prefix of it.
+//
+// commentVerRe is a substring match, which is right for pulling a version out
+// of a trailing comment but wrong for deciding whether a tag is a release:
+// `v2.1.0-rc.3` contains `v2.1.0`, so it passed. It then parsed to [2,1,0]
+// because parseVer discards the suffix, TIEING the real v2.1.0 — and the
+// specificity tiebreak counts dotted components, of which the candidate has
+// four to the release's three, so the RELEASE CANDIDATE was judged more
+// specific and won. `nox fix --actions` duly replaced a stable @v2.1.0 with a
+// release candidate's commit in the workflow that generates this project's
+// SLSA provenance. Anchored, so a prerelease or build-metadata suffix is
+// simply not a release.
+var releaseTagRe = regexp.MustCompile(`^v?\d+(?:\.\d+){0,2}$`)
 
 func commentVersion(comment string) string {
 	return commentVerRe.FindString(comment)
@@ -123,6 +156,12 @@ func runActionsFix(root string, dryRun, includeMajor bool, r actionResolver) (ap
 	// Group rewrites per file so each file is read/written once.
 	perFile := map[string][]rewrite{}
 	for _, p := range pins {
+		// A reusable workflow keeps its tag: pinning it by digest makes it
+		// unverifiable to slsa-verifier. See isReusableWorkflowRef.
+		if isReusableWorkflowRef(p.full) {
+			skipped++
+			continue
+		}
 		cur := p.currentVersion()
 		if cur == "" {
 			skipped++ // tracks a branch (e.g. @main reusable workflow) — leave it
@@ -398,8 +437,8 @@ func (g *githubResolver) latestTag(repo string) (string, error) {
 		return "", err
 	}
 	for _, t := range tags {
-		if !commentVerRe.MatchString(t.Name) {
-			continue
+		if !releaseTagRe.MatchString(t.Name) {
+			continue // prereleases and build metadata are not candidates
 		}
 		if best == "" || preferTag(best, t.Name) {
 			best = t.Name
@@ -418,6 +457,14 @@ func (g *githubResolver) latestTag(repo string) (string, error) {
 // they denote the same commit, but only the specific one still means that
 // commit tomorrow, and it is what the pin comment should record.
 func preferTag(current, candidate string) bool {
+	// A prerelease never outranks a release. latestTag already filters them
+	// out, but the ranking primitive must be right on its own: the specificity
+	// tiebreak counts dotted components, and `v2.1.0-rc.3` has one more than
+	// `v2.1.0`, so without this it declares the release candidate the more
+	// specific tag and pins it.
+	if cur, cand := releaseTagRe.MatchString(current), releaseTagRe.MatchString(candidate); cur != cand {
+		return cand // prefer the candidate only when IT is the release
+	}
 	switch cmpVersion(current, candidate) {
 	case -1:
 		return true

--- a/cli/fix_actions_test.go
+++ b/cli/fix_actions_test.go
@@ -286,3 +286,101 @@ func TestLatestTag_FallsBackToReleaseWhenTagsUnavailable(t *testing.T) {
 		t.Errorf("latestTag = %q, want v3.1.0", got)
 	}
 }
+
+// A reusable workflow must NOT be rewritten to a digest.
+//
+// slsa-verifier resolves a trusted builder's identity from the ref, so pinning
+// slsa-github-generator by SHA makes it unverifiable — upstream states the
+// builders "MUST be referenced by tag ... contrary to the GitHub best practice
+// for third-party actions ... but intentional due to limits in GitHub Actions".
+// This tool pinned it anyway, and SLSA provenance vanished from six nox
+// releases while every job but `final` reported success.
+//
+// The discriminator is the path: GitHub requires reusable workflows to live in
+// .github/workflows/. An action published in a subdirectory
+// (anchore/sbom-action/download-syft) is NOT a reusable workflow and must keep
+// being pinned.
+func TestIsReusableWorkflowRef(t *testing.T) {
+	cases := []struct {
+		full string
+		want bool
+	}{
+		{"slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml", true},
+		{"owner/repo/.github/workflows/build.yaml", true},
+		{"anchore/sbom-action/download-syft", false},
+		{"actions/checkout", false},
+		{"github/codeql-action/upload-sarif", false},
+		{"owner/repo/some/nested/action.yml", false},
+	}
+	for _, tc := range cases {
+		if got := isReusableWorkflowRef(tc.full); got != tc.want {
+			t.Errorf("isReusableWorkflowRef(%q) = %v, want %v", tc.full, got, tc.want)
+		}
+	}
+}
+
+// A prerelease must never be chosen as "latest".
+//
+// v2.1.0-rc.3 parsed to [2,1,0] — the -rc.3 was discarded — so it TIED v2.1.0,
+// and the specificity tiebreak then counted its dots (4 vs 3) and declared the
+// release candidate the more specific tag. `nox fix --actions` therefore
+// replaced a stable @v2.1.0 with a release candidate's commit, in the workflow
+// that produces this project's supply-chain attestations.
+func TestReleaseTagRe_RejectsPrereleases(t *testing.T) {
+	release := []string{"v1", "v1.2", "v1.2.3", "1.2.3"}
+	pre := []string{
+		"v2.1.0-rc.3", "v2.1.0-rc.0", "v1.0.0-beta", "v1.0.0-alpha.1",
+		"v2.1.0.pre.rc.3", "v1.2.3+build.5",
+	}
+	for _, r := range release {
+		if !releaseTagRe.MatchString(r) {
+			t.Errorf("release tag %q was rejected", r)
+		}
+	}
+	for _, p := range pre {
+		if releaseTagRe.MatchString(p) {
+			t.Errorf("prerelease tag %q was accepted as a release", p)
+		}
+	}
+}
+
+// The exact regression, end to end through the comparison used to pick latest:
+// given both tags, the release must win.
+func TestPreferTag_ReleaseBeatsItsOwnReleaseCandidate(t *testing.T) {
+	if preferTag("v2.1.0", "v2.1.0-rc.3") {
+		t.Error("v2.1.0-rc.3 was preferred over v2.1.0 — a release candidate must never outrank its release")
+	}
+}
+
+// The exact regression, end to end: the line `nox fix --actions` rewrote on
+// 2026-07-22, which removed SLSA provenance from six nox releases. The
+// reusable workflow must come out byte-identical, while an ordinary action in
+// the same file is still pinned — the skip must be surgical, not a blanket
+// "leave anything with a path alone".
+func TestRunActionsFix_LeavesReusableWorkflowsTagged(t *testing.T) {
+	root := t.TempDir()
+	p := writeWFPin(t, root, "slsa.yml", `jobs:
+  provenance:
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+  other:
+    steps:
+      - uses: anchore/sbom-action/download-syft@1111111111111111111111111111111111111111 # v0.24.0
+`)
+	res := fakeResolver{
+		"slsa-framework/slsa-github-generator": {"v2.2.0", "dddddddddddddddddddddddddddddddddddddddd"},
+		"anchore/sbom-action":                  {"v0.25.0", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+	}
+	runActionsFix(root, false, false, res)
+
+	got, _ := os.ReadFile(p)
+	want := `jobs:
+  provenance:
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+  other:
+    steps:
+      - uses: anchore/sbom-action/download-syft@eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee # v0.25.0
+`
+	if string(got) != want {
+		t.Errorf("reusable workflow was rewritten, or the sibling action was not:\n%s", got)
+	}
+}


### PR DESCRIPTION
Two defects in the action-pin resolver. Both fired on this repository and together **removed SLSA provenance from six releases** (v1.14.0 → v1.17.0), fixed for the workflow itself in #354 — this fixes the tool so it does not do it again.

### 1. Reusable workflows were rewritten to a digest
`slsa-verifier` resolves a trusted builder's identity **from the ref**, so pinning `slsa-github-generator` by SHA makes it unverifiable. Upstream:

> the GitHub Actions provided in this repository as builders and generators **MUST** be referenced by tag … contrary to the GitHub best practice for third-party actions … but intentional due to limits in GitHub Actions.

It broke provenance for three days while **every job except `final` reported success**, so nothing in the release path noticed.

The discriminator is the path — GitHub requires reusable workflows to live in `.github/workflows/`. That distinguishes them from an action published in a subdirectory (`anchore/sbom-action/download-syft`), which is **still pinned**. The skip is surgical, not "leave anything with a path alone", and a test asserts both halves in one file.

### 2. A prerelease could outrank its own release
Tag filtering used `commentVerRe`, a **substring** match, so `v2.1.0-rc.3` passed because it contains `v2.1.0`. It then parsed to `[2,1,0]` (`parseVer` discards the suffix) and **tied** the real v2.1.0 — at which point the specificity tiebreak counted dotted components, **4 vs 3**, and declared the release candidate *more specific*. So `@v2.1.0` was pinned to a release candidate's commit.

Fixed in two places: an anchored `releaseTagRe` for tag filtering, and `preferTag` now refuses to rank a prerelease above a release **on its own** rather than trusting the caller to have filtered.

### Verification
Both fixes **mutation-checked** — reverting either makes its test fail. Full suite green, lint 0 issues, self-scan 3 findings / 0 degradations / grade A.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj