### PR TITLE
fix(deps): VULN-001 no longer tells you to downgrade

### DIFF
--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -615,7 +615,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 						"ecosystem": pkg.Ecosystem,
 						"aliases":   aliases,
 					}
-					if fix := fixedVersion(&ov, pkg.Name, pkg.Ecosystem); fix != "" {
+					if fix := fixedVersion(&ov, pkg.Name, pkg.Ecosystem, pkg.Version); fix != "" {
 						meta["fixed_in"] = fix
 						meta["remediation_action"] = "upgrade"
 						meta["remediation_command"] = upgradeCommand(pkg.Ecosystem, pkg.Name, fix)

--- a/core/analyzers/deps/osv.go
+++ b/core/analyzers/deps/osv.go
@@ -106,13 +106,68 @@ type osvEvent struct {
 	Limit        string `json:"limit,omitempty"`
 }
 
-// fixedVersion returns the lowest fixed version listed across the affected
-// entries that match the given package name + ecosystem. Returns "" when
-// the OSV record names no fix (an unfixed vulnerability).
-func fixedVersion(vuln *osvVuln, pkgName, ecosystem string) string {
+// affectedInterval is one contiguous affected range from an OSV record:
+// versions from introduced (inclusive) up to fixed (exclusive), or through
+// lastAffected (inclusive). fixed is empty when the interval names no fix —
+// an unfixed release branch.
+type affectedInterval struct {
+	introduced   string
+	fixed        string
+	lastAffected string
+}
+
+// covers reports whether the installed version falls inside the interval.
+//
+// A version we cannot order is never treated as covered. Guessing there would
+// put us back to picking a fix at random, which is the whole defect.
+func (iv affectedInterval) covers(installed string) bool {
+	if !comparableVersion(installed) {
+		return false
+	}
+	// "0" is OSV's "since the beginning"; comparing against it directly would
+	// exclude prereleases of 0.0.0, which sort below it.
+	if iv.introduced != "" && iv.introduced != "0" {
+		if !comparableVersion(iv.introduced) || compareGoVersions(installed, iv.introduced) < 0 {
+			return false
+		}
+	}
+	switch {
+	case iv.fixed != "":
+		return comparableVersion(iv.fixed) && compareGoVersions(installed, iv.fixed) < 0
+	case iv.lastAffected != "":
+		return comparableVersion(iv.lastAffected) && compareGoVersions(installed, iv.lastAffected) <= 0
+	}
+	return true // introduced with no upper bound: still unfixed
+}
+
+// comparableVersion reports whether v carries an ordering compareGoVersions can
+// be trusted with. A value whose leading segment is not numeric — "latest",
+// "unknown", a git SHA, an empty string — does not.
+func comparableVersion(v string) bool {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	lead, _, _ := strings.Cut(v, ".")
+	lead, _, _ = strings.Cut(lead, "-")
+	lead, _, _ = strings.Cut(lead, "+")
+	if lead == "" {
+		return false
+	}
+	for _, r := range lead {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// affectedIntervals expands the affected entries matching the given package
+// name + ecosystem into flat intervals. OSV expresses a package's affected
+// versions either as several `affected` entries with one range each or as one
+// range with several introduced/fixed pairs; both mean the same thing, and both
+// occur in real advisories, so both are flattened here.
+func affectedIntervals(vuln *osvVuln, pkgName, ecosystem string) []affectedInterval {
 	want := strings.ToLower(pkgName)
 	wantEco := ecosystemToOSV(ecosystem)
-	var first string
+	var out []affectedInterval
 	for _, aff := range vuln.Affected {
 		if !strings.EqualFold(aff.Package.Name, want) {
 			continue
@@ -121,14 +176,71 @@ func fixedVersion(vuln *osvVuln, pkgName, ecosystem string) string {
 			continue
 		}
 		for _, r := range aff.Ranges {
+			cur := affectedInterval{}
+			open := false
 			for _, e := range r.Events {
-				if e.Fixed != "" && first == "" {
-					first = e.Fixed
+				switch {
+				case e.Introduced != "":
+					if open {
+						out = append(out, cur)
+					}
+					cur, open = affectedInterval{introduced: e.Introduced}, true
+				case e.Fixed != "":
+					cur.fixed = e.Fixed
+					out = append(out, cur)
+					cur, open = affectedInterval{}, false
+				case e.LastAffected != "":
+					cur.lastAffected = e.LastAffected
+					out = append(out, cur)
+					cur, open = affectedInterval{}, false
 				}
+			}
+			if open {
+				out = append(out, cur)
 			}
 		}
 	}
-	return first
+	return out
+}
+
+// fixedVersion returns the version the installed one must move to in order to
+// clear the advisory, or "" when that cannot be established.
+//
+// An advisory covering a package with maintained release branches names one fix
+// per branch. Reporting any fix other than the one for the branch in use is not
+// a cosmetic mislabel: the fix for an older branch is a *lower* version than
+// what is installed, so the remediation reads as a downgrade — to something
+// plausibly vulnerable to a different advisory, and certainly a functional
+// regression. So the interval containing the installed version selects the fix,
+// not the order the advisory happens to list its ranges in.
+//
+// "" is returned whenever no interval contains the installed version: outside
+// the ranges, on a branch with no fix yet, or with a version string that cannot
+// be ordered. That is a genuine "we do not know", and any answer invented to
+// fill it would reintroduce the defect in a new form. The finding itself still
+// stands — OSV matched the installed version server-side, so a disagreement
+// here is our range arithmetic falling short, not evidence of a false positive.
+func fixedVersion(vuln *osvVuln, pkgName, ecosystem, installed string) string {
+	intervals := affectedIntervals(vuln, pkgName, ecosystem)
+
+	// A single interval leaves nothing to select between, and its bounds are
+	// the ones OSV already matched the installed version against.
+	if len(intervals) == 1 {
+		return intervals[0].fixed
+	}
+
+	best := ""
+	for _, iv := range intervals {
+		if iv.fixed == "" || !iv.covers(installed) {
+			continue
+		}
+		// Overlapping intervals are malformed data, but if they occur the
+		// smallest upgrade that clears the advisory is the honest answer.
+		if best == "" || compareGoVersions(iv.fixed, best) < 0 {
+			best = iv.fixed
+		}
+	}
+	return best
 }
 
 // queryOSV queries the OSV.dev batch API for known vulnerabilities affecting

--- a/core/analyzers/deps/osv_test.go
+++ b/core/analyzers/deps/osv_test.go
@@ -407,49 +407,243 @@ func TestMapOSVSeverity_FallsBackToLabel(t *testing.T) {
 // fixedVersion tests
 // ---------------------------------------------------------------------------
 
-func TestFixedVersion_ExtractsFromAffected(t *testing.T) {
+// affected builds one osvAffected entry with a single range from the given
+// events, so the table below reads as version ranges rather than JSON shapes.
+func affected(name, eco string, events ...osvEvent) osvAffected {
+	return osvAffected{
+		Package: osvPackage{Name: name, Ecosystem: eco},
+		Ranges:  []osvRange{{Type: "SEMVER", Events: events}},
+	}
+}
+
+// TestFixedVersion covers the selection of a fix version out of an advisory's
+// affected ranges.
+//
+// The case that matters is an advisory with more than one range: reporting a
+// fix from a range the installed version is not in tells the operator to move
+// to a version *below* the one they are running. A security scanner that
+// recommends a downgrade is worse than one that says nothing, so every case
+// where the covering range cannot be identified expects "".
+func TestFixedVersion(t *testing.T) {
 	t.Parallel()
 
-	v := osvVuln{
-		ID: "CVE-2024-1234",
-		Affected: []osvAffected{{
-			Package: osvPackage{Name: "github.com/foo/bar", Ecosystem: "Go"},
-			Ranges: []osvRange{{
-				Type: "SEMVER",
-				Events: []osvEvent{
-					{Introduced: "0"},
-					{Fixed: "1.2.4"},
+	// The real GHSA-47m2-4cr7-mhcw, which is how this was found: two affected
+	// entries, one per maintained release branch.
+	quicGo := []osvAffected{
+		affected("github.com/quic-go/quic-go", "Go", osvEvent{Introduced: "0"}, osvEvent{Fixed: "0.49.1"}),
+		affected("github.com/quic-go/quic-go", "Go", osvEvent{Introduced: "0.50.0"}, osvEvent{Fixed: "0.54.1"}),
+	}
+
+	tests := []struct {
+		name      string
+		affected  []osvAffected
+		pkg, eco  string
+		installed string
+		want      string
+	}{
+		{
+			name:      "single range covering the installed version",
+			affected:  []osvAffected{affected("github.com/foo/bar", "Go", osvEvent{Introduced: "0"}, osvEvent{Fixed: "1.2.4"})},
+			pkg:       "github.com/foo/bar",
+			eco:       "go",
+			installed: "v1.2.0",
+			want:      "1.2.4",
+		},
+		{
+			name:      "GHSA-47m2-4cr7-mhcw: installed on the maintained branch",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v0.54.0",
+			want:      "0.54.1",
+		},
+		{
+			name:      "GHSA-47m2-4cr7-mhcw: installed in the first range",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v0.30.2",
+			want:      "0.49.1",
+		},
+		{
+			name:      "installed between two ranges is covered by neither",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v0.49.5",
+			want:      "",
+		},
+		{
+			name:      "installed above every range",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v1.0.0",
+			want:      "",
+		},
+		{
+			name: "two ranges inside one affected entry",
+			affected: []osvAffected{{
+				Package: osvPackage{Name: "p", Ecosystem: "npm"},
+				Ranges: []osvRange{
+					{Type: "SEMVER", Events: []osvEvent{{Introduced: "0"}, {Fixed: "1.9.2"}}},
+					{Type: "SEMVER", Events: []osvEvent{{Introduced: "2.0.0"}, {Fixed: "2.4.1"}}},
 				},
 			}},
-		}},
+			pkg:       "p",
+			eco:       "npm",
+			installed: "2.3.0",
+			want:      "2.4.1",
+		},
+		{
+			name: "four events in one range",
+			affected: []osvAffected{{
+				Package: osvPackage{Name: "p", Ecosystem: "npm"},
+				Ranges: []osvRange{{Type: "SEMVER", Events: []osvEvent{
+					{Introduced: "0"}, {Fixed: "1.9.2"},
+					{Introduced: "2.0.0"}, {Fixed: "2.4.1"},
+				}}},
+			}},
+			pkg:       "p",
+			eco:       "npm",
+			installed: "2.3.0",
+			want:      "2.4.1",
+		},
+		{
+			name:      "single range with no fix event",
+			affected:  []osvAffected{affected("p", "npm", osvEvent{Introduced: "0"})},
+			pkg:       "p",
+			eco:       "npm",
+			installed: "1.0.0",
+			want:      "",
+		},
+		{
+			// The branch the operator is on is still unfixed; the older branch
+			// has a fix. Reporting it would be the downgrade this test exists
+			// to prevent.
+			name: "covering range is unfixed while an earlier range is fixed",
+			affected: []osvAffected{
+				affected("p", "npm", osvEvent{Introduced: "0"}, osvEvent{Fixed: "1.5.0"}),
+				affected("p", "npm", osvEvent{Introduced: "2.0.0"}),
+			},
+			pkg:       "p",
+			eco:       "npm",
+			installed: "2.1.0",
+			want:      "",
+		},
+		{
+			name: "last_affected names no fix",
+			affected: []osvAffected{
+				affected("p", "npm", osvEvent{Introduced: "0"}, osvEvent{Fixed: "1.5.0"}),
+				affected("p", "npm", osvEvent{Introduced: "2.0.0"}, osvEvent{LastAffected: "2.9.9"}),
+			},
+			pkg:       "p",
+			eco:       "npm",
+			installed: "2.5.0",
+			want:      "",
+		},
+		{
+			name:      "v prefix on the advisory's own versions",
+			affected:  []osvAffected{affected("m", "Go", osvEvent{Introduced: "v1.0.0"}, osvEvent{Fixed: "v1.4.0"}), affected("m", "Go", osvEvent{Introduced: "v2.0.0"}, osvEvent{Fixed: "v2.1.0"})},
+			pkg:       "m",
+			eco:       "go",
+			installed: "v2.0.3",
+			want:      "v2.1.0",
+		},
+		{
+			// A prerelease sorts below its release, so v0.54.1-rc.1 is still
+			// inside [0.50.0, 0.54.1) and the fix still applies.
+			name:      "prerelease of the fix version is still affected",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v0.54.1-rc.1",
+			want:      "0.54.1",
+		},
+		{
+			name:      "prerelease of the introduced version is below the range",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "v0.50.0-beta1",
+			want:      "",
+		},
+		{
+			name:      "installed version carries no usable ordering",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "latest",
+			want:      "",
+		},
+		{
+			name:      "installed version is empty",
+			affected:  quicGo,
+			pkg:       "github.com/quic-go/quic-go",
+			eco:       "go",
+			installed: "",
+			want:      "",
+		},
+		{
+			name:      "non-matching package",
+			affected:  []osvAffected{affected("other", "Go", osvEvent{Fixed: "1.0.0"})},
+			pkg:       "github.com/foo/bar",
+			eco:       "go",
+			installed: "0.1.0",
+			want:      "",
+		},
+		{
+			name:      "matching name in a different ecosystem",
+			affected:  []osvAffected{affected("p", "npm", osvEvent{Introduced: "0"}, osvEvent{Fixed: "1.0.0"})},
+			pkg:       "p",
+			eco:       "pypi",
+			installed: "0.9.0",
+			want:      "",
+		},
+		{
+			name:      "no affected entries at all",
+			affected:  nil,
+			pkg:       "p",
+			eco:       "npm",
+			installed: "1.0.0",
+			want:      "",
+		},
 	}
-	got := fixedVersion(&v, "github.com/foo/bar", "go")
-	if got != "1.2.4" {
-		t.Errorf("expected 1.2.4, got %q", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := osvVuln{ID: "CVE-2024-1234", Affected: tt.affected}
+			if got := fixedVersion(&v, tt.pkg, tt.eco, tt.installed); got != tt.want {
+				t.Errorf("fixedVersion(%s@%s) = %q, want %q", tt.pkg, tt.installed, got, tt.want)
+			}
+		})
 	}
 }
 
-func TestFixedVersion_NoMatch(t *testing.T) {
+// TestFixedVersion_NeverBelowInstalled is the property the table above encodes
+// case by case: whatever fixedVersion returns for a comparable installed
+// version, acting on it must never be a downgrade.
+func TestFixedVersion_NeverBelowInstalled(t *testing.T) {
 	t.Parallel()
 
-	v := osvVuln{Affected: []osvAffected{{
-		Package: osvPackage{Name: "other", Ecosystem: "Go"},
-		Ranges:  []osvRange{{Events: []osvEvent{{Fixed: "1.0.0"}}}},
-	}}}
-	if got := fixedVersion(&v, "github.com/foo/bar", "go"); got != "" {
-		t.Errorf("expected empty for non-matching package, got %q", got)
-	}
-}
+	v := osvVuln{Affected: []osvAffected{
+		affected("github.com/quic-go/quic-go", "Go", osvEvent{Introduced: "0"}, osvEvent{Fixed: "0.49.1"}),
+		affected("github.com/quic-go/quic-go", "Go", osvEvent{Introduced: "0.50.0"}, osvEvent{Fixed: "0.54.1"}),
+		affected("github.com/quic-go/quic-go", "Go", osvEvent{Introduced: "0.55.0"}, osvEvent{Fixed: "0.55.3"}),
+	}}
 
-func TestFixedVersion_NoFixEvent(t *testing.T) {
-	t.Parallel()
-
-	v := osvVuln{Affected: []osvAffected{{
-		Package: osvPackage{Name: "p", Ecosystem: "npm"},
-		Ranges:  []osvRange{{Events: []osvEvent{{Introduced: "0"}}}},
-	}}}
-	if got := fixedVersion(&v, "p", "npm"); got != "" {
-		t.Errorf("expected empty for unfixed vuln, got %q", got)
+	for _, installed := range []string{
+		"v0.1.0", "v0.49.0", "v0.49.1", "v0.50.0", "v0.53.9",
+		"v0.54.0", "v0.54.1", "v0.55.0", "v0.55.2", "v0.55.3", "v1.0.0",
+	} {
+		fix := fixedVersion(&v, "github.com/quic-go/quic-go", "go", installed)
+		if fix == "" {
+			continue
+		}
+		if compareGoVersions(fix, installed) <= 0 {
+			t.Errorf("installed %s reported as fixed in %s — following that is a downgrade", installed, fix)
+		}
 	}
 }
 

--- a/core/analyzers/deps/osv_wire_test.go
+++ b/core/analyzers/deps/osv_wire_test.go
@@ -242,6 +242,56 @@ func TestOSVWire_HydratesEveryOperatorFacingField(t *testing.T) {
 	}
 }
 
+// TestOSVWire_MultiRangeAdvisoryRemediatesForwards checks the whole path, not
+// just the selection: the installed version has to reach fixedVersion from the
+// call site, and the remediation command has to carry the version that was
+// selected.
+//
+// Shaped after GHSA-47m2-4cr7-mhcw, where reporting the first range's fix told
+// operators running 0.54.0 to move to 0.49.1.
+func TestOSVWire_MultiRangeAdvisoryRemediatesForwards(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOSV(t,
+		map[string][]string{"leftpad": {"GHSA-branches"}},
+		map[string]string{
+			"GHSA-branches": `{
+				"id": "GHSA-branches",
+				"summary": "Panic on undecryptable packets",
+				"affected": [
+					{
+						"package": {"name":"leftpad","ecosystem":"npm"},
+						"ranges": [{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"0.49.1"}]}]
+					},
+					{
+						"package": {"name":"leftpad","ecosystem":"npm"},
+						"ranges": [{"type":"SEMVER","events":[{"introduced":"0.50.0"},{"fixed":"0.54.1"}]}]
+					}
+				]
+			}`,
+		})
+	defer srv.Close()
+
+	items := scanOneNPMPackage(t, srv, "leftpad", "0.54.0")
+
+	var f *findings.Finding
+	for i := range items {
+		if items[i].RuleID == "VULN-001" {
+			f = &items[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("no VULN-001 finding was emitted")
+	}
+	if got := f.Metadata["fixed_in"]; got != "0.54.1" {
+		t.Errorf("fixed_in = %q, want 0.54.1 — 0.49.1 is below the installed 0.54.0 and following it downgrades", got)
+	}
+	if got := f.Metadata["remediation_command"]; !strings.Contains(got, "0.54.1") {
+		t.Errorf("remediation_command = %q, want it to name 0.54.1", got)
+	}
+}
+
 // TestApplyVulnDetails_CopiesEveryField is the structural guard for the bug
 // that shipped twice in this file.
 //


### PR DESCRIPTION
Closes #364.

`fixedVersion` returned the **first** `fixed` event it encountered in an
advisory, regardless of which range the installed version was in. For an
advisory with one range per maintained release branch — the norm for
anything that backports — that is the fix for the *oldest* branch.

GHSA-47m2-4cr7-mhcw, on `github.com/quic-go/quic-go@v0.54.0`:

```
[0,      0.49.1)
[0.50.0, 0.54.1)
```

nox reported `fixed_in=0.49.1`. The installed version is 0.54.0, so the
remediation nox emits — down to `remediation_command`, `go get
...@v0.49.1` — moves the operator **five minor versions backwards**, onto
a branch that is unmaintained and plausibly vulnerable to advisories the
current one is not.

The second failure mode is worse than the first. A fix version below the
installed one reads as nonsense — *"we're on 0.54.0 and it says fixed in
0.49.1, so this is a false positive"* — and the advisory gets dismissed.
The finding was correct the whole time.

### Selection

The interval containing the installed version now selects the fix. OSV
writes those intervals two ways — several `affected` entries with one
range each (what GHSA-47m2-4cr7-mhcw does) or one range with several
introduced/fixed pairs — and both occur, so both are flattened before
matching. Ordering reuses `compareGoVersions`, already in this package,
which handles the `v` prefix and sorts a prerelease below its release.

### When the installed version is in no interval

No `fixed_in`, no `remediation_command`. Outside every range, on a branch
with no fix yet, or a version string with no orderable form — all of it
is a genuine "we do not know", and any value invented to fill the gap
would be the same defect wearing different clothes.

The **finding still stands**. OSV matched the installed version
server-side before we ever saw the record, so our range arithmetic
disagreeing means our arithmetic fell short — it is not evidence of a
false positive, and suppressing the finding on that basis would trade
bad remediation for a missing vulnerability.

### Verification

Reproduced first against the live advisory (`/v1/vulns/`), which is
where the two-`affected`-entries shape came from; a synthetic single
range would not have caught this.

Mutation-checked: restoring first-fix-wins fails eight table cases, the
never-below-installed property, and the end-to-end wire assertion on
`remediation_command`. Restored and green.

Self-scan: 0 findings / 0 degradations / grade A.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj
