### PR TITLE
fix(vscode): declare the VS Code version the extension actually needs

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -6,7 +6,7 @@
   "publisher": "nox-hq",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/nox-hq/nox" },
-  "engines": { "vscode": "^1.75.0" },
+  "engines": { "vscode": "^1.82.0" },
   "categories": ["Linters", "Programming Languages"],
   "activationEvents": [
     "onLanguage:go",


### PR DESCRIPTION
`package.json` advertises `engines.vscode: ^1.75.0` while its own dependency **vscode-languageclient@9 requires ^1.82.0**.

VS Code installs an extension on the strength of that field, so anyone on **1.75–1.81** could install this one and have it fail at activation. The manifest was making a promise the dependency tree could not keep.

Nothing caught it because nothing checked — the extension has no CI (#357 adds a type-check job), and `tsc` does not read `engines`.

Found while evaluating #349 (vscode-languageclient 9 → **10**, which requires **^1.91.0**) and would widen the same gap. **That bump therefore needs its own `engines` change and is deliberately not merged here.**

Verified: extension type-checks clean with the corrected field.