### PR TITLE
chore(deps): Go 1.26.5, and drop the last hardcoded toolchain pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.7.2
+          version: v2.12.2
           only-new-issues: true
 
   # Decide which operating systems the test matrix covers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:

--- a/.github/workflows/slopfeed-publish.yml
+++ b/.github/workflows/slopfeed-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Ensure signing key is configured
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nox-hq/nox
 
-go 1.25.6
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
Moves nox onto the current Go release, and makes `go.mod` the single source of truth for the toolchain everywhere.

| | From | To |
|---|---|---|
| `go` directive | `1.25.6` | **`1.26.5`** |

## The workflow half is the part worth reviewing

`release.yml` and `slopfeed-publish.yml` pinned `go-version: '1.25'` inline, while every other workflow already used `go-version-file: go.mod`.

That split meant **a go.mod bump silently did not reach the release build** — the one job where the toolchain actually ends up in shipped binaries. Both now read `go.mod`, so there is exactly one place to bump. No hardcoded `go-version:` pins remain in `.github/workflows/`.

## Verified
- `go build ./...` ✅ · `go vet ./...` ✅
- Full test suite: **55 packages ok, 0 failures**

## Companion PRs
All 18 active nox plugins are bumped to Go 1.26.5 + nox SDK v1.17.0 in parallel, so the plugin ecosystem stays on the same toolchain and host API as nox itself. Each verified with build + vet + test.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom