### PR TITLE
feat(fix): add --outdated, an opt-in dependency currency pass

### DIFF
--- a/cli/fix_cmd.go
+++ b/cli/fix_cmd.go
@@ -29,6 +29,7 @@ func runFix(args []string) int {
 		manifestRoot string
 		doActions    bool
 		onlyActions  bool
+		doOutdated   bool
 		doContent    bool
 		write        bool
 	)
@@ -38,6 +39,7 @@ func runFix(args []string) int {
 	fs.StringVar(&manifestRoot, "root", ".", "directory containing the project's manifest (go.mod)")
 	fs.BoolVar(&doActions, "actions", false, "also upgrade outdated GitHub Actions pins in .github/workflows (needs GITHUB_TOKEN)")
 	fs.BoolVar(&onlyActions, "actions-only", false, "only upgrade GitHub Actions pins; skip the package-dependency pass")
+	fs.BoolVar(&doOutdated, "outdated", false, "upgrade dependencies that are merely out of date (opt-in currency pass; reaches the network, Go only)")
 	fs.BoolVar(&doContent, "content", false, "generate deterministic patches for mechanical IAC misconfigurations (previews the diff; add --write to apply)")
 	fs.BoolVar(&write, "write", false, "with --content: apply the patches instead of only previewing them")
 	if err := fs.Parse(args); err != nil {
@@ -48,6 +50,13 @@ func runFix(args []string) int {
 	// rewrites the flagged lines with their one unambiguous secure value.
 	if doContent {
 		return runContentFix(inputPath, write)
+	}
+
+	// --outdated is a currency pass, not a security pass: it acts on the
+	// passage of time rather than on a finding, so it needs no findings.json.
+	// Handled before the deps path so it does not require a scan to have run.
+	if doOutdated {
+		return runOutdatedFix(manifestRoot, dryRun, includeMajor)
 	}
 
 	// GitHub Actions remediation runs independently of findings.json — it

--- a/cli/fix_outdated.go
+++ b/cli/fix_outdated.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// `nox fix` upgrades a dependency only when a VULN-001 finding names a
+// fixed_in version. That is the right default for a security tool — it acts on
+// evidence of a vulnerability, not on the passage of time — but it means a
+// dependency that is merely old is never touched, which is the job a version
+// bumper like Dependabot was doing.
+//
+// --outdated is the opt-in currency pass, deliberately separate from the
+// default. A security fix is something an operator wants applied without
+// argument; routine version churn is a choice with its own risk of breakage.
+// Folding them together would make `nox fix` unpredictable — you could no
+// longer tell, from the fact that it changed something, whether there had been
+// a vulnerability.
+//
+// Go only for now. `go list -m -u -json all` is an authoritative, deterministic
+// source of "what is newer", and the toolchain is already a hard requirement of
+// the Go path in applyUpgrade. Other ecosystems report as unsupported rather
+// than being guessed at.
+
+// goModuleUpdate is the `Update` field `go list -m -u` attaches to a module
+// that has a newer version available.
+type goModuleUpdate struct {
+	Path    string `json:"Path"`
+	Version string `json:"Version"`
+}
+
+// goModuleStatus is the subset of `go list -m -u -json all` output that the
+// currency planner needs.
+type goModuleStatus struct {
+	Path     string          `json:"Path"`
+	Version  string          `json:"Version"`
+	Main     bool            `json:"Main"`
+	Indirect bool            `json:"Indirect"`
+	Update   *goModuleUpdate `json:"Update"`
+}
+
+// parseGoListModules reads the stream `go list -m -u -json all` writes: a
+// sequence of concatenated JSON objects, not a JSON array.
+func parseGoListModules(out []byte) ([]goModuleStatus, error) {
+	dec := json.NewDecoder(bytes.NewReader(out))
+	var mods []goModuleStatus
+	for {
+		var m goModuleStatus
+		err := dec.Decode(&m)
+		if err == io.EOF {
+			return mods, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parsing go list output: %w", err)
+		}
+		mods = append(mods, m)
+	}
+}
+
+// planCurrencyUpgrades turns module status into upgrade actions.
+//
+// Deliberately narrow about what it will touch:
+//   - the main module is never upgraded (`go get` on your own module is
+//     meaningless, and it always appears in the listing)
+//   - indirect dependencies are left to `go mod tidy`; bumping them writes
+//     explicit requirements for packages the project does not import
+//   - a major bump needs --include-major, matching the security path
+//   - an "update" that is not actually newer is dropped, so this cannot
+//     downgrade the way VULN-001 remediation could before #372
+func planCurrencyUpgrades(mods []goModuleStatus, includeMajor bool) upgradePlan {
+	var plan upgradePlan
+	for _, m := range mods {
+		if m.Main || m.Indirect || m.Update == nil {
+			continue
+		}
+		to := m.Update.Version
+		if to == "" || m.Version == "" {
+			continue
+		}
+		// go list should only report newer versions, but a replace directive
+		// or a retracted version can produce one that is not. Applying it
+		// would be a downgrade presented as an upgrade.
+		if !versionLess(m.Version, to) {
+			continue
+		}
+		if !includeMajor && isMajorBump(m.Version, to) {
+			plan.majorSkipped++
+			continue
+		}
+		plan.actions = append(plan.actions, upgradeAction{
+			ruleID:    "OUTDATED",
+			pkg:       m.Path,
+			fromVer:   m.Version,
+			toVersion: to,
+			ecosystem: "go",
+			action:    supportedFixEcosystems["go"],
+		})
+	}
+	return plan
+}
+
+// goListModules runs `go list -m -u -json all` in root.
+//
+// This reaches the network — the module proxy has to be consulted to know what
+// is newer — so it only ever runs behind the explicit --outdated flag, and
+// never as part of a scan. nox's offline-first guarantee is about scanning;
+// asking "is there a newer release" cannot be answered offline by anything.
+func goListModules(root string) ([]goModuleStatus, error) {
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		return nil, fmt.Errorf("no go.mod in %s: %w", root, err)
+	}
+	cmd := exec.Command("go", "list", "-m", "-u", "-json", "all")
+	cmd.Dir = root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go list -m -u: %w: %s", err, stderr.String())
+	}
+	return parseGoListModules(stdout.Bytes())
+}
+
+// runOutdatedFix is the --outdated entry point: enumerate modules, plan the
+// currency upgrades, and apply them through the same machinery the security
+// path uses.
+//
+// Output distinguishes the two reasons a dependency can move. A line tagged
+// OUTDATED means "newer version exists", not "you were vulnerable" — conflating
+// them would inflate what a remediation PR appears to have fixed.
+func runOutdatedFix(manifestRoot string, dryRun, includeMajor bool) int {
+	mods, err := goListModules(manifestRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+
+	plan := planCurrencyUpgrades(mods, includeMajor)
+	if len(plan.actions) == 0 {
+		fmt.Println("nox fix --outdated: all direct dependencies are current.")
+		if plan.majorSkipped > 0 {
+			fmt.Printf("note: %d major-bump upgrade(s) held back (use --include-major to apply)\n", plan.majorSkipped)
+		}
+		return 0
+	}
+
+	for _, a := range plan.actions {
+		fmt.Printf("plan: %s %s %s -> %s  (%s)\n", a.action, a.pkg, a.fromVer, a.toVersion, a.ruleID)
+	}
+	if plan.majorSkipped > 0 {
+		fmt.Printf("note: %d major-bump upgrade(s) held back (use --include-major to apply)\n", plan.majorSkipped)
+	}
+	if dryRun {
+		return 0
+	}
+
+	failed := 0
+	for _, a := range plan.actions {
+		if err := applyUpgrade(manifestRoot, a); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: %v\n", a.pkg, err)
+			failed++
+			continue
+		}
+		fmt.Printf("applied: %s -> %s\n", a.pkg, a.toVersion)
+	}
+
+	// Only tidy when every upgrade landed. Tidying over a partial application
+	// can rewrite go.mod around a state the operator did not intend.
+	if failed == 0 {
+		if err := tidyEco(manifestRoot, "go"); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: go mod tidy failed: %v\n", err)
+		}
+		return 0
+	}
+	return 1
+}

--- a/cli/fix_outdated_test.go
+++ b/cli/fix_outdated_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"testing"
+)
+
+func mod(path, ver string) goModuleStatus {
+	return goModuleStatus{Path: path, Version: ver}
+}
+
+func withUpdate(m goModuleStatus, to string) goModuleStatus {
+	m.Update = &goModuleUpdate{Version: to}
+	return m
+}
+
+// `nox fix` upgrades a dependency only when a VULN-001 finding names a
+// fixed_in version — it is a security remediator, not a version bumper. That is
+// deliberate, but it leaves outdated-but-not-vulnerable dependencies untouched
+// forever, which is the job Dependabot was doing.
+//
+// --outdated is the opt-in currency pass. It is separate from the default
+// behaviour on purpose: a security fix is something you want applied without
+// argument, whereas routine version churn is a choice, and conflating the two
+// would make `nox fix` unpredictable.
+func TestPlanCurrencyUpgrades_UpgradesOutdatedDirectDeps(t *testing.T) {
+	mods := []goModuleStatus{
+		{Path: "example.com/main", Version: "", Main: true},
+		withUpdate(mod("github.com/nox-hq/nox", "v1.17.0"), "v1.19.1"),
+		mod("github.com/spf13/cobra", "v1.8.0"), // current, no Update field
+	}
+
+	plan := planCurrencyUpgrades(mods, false)
+
+	if len(plan.actions) != 1 {
+		t.Fatalf("expected exactly 1 upgrade, got %d: %+v", len(plan.actions), plan.actions)
+	}
+	a := plan.actions[0]
+	if a.pkg != "github.com/nox-hq/nox" || a.fromVer != "v1.17.0" || a.toVersion != "v1.19.1" {
+		t.Errorf("wrong upgrade planned: %+v", a)
+	}
+	if a.ecosystem != "go" {
+		t.Errorf("ecosystem = %q, want go", a.ecosystem)
+	}
+	// The rule ID distinguishes currency upgrades from VULN-001 remediation in
+	// the plan output, so an operator can see which is which at a glance.
+	if a.ruleID == "VULN-001" {
+		t.Error("a currency upgrade is attributed to VULN-001, which claims a vulnerability that was never found")
+	}
+}
+
+// The main module always appears in `go list -m -u all` and must never be
+// upgraded — `go get` on your own module is meaningless.
+func TestPlanCurrencyUpgrades_SkipsTheMainModule(t *testing.T) {
+	mods := []goModuleStatus{
+		withUpdate(goModuleStatus{Path: "example.com/main", Version: "v0.1.0", Main: true}, "v0.2.0"),
+	}
+	if plan := planCurrencyUpgrades(mods, false); len(plan.actions) != 0 {
+		t.Errorf("planned an upgrade of the main module: %+v", plan.actions)
+	}
+}
+
+// Indirect dependencies are `go mod tidy`'s business. Bumping them directly
+// writes explicit requirements into go.mod for things the project does not
+// import, which is churn the operator did not ask for and has to unpick.
+func TestPlanCurrencyUpgrades_SkipsIndirectDeps(t *testing.T) {
+	m := withUpdate(mod("golang.org/x/sys", "v0.20.0"), "v0.24.0")
+	m.Indirect = true
+
+	if plan := planCurrencyUpgrades([]goModuleStatus{m}, false); len(plan.actions) != 0 {
+		t.Errorf("planned an upgrade of an indirect dependency: %+v", plan.actions)
+	}
+}
+
+// Same guard the security path uses: a major bump can break the build, so it
+// needs --include-major. Counted rather than dropped silently, so the operator
+// can see there is something waiting.
+func TestPlanCurrencyUpgrades_HoldsMajorBumpsUnlessAsked(t *testing.T) {
+	mods := []goModuleStatus{withUpdate(mod("github.com/foo/bar", "v1.2.0"), "v2.0.0")}
+
+	plan := planCurrencyUpgrades(mods, false)
+	if len(plan.actions) != 0 {
+		t.Errorf("applied a major bump without --include-major: %+v", plan.actions)
+	}
+	if plan.majorSkipped != 1 {
+		t.Errorf("major bump not reported as held back (majorSkipped=%d)", plan.majorSkipped)
+	}
+
+	if plan := planCurrencyUpgrades(mods, true); len(plan.actions) != 1 {
+		t.Errorf("--include-major did not release the major bump: %+v", plan.actions)
+	}
+}
+
+// A module with no Update field is already current. This is the common case and
+// must produce no action at all — not a no-op `go get` that rewrites go.mod
+// timestamps and makes an empty PR look like a real change.
+func TestPlanCurrencyUpgrades_IgnoresCurrentModules(t *testing.T) {
+	mods := []goModuleStatus{
+		mod("github.com/a/b", "v1.0.0"),
+		mod("github.com/c/d", "v2.3.4"),
+	}
+	if plan := planCurrencyUpgrades(mods, false); len(plan.actions) != 0 {
+		t.Errorf("planned upgrades for already-current modules: %+v", plan.actions)
+	}
+}
+
+// Defensive: `go list` can report an Update whose version is not actually
+// newer (replace directives, retracted versions resolving oddly). Applying it
+// would be a downgrade — the exact defect fixed for VULN-001 in #372, and it
+// must not reappear on this path.
+func TestPlanCurrencyUpgrades_NeverDowngrades(t *testing.T) {
+	mods := []goModuleStatus{withUpdate(mod("github.com/foo/bar", "v1.5.0"), "v1.4.0")}
+	if plan := planCurrencyUpgrades(mods, false); len(plan.actions) != 0 {
+		t.Errorf("planned a downgrade: %+v", plan.actions)
+	}
+}
+
+// Parsing the real shape `go list -m -u -json all` emits: a stream of
+// concatenated JSON objects, not an array.
+func TestParseGoListModules_ReadsConcatenatedJSONStream(t *testing.T) {
+	stream := `{"Path":"example.com/main","Main":true}
+{"Path":"github.com/nox-hq/nox","Version":"v1.17.0","Update":{"Path":"github.com/nox-hq/nox","Version":"v1.19.1"}}
+{"Path":"golang.org/x/sys","Version":"v0.20.0","Indirect":true}
+`
+	mods, err := parseGoListModules([]byte(stream))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(mods) != 3 {
+		t.Fatalf("expected 3 modules, got %d", len(mods))
+	}
+	if !mods[0].Main {
+		t.Error("main module flag lost")
+	}
+	if mods[1].Update == nil || mods[1].Update.Version != "v1.19.1" {
+		t.Errorf("update not parsed: %+v", mods[1])
+	}
+	if !mods[2].Indirect {
+		t.Error("indirect flag lost")
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -519,6 +519,42 @@ matters is rotating it at the provider, which no tool can do for you.
 So: a clean `fix` run means the remediable classes were handled. It is not a
 statement that the SAST findings were.
 
+#### `--outdated`: currency, not security
+
+By default `fix` upgrades a dependency only when a `VULN-001` finding names a
+`fixed_in` version. It acts on evidence of a vulnerability, not on the passage
+of time — so a dependency that is merely old is never touched.
+
+That is the right default, but it leaves a gap if `fix` is the only thing
+maintaining your dependencies: outdated-but-not-vulnerable packages drift
+indefinitely. `--outdated` is the opt-in currency pass.
+
+```bash
+nox fix --outdated --dry-run     # what is behind, and by how much
+nox fix --outdated               # apply, then `go mod tidy`
+nox fix --outdated --include-major
+```
+
+It is a separate flag on purpose. A security fix is something you want applied
+without argument; routine version churn is a choice with its own risk of
+breaking a build. Kept together, you could no longer tell from the fact that
+`fix` changed something whether there had been a vulnerability at all — so
+currency upgrades are reported as `OUTDATED`, never as `VULN-001`.
+
+Scope and guarantees:
+
+- **Go only.** `go list -m -u -json all` is an authoritative answer to "what is
+  newer"; other ecosystems are not guessed at.
+- **Direct dependencies only.** Indirect ones are `go mod tidy`'s business —
+  bumping them writes explicit requirements for packages you do not import.
+- **Never downgrades.** A replace directive or retracted version can make
+  `go list` report an "update" that is not newer; those are dropped.
+- **Major bumps held** unless `--include-major`, and counted so you can see
+  something is waiting.
+- **Reaches the network.** This is the one thing that cannot be answered
+  offline. It runs only behind this flag, never as part of a scan, so nox's
+  offline-first scanning guarantee is unaffected.
+
 ### variants
 
 Report first-party code that reproduces the root-cause pattern of a known CVE —


### PR DESCRIPTION
Prerequisite for retiring Dependabot in favour of nox.

## Why nox couldn't replace Dependabot yet

`nox fix` upgrades a dependency only when a `VULN-001` finding names a `fixed_in` version — it acts on evidence of a vulnerability, not the passage of time. Correct for a security primitive, but it means outdated-but-not-vulnerable dependencies are never touched.

That gap is observable, not theoretical: **`nox-remediate` ran green across all 18 plugin repos on 2026-07-22, and every one was still on `github.com/nox-hq/nox v1.17.0` today.** Working exactly as designed, and not doing the currency job at all — because it was never that job.

## What this adds

```bash
nox fix --outdated --dry-run     # what is behind, and by how much
nox fix --outdated               # apply, then go mod tidy
nox fix --outdated --include-major
```

Real output against a plugin repo:

```
plan: go get github.com/nox-hq/nox v1.17.0 -> v1.19.1  (OUTDATED)
plan: go get go.klarlabs.de/agent/contrib/planner-llm v0.3.0 -> v0.4.0  (OUTDATED)
```

## Why a separate flag

A security fix is something you want applied without argument; routine version churn is a choice with its own risk of breaking a build. Folded together, you could no longer tell from the fact that `fix` changed something whether there had been a vulnerability. Currency upgrades report as `OUTDATED`, never `VULN-001` — otherwise a remediation PR would appear to have fixed vulnerabilities it never found.

## Deliberately narrow

- **Go only** — `go list -m -u -json all` is authoritative; other ecosystems aren't guessed at.
- **Direct deps only** — indirect ones are `go mod tidy`'s business; bumping them writes explicit requirements for packages you don't import.
- **Never downgrades** — a replace directive or retracted version can make `go list` report an "update" that isn't newer. That's the exact defect fixed for `VULN-001` in #372, and it must not reappear on a new path.
- **Major bumps held** unless `--include-major`, counted rather than dropped silently.
- **Tidy only on full success**, so a partial application doesn't get `go.mod` rewritten around a state nobody intended.

## Network

This reaches the network, which nothing else in `fix` does — unavoidable, since "is there a newer release" cannot be answered offline. It runs only behind the flag and never during a scan, so the offline-first **scanning** guarantee is untouched.

## Verification

End-to-end on a real plugin clone: `v1.17.0 → v1.19.1` plus a second stale dependency applied, after which the repo **still builds and its tests pass** — so the two-minor jump is safe for the fleet.

Seven unit tests. The main-module, indirect-dep and downgrade guards are each mutation-checked (reverted, confirmed the specific test fails, restored).

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj