### PR TITLE
fix(vscode): resolve modules the way modern packages publish them

### DIFF
--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "ES2021",
     "lib": ["ES2021"],
     "outDir": "out",


### PR DESCRIPTION
The extension compiles under TypeScript's **legacy `node` module resolution**, which predates the `exports` field. A dependency publishing its types behind an exports map is invisible to it — `vscode-languageclient@10` moves `vscode-languageclient/node` there:

```
error TS2307: Cannot find module 'vscode-languageclient/node'
  There are types at .../lib/node/main.d.ts, but this result could not be resolved
  under your current 'moduleResolution' setting.
```

`module: node16` + `moduleResolution: node16` reads exports maps while still emitting **CommonJS**, which is what the VS Code extension host loads.

### Why this is separate from #349
It is compatible **both ways** — the tree compiles clean under the current v9 *and* under v10. So this merges now, and #349 becomes an ordinary dependency bump instead of a migration disguised as one. (#349 still additionally needs `engines.vscode: ^1.91.0`; #358 corrects the currently-wrong `^1.75.0` → `^1.82.0` for v9.)

### How it was found
By the extension type-check job added in #357 — **on its first run**, against the Dependabot bumps.

Worth recording: my own local check beforehand was **weaker than CI**. `npm install` over an existing `node_modules` resolved the old layout and reported success; CI's clean `npm ci` did not. The gate caught what my manual verification missed.