### PR TITLE
fix(cli): say when an installed plugin will not run here

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,11 @@ See [`docs/plugin-authoring.md`](docs/plugin-authoring.md) for the full SDK guid
 
 The official registry is auto-added on first run; no `nox registry add` needed for the public set. Operators add private registries on top.
 
-**Recommended: declare plugins in `.nox.yaml`** so anyone cloning your project gets the right set automatically:
+**Declaring plugins in `.nox.yaml` is what makes them run during a scan.**
+Installing a plugin puts it on the machine; listing it under `plugins.required`
+is what enables it for a project. That separation is deliberate — it keeps a
+scan's results from depending on which plugins happen to be installed, so
+everyone cloning your project gets the same set and the same findings:
 
 ```yaml
 # .nox.yaml
@@ -669,7 +673,11 @@ nox scan .                        # auto-installs missing required plugins
 nox scan . --no-auto-install      # opt out
 ```
 
-**One-shot install (no manifest):**
+**Working with plugins directly (no manifest).** These commands address a
+plugin by name and do not consult `.nox.yaml`. Note that `nox plugin install`
+alone does *not* make a plugin participate in `nox scan` — add it to
+`plugins.required` for that. `nox plugin list` shows which installed plugins
+are active in the current directory:
 
 ```bash
 # Search and install (registry auto-configured)

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -455,6 +455,16 @@ func runPluginInstall(args []string) int {
 	}
 
 	fmt.Printf("Installed %s@%s (%s)\n", name, ve.Version, trustLevel)
+
+	// Installing is a machine-level action; enabling is a project-level one.
+	// Saying so here is the difference between a user's next scan working and
+	// them concluding the plugin found nothing. Only shown when the project
+	// does not already require it, so the common case stays quiet. See #376.
+	if cwd, wdErr := os.Getwd(); wdErr == nil {
+		if !projectEnablesPlugin(requiredPluginsForDir(cwd), name) {
+			fmt.Print(enablePluginHint(name))
+		}
+	}
 	return 0
 }
 
@@ -582,13 +592,37 @@ func runPluginList(args []string) int {
 		return 0
 	}
 
+	// ACTIVE answers the question the other four columns cannot: whether this
+	// plugin will actually run here. Installed-but-not-required is a normal
+	// state, not an error, but it is indistinguishable from "enabled and found
+	// nothing" once a scan comes back quiet. See #376.
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	required := requiredPluginsForDir(cwd)
+
+	var inactive int
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tVERSION\tTRUST\tINSTALLED")
+	_, _ = fmt.Fprintln(w, "NAME\tVERSION\tTRUST\tINSTALLED\tACTIVE HERE")
 	for i := range st.Plugins {
 		p := &st.Plugins[i]
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, p.Version, p.TrustLevel, p.InstalledAt.Format("2006-01-02"))
+		active := "no"
+		if projectEnablesPlugin(required, p.Name) {
+			active = "yes"
+		} else {
+			inactive++
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			p.Name, p.Version, p.TrustLevel, p.InstalledAt.Format("2006-01-02"), active)
 	}
 	_ = w.Flush()
+
+	if inactive > 0 {
+		fmt.Printf("\n%d installed plugin(s) will not run in this directory: they are not listed\n"+
+			"under plugins.required in .nox.yaml. Plugins are opt-in per project so that a\n"+
+			"scan does not depend on what happens to be installed on the machine.\n", inactive)
+	}
 	return 0
 }
 

--- a/cli/plugin_enablement.go
+++ b/cli/plugin_enablement.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nox-hq/nox/core"
+)
+
+// Installing a plugin does not make it run. `plugins.required` in the
+// project's .nox.yaml is what enables it, and that separation is deliberate:
+// nox's first design constraint is that the same inputs produce the same
+// outputs with no hidden state, so a globally-installed plugin that ran
+// automatically would make a scan's findings depend on which plugins happen to
+// be present on the machine. Two developers on one repository would get
+// different results.
+//
+// The price of that correctness is a silent dead end. `nox plugin install`
+// succeeds, `nox plugin list` shows the plugin, `nox scan` reports nothing, and
+// the natural reading is that the plugin found nothing rather than that it
+// never ran. The helpers here exist so the CLI can say which of the two it is.
+// See #376.
+
+// projectEnablesPlugin reports whether name appears in a project's
+// `plugins.required` list.
+//
+// Entries may carry a version constraint (`nox/reachability@>=0.5`), which is
+// the form both the README and docs/marketplace.md show, so the constraint is
+// stripped before comparing. Matching is exact on the remaining name — a
+// project requiring `nox/reachability-extra` has not enabled
+// `nox/reachability`.
+func projectEnablesPlugin(required []string, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for _, spec := range required {
+		if pluginNameFromSpec(spec) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// pluginNameFromSpec strips a version constraint and surrounding whitespace
+// from a `plugins.required` entry, leaving the bare plugin name.
+func pluginNameFromSpec(spec string) string {
+	spec = strings.TrimSpace(spec)
+	if i := strings.Index(spec, "@"); i >= 0 {
+		spec = spec[:i]
+	}
+	return strings.TrimSpace(spec)
+}
+
+// enablePluginHint returns the message shown after installing a plugin the
+// current project does not require. It contains the literal YAML to add rather
+// than a description of it — a hint that says "add it to your config" without
+// saying what to write leaves the reader exactly where they were.
+func enablePluginHint(name string) string {
+	return fmt.Sprintf(`[note] %s is installed but not enabled for this project.
+       Plugins run only when the project asks for them, so that a scan does
+       not depend on what happens to be installed on the machine.
+       Add it to .nox.yaml:
+
+         plugins:
+           required:
+             - %s
+`, name, name)
+}
+
+// requiredPluginsForDir loads the `plugins.required` list for a directory,
+// returning nil when there is no config or it cannot be read. A hint or an
+// ACTIVE column is advisory output; failing a command over it would be worse
+// than omitting it.
+func requiredPluginsForDir(dir string) []string {
+	cfg, err := core.LoadScanConfig(dir)
+	if err != nil || cfg == nil {
+		return nil
+	}
+	return cfg.Plugins.Required
+}

--- a/cli/plugin_enablement_test.go
+++ b/cli/plugin_enablement_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Installing a plugin does not make it run — `plugins.required` in the
+// project's .nox.yaml decides that, and deliberately so: nox's first design
+// constraint is that the same inputs produce the same outputs with no hidden
+// state, and a globally-installed plugin that ran automatically would make
+// findings depend on which plugins happen to be on the machine.
+//
+// The cost of that correct design is a quiet dead end: install succeeds, `nox
+// plugin list` shows the plugin, the scan reports nothing, and the natural
+// reading is "the plugin found nothing" rather than "the plugin never ran".
+// These helpers are what the CLI uses to close that gap. See #376.
+func TestProjectEnablesPlugin(t *testing.T) {
+	cases := []struct {
+		name     string
+		required []string
+		plugin   string
+		want     bool
+	}{
+		{
+			name:     "bare name listed",
+			required: []string{"nox/reachability"},
+			plugin:   "nox/reachability",
+			want:     true,
+		},
+		{
+			// The documented form in the README carries a constraint, so a
+			// naive string compare reports the plugin inactive when it is
+			// listed — the exact case the feature exists to report on.
+			name:     "listed with a version constraint",
+			required: []string{"nox/reachability@>=0.5"},
+			plugin:   "nox/reachability",
+			want:     true,
+		},
+		{
+			name:     "pinned to an exact version",
+			required: []string{"nox/grc@0.5.0"},
+			plugin:   "nox/grc",
+			want:     true,
+		},
+		{
+			name:     "not listed at all",
+			required: []string{"nox/ai-eval", "nox/taint-analysis"},
+			plugin:   "nox/reachability",
+			want:     false,
+		},
+		{
+			name:     "empty config enables nothing",
+			required: nil,
+			plugin:   "nox/reachability",
+			want:     false,
+		},
+		{
+			// Prefix collisions must not read as a match: a project requiring
+			// nox/reachability-extra has not enabled nox/reachability.
+			name:     "a longer name sharing a prefix is not a match",
+			required: []string{"nox/reachability-extra"},
+			plugin:   "nox/reachability",
+			want:     false,
+		},
+		{
+			name:     "surrounding whitespace is tolerated",
+			required: []string{"  nox/reachability  "},
+			plugin:   "nox/reachability",
+			want:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectEnablesPlugin(tc.required, tc.plugin); got != tc.want {
+				t.Errorf("projectEnablesPlugin(%q, %q) = %v, want %v",
+					tc.required, tc.plugin, got, tc.want)
+			}
+		})
+	}
+}
+
+// The hint has one job: make the next step copy-pasteable. A message that says
+// "add it to your config" without saying what to write leaves the user in the
+// same place.
+func TestEnablePluginHint_IsCopyPasteable(t *testing.T) {
+	got := enablePluginHint("nox/reachability")
+
+	for _, want := range []string{".nox.yaml", "plugins:", "required:", "nox/reachability"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hint is missing %q, so it cannot be acted on directly:\n%s", want, got)
+		}
+	}
+
+	// The snippet must be valid YAML shape: `required:` is a list, so the
+	// plugin has to appear as an item, not a bare line.
+	if !strings.Contains(got, "- nox/reachability") {
+		t.Errorf("plugin is not rendered as a YAML list item; pasting this produces invalid config:\n%s", got)
+	}
+}
+
+// The hint names the specific plugin just installed, not a placeholder.
+func TestEnablePluginHint_NamesThePluginInstalled(t *testing.T) {
+	got := enablePluginHint("nox/taint-analysis")
+	if strings.Contains(got, "reachability") {
+		t.Errorf("hint mentions an unrelated plugin:\n%s", got)
+	}
+	if !strings.Contains(got, "nox/taint-analysis") {
+		t.Errorf("hint does not name the installed plugin:\n%s", got)
+	}
+}
+
+func seedPlugins(t *testing.T, home string, names ...string) {
+	t.Helper()
+	st := &State{}
+	for _, n := range names {
+		st.AddPlugin(&InstalledPlugin{
+			Name: n, Version: "0.9.0", TrustLevel: "community", InstalledAt: time.Now(),
+		})
+	}
+	if err := SaveState(filepath.Join(home, "state.json"), st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+// The whole point of the ACTIVE column: in a directory with no .nox.yaml,
+// nothing an operator has installed will run, and the listing has to say so.
+// Before this, all four columns described a plugin that was about to do
+// nothing, and read as confirmation that it was set up.
+func TestPluginList_ReportsInstalledPluginsAsInactiveWithoutConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NOX_HOME", home)
+	seedPlugins(t, home, "nox/reachability")
+	t.Chdir(t.TempDir()) // a project with no .nox.yaml
+
+	out := captureStdout(t, func() {
+		if code := runPlugin([]string{"list"}); code != 0 {
+			t.Fatalf("plugin list exited %d", code)
+		}
+	})
+
+	if !strings.Contains(out, "ACTIVE") {
+		t.Errorf("listing has no ACTIVE column, so it cannot distinguish "+
+			"'installed' from 'will actually run here':\n%s", out)
+	}
+	if !strings.Contains(out, "will not run in this directory") {
+		t.Errorf("no explanation that the installed plugin is inactive here:\n%s", out)
+	}
+}
+
+// The converse: once the project requires it, the same plugin must read as
+// active — otherwise the column is noise that says "no" forever.
+func TestPluginList_ReportsActiveWhenProjectRequiresIt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NOX_HOME", home)
+	seedPlugins(t, home, "nox/reachability")
+
+	proj := t.TempDir()
+	// Written with a version constraint, the form the README documents.
+	cfg := "plugins:\n  required:\n    - nox/reachability@>=0.5\n"
+	if err := os.WriteFile(filepath.Join(proj, ".nox.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Chdir(proj)
+
+	out := captureStdout(t, func() {
+		if code := runPlugin([]string{"list"}); code != 0 {
+			t.Fatalf("plugin list exited %d", code)
+		}
+	})
+
+	if strings.Contains(out, "will not run in this directory") {
+		t.Errorf("a plugin listed in plugins.required was reported as inactive:\n%s", out)
+	}
+	if !strings.Contains(out, "yes") {
+		t.Errorf("required plugin is not marked active:\n%s", out)
+	}
+}

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -51,7 +51,13 @@ Auto-install on scan: every `nox scan` checks the manifest and
 installs missing entries silently. Operators bypass with
 `nox scan --no-auto-install` or by setting `auto_install: false`.
 
-### One-shot CLI (no manifest)
+### Working with plugins directly (no manifest)
+
+These commands address a plugin by name and do not consult `.nox.yaml`.
+Installing a plugin does not by itself make it participate in `nox scan` — it
+has to be listed under `plugins.required` for that, so that a scan's results do
+not depend on what happens to be installed on the machine. `nox plugin list`
+reports which installed plugins are active in the current directory.
 
 ```bash
 nox plugin search ai


### PR DESCRIPTION
Closes #376.

## The dead end

```
$ nox plugin install nox/reachability     # succeeds
$ nox plugin list                          # shows it
$ nox scan .                               # nothing, no warning
```

The natural reading is "the plugin found nothing." The truth is it never ran — enabling also requires listing it under `plugins.required`.

## The requirement is correct and stays

nox's first design constraint is *deterministic: same inputs, same outputs, no hidden state*. A globally-installed plugin that ran automatically would make findings depend on what happens to be installed on the machine — two developers on one repo would get different results. It's documented too, in the README and `docs/marketplace.md`.

What was missing was a signal at the point of confusion. The degradation model already reports required-but-not-installed, unusable-binary and integrity-mismatch. Installed-but-not-listed was the one state with nothing to show for it — and unlike the others, it's the *expected* outcome of following the install instructions.

## Changes — CLI only, scan semantics untouched

**`plugin list` gains an ACTIVE HERE column:**

```
NAME                VERSION  TRUST      INSTALLED   ACTIVE HERE
nox/reachability    0.9.0    community  2026-07-26  no
nox/taint-analysis  0.7.2    community  2026-07-26  no

2 installed plugin(s) will not run in this directory: they are not listed
under plugins.required in .nox.yaml. Plugins are opt-in per project so that a
scan does not depend on what happens to be installed on the machine.
```

and in a project that requires it:

```
nox/reachability    0.9.0    community  2026-07-26  yes
```

**`plugin install` prints the snippet to add** — the literal YAML, not a description of it, and only when the project doesn't already require it, so the configured case stays quiet.

## Detail worth reviewing

Matching strips the version constraint. `nox/reachability@>=0.5` is the form both docs show, and a naive compare would report a *listed* plugin as inactive — precisely the confusion the column exists to prevent. Exact match otherwise, so `nox/reachability-extra` doesn't enable `nox/reachability`.

Advisory output never fails a command: an unreadable or missing config yields no hint rather than an error.

## Verification

Seven table cases on the matcher plus two tests driving `runPlugin(["list"])` end-to-end through a real temp project. Mutation-checked both ways — dropping the constraint stripping fails 3 tests, removing the column fails 1. Also ran a built binary against the actual `nox/reachability` install; output above is real, not illustrative.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj