### PR TITLE
fix(cli): an explicit -format is no longer overridden by .nox.yaml

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -149,8 +149,12 @@ func run(args []string) int {
 		versionFlag bool
 	)
 
-	fs.StringVar(&formatFlag, "format", "json", "output formats: json,sarif,cdx,spdx,all (comma-separated)")
-	fs.StringVar(&outputDir, "output", ".", "output directory for report files")
+	// Defaults are deliberately EMPTY so "flag absent" is distinguishable from
+	// "flag explicitly set to the default". The built-in defaults are applied by
+	// resolveOutputFormat/resolveOutputDir after config is read. See the comment
+	// on those functions.
+	fs.StringVar(&formatFlag, "format", "", "output formats: json,sarif,cdx,spdx,all (comma-separated) (default \"json\")")
+	fs.StringVar(&outputDir, "output", "", "output directory for report files (default \".\")")
 	fs.StringVar(&rulesFlag, "rules", "", "path to custom rules YAML file or directory")
 	fs.BoolVar(&quietFlag, "quiet", false, "suppress all output except errors")
 	fs.BoolVar(&quietFlag, "q", false, "suppress all output except errors (shorthand)")
@@ -300,6 +304,45 @@ func parseInterspersed(fs *flag.FlagSet, args []string) ([]string, error) {
 	}
 }
 
+// resolveOutputFormat picks the output format from the CLI flag, then
+// .nox.yaml, then the built-in default.
+//
+// The previous form compared the flag's VALUE to its default —
+// `if formatFlag == "json" && cfg.Output.Format != ""` — so an explicit
+// `-format json` was indistinguishable from the flag being absent, and config
+// overrode a value the caller had deliberately typed. The comment above it
+// said CLI flags take precedence, which is what everyone assumed.
+//
+// It disabled the security gate on two repositories: CI ran
+// `nox scan … -format json,sarif` and gated on findings.json, both repos had
+// `output.format: sarif` in .nox.yaml, so findings.json was never written and
+// the gating step skipped on the missing file — and a skipped step is a green
+// check. Exit 0, no warning, 20 and 63 ungated SARIF results.
+//
+// The flags now default to empty, so "absent" is representable and config can
+// fill it in without ever overriding an argument that was actually passed.
+func resolveOutputFormat(flagValue, configValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if configValue != "" {
+		return configValue
+	}
+	return "json"
+}
+
+// resolveOutputDir applies the same precedence to the output directory, which
+// carried the identical defect against ".".
+func resolveOutputDir(flagValue, configValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if configValue != "" {
+		return configValue
+	}
+	return "."
+}
+
 func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verbose bool) int {
 	// Parse scan-specific flags.
 	scanFS := flag.NewFlagSet("scan", flag.ContinueOnError)
@@ -404,13 +447,9 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		}
 	}
 
-	// Apply output defaults from config (CLI flags take precedence).
-	if formatFlag == "json" && cfg.Output.Format != "" {
-		formatFlag = cfg.Output.Format
-	}
-	if outputDir == "." && cfg.Output.Directory != "" {
-		outputDir = cfg.Output.Directory
-	}
+	// Precedence is flag > config > default.
+	formatFlag = resolveOutputFormat(formatFlag, cfg.Output.Format)
+	outputDir = resolveOutputDir(outputDir, cfg.Output.Directory)
 
 	formats := parseFormats(formatFlag)
 

--- a/cli/output_precedence_test.go
+++ b/cli/output_precedence_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+// `output.format` in .nox.yaml silently overrode an explicit `-format` on the
+// command line, because the check compared the flag's VALUE to its default:
+//
+//	if formatFlag == "json" && cfg.Output.Format != "" { formatFlag = ... }
+//
+// So `-format json` — deliberately typed by the caller — was indistinguishable
+// from "flag absent", and config won. The comment above it said "CLI flags take
+// precedence", which is what everyone reasonably assumed.
+//
+// It disabled the security gate on two repositories. A shared CI workflow ran
+// `nox scan … -format json,sarif` and gated on findings.json; both repos had
+// `output.format: sarif` in .nox.yaml, so findings.json was never written, the
+// gating step skipped on the missing file, and a skipped step in GitHub Actions
+// is a green check. 20 and 63 SARIF results respectively, neither gated.
+//
+// Precedence is flag > config > default: config supplies the value when the
+// flag is ABSENT, never overrides one that was given.
+func TestResolveOutputFormat(t *testing.T) {
+	cases := []struct {
+		name      string
+		flagValue string // "" means the flag was not passed
+		configVal string
+		want      string
+	}{
+		{"neither: built-in default", "", "", "json"},
+		{"config only", "", "sarif", "sarif"},
+		{"explicit flag beats config", "json", "sarif", "json"},
+		{"explicit flag, no config", "sarif", "", "sarif"},
+		{"explicit multi-format beats config", "json,sarif", "sarif", "json,sarif"},
+		// The regression that shipped: an explicit value that happens to equal
+		// the built-in default must still win.
+		{"explicit value equal to the default still wins", "json", "cdx", "json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveOutputFormat(tc.flagValue, tc.configVal); got != tc.want {
+				t.Errorf("resolveOutputFormat(flag=%q, config=%q) = %q, want %q",
+					tc.flagValue, tc.configVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// The output directory carried the identical defect, comparing against ".".
+func TestResolveOutputDir(t *testing.T) {
+	cases := []struct{ name, flagValue, configVal, want string }{
+		{"neither", "", "", "."},
+		{"config only", "", "nox-out", "nox-out"},
+		{"explicit flag beats config", "reports", "nox-out", "reports"},
+		{"explicit value equal to the default still wins", ".", "nox-out", "."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveOutputDir(tc.flagValue, tc.configVal); got != tc.want {
+				t.Errorf("resolveOutputDir(flag=%q, config=%q) = %q, want %q",
+					tc.flagValue, tc.configVal, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #362.

`output.format` in a project's `.nox.yaml` silently overrode an explicit `-format`, because the check compared the flag's **value** to its default:

```go
if formatFlag == "json" && cfg.Output.Format != "" { ... }
```

So `-format json` — deliberately typed — was indistinguishable from the flag being absent, and config won. The comment directly above it said *"CLI flags take precedence"*.

### What it cost
It **disabled the security gate on two repositories**. CI ran `nox scan … -format json,sarif` and gated on `findings.json`; both repos carried `output.format: sarif`, so `findings.json` was never written, the gating step skipped on the missing file — and a skipped step in GitHub Actions is a **green check**. 20 and 63 SARIF results respectively, neither gated, exit 0, no warning.

### The fix
Both flags default to **empty**, making "absent" representable, and precedence is resolved explicitly: **flag > config > default**. `-output` carried the identical defect against `"."` and is fixed the same way.

### Verified end to end
With `output.format: sarif` in `.nox.yaml`:

| invocation | writes |
|---|---|
| `-format json` | `findings.json` ✅ flag wins |
| *(no flag)* | `results.sarif` ✅ config still applies |
| `-format json,sarif` | both ✅ |

**My first attempt at that check was inconclusive** and I nearly reported it as proof: `.nox.yaml` sat beside the scan target rather than inside it, so config never loaded and both cases passed for the wrong reason. Re-ran with the config in the scan root.

Also worth noting from the issue: the CI side is being fixed separately so a missing `findings.json` is fatal rather than skipped — that defence is worth having regardless of this fix.