### PR TITLE
docs(changelog): 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-26
+
+### Added
+
+- **`nox fix --outdated` — an opt-in dependency currency pass.** By default
+  `fix` upgrades a dependency only when a `VULN-001` finding names a `fixed_in`
+  version: it acts on evidence of a vulnerability, not on the passage of time.
+  That is the right default for a security tool, but it means `fix` cannot stand
+  in for a version bumper, because a package that is merely old is never
+  touched.
+
+  The gap was observable rather than theoretical. `nox-remediate` ran green
+  across all 18 plugin repositories on 2026-07-22, and every one of them was
+  still on `github.com/nox-hq/nox v1.17.0` days later — working exactly as
+  designed, and not doing the currency job at all, because it was never that
+  job.
+
+  `--outdated` is deliberately a separate flag. A security fix is something an
+  operator wants applied without argument; routine version churn is a choice
+  with its own risk of breaking a build. Folded together, you could no longer
+  tell from the fact that `fix` changed something whether there had been a
+  vulnerability — so currency upgrades report as `OUTDATED` and never as
+  `VULN-001`.
+
+  Narrow on purpose: Go only (`go list -m -u -json all` is an authoritative
+  answer to "what is newer"); direct dependencies only, since indirect ones are
+  `go mod tidy`'s business; major bumps held unless `--include-major`; and it
+  never downgrades — a replace directive or a retracted version can make
+  `go list` report an "update" that is not newer, which is the defect fixed for
+  `VULN-001` in #372 and must not reappear on a new path.
+
+  This is the first thing in `fix` that reaches the network, which is
+  unavoidable: whether a newer release exists cannot be answered offline. It
+  runs only behind the flag and never during a scan, so the offline-first
+  guarantee for scanning is unchanged. (#378)
+
+### Fixed
+
+- Documented that `--outdated`, like `--content`, is a mode rather than a
+  modifier: it returns before the dependency and Action passes, so
+  `nox fix --outdated --actions` does the currency pass only and silently skips
+  Action pins. Two invocations are needed for both.
+
 ## [1.19.1] - 2026-07-26
 
 ### Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -555,6 +555,16 @@ Scope and guarantees:
   offline. It runs only behind this flag, never as part of a scan, so nox's
   offline-first scanning guarantee is unaffected.
 
+`--outdated` is a *mode*, not a modifier: like `--content`, it returns before
+the dependency and Action passes run. `nox fix --outdated --actions` therefore
+does the currency pass **only** and silently skips Action pins. To do both, run
+two commands:
+
+```bash
+nox fix --actions --input findings.json --root .
+nox fix --outdated --root .
+```
+
 ### variants
 
 Report first-party code that reproduces the root-cause pattern of a known CVE —


### PR DESCRIPTION
Changelog for 1.20.0, plus a documentation note I owe after reading the org-wide remediation workflow.

`--outdated` is a **mode**, not a modifier — it returns before the dependency and Action passes, exactly like `--content`. So `nox fix --outdated --actions` does the currency pass only and silently skips Action pins.

That workflow already carries a long comment warning about this for `--content`:

> The IaC content pass is a SECOND invocation, not another flag on the line above. `--content` short-circuits inside nox fix […] so `nox fix --actions --content` silently does content only and drops the upgrades the previous line would have made.

Shipping a second flag with the same shape and no note is how someone loses their Action pins with no failure to look at. Documented rather than left to be rediscovered.

Going through a PR rather than pushing to main: `pull_request` has no `paths-ignore`, precisely so docs-only changes stay mergeable without an admin override.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj