### PR TITLE
fix(sarif): a location-less finding no longer breaks the whole upload

### DIFF
--- a/core/report/sarif/location_test.go
+++ b/core/report/sarif/location_test.go
@@ -1,0 +1,93 @@
+package sarif
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// A finding with no file location must not cost every other finding its
+// upload.
+//
+// Some verdicts are about the dependency graph rather than a line of source —
+// a reachability class, or a repository-scoped "no private registry
+// configured" — and they arrive with an empty path. nox wrote that straight
+// into SARIF as artifactLocation.uri "", and GitHub rejects the SUBMISSION,
+// not the result:
+//
+//	Code Scanning could not process the submitted SARIF file:
+//	locationFromSarifResult: expected artifact location
+//
+// So one plugin emitting one location-less finding silently costs a repository
+// its entire code-scanning upload, while the same scan looks clean locally.
+// Any analyzer can produce this shape, so the blast radius belongs in core.
+func TestGenerate_LocationLessFindingDoesNotEmitEmptyURI(t *testing.T) {
+	fs := findings.NewFindingSet()
+	fs.Add(findings.NewFinding("REACH-001", findings.SeverityInfo, findings.ConfidenceHigh,
+		findings.Location{FilePath: ""}, "dependency is not reachable"))
+	fs.Add(findings.NewFinding("SEC-001", findings.SeverityHigh, findings.ConfidenceHigh,
+		findings.Location{FilePath: "main.go", StartLine: 12}, "hardcoded secret"))
+
+	out, err := NewReporter("test", rules.NewRuleSet()).Generate(fs)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if strings.Contains(string(out), `"uri": ""`) {
+		t.Error(`SARIF contains artifactLocation.uri "" — GitHub rejects the whole file for this`)
+	}
+	// A nil slice serialises as `"locations": null`, which is no better than an
+	// empty uri: the key must be absent entirely.
+	if strings.Contains(string(out), `"locations": null`) {
+		t.Error(`SARIF contains "locations": null — the key must be omitted, not nulled`)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Results []struct {
+				RuleID    string `json:"ruleId"`
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(doc.Runs))
+	}
+
+	byRule := map[string]int{}
+	for _, r := range doc.Runs[0].Results {
+		byRule[r.RuleID] = len(r.Locations)
+		for _, l := range r.Locations {
+			if l.PhysicalLocation.ArtifactLocation.URI == "" {
+				t.Errorf("%s emitted a location with an empty uri", r.RuleID)
+			}
+		}
+	}
+
+	// Both findings must survive. Dropping the located one would be a
+	// regression; dropping the location-less one loses a real verdict.
+	if _, ok := byRule["SEC-001"]; !ok {
+		t.Error("the located finding disappeared from SARIF")
+	}
+	if _, ok := byRule["REACH-001"]; !ok {
+		t.Error("the location-less finding was dropped entirely; it should be reported without a location")
+	}
+	if n := byRule["REACH-001"]; n != 0 {
+		t.Errorf("location-less finding carries %d locations, want 0 — an absent array cannot trip "+
+			"'expected artifact location', an empty-uri entry does", n)
+	}
+	if n := byRule["SEC-001"]; n != 1 {
+		t.Errorf("located finding carries %d locations, want 1", n)
+	}
+}

--- a/core/report/sarif/sarif.go
+++ b/core/report/sarif/sarif.go
@@ -99,11 +99,14 @@ type Message struct {
 
 // Result is a single finding expressed in SARIF format.
 type Result struct {
-	RuleID       string            `json:"ruleId"`
-	RuleIndex    int               `json:"ruleIndex"`
-	Level        string            `json:"level"`
-	Message      Message           `json:"message"`
-	Locations    []Location        `json:"locations"`
+	RuleID    string  `json:"ruleId"`
+	RuleIndex int     `json:"ruleIndex"`
+	Level     string  `json:"level"`
+	Message   Message `json:"message"`
+	// omitempty matters: a nil slice would serialise as `"locations": null`,
+	// which is no more acceptable to a consumer than an empty uri. A
+	// location-less result must have no locations KEY at all.
+	Locations    []Location        `json:"locations,omitempty"`
 	Fingerprints map[string]string `json:"fingerprints"`
 	// Properties carries the finding's Metadata — the reachability class, the
 	// vuln class, and the original-severity downgrade audit trail. Without it a
@@ -185,16 +188,40 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			idx = 0
 		}
 
-		phys := PhysicalLocation{
-			ArtifactLocation: ArtifactLocation{URI: encodeURI(f.Location.FilePath)},
-		}
-		if f.Location.StartLine > 0 {
-			phys.Region = &Region{
-				StartLine:   f.Location.StartLine,
-				StartColumn: f.Location.StartColumn,
-				EndLine:     f.Location.EndLine,
-				EndColumn:   f.Location.EndColumn,
+		// A finding with no file is reported WITHOUT a location, never with an
+		// empty one.
+		//
+		// Some verdicts are about the dependency graph rather than a line of
+		// source — a reachability class, or a repository-scoped "no private
+		// registry configured" — and arrive with an empty path. Writing that
+		// through produced `"uri": ""`, and GitHub rejects the SUBMISSION for
+		// it, not the offending result:
+		//
+		//	locationFromSarifResult: expected artifact location
+		//
+		// So one location-less finding from one plugin cost a repository its
+		// entire code-scanning upload, while the same scan looked clean
+		// locally. Any analyzer can emit this shape, so the containment
+		// belongs here rather than in each of them.
+		//
+		// The result is kept: SARIF permits a result with no locations, and
+		// dropping it would trade a broken upload for a silently missing
+		// verdict — the worse failure for a security tool. An absent array
+		// cannot trip "expected artifact location"; an empty-uri entry does.
+		var locations []Location
+		if f.Location.FilePath != "" {
+			phys := PhysicalLocation{
+				ArtifactLocation: ArtifactLocation{URI: encodeURI(f.Location.FilePath)},
 			}
+			if f.Location.StartLine > 0 {
+				phys.Region = &Region{
+					StartLine:   f.Location.StartLine,
+					StartColumn: f.Location.StartColumn,
+					EndLine:     f.Location.EndLine,
+					EndColumn:   f.Location.EndColumn,
+				}
+			}
+			locations = []Location{{PhysicalLocation: phys}}
 		}
 
 		result := Result{
@@ -202,7 +229,7 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			RuleIndex:    idx,
 			Level:        severityToLevel(f.Severity),
 			Message:      Message{Text: f.Message},
-			Locations:    []Location{{PhysicalLocation: phys}},
+			Locations:    locations,
 			Fingerprints: map[string]string{"nox/v1": f.Fingerprint},
 			Properties:   sarifProperties(f),
 		}


### PR DESCRIPTION
Closes half of #365.

Some verdicts are about the dependency graph rather than a line of source — a reachability class, or a repository-scoped "no private registry configured" — and arrive with an empty path. nox wrote that straight through as `"uri": ""`, and GitHub rejects the **submission** for it, not the offending result:

```
locationFromSarifResult: expected artifact location
```

So **one location-less finding from one plugin cost a repository its entire code-scanning upload** — and the same scan looked clean locally, which is exactly where anyone would go to reproduce it.

### The fix
A finding with no file is reported with **no locations at all**. The result is **kept, not dropped**: SARIF permits a result without locations, and dropping it would trade a broken upload for a silently missing verdict — the worse failure for a security tool.

`locations` also needed `omitempty`. A nil slice serialises as `"locations": null`, which is no more acceptable than an empty uri; the key must be **absent**. I only caught that by inspecting the emitted JSON after the first fix looked green.

**Both halves mutation-checked** — reverting either one fails the test.

### Scope
This is the containment, not the cure. Any analyzer can emit this shape, so the blast radius belongs in core. The plugin-side half (#366) is still worth doing: a reachability verdict annotates a `VULN-001` that *does* have a location, so pointing it at the manifest would be both valid SARIF and more useful than no location.

### Disclosure
I widened this bug's reach earlier today. In #330 I canonicalised repo-scoped plugin findings (e.g. `DEPCONF-002`) to the empty path to fix a suppression degradation — correct in itself, but it created more findings of exactly the shape that breaks SARIF. I did not consider the SARIF path at the time.