### PR TITLE
fix(action): stop a throttled version lookup from failing the security gate

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -34,25 +34,65 @@ detect_platform() {
 
 # --- Version resolution ---
 
+# api_get fetches a GitHub API URL and echoes the response body, retrying
+# transient failures on the same schedule as fetch_asset below.
+#
+# It exists because the version lookup used to be a bare `curl -fsSL`, which
+# exits non-zero on any 403 and so killed the action before it ever reached the
+# retry-hardened download. GitHub answers 403 for rate limiting, and the
+# anonymous budget is 60 requests/hour shared across a runner IP — a burst of
+# plugin CI runs hits it routinely. The result was a red security gate whose
+# only log line was `curl: (22) ... error: 403`, followed by a second red check
+# when the SARIF upload found no file. Neither had anything to do with security.
+#
+# The API base is overridable so tests can point at a stub; it is not a
+# supported input.
+api_get() {
+  local url="$1"
+  local attempt=1 max=3 code="" tmp
+  tmp="$(mktemp)"
+
+  while :; do
+    # The Authorization header pattern uses ${GITHUB_TOKEN:+...}, which the
+    # secrets analyzer flags as SEC-161/SEC-163; the env-var name is not a
+    # secret. (Inline `# nox:ignore ...` comments break multiline shell
+    # commands — leave them out of pipelines.)
+    code=$(curl -sSL -w "%{http_code}" -o "${tmp}" \
+      -H "Accept: application/vnd.github+json" \
+      ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
+      "${url}" 2>/dev/null || true)
+
+    if [[ "${code}" == "200" ]]; then
+      cat "${tmp}"
+      rm -f "${tmp}"
+      return 0
+    fi
+
+    if (( attempt >= max )); then
+      rm -f "${tmp}"
+      return 1
+    fi
+
+    echo "GitHub API returned HTTP ${code:-unknown}; retrying (${attempt}/${max})..." >&2
+    sleep $(( attempt * ${NOX_RETRY_BACKOFF_SECS:-3} ))
+    attempt=$(( attempt + 1 ))
+  done
+}
+
 resolve_version() {
   local version="$1"
 
   if [[ "${version}" == "latest" ]]; then
     local tag
-    # The Authorization header pattern below uses ${GITHUB_TOKEN:+...}
-    # which the secrets analyzer flags as SEC-161/SEC-163; the env-var
-    # name is not a secret. (Inline `# nox:ignore ...` comments break
-    # multiline shell commands — leave them out of pipelines.)
-    tag=$(curl -fsSL \
-      -H "Accept: application/vnd.github+json" \
-      ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
-      "https://api.github.com/repos/${REPO}/releases/latest" \
-      | grep -o '"tag_name":\s*"[^"]*"' \
+    tag=$(api_get "${NOX_API_BASE:-https://api.github.com}/repos/${REPO}/releases/latest" \
+      | grep -o '"tag_name":[[:space:]]*"[^"]*"' \
       | head -1 \
       | cut -d'"' -f4)
 
     if [[ -z "${tag}" ]]; then
-      echo "::error::Failed to resolve latest nox version from GitHub releases"
+      echo "::error::Failed to resolve latest nox version from GitHub releases." \
+        "If this says HTTP 403 above it is GitHub rate limiting, not a missing" \
+        "release — pin an explicit \`version:\` to skip the lookup entirely."
       exit 2
     fi
 

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,13 @@ runs:
       id: scan
       shell: bash
       env:
+        # A composite action's step sees only what this block maps. action.sh
+        # has always sent `Authorization: Bearer ${GITHUB_TOKEN}` when the
+        # variable is set, but nothing ever set it — so both the version lookup
+        # and the asset download went out anonymous, against the 60-per-hour
+        # budget shared by every job on the runner's IP, and were throttled with
+        # a 403 accordingly.
+        GITHUB_TOKEN: ${{ github.token }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_OUTPUT: ${{ inputs.output }}

--- a/cli/action_version_lookup_test.go
+++ b/cli/action_version_lookup_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// runResolveVersion runs resolve_version (and the helper it delegates to)
+// against a stub API, and reports the resolved version plus exit status.
+func runResolveVersion(t *testing.T, base, version string) (string, bool) {
+	t.Helper()
+	fns := extractShellFunc(t, "api_get") + "\n" + extractShellFunc(t, "resolve_version")
+	script := fns + "\nresolve_version \"" + version + "\"\n"
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"NOX_RETRY_BACKOFF_SECS=0",
+		"NOX_API_BASE="+base,
+	)
+	b, err := cmd.Output()
+	return strings.TrimSpace(string(b)), err == nil
+}
+
+// fetch_asset was hardened against GitHub's release throttle (see
+// TestActionFetchAsset_RetriesTransientThrottle) but resolve_version, which runs
+// FIRST, was left on a bare `curl -fsSL` that exits non-zero on any 403 — so the
+// action died before ever reaching the retry-hardened download.
+//
+// This is not hypothetical. Nox-HQ/nox-plugin-risk-score#21 and
+// nox-plugin-sast#22 both sat blocked on `Nox PR Gate (high/critical)` failing
+// 9s in with `curl: (22) The requested URL returned error: 403`, and the gate's
+// own SARIF upload then failed with "Path does not exist" — two red checks, no
+// scan, nothing to do with security.
+//
+// A gate that goes red because GitHub throttled an API call is one people learn
+// to re-run without reading, which is the failure mode the fetch_asset comment
+// already argues against. The same argument applies one function earlier.
+func TestActionResolveVersion_RetriesTransientThrottle(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&n, 1) <= 2 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		_, _ = w.Write([]byte(`{"tag_name": "v1.18.0"}`))
+	}))
+	defer srv.Close()
+
+	got, ok := runResolveVersion(t, srv.URL, "latest")
+	if !ok {
+		t.Fatalf("resolve_version gave up on a throttle that cleared; got %q", got)
+	}
+	if got != "1.18.0" {
+		t.Errorf("resolved version = %q, want 1.18.0", got)
+	}
+	if attempts := atomic.LoadInt32(&n); attempts < 3 {
+		t.Errorf("expected at least 3 attempts, got %d", attempts)
+	}
+}
+
+// Retrying must not turn a genuine outage into a hang or, worse, into a silent
+// success that installs nothing. When the lookup never recovers the action still
+// has to fail loudly.
+func TestActionResolveVersion_StillFailsWhenThrottleNeverClears(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	if got, ok := runResolveVersion(t, srv.URL, "latest"); ok {
+		t.Errorf("resolve_version succeeded against a permanently throttled API, returning %q", got)
+	}
+}
+
+// An explicit version must never touch the network at all — pinning is the
+// escape hatch from exactly this flake, so it cannot depend on the API being up.
+func TestActionResolveVersion_PinnedVersionSkipsTheAPI(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	got, ok := runResolveVersion(t, srv.URL, "1.17.0")
+	if !ok || got != "1.17.0" {
+		t.Fatalf("pinned version did not pass through: got %q ok=%v", got, ok)
+	}
+	if attempts := atomic.LoadInt32(&n); attempts != 0 {
+		t.Errorf("pinned version made %d API call(s); it must not touch the network", attempts)
+	}
+}
+
+// action.sh sends `Authorization: Bearer ${GITHUB_TOKEN}` when the variable is
+// set — but a composite action's step only sees what its own `env:` block maps,
+// and action.yml never mapped GITHUB_TOKEN. So `${GITHUB_TOKEN:+...}` expanded
+// to nothing on every real run and BOTH the version lookup and the asset
+// download went out unauthenticated, sharing the runner IP's 60-requests/hour
+// anonymous budget with every other job on that host. That is why a fleet of
+// plugin CI runs could reproduce the 403 at all.
+//
+// Same shape as the fail-on-degraded defect: action.sh reads an env var,
+// action.yml has to supply it, and nothing connects the two halves.
+func TestActionYAMLSuppliesTheTokenActionSHReads(t *testing.T) {
+	sh, err := os.ReadFile(filepath.Join("..", "action.sh"))
+	if err != nil {
+		t.Fatalf("read action.sh: %v", err)
+	}
+	if !strings.Contains(string(sh), "GITHUB_TOKEN") {
+		t.Skip("action.sh no longer authenticates its GitHub API calls")
+	}
+
+	yml, err := os.ReadFile(filepath.Join("..", "action.yml"))
+	if err != nil {
+		t.Fatalf("read action.yml: %v", err)
+	}
+	if !strings.Contains(string(yml), "GITHUB_TOKEN:") {
+		t.Error("action.sh authenticates with GITHUB_TOKEN but action.yml's env block never " +
+			"maps it, so the header is empty on every run and both API calls are anonymous " +
+			"(60/hour per runner IP) — add `GITHUB_TOKEN: ${{ github.token }}`")
+	}
+}


### PR DESCRIPTION
## What broke

`Nox PR Gate (high/critical)` was failing on `nox-plugin-risk-score#21` and `nox-plugin-sast#22`, 9 seconds in, with one log line:

```
curl: (22) The requested URL returned error: 403
##[error]Process completed with exit code 2.
```

then a second red check right after it:

```
##[error]Path does not exist: nox-pr/results.sarif
```

No scan ran. Two failed checks, neither of them about security. Both PRs were blocked on it.

## Two defects

**1. The version lookup had no retry.** `fetch_asset` was hardened against GitHub's 403 throttle, and its comment makes the case well: *"a gate that goes red for a reason unrelated to security is one people learn to re-run without reading."* But `resolve_version` runs first, and it was a bare `curl -fsSL` — non-zero on any 403. The action died before it ever reached the hardened code. Extracted `api_get` with the same 3-attempt schedule and routed the lookup through it.

**2. The token was never wired.** `action.sh` has always sent `Authorization: Bearer ${GITHUB_TOKEN}` when the variable is set — but `action.yml`'s `env:` block never mapped it. A composite action's step sees only what that block maps, so `${GITHUB_TOKEN:+...}` expanded to nothing on **every** run: both the version lookup and the asset download went out anonymous, against the 60-requests/hour budget shared by every job on the runner's IP. That is why a burst of plugin CI runs could reproduce the 403 at all.

Same shape as the `fail-on-degraded` defect — action.sh reads an env var, action.yml has to supply it, nothing connects the halves.

## Also

- The error message now names rate limiting and points at pinning `version:` as the escape hatch, since a pinned version skips the lookup entirely.
- `\s` in the `tag_name` grep → `[[:space:]]`. `\s` is a GNU extension that silently fails to match on BSD grep.

## Tests

Four, all mutation-checked (reverted each half, confirmed the right test fails):

- recovery from a throttle that clears
- loud failure when it never clears — retrying must not become a silent success that installs nothing
- a pinned version makes **zero** network calls
- `action.yml` supplies every variable `action.sh` authenticates with

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj