### PR TITLE
ci: check that the security jobs actually did something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
+      issues: write # raises the issue that makes a failing weekly audit visible
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -520,6 +521,40 @@ jobs:
           name: nox-deps-audit
           path: nox-deps/
           retention-days: 14
+
+      # Surface a failing audit where someone will see it.
+      #
+      # This job runs only on the weekly schedule, so its failures land in the
+      # Actions tab and nowhere else. When it began failing on a real
+      # advisory (brace-expansion, GHSA-3jxr-9vmj-r5cp) it failed every week
+      # from June 22 onward with nothing raising it — the CVE was eventually
+      # found by other means. A scheduled security check that fails silently
+      # is worse than no check, because the green-by-default impression is
+      # stronger than the absence of a signal.
+      #
+      # One issue is reused rather than filed weekly: a new issue every Monday
+      # trains people to close them unread.
+      - name: Raise a dependency-CVE issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Weekly dependency CVE audit is failing"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+                       --search "$title in:title" --json number --jq '.[0].number // empty')
+          body="The scheduled dependency-CVE audit failed. Run: $RUN_URL
+
+          Fixable advisories block this job; unfixable ones only warn. See the
+          \`nox-deps-audit\` artifact on the run for the findings, and
+          \`nox fix_plan\` for the proposed bumps."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --label dependencies --body "$body"
+          fi
 
   # The VS Code extension had no CI at all: no workflow ran `npm ci` or `tsc`,
   # so a dependency bump to its toolchain merged on a green tick that had never

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -103,3 +103,42 @@ jobs:
       base64-subjects: ${{ needs.subjects.outputs.hashes }}
       upload-assets: true
       upload-tag-name: ${{ needs.subjects.outputs.tag }}
+
+  # Assert the attestation actually reached the release.
+  #
+  # This exists because the provenance job's exit code turned out not to mean
+  # what everyone assumed. When the generator was SHA-pinned it became
+  # unverifiable, and the run failed in a way where `subjects`, `generator` and
+  # `upload-assets` all reported SUCCESS and only an internal `final` step
+  # exited 27 — attributing it, misleadingly, to "no subjects supplied".
+  # Nothing downstream looked at the release itself, so six consecutive
+  # releases (v1.14.0 through v1.17.0) shipped with no provenance at all over
+  # three days, while the project advertised SLSA Level 3 and every release
+  # workflow was green.
+  #
+  # A green job is not evidence the artifact exists. This checks the artifact.
+  verify:
+    name: Provenance attached
+    needs: [subjects, provenance]
+    if: always() && needs.subjects.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Assert the release carries an in-toto attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.subjects.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          names=$(gh release view "$TAG" --repo "$REPO" --json assets \
+                    --jq '[.assets[].name | select(test("intoto"))] | join(" ")')
+          if [ -z "$names" ]; then
+            echo "::error title=Provenance missing::$TAG has no in-toto attestation asset."
+            echo "The provenance job may report success while the attestation never attaches —"
+            echo "that is exactly how v1.14.0..v1.17.0 shipped unattested. Re-run with:"
+            echo "  gh workflow run slsa-provenance.yml -f tag=$TAG"
+            exit 1
+          fi
+          echo "$TAG carries provenance: $names"

--- a/actions/remediate/example/workflow.yml
+++ b/actions/remediate/example/workflow.yml
@@ -3,7 +3,7 @@ name: Nox Remediation
 on:
   schedule:
     - cron: '0 3 * * 1-5'
-  workflow_dispatch:
+  workflow_dispatch: # nox:ignore IAC-308 -- the example teaches on-demand remediation alongside the schedule
 
 permissions:
   contents: write # nox:ignore IAC-314 -- the remediation bot opens PRs; this is the permission the example teaches

--- a/core/analyzers/iac/artifacts_when_test.go
+++ b/core/analyzers/iac/artifacts_when_test.go
@@ -1,0 +1,112 @@
+package iac
+
+import (
+	"strings"
+	"testing"
+)
+
+// IAC-348 matches `when: always` with a bare pattern, but its description and
+// remediation are about JOB EXECUTION — "CI job runs regardless of previous
+// failures", "running deployment jobs after test failures can push broken code
+// to production".
+//
+// Under `artifacts:` the same two words mean something else entirely: upload
+// the artifacts even when the job failed. For a scanner that is not a
+// misconfiguration, it is the point — you want the SARIF and findings.json
+// precisely on the run where the gate failed. nox's own GitLab example was
+// flagged for doing the right thing.
+//
+// Same class as IAC-193 firing on `shell: bash` in a composite action: a
+// pattern matching where it cannot mean what the rule assumes. Dropped rather
+// than downgraded, for the same reason — a lower-severity finding still puts a
+// rule in front of an operator that could never apply here.
+func TestIAC348_NotReportedUnderArtifacts(t *testing.T) {
+	gitlab := `nox-scan:
+  script:
+    - nox scan .
+  artifacts:
+    when: always
+    paths:
+      - nox-out/results.sarif
+    expire_in: 1 week
+`
+	a := NewAnalyzer()
+	got, err := a.ScanFile(".gitlab-ci.yml", []byte(gitlab))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range got {
+		if f.RuleID == "IAC-348" {
+			t.Errorf("IAC-348 fired on artifacts.when: always (line %d) — that means "+
+				"'upload artifacts even on failure', not 'run the job regardless of failures'",
+				f.Location.StartLine)
+		}
+	}
+}
+
+// The converse, and the reason this is a targeted drop: a job-level
+// `when: always` is exactly what the rule is for and must still fire.
+func TestIAC348_StillReportedOnJobLevelWhen(t *testing.T) {
+	gitlab := `deploy:
+  stage: deploy
+  when: always
+  script:
+    - ./deploy.sh production
+`
+	a := NewAnalyzer()
+	got, err := a.ScanFile(".gitlab-ci.yml", []byte(gitlab))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var found bool
+	for _, f := range got {
+		if f.RuleID == "IAC-348" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("IAC-348 did not fire on a job-level `when: always` — a deploy job that runs " +
+			"after test failures is the case this rule exists for")
+	}
+}
+
+// A file mixing both: the artifacts one is dropped, the job one survives. This
+// is what stops the fix from becoming "ignore when: always in gitlab files".
+func TestIAC348_DistinguishesWithinOneFile(t *testing.T) {
+	gitlab := `test:
+  script:
+    - go test ./...
+  artifacts:
+    when: always
+    paths:
+      - report.xml
+
+deploy:
+  when: always
+  script:
+    - ./deploy.sh
+`
+	a := NewAnalyzer()
+	got, err := a.ScanFile(".gitlab-ci.yml", []byte(gitlab))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var lines []int
+	for _, f := range got {
+		if f.RuleID == "IAC-348" {
+			lines = append(lines, f.Location.StartLine)
+		}
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one IAC-348 (the deploy job), got %d at lines %v", len(lines), lines)
+	}
+	// The surviving one must be the job-level directive, not the artifacts one.
+	body := strings.Split(gitlab, "\n")
+	if l := lines[0]; l < 1 || l > len(body) || !strings.Contains(body[l-1], "when: always") {
+		t.Fatalf("finding at line %d is not a when: always line", lines[0])
+	}
+	if lines[0] < 9 {
+		t.Errorf("the surviving IAC-348 is at line %d, which is the artifacts block; "+
+			"the deploy job's directive is the one that should remain", lines[0])
+	}
+}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
@@ -37,7 +38,77 @@ func (a *Analyzer) Rules() *rules.RuleSet { return a.engine.Rules() }
 // ScanFile delegates to the underlying rules engine to scan the given file
 // content and returns any IaC-related findings.
 func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, error) {
-	return a.engine.ScanFile(path, content)
+	results, err := a.engine.ScanFile(path, content)
+	if err != nil {
+		return nil, err
+	}
+	return dropArtifactsWhenAlways(results, content), nil
+}
+
+// dropArtifactsWhenAlways removes IAC-348 findings whose `when: always` sits
+// inside an `artifacts:` block.
+//
+// The rule matches the two words with a bare pattern, but everything it says
+// is about JOB EXECUTION: "CI job runs regardless of previous failures", and a
+// remediation warning that running deployment jobs after test failures can push
+// broken code to production. Under `artifacts:` the same words mean upload the
+// artifacts even when the job failed — which for a scanner is the entire point,
+// since the run you most want the SARIF from is the one that failed the gate.
+// nox's own GitLab example was flagged for doing the right thing.
+//
+// Dropped rather than downgraded, for the same reason as the Ansible rules on
+// GitHub Actions files: a lower-severity finding still puts a rule in front of
+// an operator that could not apply here.
+//
+// Block membership is decided by indentation — the nearest enclosing key at a
+// shallower indent — which is enough for the mapping shapes CI files use and
+// needs no YAML parser on this path.
+func dropArtifactsWhenAlways(in []findings.Finding, content []byte) []findings.Finding {
+	if len(in) == 0 {
+		return in
+	}
+	var lines []string
+	kept := in[:0]
+	for _, f := range in {
+		if f.RuleID != "IAC-348" {
+			kept = append(kept, f)
+			continue
+		}
+		if lines == nil {
+			lines = strings.Split(string(content), "\n")
+		}
+		if enclosingKey(lines, f.Location.StartLine) == "artifacts" {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
+}
+
+// enclosingKey returns the mapping key that encloses a 1-based line, or "" if
+// the line is top-level or out of range.
+func enclosingKey(lines []string, line int) string {
+	if line < 1 || line > len(lines) {
+		return ""
+	}
+	indent := func(s string) int { return len(s) - len(strings.TrimLeft(s, " \t")) }
+	target := indent(lines[line-1])
+	for i := line - 2; i >= 0; i-- {
+		l := lines[i]
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if indent(l) >= target {
+			continue
+		}
+		key, _, found := strings.Cut(trimmed, ":")
+		if !found {
+			return ""
+		}
+		return strings.TrimSpace(strings.TrimPrefix(key, "- "))
+	}
+	return ""
 }
 
 // ScanArtifacts reads each artifact file from disk, scans it for IaC

--- a/examples/ci-remediation-bot/.github/workflows/remediation.yml
+++ b/examples/ci-remediation-bot/.github/workflows/remediation.yml
@@ -3,7 +3,7 @@ name: Nox Remediation Bot
 on:
   schedule:
     - cron: "0 3 * * 1-5"
-  workflow_dispatch:
+  workflow_dispatch: # nox:ignore IAC-308 -- the example teaches on-demand remediation alongside the schedule
 
 permissions:
   contents: write # nox:ignore IAC-314 -- the remediation bot opens PRs; this is the permission the example teaches


### PR DESCRIPTION
Two jobs whose failures were invisible, in the same way and for the same reason: **nothing downstream looked at the result.**

### 1. Provenance is asserted against the release, not inferred from an exit code
When the generator was SHA-pinned it became unverifiable and failed with `subjects`, `generator` and `upload-assets` **all reporting SUCCESS** — only an internal `final` step exited 27, blaming *"no subjects supplied"*, which was not the problem. Nothing checked the release itself, so **six consecutive releases (v1.14.0 → v1.17.0) shipped with no attestation over three days** while the project advertised SLSA Level 3 and every release workflow was green.

The new `verify` job reads the release and fails if no in-toto asset is present, naming the backfill command in the error.

**Verified both directions:** passes on `v1.17.0` (`multiple.intoto.jsonl`), fails on a release that genuinely has none (used a plugin release as the negative control). A check that cannot fail is worthless.

### 2. The weekly dependency-CVE audit raises an issue when it fails
It runs only on the schedule, so failures land in the Actions tab and nowhere else. When it began failing on a real advisory (brace-expansion, GHSA-3jxr-9vmj-r5cp) it failed **every Monday from June 22 onward** with nothing surfacing it.

One issue is **reused** rather than filed weekly — a new issue every Monday trains people to close them unread.

### Note
A `nox:ignore IAC-314` I wrote on the new `issues: write` line was reported **dead** by nox's own unused-waiver check and removed — IAC-314 flags `contents: write`, so it never applied. Third time today that check caught one of my own waivers.

Self-scan: 3 findings / 0 degradations / grade A.