### PR TITLE
fix(core): one dataflow reported from both ends is one finding

### DIFF
--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -227,6 +228,120 @@ func (fs *FindingSet) Deduplicate() {
 		unique = append(unique, finding)
 	}
 	fs.items = unique
+}
+
+// flowKey identifies one source→sink dataflow independently of which end of it
+// a finding chose to anchor to.
+type flowKey struct {
+	ruleID     string
+	path       string
+	sourceLine string
+	sinkLine   string
+	sourceVar  string
+}
+
+// flowIdentity returns the dataflow a finding describes, and whether it
+// describes one at all. A finding qualifies only if it names the tainted
+// variable and the line its value came from; anything else is not a flow report
+// and is never a candidate for flow collapsing.
+//
+// The sink line is read from metadata when present and otherwise taken from the
+// finding's own location: an analyzer that does not say where the sink is is
+// anchored at it. That convention is what lets a source-anchored finding and a
+// sink-anchored one about the same flow produce the same key.
+func flowIdentity(f *Finding) (flowKey, bool) {
+	sourceLine, sourceVar := f.Metadata["source_line"], f.Metadata["source_var"]
+	if sourceLine == "" || sourceVar == "" {
+		return flowKey{}, false
+	}
+	sinkLine := f.Metadata["sink_line"]
+	if sinkLine == "" {
+		sinkLine = strconv.Itoa(f.Location.StartLine)
+	}
+	return flowKey{
+		ruleID:     f.RuleID,
+		path:       normaliseFilePath(f.Location.FilePath),
+		sourceLine: sourceLine,
+		sinkLine:   sinkLine,
+		sourceVar:  sourceVar,
+	}, true
+}
+
+// anchoredAtSink reports whether a flow finding sits on its sink line.
+func anchoredAtSink(f *Finding) bool {
+	sinkLine := f.Metadata["sink_line"]
+	return sinkLine == "" || sinkLine == strconv.Itoa(f.Location.StartLine)
+}
+
+// preferFlowFinding reports whether a should be kept over b when both describe
+// the same flow. The sink anchor wins — that is where the fix goes, and it is
+// the anchor already recorded in existing baselines. The remaining tiebreaks
+// (line, then fingerprint) exist only to make the choice independent of the
+// order analyzers happened to run in.
+func preferFlowFinding(a, b *Finding) bool {
+	if as, bs := anchoredAtSink(a), anchoredAtSink(b); as != bs {
+		return as
+	}
+	if a.Location.StartLine != b.Location.StartLine {
+		return a.Location.StartLine < b.Location.StartLine
+	}
+	return a.Fingerprint < b.Fingerprint
+}
+
+// DeduplicateFlows collapses findings that describe the SAME source→sink
+// dataflow but disagree about which end of it to report.
+//
+// Deduplicate cannot do this. Its key is the fingerprint, which hashes the
+// finding's message, plus the location — and two analyzers describing one flow
+// word it differently and anchor it differently, so they collide on neither.
+// The concrete case is Nox's built-in taint model and the nox/taint-analysis
+// plugin: for one tainted variable reaching one sink, the built-in reports the
+// sink line and the plugin reports the source line, under the same rule ID. One
+// vulnerability then costs two alerts and two baseline entries, and no baseline
+// can suppress both because the fingerprints differ.
+//
+// Identity is (rule, normalised path, source line, sink line, source variable),
+// taken from the flow metadata analyzers already emit. Nothing weaker would be
+// safe and nothing stronger is needed: two findings agreeing on all five are
+// the same flow by any definition, and requiring more — the source kind, say —
+// would let two engines that classify one HTTP source differently keep
+// double-reporting it.
+//
+// Only a finding carrying that metadata participates, so this cannot touch a
+// finding that is not a flow report, and a flow no other analyzer found is
+// always kept. The collapse also only ever discards the source-anchored member
+// of a pair, so a plugin cannot use it to displace a core finding.
+func (fs *FindingSet) DeduplicateFlows() {
+	best := make(map[flowKey]int, len(fs.items))
+	drop := make(map[int]struct{})
+	for i := range fs.items {
+		key, ok := flowIdentity(&fs.items[i])
+		if !ok {
+			continue
+		}
+		prev, seen := best[key]
+		if !seen {
+			best[key] = i
+			continue
+		}
+		keep, discard := prev, i
+		if preferFlowFinding(&fs.items[i], &fs.items[prev]) {
+			keep, discard = i, prev
+		}
+		best[key] = keep
+		drop[discard] = struct{}{}
+	}
+	if len(drop) == 0 {
+		return
+	}
+	kept := make([]Finding, 0, len(fs.items)-len(drop))
+	for i := range fs.items {
+		if _, dropped := drop[i]; dropped {
+			continue
+		}
+		kept = append(kept, fs.items[i])
+	}
+	fs.items = kept
 }
 
 // SuppressDuplicateVulnClass drops a finding from suppressRulePrefix when

--- a/core/findings/findings_test.go
+++ b/core/findings/findings_test.go
@@ -1,6 +1,7 @@
 package findings
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -221,6 +222,114 @@ func TestFindingSet_Deduplicate(t *testing.T) {
 
 	if len(fs.Findings()) != 2 {
 		t.Fatalf("expected 2 findings after dedup, got %d", len(fs.Findings()))
+	}
+}
+
+// sinkAnchored builds a flow finding shaped like the built-in taint model's:
+// located at the sink, with no sink_line metadata.
+func sinkAnchored(rule, path string, sinkLine, sourceLine int, sourceVar string) Finding {
+	return Finding{
+		RuleID:   rule,
+		Location: Location{FilePath: path, StartLine: sinkLine},
+		Message:  "built-in: " + sourceVar + " reaches a sink",
+		Metadata: map[string]string{
+			"source_line": strconv.Itoa(sourceLine),
+			"source_var":  sourceVar,
+		},
+	}
+}
+
+// sourceAnchored builds a flow finding shaped like the taint-analysis plugin's:
+// located at the source, with the sink line carried in metadata.
+func sourceAnchored(rule, path string, sinkLine, sourceLine int, sourceVar string) Finding {
+	return Finding{
+		RuleID:   rule,
+		Location: Location{FilePath: path, StartLine: sourceLine},
+		Message:  "plugin: " + sourceVar + " flows to a sink",
+		Metadata: map[string]string{
+			"sink_line":   strconv.Itoa(sinkLine),
+			"source_line": strconv.Itoa(sourceLine),
+			"source_var":  sourceVar,
+		},
+	}
+}
+
+func TestFindingSet_DeduplicateFlows_CollapsesToSinkAnchor(t *testing.T) {
+	t.Parallel()
+
+	for _, order := range []string{"builtin-first", "plugin-first"} {
+		t.Run(order, func(t *testing.T) {
+			t.Parallel()
+			builtin := sinkAnchored("TAINT-001", "sqli.go", 12, 11, "q")
+			plugin := sourceAnchored("TAINT-001", "./sqli.go", 12, 11, "q")
+
+			fs := NewFindingSet()
+			if order == "builtin-first" {
+				fs.Add(builtin)
+				fs.Add(plugin)
+			} else {
+				fs.Add(plugin)
+				fs.Add(builtin)
+			}
+			fs.DeduplicateFlows()
+
+			got := fs.Findings()
+			if len(got) != 1 {
+				t.Fatalf("one flow reported from both ends must collapse to 1 finding, got %d", len(got))
+			}
+			// The sink anchor wins regardless of which analyzer reported first:
+			// the result must not depend on analyzer ordering.
+			if got[0].Location.StartLine != 12 {
+				t.Fatalf("kept the finding at line %d, want the sink line 12", got[0].Location.StartLine)
+			}
+		})
+	}
+}
+
+func TestFindingSet_DeduplicateFlows_KeepsDistinctFlows(t *testing.T) {
+	t.Parallel()
+
+	fs := NewFindingSet()
+	// Same rule and file, but a different variable, a different source line and
+	// a different sink line: three genuinely distinct vulnerabilities.
+	fs.Add(sinkAnchored("TAINT-001", "app.go", 12, 11, "q"))
+	fs.Add(sourceAnchored("TAINT-001", "app.go", 12, 11, "other"))
+	fs.Add(sourceAnchored("TAINT-001", "app.go", 12, 9, "q"))
+	fs.Add(sourceAnchored("TAINT-001", "app.go", 40, 11, "q"))
+
+	fs.DeduplicateFlows()
+
+	if len(fs.Findings()) != 4 {
+		t.Fatalf("distinct flows must all survive, got %d of 4", len(fs.Findings()))
+	}
+}
+
+func TestFindingSet_DeduplicateFlows_IgnoresNonFlowFindings(t *testing.T) {
+	t.Parallel()
+
+	fs := NewFindingSet()
+	// No flow metadata at all: two secrets on the same line of the same file
+	// under one rule are not a flow and must never be collapsed by this pass.
+	fs.Add(Finding{RuleID: "SEC-001", Location: Location{FilePath: "a.go", StartLine: 3}, Message: "aws key"})
+	fs.Add(Finding{RuleID: "SEC-001", Location: Location{FilePath: "a.go", StartLine: 3}, Message: "gcp key"})
+	// Partial flow metadata is not enough to identify a flow either.
+	fs.Add(Finding{
+		RuleID:   "TAINT-001",
+		Location: Location{FilePath: "a.go", StartLine: 12},
+		Message:  "no source var",
+		Metadata: map[string]string{"source_line": "11"},
+	})
+	fs.Add(Finding{
+		RuleID:   "TAINT-001",
+		Location: Location{FilePath: "a.go", StartLine: 12},
+		Message:  "no source line",
+		Metadata: map[string]string{"source_var": "q"},
+	})
+
+	fs.DeduplicateFlows()
+
+	if len(fs.Findings()) != 4 {
+		t.Fatalf("findings without flow identity must be untouched, got %d of 4", len(fs.Findings()))
 	}
 }
 

--- a/core/plugin_hook_test.go
+++ b/core/plugin_hook_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -90,6 +91,148 @@ func TestRunScan_MergesPluginFindings(t *testing.T) {
 	}
 	if len(result.Graphs) != 1 {
 		t.Errorf("result.Graphs = %d, want 1", len(result.Graphs))
+	}
+}
+
+// TestRunScan_PluginAndBuiltinTaintFlowReportedOnce covers the double-report in
+// issue #368: the taint-analysis plugin anchors a flow at its SOURCE line while
+// the built-in taint model anchors the same flow at its SINK line, so one
+// vulnerability arrived as two findings with two fingerprints — two alerts and
+// two baseline entries.
+//
+// The source files and the plugin payload below are the reproduction from the
+// issue: the built-in engine really runs over them, and the hook emits exactly
+// what nox/taint-analysis@0.7.2 emits for them.
+func TestRunScan_PluginAndBuiltinTaintFlowReportedOnce(t *testing.T) {
+	dir := t.TempDir()
+	writeNoxConfigRequiring(t, dir, "nox/taint-analysis")
+
+	// Source on line 11, sink on line 12.
+	writeGoFile(t, dir, "sqli.go", `package repro
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+var db *sql.DB
+
+func handleSQL(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	rows, err := db.Query("SELECT * FROM users WHERE name = '" + q + "'")
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	w.Write([]byte("ok"))
+}
+`)
+	// Source on line 9, sink on line 10; the tainted read is echoed on line 14,
+	// which only the plugin detects.
+	writeGoFile(t, dir, "path.go", `package repro
+
+import (
+	"net/http"
+	"os"
+)
+
+func handlePath(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Query().Get("p")
+	b, err := os.ReadFile("/data/" + p)
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+`)
+
+	setHook(t, func(context.Context, string, []string) (*PluginScanOutput, error) {
+		return &PluginScanOutput{Findings: []findings.Finding{
+			{
+				RuleID: "TAINT-001", Severity: findings.SeverityHigh, Confidence: findings.ConfidenceHigh,
+				Location: findings.Location{FilePath: "sqli.go", StartLine: 11, EndLine: 11},
+				Message:  "SQL Injection: tainted input flows to SQL execution: q flows from http_query (line 11) to db.Query (line 12) in handleSQL",
+				Metadata: map[string]string{
+					"cwe": "CWE-89", "function": "handleSQL", "language": "go",
+					"sink_line": "12", "source_kind": "http_query", "source_line": "11", "source_var": "q",
+				},
+			},
+			{
+				RuleID: "TAINT-004", Severity: findings.SeverityHigh, Confidence: findings.ConfidenceHigh,
+				Location: findings.Location{FilePath: "path.go", StartLine: 9, EndLine: 9},
+				Message:  "Path Traversal: tainted input flows to file operations: p flows from http_query (line 9) to os.ReadFile (line 10) in handlePath",
+				Metadata: map[string]string{
+					"cwe": "CWE-22", "function": "handlePath", "language": "go",
+					"sink_line": "10", "source_kind": "http_query", "source_line": "9", "source_var": "p",
+				},
+			},
+			{
+				RuleID: "TAINT-003", Severity: findings.SeverityMedium, Confidence: findings.ConfidenceHigh,
+				Location: findings.Location{FilePath: "path.go", StartLine: 10, EndLine: 10},
+				Message:  "XSS: tainted input flows to HTML output: b flows from http_query (line 10) to w.Write (line 14) in handlePath",
+				Metadata: map[string]string{
+					"cwe": "CWE-79", "function": "handlePath", "language": "go",
+					"sink_line": "14", "source_kind": "http_query", "source_line": "10", "source_var": "b",
+				},
+			},
+		}}, nil
+	})
+
+	result, err := RunScan(dir)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+
+	byRule := map[string][]findings.Finding{}
+	for _, f := range result.Findings.Findings() {
+		if strings.HasPrefix(f.RuleID, "TAINT-") {
+			byRule[f.RuleID] = append(byRule[f.RuleID], f)
+		}
+	}
+
+	// Direction 1: the two anchors on one flow collapse to one finding, kept at
+	// the sink — that is where the fix goes, and it is the anchor already in
+	// everyone's baselines.
+	for _, tc := range []struct {
+		rule     string
+		file     string
+		sinkLine int
+	}{
+		{"TAINT-001", "sqli.go", 12},
+		{"TAINT-004", "path.go", 10},
+	} {
+		got := byRule[tc.rule]
+		if len(got) != 1 {
+			t.Errorf("%s: got %d findings, want 1 (same flow reported by both the built-in model and the plugin)", tc.rule, len(got))
+			for _, f := range got {
+				t.Logf("  %s:%d %s", f.Location.FilePath, f.Location.StartLine, f.Message)
+			}
+			continue
+		}
+		if got[0].Location.FilePath != tc.file || got[0].Location.StartLine != tc.sinkLine {
+			t.Errorf("%s: kept %s:%d, want the sink anchor %s:%d",
+				tc.rule, got[0].Location.FilePath, got[0].Location.StartLine, tc.file, tc.sinkLine)
+		}
+	}
+
+	// Direction 2: the plugin's genuinely-new flow — an XSS the built-in model
+	// does not detect at all — is untouched. Collapsing duplicates must never
+	// cost real coverage.
+	xss := byRule["TAINT-003"]
+	if len(xss) != 1 {
+		t.Fatalf("TAINT-003: got %d findings, want the plugin's unique XSS flow kept", len(xss))
+	}
+	if xss[0].Location.StartLine != 10 || xss[0].Metadata["source_var"] != "b" {
+		t.Errorf("TAINT-003: kept %s:%d (source_var=%q), want the plugin finding at path.go:10 (source_var=b)",
+			xss[0].Location.FilePath, xss[0].Location.StartLine, xss[0].Metadata["source_var"])
+	}
+}
+
+// writeGoFile writes a Go source file into dir for a scan test.
+func writeGoFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
 	}
 }
 

--- a/core/scan.go
+++ b/core/scan.go
@@ -883,6 +883,14 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		)
 	}
 
+	// Collapse one dataflow reported from both ends. The built-in taint model
+	// anchors a flow at its sink; the taint-analysis plugin anchors the same
+	// flow at its source. Neither the fingerprint nor the location matches, so
+	// one vulnerability survives as two findings and two baseline entries.
+	// Runs before the class suppression below, which is location-keyed and
+	// would otherwise be comparing against the wrong end of the flow.
+	allFindings.DeduplicateFlows()
+
 	// Drop a taint finding when another analyzer already reports the same vuln
 	// class at the same location — e.g. the taint engine's TAINT-003 SSTI sink
 	// firing on a render_template_string call that a variants CVE signature

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -92,6 +92,28 @@ func handleScan(ctx context.Context, req sdk.ToolRequest) (*pluginv1.InvokeToolR
 }
 ```
 
+### Reporting a dataflow
+
+A plugin that reports a source→sink flow under a rule ID core also emits
+(`TAINT-*`) must say which flow it found, or the same vulnerability is
+reported twice: core anchors a flow at its sink, plugins commonly anchor at
+the source, and the two locations and wordings give two fingerprints that no
+baseline can suppress together.
+
+Emit three metadata keys and nox will collapse the pair, keeping the sink
+anchor:
+
+```go
+    .WithMetadata("source_line", "11").  // where the untrusted value entered
+    .WithMetadata("source_var", "q").    // the tainted identifier
+    .WithMetadata("sink_line", "12").    // where it reached the sink
+```
+
+Omit `sink_line` if the finding is already located at the sink. A finding
+missing `source_line` or `source_var` is not treated as a flow report and is
+never collapsed — including a flow no other analyzer found, which is always
+kept.
+
 ### Tool Request
 
 ```go


### PR DESCRIPTION
Closes #368.

With `nox/taint-analysis` in `plugins.required`, one SQL injection
arrives as two alerts. The built-in Go taint model anchors a flow at its
**sink**; the plugin anchors the same flow at its **source**. Same rule
ID, same file, same variable, same vulnerability — two findings.

`Deduplicate()` cannot see it. Its key is the v2 fingerprint, which
hashes the finding's *message*, plus the location. Two analyzers
describing one flow word it differently and point at different lines, so
they collide on neither half of that key:

```
sqli.go:11  TAINT-001  SQL Injection: q flows from http_query (line 11) to db.Query (line 12)
sqli.go:12  TAINT-001  Untrusted input (http_query via "q") reaches sql_injection sink "db.Query"
```

The consequence is not just noise. **No baseline entry can suppress
both** — two fingerprints need two entries — and each new repo that
enables the plugin has every SQL-injection and path-traversal finding
counted twice by the CI net-new gate. On the four-file reproduction in
the issue: 8 findings, of which 2 are the same two vulnerabilities
counted again.

### The fix
`DeduplicateFlows()` collapses findings that agree on (rule, normalised
path, source line, sink line, source variable) — the flow metadata
analyzers already emit. The **sink** anchor is kept: that is where the
fix goes, and it is the anchor already in everyone's baselines, so no
existing baseline entry is invalidated (verified: every built-in
fingerprint from a plugin-less scan survives the plugin-enabled one).

Identity is deliberately those five fields and no more. Anything weaker
is unsafe. Anything stronger — the source *kind*, say — would let two
engines that classify one HTTP source differently keep double-reporting
it.

### What it must not do
The plugin's real contribution here is coverage core lacks: a TAINT-003
XSS on the tainted value being echoed back, which the built-in model
misses entirely. A finding without `source_line`/`source_var` is not a
flow report and is untouched; a flow only one analyzer found is always
kept. The test asserts both directions — the duplicate collapses **and**
the unique plugin finding survives. Mutation-checked: reverting the fix
fails it.

### Placement
This belongs in core, not the plugin. Core is the only place that sees
both engines' output, and the same collapse now protects against any
other plugin double-reporting a flow core already covers. A plugin-side
change would also help — anchoring at the sink would make the two agree
on location — but it would fix one plugin, and the fingerprints would
still differ.

Not the `nox/sast` case. That plugin was retired in 1.10.0 because seven
of its nine rules were pure duplication. This one is additive on the
same corpus, so retiring its overlapping Go rules would cost real
findings.

### Aside
The issue also notes no taint findings on equivalent Python and
JavaScript samples. Not investigated here; that is a separate question
from the double-report.

Self-scan: 0 findings / 0 degradations / grade A.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj

