### PR TITLE
fix(rules): five precision defects that failed gates on code holding no secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Five rule-precision defects that put false high/critical findings on the
+  gate.** Each fired on ordinary code containing no credential and no
+  vulnerability, and all five land in the high/critical band the shared CI gate
+  fails on, so each one blocked a repository outright.
+
+  `SEC-147` matched the Resend prefix at the seam of an identifier —
+  `TestSessionSto`**`re_`**`LoadsLegacySnapshot…` supplies `re_` and 38
+  alphanumerics — and reported a high-severity API key on a Go test function
+  name. `SEC-003` and `SEC-213` had the same seam for `ghs_`. All three now
+  require a word boundary on the left; an issued key never continues a
+  preceding word.
+
+  `SEC-435` required its `gh[pousr]_` prefix and exactly ONE further character,
+  so any five-character run beginning `ghs_` was a GitHub token — including
+  `"ghs_fake_install_token"`, a shape GitHub does not issue. It now requires
+  the issued shape (prefix plus 36 alphanumerics), which costs no detection:
+  every well-formed token is already covered by `SEC-003`/`SEC-213`/`SEC-215`/
+  `SEC-216`/`SEC-217`.
+
+  `SEC-004` reported **critical** on an HTML `placeholder=` attribute holding
+  `-----BEGIN RSA PRIVATE KEY-----`. That is the hint shown in an empty field,
+  telling a user what to paste; the key material is theirs and arrives at
+  runtime. Matches inside display-text attributes (`placeholder`, `aria-label`,
+  `alt`, `title`, `label`) are dropped. `value=` and every other attribute are
+  untouched — a key really can be pasted into one of those.
+
+  `SEC-240`, the Terraform password-field rule, fired on a Go doc comment:
+  its separator alternation includes `,`, so
+  `// "bot_token" pops a password input, "imap_password" pops …` parses as a
+  field, a separator and a quoted value. A comment holds prose describing
+  configuration, not configuration. The assignment-shaped rules — derived from
+  the rule table, not a hand-kept list — no longer match inside comments.
+  Provider rules are unchanged: a full token in a comment is a real leak and is
+  still reported, as is a credential genuinely left in a commented-out
+  assignment, which the generic keyword rules still catch.
+
+  `AI-049` ("AI output passed to eval/exec", CWE-95) fired on textbook
+  parameterised SQL — ``db.Exec(`INSERT INTO schedules (id, prompt) VALUES (?,
+  ?)`)`` — because the AI-vocabulary token it gates on was a *column name*
+  inside the query text. `database/sql`'s `Exec` evaluates SQL, not code, so
+  CWE-95 cannot apply to it. A call executing a SQL statement is dropped. The
+  discriminator is the SQL text, not the receiver: `db.Exec(model_output)`, a
+  model emitting raw SQL that is then executed, still fires.
+
 ## [1.18.0] - 2026-07-26
 
 ### Fixed

--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -189,6 +189,13 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			if results[i].RuleID == "AI-002" && !hasPromptContext(content, &results[i]) {
 				continue
 			}
+			// AI-049 asserts an eval/code-execution sink (CWE-95). A call
+			// executing a SQL statement is a database sink, and the AI token
+			// the rule gated on is a column name inside the query text — see
+			// isSQLStatementExec.
+			if results[i].RuleID == "AI-049" && isSQLStatementExec(content, &results[i]) {
+				continue
+			}
 			fs.Add(results[i])
 		}
 

--- a/core/analyzers/ai/precision_361_test.go
+++ b/core/analyzers/ai/precision_361_test.go
@@ -1,0 +1,100 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanOneAI runs the full ScanArtifacts pipeline over a single in-memory file.
+// The sink post-filters live there, not in ScanFile.
+func scanOneAI(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	abs := filepath.Join(dir, name)
+	if err := os.WriteFile(abs, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fs, _, err := NewAnalyzer().ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: abs, Type: discovery.Source}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+// TestAI049_SQLStatementIsNotAnEvalSink covers AI-049 ("AI output passed to
+// eval/exec function", CWE-95) reporting high severity on textbook
+// PARAMETERISED SQL:
+//
+//	r.db.Exec(`INSERT INTO schedules (id, prompt) VALUES (?, ?)`, 1, "x")
+//
+// The rule gates on an AI-vocabulary token inside the call arguments, to
+// separate a real eval sink from a database call. Here the token `prompt` is a
+// COLUMN NAME inside the SQL text, so the gate passes on a statement that
+// contains no AI-derived value at all and is placeholder-parameterised — the
+// safe form. `database/sql`'s Exec evaluates SQL, not code, so CWE-95 cannot
+// apply to it whatever the arguments are.
+//
+// The guards are the true positives that must survive: a bare AI variable
+// passed to eval/exec, and an AI value interpolated into exec'd code.
+func TestAI049_SQLStatementIsNotAnEvalSink(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		src  string
+		want bool
+	}{
+		{
+			name: "parameterised INSERT with a column named prompt",
+			file: "repo.go",
+			src:  "package p\n\nfunc (r *Repo) Save() error {\n\t_, err := r.db.Exec(`INSERT INTO schedules (id, prompt) VALUES (?, ?)`, 1, \"x\")\n\treturn err\n}\n",
+			want: false,
+		},
+		{
+			name: "parameterised SELECT with a column named completion",
+			file: "repo.py",
+			src:  "cur.execute(\"SELECT id, completion FROM runs WHERE id = %s\", (run_id,))\n",
+			want: false,
+		},
+		{
+			name: "model output passed straight to eval",
+			file: "run.py",
+			src:  "eval(llm_output)\n",
+			want: true,
+		},
+		{
+			name: "prompt interpolated into exec'd code",
+			file: "run.py",
+			src:  "exec(f\"result = compute({prompt})\")\n",
+			want: true,
+		},
+		{
+			name: "model output executed as a statement, not SQL text",
+			file: "run.py",
+			src:  "exec(model_output)\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanOneAI(t, tc.file, tc.src)
+			var ids []string
+			fired := false
+			for i := range got {
+				ids = append(ids, got[i].RuleID)
+				if got[i].RuleID == "AI-049" {
+					fired = true
+				}
+			}
+			if fired != tc.want {
+				t.Errorf("AI-049 fired=%v want=%v (all: %s)", fired, tc.want, strings.Join(ids, ","))
+			}
+		})
+	}
+}

--- a/core/analyzers/ai/sql_sink.go
+++ b/core/analyzers/ai/sql_sink.go
@@ -1,0 +1,44 @@
+package ai
+
+import (
+	"regexp"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// sqlStatementRE recognises the opening of a SQL statement. The keyword pair is
+// required (`INSERT INTO`, not a bare `INSERT`) so an English sentence
+// containing "select" or "update" is not mistaken for SQL.
+var sqlStatementRE = regexp.MustCompile(`(?i)\b(?:SELECT\s+[\w*` + "`" + `"\[]|INSERT\s+INTO|INSERT\s+OR\s+\w+\s+INTO|REPLACE\s+INTO|UPDATE\s+\w+\s+SET|DELETE\s+FROM|CREATE\s+(?:TABLE|INDEX|VIEW)|ALTER\s+TABLE|DROP\s+TABLE|UPSERT\s+INTO|WITH\s+\w+\s+AS\s*\()`)
+
+// isSQLStatementExec reports whether an AI-049 match is a database call
+// executing a SQL statement rather than a code-evaluation sink.
+//
+// AI-049 is "AI output passed to eval/exec function", CWE-95 (eval injection).
+// It separates a real eval sink from a database call by requiring an
+// AI-vocabulary token (`prompt`, `completion`, `model_output`, …) among the call
+// arguments. That gate fails when the token is a COLUMN NAME inside the SQL
+// text:
+//
+//	r.db.Exec(`INSERT INTO schedules (id, prompt) VALUES (?, ?)`, 1, "x")
+//
+// which is placeholder-parameterised SQL — the safe form — carrying no
+// AI-derived value at all. `database/sql`'s Exec and DB-API's execute evaluate
+// SQL, not code, so CWE-95 cannot apply to them whatever the arguments are, and
+// the finding is categorically wrong rather than merely low-value. It is
+// therefore dropped, following IAC-193.
+//
+// The discriminator is the SQL text, not the receiver name. `db.Exec(model_output)`
+// — a model emitting raw SQL that is then executed — carries no SQL literal at
+// the call site and still fires, as it should. AI content interpolated into
+// exec'd code (`exec(f"run({prompt})")`) is likewise untouched: it has no SQL
+// statement in it.
+func isSQLStatementExec(content []byte, f *findings.Finding) bool {
+	start := lexctx.LineColToOffset(content, f.Location.StartLine, f.Location.StartColumn)
+	end := lexctx.LineColToOffset(content, f.Location.EndLine, f.Location.EndColumn)
+	if end <= start || end > len(content) {
+		return false
+	}
+	return sqlStatementRE.Match(content[start:end])
+}

--- a/core/analyzers/secrets/precision_361_test.go
+++ b/core/analyzers/secrets/precision_361_test.go
@@ -1,0 +1,240 @@
+package secrets
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanOne runs the full ScanArtifacts pipeline (not the bare engine) over a
+// single in-memory file. The post-filters that decide these cases live in
+// ScanArtifacts, so a ScanFile-based test would not exercise them.
+func scanOne(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	abs := filepath.Join(dir, name)
+	if err := os.WriteFile(abs, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: abs, Type: discovery.Source}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+func firedRule(f []findings.Finding, id string) bool {
+	for i := range f {
+		if f[i].RuleID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func ruleIDs(f []findings.Finding) string {
+	var ids []string
+	for i := range f {
+		ids = append(ids, f[i].RuleID)
+	}
+	return strings.Join(ids, ",")
+}
+
+// TestProviderPrefixNeedsLeftWordBoundary covers the class where a provider
+// key prefix is matched in the MIDDLE of an ordinary identifier.
+//
+// `TestSessionStore_LoadsLegacySnapshotWithoutSchemaField` contains `re_` at the
+// seam of `Store_Loads`, and 38 alphanumerics follow it, so the Resend rule
+// reported a high-severity API key on a Go test function name. The same seam
+// exists for the GitHub rules: `TestProcessHighs_Lows…` contains `ghs_`.
+//
+// A credential is never glued to the tail of a preceding word, so requiring a
+// word boundary on the left removes the whole class. The second half of each
+// case is the regression guard: a real key, which always begins at a boundary
+// (after a quote, an `=`, or whitespace), must still be reported.
+func TestProviderPrefixNeedsLeftWordBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		rule string
+		src  string
+		want bool
+	}{
+		{
+			name: "resend prefix inside a Go identifier",
+			rule: "SEC-147",
+			src:  "package p\n\nfunc TestSessionStore_LoadsLegacySnapshotWithoutSchemaField(t *testing.T) {}\n",
+			want: false,
+		},
+		{
+			name: "real resend key in a Go string",
+			rule: "SEC-147",
+			src:  "package p\n\nvar k = \"re_2xKq7ZmT4bWvR8nHs5LpYd3JcF6gAe1U\"\n",
+			want: true,
+		},
+		{
+			name: "github app prefix inside a Go identifier",
+			rule: "SEC-003",
+			src:  "package p\n\nfunc TestProcessHighs_LowsAcrossTheWholeWindowDeterministic(t *testing.T) {}\n",
+			want: false,
+		},
+		{
+			name: "real github token in a Go string",
+			rule: "SEC-003",
+			src:  "package p\n\nvar k = \"ghs_16C7e42F292c6912E7710c838347Ae178B4a\"\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanOne(t, "store_test.go", tc.src)
+			if fired := firedRule(got, tc.rule); fired != tc.want {
+				t.Errorf("%s fired=%v want=%v (all: %s)", tc.rule, fired, tc.want, ruleIDs(got))
+			}
+		})
+	}
+}
+
+// TestGitHubTokenRuleRequiresIssuedShape covers SEC-435, whose pattern required
+// a `gh[pousr]_` prefix and exactly ONE further character. Any five-character
+// run beginning `ghs_` was a high-severity "Detected GitHub Token" — including
+// the string literal `"ghs_fake_install_token"` in a _test.go file, which is
+// not a shape GitHub ever issues (its tokens are 36 alphanumerics, never
+// underscores).
+//
+// The rule contributed no unique detection: every well-formed GitHub token it
+// could catch is already caught by SEC-003/SEC-213/SEC-215/SEC-216/SEC-217, so
+// giving it the issued shape costs no recall.
+//
+// The guards assert both halves of that: the rule itself still matches an
+// issued token (at the engine, since specificity dedup then collapses it into
+// SEC-003), and the token is still REPORTED end to end.
+func TestGitHubTokenRuleRequiresIssuedShape(t *testing.T) {
+	const fixture = "package p\n\n// github installation token exchange\nfunc TestAuth(tok string) bool { return tok != \"ghs_fake_install_token\" }\n"
+	const issued = "package p\n\n// github\nvar tok = \"ghs_16C7e42F292c6912E7710c838347Ae178B4a\"\n"
+
+	t.Run("test fixture that is not an issued token shape", func(t *testing.T) {
+		got := scanOne(t, "auth_test.go", fixture)
+		if firedRule(got, "SEC-435") {
+			t.Errorf("SEC-435 fired on a literal named fake (all: %s)", ruleIDs(got))
+		}
+	})
+
+	t.Run("rule still matches an issued token", func(t *testing.T) {
+		got, err := NewAnalyzer().ScanFile("auth.go", []byte(issued))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !firedRule(got, "SEC-435") {
+			t.Errorf("SEC-435 must still match an issued GitHub token (all: %s)", ruleIDs(got))
+		}
+	})
+
+	t.Run("issued token is still reported end to end", func(t *testing.T) {
+		got := scanOne(t, "auth.go", issued)
+		if len(got) == 0 {
+			t.Error("an issued GitHub token must still be reported, got no findings")
+		}
+	})
+}
+
+// TestPrivateKeyHeaderInDisplayAttribute covers SEC-004 firing critical on
+//
+//	<input placeholder="-----BEGIN RSA PRIVATE KEY-----…" />
+//
+// A `placeholder` attribute is the text shown to a user in an empty field. It
+// tells the operator what to paste; the key material is theirs and arrives at
+// runtime. No secret is present in the repository, yet this was a CRITICAL
+// finding — the band the shared CI gate fails on.
+//
+// The guard cases assert the rule still fires on key material that is genuinely
+// in the tree, including in an ordinary attribute such as `value=`.
+func TestPrivateKeyHeaderInDisplayAttribute(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		src  string
+		want bool
+	}{
+		{
+			name: "jsx placeholder attribute",
+			file: "ui.tsx",
+			src:  "export const K = () => (\n  <input placeholder=\"-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----\" />\n);\n",
+			want: false,
+		},
+		{
+			name: "html aria-label attribute",
+			file: "form.html",
+			src:  "<textarea aria-label=\"-----BEGIN OPENSSH PRIVATE KEY----- goes here\"></textarea>\n",
+			want: false,
+		},
+		{
+			name: "real private key in a Go source constant",
+			file: "key.go",
+			src:  "package p\n\nconst k = `-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----`\n",
+			want: true,
+		},
+		{
+			name: "private key pasted into a value attribute",
+			file: "ui.tsx",
+			src:  "export const K = () => (\n  <input value=\"-----BEGIN RSA PRIVATE KEY-----\" />\n);\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanOne(t, tc.file, tc.src)
+			if fired := firedRule(got, "SEC-004"); fired != tc.want {
+				t.Errorf("SEC-004 fired=%v want=%v (all: %s)", fired, tc.want, ruleIDs(got))
+			}
+		})
+	}
+}
+
+// TestConfigFieldRuleNotMatchedInProse covers SEC-240, the Gitleaks-imported
+// HashiCorp Terraform password-field rule, firing high on a Go doc comment:
+//
+//	// "bot_token" pops a password input, "imap_password" pops an app-password wizard.
+//
+// The rule infers a credential from a `field <separator> "value"` shape. Its
+// separator alternation includes `,`, so the prose above parses as
+// `password …` `,` `"imap_password"`. There is no assignment in a comment —
+// there is prose describing one — so the inference cannot hold.
+//
+// The guards are the two ways this must NOT become a false negative: the same
+// rule on a genuine Terraform assignment, and a credential a developer really
+// did leave in a comment (still reported, by the generic keyword rule).
+func TestConfigFieldRuleNotMatchedInProse(t *testing.T) {
+	t.Run("terraform password rule on a Go doc comment", func(t *testing.T) {
+		src := "package p\n\n// Fields render by name:\n// \"bot_token\" pops a password input, \"imap_password\" pops an app-password wizard.\nfunc Manifest() {}\n"
+		got := scanOne(t, "manifest.go", src)
+		if firedRule(got, "SEC-240") {
+			t.Errorf("SEC-240 fired on a Go doc comment (all: %s)", ruleIDs(got))
+		}
+	})
+
+	t.Run("terraform password rule on a real assignment", func(t *testing.T) {
+		src := "resource \"azurerm_mssql_server\" \"x\" {\n  administrator_login_password = \"h7Qz2LmXk9Ta\"\n}\n"
+		got := scanOne(t, "main.tf", src)
+		if !firedRule(got, "SEC-240") {
+			t.Errorf("SEC-240 must still fire on a Terraform password assignment (all: %s)", ruleIDs(got))
+		}
+	})
+
+	t.Run("credential genuinely left in a comment is still reported", func(t *testing.T) {
+		for _, tc := range []struct{ file, src string }{
+			{"app.go", "package p\n\n// password = \"h7Qz2LmXk9Ta\"\nfunc M() {}\n"},
+			{"vals.yaml", "# password: \"h7Qz2LmXk9Ta\"\n"},
+		} {
+			got := scanOne(t, tc.file, tc.src)
+			if len(got) == 0 {
+				t.Errorf("%s: a credential leaked in a comment must still be reported, got none", tc.file)
+			}
+		}
+	})
+}

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -138,7 +138,9 @@ func builtinSecretRules() []*rules.Rule {
 		// -----------------------------------------------------------------
 		{
 			id: "SEC-003", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:     `gh[pso]_[A-Za-z0-9_]{36,}`,
+			// \b on the left — same seam as SEC-147: `TestProcessHigh|s_Lows…`
+			// supplies `ghs_` followed by 36+ identifier characters.
+			pattern:     `\bgh[pso]_[A-Za-z0-9_]{36,}`,
 			description: "GitHub Personal Access Token detected",
 			cwe:         "CWE-798", keywords: []string{"ghp_", "ghs_", "gho_"},
 			remediation: "Revoke the token at github.com/settings/tokens and generate a new one. Use GITHUB_TOKEN environment variable or GitHub Actions secrets.",
@@ -1276,7 +1278,11 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-147", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:     `re_[A-Za-z0-9]{32,}`,
+			// \b on the left: without it the prefix matches at the seam of an
+			// ordinary identifier — `TestSessionSto|re_Loads…` supplies `re_`
+			// plus 38 alphanumerics. An issued key never continues a preceding
+			// word; it follows a quote, an `=` or whitespace.
+			pattern:     `\bre_[A-Za-z0-9]{32,}`,
 			description: "Resend API Key detected",
 			cwe:         "CWE-798", keywords: []string{"re_"},
 			remediation: "Rotate the exposed key immediately. Use environment variables or a secrets manager.",
@@ -1830,7 +1836,7 @@ func builtinSecretRules() []*rules.Rule {
 
 		{
 			id: "SEC-213", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?:ghu|ghs)_[0-9a-zA-Z]{36}`,
+			pattern:     `\b(?:ghu|ghs)_[0-9a-zA-Z]{36}`,
 			description: "Identified a GitHub App Token, which may compromise GitHub application integrations and source code security.",
 			cwe:         "CWE-798", keywords: []string{"ghu_", "ghs_"},
 			remediation: "Imported from Gitleaks: github-app-token",
@@ -3173,7 +3179,13 @@ func builtinSecretRules() []*rules.Rule {
 		{id: "SEC-428", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `-----BEGIN OPENSSH PRIVATE KEY-----`, description: "Detected OpenSSH Key", cwe: "CWE-798", keywords: []string{"openssh_key"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-429", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `-----BEGIN PGP PRIVATE KEY BLOCK-----`, description: "Detected PGP Key", cwe: "CWE-798", keywords: []string{"pgp_key"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-434", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `bootstrap\.servers`, description: "Detected Kafka", cwe: "CWE-798", keywords: []string{"kafka"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
-		{id: "SEC-435", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `gh[pousr]_[A-Za-z0-9_]`, description: "Detected GitHub Token", cwe: "CWE-798", keywords: []string{"github"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
+		// The pattern carried a single body character (`gh[pousr]_[A-Za-z0-9_]`),
+		// so any five-character run beginning `ghs_` was a high-severity GitHub
+		// token — including `"ghs_fake_install_token"`, a shape GitHub does not
+		// issue. GitHub tokens are the prefix plus 36 alphanumerics, and every
+		// well-formed one is already covered by SEC-003/SEC-213/SEC-215/SEC-216/
+		// SEC-217, so requiring the issued shape here costs no detection.
+		{id: "SEC-435", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `\bgh[pousr]_[A-Za-z0-9]{36}`, description: "Detected GitHub Token", cwe: "CWE-798", keywords: []string{"github"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-436", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `glpat-`, description: "Detected GitLab Token", cwe: "CWE-798", keywords: []string{"gitlab"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-437", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `xox[baprs]-[A-Za-z0-9-]{20,}`, description: "Detected Slack Token", cwe: "CWE-798", keywords: []string{"slack"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}, secretShape: true, minEntropy: 3.0},
 		{id: "SEC-438", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `sk_live_`, description: "Detected Stripe Key", cwe: "CWE-798", keywords: []string{"stripe"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -191,6 +191,20 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			if isPlaceholderFinding(content, &results[i]) {
 				continue
 			}
+			// A secret shown inside a display-text HTML/JSX attribute
+			// (`placeholder=`, `aria-label=`, `title=`) is the instruction
+			// telling a user what to paste, not key material the repository
+			// holds.
+			if inDisplayTextAttribute(content, &results[i]) {
+				continue
+			}
+			// An assignment-shaped config-field rule that matched inside a
+			// comment found prose describing a field, not a field being
+			// assigned. Provider rules are untouched — a full token in a
+			// comment is a real leak.
+			if dropConfigFieldRuleInComment(lang, content, &results[i]) {
+				continue
+			}
 			fs.Add(results[i])
 		}
 

--- a/core/analyzers/secrets/srccontext.go
+++ b/core/analyzers/secrets/srccontext.go
@@ -1,0 +1,129 @@
+package secrets
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// This file holds the two source-context filters that decide when a secret rule
+// cannot mean what it assumes, and the match is therefore dropped rather than
+// downgraded. The precedent is IAC-193 (an Ansible rule on a GitHub Actions
+// file): a categorically wrong finding left at a lower severity still costs an
+// operator the triage.
+
+// displayTextAttrRE matches an HTML/JSX attribute whose value is text shown to a
+// user rather than data the program holds: the hint in an empty input, an
+// accessible name, a tooltip, the fallback for an image.
+//
+// `value=`, `defaultValue=`, `content=` and every other attribute are
+// deliberately absent — a private key really can be pasted into one of those,
+// and that is a finding.
+var displayTextAttrRE = regexp.MustCompile(`(?i)(?:^|[\s{(])(placeholder|aria-label|aria-placeholder|aria-description|alt|title|label)\s*=\s*["']`)
+
+// inDisplayTextAttribute reports whether the finding's match sits inside the
+// quoted value of a display-text HTML/JSX attribute.
+//
+// SEC-004 reported CRITICAL on
+//
+//	<input placeholder="-----BEGIN RSA PRIVATE KEY-----…" />
+//
+// which is the instruction telling a user what to paste. The key material is
+// theirs and arrives at runtime; the repository holds no secret. Critical is
+// the band the shared CI gate fails on, so there is no severity headroom to
+// absorb this — it blocks the repository outright.
+//
+// The check is line-local and requires a tag opener before the attribute, so a
+// YAML or JSON key that happens to be called `title` or `label` is untouched.
+func inDisplayTextAttribute(content []byte, f *findings.Finding) bool {
+	line := lineOf(content, f.Location.StartLine)
+	if line == "" || !strings.Contains(line, "<") {
+		return false
+	}
+	// StartColumn is 1-based over the line.
+	col := f.Location.StartColumn - 1
+	if col < 0 || col > len(line) {
+		return false
+	}
+	for _, loc := range displayTextAttrRE.FindAllStringSubmatchIndex(line, -1) {
+		// loc[1] is one past the opening quote of the attribute value.
+		open := loc[1]
+		if open > len(line) || open == 0 {
+			continue
+		}
+		quote := line[open-1]
+		if open > col {
+			continue // attribute begins after the match
+		}
+		end := strings.IndexByte(line[open:], quote)
+		if end < 0 {
+			// Unterminated on this line: treat the rest of the line as the
+			// attribute value, which is what a multi-line JSX attribute is.
+			return true
+		}
+		if col < open+end {
+			return true
+		}
+	}
+	return false
+}
+
+// configFieldSeparators is the separator alternation shared by the
+// Gitleaks-imported "field <separator> value" rules. A rule carrying it does not
+// recognise a credential by its shape — it infers one from an ASSIGNMENT: a
+// field whose name looks credential-ish, a separator, and a quoted value.
+const configFieldSeparators = `(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)`
+
+// configFieldRules is the set of rule IDs whose pattern carries that
+// alternation, derived from the rule table itself so an import added there is
+// covered without a second list to keep in sync.
+var configFieldRules = func() map[string]bool {
+	ids := make(map[string]bool)
+	for _, r := range builtinSecretRules() {
+		if strings.Contains(r.Pattern, configFieldSeparators) {
+			ids[r.ID] = true
+		}
+	}
+	return ids
+}()
+
+// dropConfigFieldRuleInComment reports whether a config-field rule matched
+// entirely inside a comment, where its inference cannot hold.
+//
+// SEC-240 (Gitleaks `hashicorp-tf-password`) reported high severity on a Go doc
+// comment:
+//
+//	// "bot_token" pops a password input, "imap_password" pops an app-password wizard.
+//
+// Its separator alternation includes `,`, so the prose parses as `password …`
+// `,` `"imap_password"` — a field, a separator, a quoted value. But a comment
+// contains prose describing configuration, not configuration, so there is no
+// assignment for the rule to have found. Applying a Terraform rule to a Go doc
+// comment compounds the error.
+//
+// This is scoped to the assignment-shaped rules on purpose. The secrets analyzer
+// deliberately keeps comment matches for PROVIDER rules, where the token itself
+// is the evidence and a credential pasted into a comment is a real leak. A
+// credential genuinely left in a comment stays reported here too: the generic
+// keyword rules (SEC-005/SEC-080/SEC-112/SEC-402), which are not
+// assignment-shaped, still fire on it — see TestConfigFieldRuleNotMatchedInProse.
+func dropConfigFieldRuleInComment(lang lexctx.Lang, content []byte, f *findings.Finding) bool {
+	if lang == lexctx.LangUnknown || !configFieldRules[f.RuleID] {
+		return false
+	}
+	start := lexctx.LineColToOffset(content, f.Location.StartLine, f.Location.StartColumn)
+	end := lexctx.LineColToOffset(content, f.Location.EndLine, f.Location.EndColumn)
+	if end <= start {
+		end = start + 1
+	}
+	regions := lexctx.Classify(lang, content)
+	if len(regions) == 0 {
+		return false
+	}
+	// Every byte of the match must be comment. A match that leaks out of a
+	// comment into code is suspect but not clearly prose, so it is kept.
+	return lexctx.KindAt(regions, start) == lexctx.KindComment &&
+		lexctx.KindAt(regions, end-1) == lexctx.KindComment
+}

--- a/core/analyzers/secrets/srccontext.go
+++ b/core/analyzers/secrets/srccontext.go
@@ -122,8 +122,22 @@ func dropConfigFieldRuleInComment(lang lexctx.Lang, content []byte, f *findings.
 	if len(regions) == 0 {
 		return false
 	}
-	// Every byte of the match must be comment. A match that leaks out of a
-	// comment into code is suspect but not clearly prose, so it is kept.
-	return lexctx.KindAt(regions, start) == lexctx.KindComment &&
-		lexctx.KindAt(regions, end-1) == lexctx.KindComment
+	// EVERY region the match overlaps must be comment. Testing only the two
+	// endpoints would accept a match that begins in one comment, crosses code,
+	// and ends in the next — and a match leaking out of a comment into code is
+	// suspect but not clearly prose, so it is kept.
+	overlapped := false
+	for _, r := range regions {
+		if r.End <= start {
+			continue
+		}
+		if r.Start >= end {
+			break
+		}
+		if r.Kind != lexctx.KindComment {
+			return false
+		}
+		overlapped = true
+	}
+	return overlapped
 }


### PR DESCRIPTION

Closes #361.

Five rules reported high/critical on ordinary code. None of the matches
was a credential or a vulnerability, and high/critical is the band the
shared CI gate fails on — so there was no severity headroom to absorb
any of them and each one blocked a repository outright. Across three
repositories in one fleet that was 13 findings, zero of them real, and
the rational response to a gate like that is to stop believing it.

**A provider prefix matched at the seam of an identifier.** `SEC-147`
found `re_` inside `TestSessionSto|re_LoadsLegacySnapshotWithout…`,
followed by 38 alphanumerics, and called a Go test function name a
Resend API key. `SEC-003` and `SEC-213` have the identical seam for
`ghs_` — `TestProcessHigh|s_Lows…` — which is how a rule already carried
by the precision baseline was one plausible function name away from the
same failure. All three now require a word boundary on the left. An
issued key follows a quote, an `=` or whitespace; it never continues a
preceding word.

**A rule required its prefix and one further character.** `SEC-435`'s
pattern was `gh[pousr]_[A-Za-z0-9_]`, so every five-character run
beginning `ghs_` was a high-severity GitHub token — including the
literal `"ghs_fake_install_token"` in a `_test.go`, which is not a shape
GitHub issues. Tightening it to the issued shape costs no detection:
probing every GitHub token format shows each one already reported by
`SEC-003`/`SEC-213`/`SEC-215`/`SEC-216`/`SEC-217`, and specificity dedup
was already collapsing `SEC-435` into them. It contributed noise and
nothing else.

**Key material was inferred from the text on a form.** `SEC-004`
reported CRITICAL on `<input placeholder="-----BEGIN RSA PRIVATE
KEY-----…" />`. That string is the hint shown in an empty field telling
the user what to paste; the key is theirs and arrives at runtime, and
the repository holds no secret at all. Display-text attributes
(`placeholder`, `aria-label`, `alt`, `title`, `label`) are now dropped.
`value=`, `content=` and the rest are deliberately absent from that
list — a key really can be pasted into one of those, and that is a
finding.

**An assignment was inferred from prose.** `SEC-240` — the Gitleaks
`hashicorp-tf-password` import — fired on a Go doc comment. Its
separator alternation includes `,`, so `// "bot_token" pops a password
input, "imap_password" pops an app-password wizard.` parses as a field,
a separator and a quoted value. A comment contains prose describing
configuration, not configuration, so there is nothing for the rule to
have found; applying a Terraform rule to a Go doc comment compounds it.
The 84 assignment-shaped rules — derived from the rule table rather than
a list to keep in sync — no longer match inside comments.

Path-scoping was the obvious alternative and would have been wrong: a
probe found `SEC-240` is the ONLY rule that reports
`administratorLoginPassword` in an ARM template, so restricting it to
`.tf` would have traded this false positive for a real false negative.
Provider rules are untouched for the same reason — a full token in a
comment is a genuine leak. A credential left in a commented-out
assignment is still reported, by the generic keyword rules, and there is
a test for it.

**A database call was treated as an eval sink.** `AI-049` claims CWE-95,
AI output reaching `eval`/`exec`. It separates a real eval sink from a
database call by requiring an AI-vocabulary token among the arguments,
and that gate fails when the token is a COLUMN NAME:

    r.db.Exec(`INSERT INTO schedules (id, prompt) VALUES (?, ?)`, 1, "x")

This is placeholder-parameterised SQL — the safe form — carrying nothing
AI-derived. `database/sql`'s `Exec` evaluates SQL, not code, so CWE-95
cannot apply to it whatever the arguments are. A call executing a SQL
statement is dropped. The discriminator is the SQL text and not the
receiver name, which matters: `db.Exec(model_output)` — a model emitting
raw SQL that is then executed — has no SQL literal at the call site and
still fires.

Findings are DROPPED rather than downgraded throughout, following
`IAC-193`: when a rule cannot mean what it assumes, a lower severity
still costs an operator the triage.

### Verification

All five mutation-checked: reverting any one fix fails its test and only
its test, restoring it passes. Each fix carries a true-positive guard in
the same test — a real Resend key, a well-formed GitHub token, a private
key in a Go constant and in a `value=` attribute, a Terraform password
assignment, a credential leaked in a comment, `eval(llm_output)`,
`exec(f"run({prompt})")`, `exec(model_output)`.

The 5-file reproduction from #361 goes from 5 findings to 0. All 19
precision gates hold. Self-scan: 0 findings / 0 degradations / grade A —
and the two rules whose doc comments in this change quote the offending
strings are flagged by the pre-fix binary and not by the post-fix one,
which is the end-to-end proof on nox's own tree.

### Measurement note

The issue observes that labelled-corpus precision for these rules reads
1.00, and that is what made a fleet-wide bump look safe. It is accurate
and useless: the corpus contains no Go identifier with `re_` mid-word,
no parameterised `db.Exec`, no credential-shaped doc comment and no
`placeholder=` attribute. Nothing here raises the measured number,
because the corpus never measured this.


https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj
