### PR TITLE
feat(fix): extend --outdated to npm, PyPI, Cargo, RubyGems, Composer and NuGet

### DIFF
--- a/cli/fix_cmd.go
+++ b/cli/fix_cmd.go
@@ -166,10 +166,13 @@ type upgradePlan struct {
 // directly. Other ecosystems get counted as skipped — operators can
 // still see the fixed_in metadata in findings.json, just not auto-apply.
 var supportedFixEcosystems = map[string]string{
-	"go":    "go get",
-	"npm":   "npm install",
-	"pypi":  "pip install",
-	"cargo": "cargo update",
+	"go":       "go get",
+	"npm":      "npm install",
+	"pypi":     "pip install",
+	"cargo":    "cargo update",
+	"rubygems": "bundle update",
+	"composer": "composer update",
+	"nuget":    "dotnet add package",
 }
 
 // planUpgrades extracts upgrade actions from VULN findings. Skips
@@ -249,6 +252,12 @@ func applyUpgrade(manifestRoot string, a upgradeAction) error {
 		return applyPyPIUpgrade(manifestRoot, a)
 	case "cargo":
 		return applyCargoUpgrade(manifestRoot, a)
+	case "rubygems":
+		return applyRubyGemsUpgrade(manifestRoot, a)
+	case "composer":
+		return applyComposerUpgrade(manifestRoot, a)
+	case "nuget":
+		return applyNuGetUpgrade(manifestRoot, a)
 	}
 	return fmt.Errorf("ecosystem %q not supported by applyUpgrade", a.ecosystem)
 }
@@ -280,6 +289,28 @@ func applyPyPIUpgrade(manifestRoot string, a upgradeAction) error {
 // rewrites Cargo.lock.
 func applyCargoUpgrade(manifestRoot string, a upgradeAction) error {
 	return runIn(manifestRoot, "cargo", "update", "-p", a.pkg, "--precise", strings.TrimPrefix(a.toVersion, "v"))
+}
+
+// applyRubyGemsUpgrade runs `bundle update <gem> --conservative`.
+//
+// Deliberately not a Gemfile rewrite: the Gemfile constraint is the operator's
+// declared intent, and bundler resolving within it is the behaviour a Ruby
+// project expects. If the constraint pins below the latest release, bundler
+// says so rather than nox silently editing the pin away.
+func applyRubyGemsUpgrade(manifestRoot string, a upgradeAction) error {
+	return runIn(manifestRoot, "bundle", "update", a.pkg, "--conservative")
+}
+
+// applyComposerUpgrade runs `composer update <vendor/pkg> --with-dependencies`.
+// Composer resolves within the composer.json constraint for the same reason.
+func applyComposerUpgrade(manifestRoot string, a upgradeAction) error {
+	return runIn(manifestRoot, "composer", "update", a.pkg, "--with-dependencies")
+}
+
+// applyNuGetUpgrade runs `dotnet add package <id> --version <v>`, which
+// rewrites the PackageReference in the project file.
+func applyNuGetUpgrade(manifestRoot string, a upgradeAction) error {
+	return runIn(manifestRoot, "dotnet", "add", "package", a.pkg, "--version", strings.TrimPrefix(a.toVersion, "v"))
 }
 
 func runIn(dir, name string, args ...string) error {

--- a/cli/fix_outdated.go
+++ b/cli/fix_outdated.go
@@ -23,10 +23,10 @@ import (
 // longer tell, from the fact that it changed something, whether there had been
 // a vulnerability.
 //
-// Go only for now. `go list -m -u -json all` is an authoritative, deterministic
-// source of "what is newer", and the toolchain is already a hard requirement of
-// the Go path in applyUpgrade. Other ecosystems report as unsupported rather
-// than being guessed at.
+// Go resolves through the toolchain (`go list -m -u -json all`), which already
+// understands replace directives, retractions and the module graph — none of
+// which a bare proxy query honours. Every other ecosystem resolves against its
+// own registry; see outdated_registry.go.
 
 // goModuleUpdate is the `Update` field `go list -m -u` attaches to a module
 // that has a newer version available.
@@ -134,15 +134,45 @@ func goListModules(root string) ([]goModuleStatus, error) {
 // OUTDATED means "newer version exists", not "you were vulnerable" — conflating
 // them would inflate what a remediation PR appears to have fixed.
 func runOutdatedFix(manifestRoot string, dryRun, includeMajor bool) int {
-	mods, err := goListModules(manifestRoot)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 2
+	var plan upgradePlan
+	var degraded []string
+
+	// Go is resolved through the toolchain rather than a registry call:
+	// `go list -m -u` already understands replace directives, retractions and
+	// the module graph, none of which a proxy query would honour. Absent go.mod
+	// is not an error — a JavaScript project has nothing to report here.
+	if _, statErr := os.Stat(filepath.Join(manifestRoot, "go.mod")); statErr == nil {
+		mods, err := goListModules(manifestRoot)
+		if err != nil {
+			degraded = append(degraded, fmt.Sprintf("go: %v", err))
+		} else {
+			goPlan := planCurrencyUpgrades(mods, includeMajor)
+			plan.actions = append(plan.actions, goPlan.actions...)
+			plan.skipped += goPlan.skipped
+			plan.majorSkipped += goPlan.majorSkipped
+		}
 	}
 
-	plan := planCurrencyUpgrades(mods, includeMajor)
+	// Everything else resolves against its own registry.
+	regPlan, regDegraded := planRegistryCurrency(manifestRoot, includeMajor, registryBase)
+	plan.actions = append(plan.actions, regPlan.actions...)
+	plan.skipped += regPlan.skipped
+	plan.majorSkipped += regPlan.majorSkipped
+	degraded = append(degraded, regDegraded...)
+
+	// Report what could not be checked before reporting what was found, so a
+	// short list is never mistaken for a clean bill of health. This is the same
+	// contract as the scan degradations model.
+	for _, d := range degraded {
+		fmt.Fprintf(os.Stderr, "degraded: could not determine the latest version — %s\n", d)
+	}
+
 	if len(plan.actions) == 0 {
-		fmt.Println("nox fix --outdated: all direct dependencies are current.")
+		if len(degraded) > 0 {
+			fmt.Printf("nox fix --outdated: no upgrades found, but %d dependency check(s) could not complete (see above).\n", len(degraded))
+		} else {
+			fmt.Println("nox fix --outdated: all direct dependencies are current.")
+		}
 		if plan.majorSkipped > 0 {
 			fmt.Printf("note: %d major-bump upgrade(s) held back (use --include-major to apply)\n", plan.majorSkipped)
 		}
@@ -172,8 +202,14 @@ func runOutdatedFix(manifestRoot string, dryRun, includeMajor bool) int {
 	// Only tidy when every upgrade landed. Tidying over a partial application
 	// can rewrite go.mod around a state the operator did not intend.
 	if failed == 0 {
-		if err := tidyEco(manifestRoot, "go"); err != nil {
-			fmt.Fprintf(os.Stderr, "warn: go mod tidy failed: %v\n", err)
+		used := map[string]bool{}
+		for _, a := range plan.actions {
+			used[a.ecosystem] = true
+		}
+		for eco := range used {
+			if err := tidyEco(manifestRoot, eco); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: %s tidy failed: %v\n", eco, err)
+			}
 		}
 		return 0
 	}

--- a/cli/outdated_registry.go
+++ b/cli/outdated_registry.go
@@ -45,9 +45,12 @@ type directDep struct {
 // registryBase maps an ecosystem to its default registry root. Overridable per
 // call so tests can point at a stub.
 var registryBase = map[string]string{
-	"npm":   "https://registry.npmjs.org",
-	"pypi":  "https://pypi.org",
-	"cargo": "https://crates.io",
+	"npm":      "https://registry.npmjs.org",
+	"pypi":     "https://pypi.org",
+	"cargo":    "https://crates.io",
+	"rubygems": "https://rubygems.org",
+	"composer": "https://repo.packagist.org",
+	"nuget":    "https://api.nuget.org",
 }
 
 var httpClient = &http.Client{Timeout: 20 * time.Second}
@@ -74,6 +77,15 @@ func resolveLatest(eco, pkg, base string) (string, error) {
 		url = base + "/pypi/" + pkg + "/json"
 	case "cargo":
 		url = base + "/api/v1/crates/" + pkg
+	case "rubygems":
+		url = base + "/api/v1/gems/" + pkg + ".json"
+	case "composer":
+		url = base + "/p2/" + pkg + ".json"
+	case "nuget":
+		// NuGet ids are case-insensitive, but the flat-container path is not:
+		// `Newtonsoft.Json` 404s where `newtonsoft.json` succeeds, and a 404
+		// here would report a perfectly ordinary package as un-checkable.
+		url = base + "/v3-flatcontainer/" + strings.ToLower(pkg) + "/index.json"
 	default:
 		return "", fmt.Errorf("ecosystem %q has no currency resolver yet", eco)
 	}
@@ -82,6 +94,12 @@ func resolveLatest(eco, pkg, base string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%s registry: %w", eco, err)
 	}
+	// crates.io rejects requests without a descriptive User-Agent with HTTP 403
+	// — Go's client sends none by default, so every cargo lookup failed against
+	// the live registry while passing against stubs. Sent to all registries:
+	// identifying the client is expected etiquette and some others rate-limit
+	// anonymous traffic harder.
+	req.Header.Set("User-Agent", "nox (+https://github.com/nox-hq/nox)")
 	if eco == "npm" {
 		// The full packument for a popular package is enormous — typescript and
 		// @types/node both exceed 8 MB, which silently truncated the read and
@@ -141,8 +159,64 @@ func resolveLatest(eco, pkg, base string) (string, error) {
 			return doc.Crate.MaxStable, nil
 		}
 		return doc.Crate.Max, nil
+	case "rubygems":
+		var doc struct {
+			Version string `json:"version"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing rubygems response for %s: %w", pkg, err)
+		}
+		return doc.Version, nil
+	case "composer":
+		var doc struct {
+			Packages map[string][]struct {
+				Version string `json:"version"`
+			} `json:"packages"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing packagist response for %s: %w", pkg, err)
+		}
+		// Newest first, but mixed with branch aliases (dev-main) and
+		// prereleases, so the first entry is often not a released version.
+		for _, v := range doc.Packages[pkg] {
+			if isStableVersion(v.Version) {
+				return v.Version, nil
+			}
+		}
+		return "", nil
+	case "nuget":
+		var doc struct {
+			Versions []string `json:"versions"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing nuget response for %s: %w", pkg, err)
+		}
+		// ASCENDING and including prereleases, so the last element is
+		// frequently a beta — verified against the live API, where
+		// newtonsoft.json ends 13.0.4, 13.0.5-beta1. Walk backwards to the
+		// highest stable rather than taking the tail.
+		for i := len(doc.Versions) - 1; i >= 0; i-- {
+			if isStableVersion(doc.Versions[i]) {
+				return doc.Versions[i], nil
+			}
+		}
+		return "", nil
 	}
 	return "", fmt.Errorf("unreachable resolver for %q", eco)
+}
+
+// isStableVersion reports whether a version string is a plain release rather
+// than a prerelease or a branch alias. SemVer puts prerelease data after a
+// hyphen; Packagist additionally publishes `dev-<branch>` pseudo-versions, and
+// NuGet mixes `-beta`/`-rc` straight into its ascending version list.
+//
+// Returning a prerelease from a currency pass would push a beta into someone's
+// manifest, which is the one thing an unattended upgrade must never do.
+func isStableVersion(v string) bool {
+	if v == "" || strings.HasPrefix(v, "dev-") {
+		return false
+	}
+	return !strings.Contains(v, "-")
 }
 
 // pkgNameForPath recovers the package name from a stub registry path. Test
@@ -155,6 +229,12 @@ func pkgNameForPath(path, eco string) string {
 		return strings.TrimSuffix(strings.TrimPrefix(path, "/pypi/"), "/json")
 	case "cargo":
 		return strings.TrimPrefix(path, "/api/v1/crates/")
+	case "rubygems":
+		return strings.TrimSuffix(strings.TrimPrefix(path, "/api/v1/gems/"), ".json")
+	case "composer":
+		return strings.TrimSuffix(strings.TrimPrefix(path, "/p2/"), ".json")
+	case "nuget":
+		return strings.TrimSuffix(strings.TrimPrefix(path, "/v3-flatcontainer/"), "/index.json")
 	}
 	return path
 }
@@ -168,6 +248,9 @@ func directDeps(root string) []directDep {
 	out = append(out, npmDirectDeps(root)...)
 	out = append(out, cargoDirectDeps(root)...)
 	out = append(out, pypiDirectDeps(root)...)
+	out = append(out, rubygemsDirectDeps(root)...)
+	out = append(out, composerDirectDeps(root)...)
+	out = append(out, nugetDirectDeps(root)...)
 	return out
 }
 
@@ -342,4 +425,135 @@ func planRegistryCurrency(root string, includeMajor bool, base map[string]string
 		})
 	}
 	return plan, degraded
+}
+
+var gemfileLine = regexp.MustCompile(`^\s*gem\s+["']([^"']+)["']`)
+var gemfileLockSpec = regexp.MustCompile(`^\s{4}([A-Za-z0-9._-]+) \(([^)]+)\)`)
+
+// rubygemsDirectDeps takes names from the Gemfile's `gem "name"` lines and
+// resolved versions from Gemfile.lock.
+//
+// Gemfile.lock indents direct and transitive specs differently: entries under
+// `specs:` are indented four spaces, their dependencies six. Matching on the
+// four-space form alone would still include transitive gems that happen to be
+// top-level specs, which is why names come from the Gemfile.
+func rubygemsDirectDeps(root string) []directDep {
+	raw := readIfPresent(filepath.Join(root, "Gemfile"))
+	if raw == nil {
+		return nil
+	}
+	names := map[string]bool{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if m := gemfileLine.FindStringSubmatch(line); m != nil {
+			names[m[1]] = true
+		}
+	}
+
+	resolved := map[string]string{}
+	if lock := readIfPresent(filepath.Join(root, "Gemfile.lock")); lock != nil {
+		for _, line := range strings.Split(string(lock), "\n") {
+			if m := gemfileLockSpec.FindStringSubmatch(line); m != nil {
+				resolved[m[1]] = m[2]
+			}
+		}
+	}
+
+	var out []directDep
+	for name := range names {
+		out = append(out, directDep{eco: "rubygems", name: name, version: resolved[name]})
+	}
+	return out
+}
+
+// composerDirectDeps reads require/require-dev from composer.json and resolved
+// versions from composer.lock.
+//
+// Platform requirements (php, ext-*, lib-*, composer-*) are dropped: they are
+// constraints on the runtime, not packages, and Packagist has no entry for
+// them — querying one would produce a spurious "could not determine" line for
+// something that was never a dependency.
+func composerDirectDeps(root string) []directDep {
+	raw := readIfPresent(filepath.Join(root, "composer.json"))
+	if raw == nil {
+		return nil
+	}
+	var manifest struct {
+		Require    map[string]string `json:"require"`
+		RequireDev map[string]string `json:"require-dev"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil
+	}
+
+	resolved := map[string]string{}
+	if lock := readIfPresent(filepath.Join(root, "composer.lock")); lock != nil {
+		var doc struct {
+			Packages    []struct{ Name, Version string } `json:"packages"`
+			PackagesDev []struct{ Name, Version string } `json:"packages-dev"`
+		}
+		if err := json.Unmarshal(lock, &doc); err == nil {
+			for _, set := range [][]struct{ Name, Version string }{doc.Packages, doc.PackagesDev} {
+				for _, p := range set {
+					resolved[p.Name] = strings.TrimPrefix(p.Version, "v")
+				}
+			}
+		}
+	}
+
+	var out []directDep
+	for _, set := range []map[string]string{manifest.Require, manifest.RequireDev} {
+		for name := range set {
+			if isComposerPlatformRequirement(name) {
+				continue
+			}
+			out = append(out, directDep{eco: "composer", name: name, version: resolved[name]})
+		}
+	}
+	return out
+}
+
+// isComposerPlatformRequirement reports whether a composer `require` key names
+// the runtime rather than a package. A real package is always `vendor/name`.
+func isComposerPlatformRequirement(name string) bool {
+	if !strings.Contains(name, "/") {
+		return true // "php", "hhvm"
+	}
+	for _, p := range []string{"ext-", "lib-", "composer-"} {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+var packageRefRe = regexp.MustCompile(`<PackageReference\s+Include="([^"]+)"\s+Version="([^"]+)"`)
+
+// nugetDirectDeps reads <PackageReference> entries from every project file in
+// root. Unlike npm or Cargo there is no lockfile in a default project: the
+// Include/Version pair in the .csproj IS the resolved version.
+//
+// <ProjectReference> is deliberately not matched — it names a sibling project
+// on disk, not a package, and Packagist-style lookups for it would 404.
+func nugetDirectDeps(root string) []directDep {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []directDep
+	seen := map[string]bool{}
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || (!strings.HasSuffix(n, ".csproj") && !strings.HasSuffix(n, ".fsproj") && !strings.HasSuffix(n, ".vbproj")) {
+			continue
+		}
+		raw := readIfPresent(filepath.Join(root, n))
+		for _, m := range packageRefRe.FindAllStringSubmatch(string(raw), -1) {
+			if seen[m[1]] {
+				continue
+			}
+			seen[m[1]] = true
+			out = append(out, directDep{eco: "nuget", name: m[1], version: m[2]})
+		}
+	}
+	return out
 }

--- a/cli/outdated_registry.go
+++ b/cli/outdated_registry.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Multi-ecosystem support for `nox fix --outdated`.
+//
+// Currency needs two things that vulnerability scanning does not, which is why
+// it cannot simply reuse the deps analyzer:
+//
+//  1. WHICH DEPENDENCIES ARE DIRECT. deps.Package is parsed from lockfiles,
+//     which are flat and contain the entire transitive closure. Upgrading a
+//     transitive package writes an explicit requirement for something the
+//     project never imports — churn the operator then has to unpick. Directness
+//     is declared in the MANIFEST (package.json, Cargo.toml, requirements.txt),
+//     so both files are read: names from the manifest, resolved versions from
+//     the lockfile.
+//
+//  2. WHAT THE LATEST VERSION IS, which only a registry can answer. Go gets
+//     this from `go list -m -u`; every other ecosystem needs an HTTP call.
+//
+// Registries are queried directly rather than shelling out to npm/pip/cargo,
+// so planning needs no toolchain and behaves the same everywhere. Applying an
+// upgrade still uses the native command, which is where a toolchain genuinely
+// belongs.
+
+// directDep is one direct dependency with its currently-resolved version.
+// An empty version means the manifest pins a range and no lockfile entry
+// resolved it; the planner skips those rather than inventing a current version.
+type directDep struct {
+	eco     string
+	name    string
+	version string
+}
+
+// registryBase maps an ecosystem to its default registry root. Overridable per
+// call so tests can point at a stub.
+var registryBase = map[string]string{
+	"npm":   "https://registry.npmjs.org",
+	"pypi":  "https://pypi.org",
+	"cargo": "https://crates.io",
+}
+
+var httpClient = &http.Client{Timeout: 20 * time.Second}
+
+// resolveLatest asks an ecosystem's registry for the latest STABLE version.
+//
+// Each registry expresses that differently, and picking the wrong field means
+// silently proposing a prerelease: npm publishes channels under dist-tags where
+// only `latest` is stable, and crates.io reports both max_version (which
+// includes prereleases) and max_stable_version.
+func resolveLatest(eco, pkg, base string) (string, error) {
+	if base == "" {
+		base = registryBase[eco]
+	}
+	if base == "" {
+		return "", fmt.Errorf("no registry configured for ecosystem %q", eco)
+	}
+
+	var url string
+	switch eco {
+	case "npm":
+		url = base + "/" + pkg
+	case "pypi":
+		url = base + "/pypi/" + pkg + "/json"
+	case "cargo":
+		url = base + "/api/v1/crates/" + pkg
+	default:
+		return "", fmt.Errorf("ecosystem %q has no currency resolver yet", eco)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx // short-lived CLI call with a client timeout
+	if err != nil {
+		return "", fmt.Errorf("%s registry: %w", eco, err)
+	}
+	if eco == "npm" {
+		// The full packument for a popular package is enormous — typescript and
+		// @types/node both exceed 8 MB, which silently truncated the read and
+		// surfaced as "unexpected end of JSON input". The abbreviated document
+		// carries dist-tags and is orders of magnitude smaller.
+		req.Header.Set("Accept", "application/vnd.npm.install-v1+json")
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s registry: %w", eco, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Anything but 200 is an error, never an empty result. A silent "" would be
+	// indistinguishable from "already current", so a rate-limited or unreachable
+	// registry would quietly report the whole project as up to date.
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s registry returned HTTP %d for %s", eco, resp.StatusCode, pkg)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return "", fmt.Errorf("reading %s registry response: %w", eco, err)
+	}
+
+	switch eco {
+	case "npm":
+		var doc struct {
+			DistTags map[string]string `json:"dist-tags"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing npm response for %s: %w", pkg, err)
+		}
+		return doc.DistTags["latest"], nil
+	case "pypi":
+		var doc struct {
+			Info struct {
+				Version string `json:"version"`
+			} `json:"info"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing pypi response for %s: %w", pkg, err)
+		}
+		return doc.Info.Version, nil
+	case "cargo":
+		var doc struct {
+			Crate struct {
+				MaxStable string `json:"max_stable_version"`
+				Max       string `json:"max_version"`
+			} `json:"crate"`
+		}
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return "", fmt.Errorf("parsing crates.io response for %s: %w", pkg, err)
+		}
+		// max_version includes prereleases; max_stable_version is the one a
+		// currency pass wants. Fall back only when no stable release exists.
+		if doc.Crate.MaxStable != "" {
+			return doc.Crate.MaxStable, nil
+		}
+		return doc.Crate.Max, nil
+	}
+	return "", fmt.Errorf("unreachable resolver for %q", eco)
+}
+
+// pkgNameForPath recovers the package name from a stub registry path. Test
+// helper kept beside the resolver so the two stay in step.
+func pkgNameForPath(path, eco string) string {
+	switch eco {
+	case "npm":
+		return strings.TrimPrefix(path, "/")
+	case "pypi":
+		return strings.TrimSuffix(strings.TrimPrefix(path, "/pypi/"), "/json")
+	case "cargo":
+		return strings.TrimPrefix(path, "/api/v1/crates/")
+	}
+	return path
+}
+
+// directDeps enumerates direct dependencies across every ecosystem whose
+// manifest is present in root. Missing or malformed manifests are skipped
+// rather than failing: a repo with a broken package.json should still get its
+// Cargo dependencies checked.
+func directDeps(root string) []directDep {
+	var out []directDep
+	out = append(out, npmDirectDeps(root)...)
+	out = append(out, cargoDirectDeps(root)...)
+	out = append(out, pypiDirectDeps(root)...)
+	return out
+}
+
+func readIfPresent(path string) []byte {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// npmDirectDeps reads names from package.json (dependencies AND
+// devDependencies — a dev dependency still runs in CI and still carries
+// vulnerabilities) and resolved versions from package-lock.json.
+func npmDirectDeps(root string) []directDep {
+	raw := readIfPresent(filepath.Join(root, "package.json"))
+	if raw == nil {
+		return nil
+	}
+	var manifest struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil
+	}
+
+	resolved := map[string]string{}
+	if lock := readIfPresent(filepath.Join(root, "package-lock.json")); lock != nil {
+		var doc struct {
+			Packages map[string]struct {
+				Version string `json:"version"`
+			} `json:"packages"`
+		}
+		if err := json.Unmarshal(lock, &doc); err == nil {
+			for path, e := range doc.Packages {
+				// Keys look like "node_modules/express" or
+				// "node_modules/@scope/thing"; the root package has key "".
+				if name, ok := strings.CutPrefix(path, "node_modules/"); ok {
+					resolved[name] = e.Version
+				}
+			}
+		}
+	}
+
+	var out []directDep
+	for _, set := range []map[string]string{manifest.Dependencies, manifest.DevDependencies} {
+		for name := range set {
+			out = append(out, directDep{eco: "npm", name: name, version: resolved[name]})
+		}
+	}
+	return out
+}
+
+var cargoDepLine = regexp.MustCompile(`^\s*([A-Za-z0-9_-]+)\s*=`)
+
+// cargoDirectDeps reads the [dependencies] and [dev-dependencies] tables of
+// Cargo.toml for names, and Cargo.lock for resolved versions. Only the key is
+// taken from the manifest, so both `serde = "1"` and the table form
+// `tokio = { version = "1.20" }` are handled.
+func cargoDirectDeps(root string) []directDep {
+	raw := readIfPresent(filepath.Join(root, "Cargo.toml"))
+	if raw == nil {
+		return nil
+	}
+
+	names := map[string]bool{}
+	inDeps := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "[") {
+			inDeps = t == "[dependencies]" || t == "[dev-dependencies]" || t == "[build-dependencies]"
+			continue
+		}
+		if !inDeps || t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		if m := cargoDepLine.FindStringSubmatch(line); m != nil {
+			names[m[1]] = true
+		}
+	}
+
+	resolved := map[string]string{}
+	if lock := readIfPresent(filepath.Join(root, "Cargo.lock")); lock != nil {
+		var name string
+		for _, line := range strings.Split(string(lock), "\n") {
+			t := strings.TrimSpace(line)
+			switch {
+			case strings.HasPrefix(t, "name = "):
+				name = strings.Trim(strings.TrimPrefix(t, "name = "), `"`)
+			case strings.HasPrefix(t, "version = ") && name != "":
+				resolved[name] = strings.Trim(strings.TrimPrefix(t, "version = "), `"`)
+				name = ""
+			}
+		}
+	}
+
+	var out []directDep
+	for name := range names {
+		out = append(out, directDep{eco: "cargo", name: name, version: resolved[name]})
+	}
+	return out
+}
+
+// pypiExactPin matches only `name == version`. A range (`>=2.0,<3.0`) has no
+// single current version, so it is recorded with an empty version and skipped
+// by the planner rather than being assigned a version it does not have.
+var pypiExactPin = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._-]*)\s*==\s*([A-Za-z0-9][A-Za-z0-9._+!-]*)`)
+var pypiAnyReq = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:[<>=!~]|$)`)
+
+func pypiDirectDeps(root string) []directDep {
+	raw := readIfPresent(filepath.Join(root, "requirements.txt"))
+	if raw == nil {
+		return nil
+	}
+	var out []directDep
+	for _, line := range strings.Split(string(raw), "\n") {
+		t := strings.TrimSpace(line)
+		// Strip inline comments before matching, so `urllib3 == 1.26.12  # x`
+		// does not carry the comment into the version.
+		if i := strings.Index(t, "#"); i >= 0 {
+			t = strings.TrimSpace(t[:i])
+		}
+		// Skip blanks, editable installs, options and requirement includes.
+		if t == "" || strings.HasPrefix(t, "-") {
+			continue
+		}
+		if m := pypiExactPin.FindStringSubmatch(t); m != nil {
+			out = append(out, directDep{eco: "pypi", name: m[1], version: m[2]})
+			continue
+		}
+		if m := pypiAnyReq.FindStringSubmatch(t); m != nil {
+			out = append(out, directDep{eco: "pypi", name: m[1]})
+		}
+	}
+	return out
+}
+
+// planRegistryCurrency plans upgrades for every non-Go ecosystem found in root.
+//
+// Failures are reported, never swallowed: a registry that is unreachable or
+// rate-limiting must not make a project look up to date. Each is returned as a
+// degradation string so the caller can print them, matching nox's "report what
+// you could not check" model.
+func planRegistryCurrency(root string, includeMajor bool, base map[string]string) (upgradePlan, []string) {
+	var plan upgradePlan
+	var degraded []string
+
+	for _, d := range directDeps(root) {
+		if d.version == "" {
+			// A range pin with no lockfile entry: there is no single current
+			// version to compare, so there is nothing honest to say.
+			plan.skipped++
+			continue
+		}
+		latest, err := resolveLatest(d.eco, d.name, base[d.eco])
+		if err != nil {
+			degraded = append(degraded, fmt.Sprintf("%s/%s: %v", d.eco, d.name, err))
+			continue
+		}
+		if latest == "" || !versionLess(d.version, latest) {
+			continue
+		}
+		if !includeMajor && isMajorBump(d.version, latest) {
+			plan.majorSkipped++
+			continue
+		}
+		plan.actions = append(plan.actions, upgradeAction{
+			ruleID:    "OUTDATED",
+			pkg:       d.name,
+			fromVer:   d.version,
+			toVersion: latest,
+			ecosystem: d.eco,
+			action:    supportedFixEcosystems[d.eco],
+		})
+	}
+	return plan, degraded
+}

--- a/cli/outdated_registry.go
+++ b/cli/outdated_registry.go
@@ -78,7 +78,7 @@ func resolveLatest(eco, pkg, base string) (string, error) {
 		return "", fmt.Errorf("ecosystem %q has no currency resolver yet", eco)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx // short-lived CLI call with a client timeout
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody) //nolint:noctx // short-lived CLI call with a client timeout
 	if err != nil {
 		return "", fmt.Errorf("%s registry: %w", eco, err)
 	}
@@ -312,10 +312,7 @@ func pypiDirectDeps(root string) []directDep {
 // rate-limiting must not make a project look up to date. Each is returned as a
 // degradation string so the caller can print them, matching nox's "report what
 // you could not check" model.
-func planRegistryCurrency(root string, includeMajor bool, base map[string]string) (upgradePlan, []string) {
-	var plan upgradePlan
-	var degraded []string
-
+func planRegistryCurrency(root string, includeMajor bool, base map[string]string) (plan upgradePlan, degraded []string) {
 	for _, d := range directDeps(root) {
 		if d.version == "" {
 			// A range pin with no lockfile entry: there is no single current

--- a/cli/outdated_registry_test.go
+++ b/cli/outdated_registry_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Currency needs two things per ecosystem that vulnerability scanning does not:
+//
+//  1. Which dependencies are DIRECT. deps.Package comes from lockfiles, which
+//     are flat and include the whole transitive closure. Upgrading a transitive
+//     package writes an explicit requirement for something the project does not
+//     import — churn the operator has to unpick. Directness lives in the
+//     manifest, not the lockfile.
+//  2. What the latest published version is, which only a registry can answer.
+//
+// These tests cover both, per ecosystem, against stub registries.
+
+func writeManifest(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestDirectDeps_NPM(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "package.json", `{
+	  "name": "app",
+	  "dependencies":    { "express": "^4.18.0", "@scope/thing": "1.2.3" },
+	  "devDependencies": { "jest": "~29.0.0" }
+	}`)
+	// The lockfile carries the resolved versions AND the transitive closure.
+	writeManifest(t, dir, "package-lock.json", `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "node_modules/express":      { "version": "4.18.2" },
+	    "node_modules/@scope/thing": { "version": "1.2.3" },
+	    "node_modules/jest":         { "version": "29.0.1" },
+	    "node_modules/body-parser":  { "version": "1.20.0" }
+	  }
+	}`)
+
+	got := directDeps(dir)
+	byName := map[string]string{}
+	for _, d := range got {
+		if d.eco == "npm" {
+			byName[d.name] = d.version
+		}
+	}
+
+	for name, want := range map[string]string{
+		"express":      "4.18.2",
+		"@scope/thing": "1.2.3",
+		"jest":         "29.0.1", // devDependencies count: they run in CI
+	} {
+		if byName[name] != want {
+			t.Errorf("npm %s = %q, want %q (resolved version must come from the lockfile, not the range)", name, byName[name], want)
+		}
+	}
+	// The whole point: a transitive package must not appear.
+	if v, ok := byName["body-parser"]; ok {
+		t.Errorf("body-parser is transitive but was reported as direct (version %q)", v)
+	}
+}
+
+func TestDirectDeps_Cargo(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "Cargo.toml", `
+[package]
+name = "app"
+
+[dependencies]
+serde = "1.0.100"
+tokio = { version = "1.20", features = ["full"] }
+
+[dev-dependencies]
+proptest = "1.0"
+`)
+	writeManifest(t, dir, "Cargo.lock", `
+[[package]]
+name = "serde"
+version = "1.0.150"
+
+[[package]]
+name = "tokio"
+version = "1.28.0"
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+
+[[package]]
+name = "libc"
+version = "0.2.140"
+`)
+
+	byName := map[string]string{}
+	for _, d := range directDeps(dir) {
+		if d.eco == "cargo" {
+			byName[d.name] = d.version
+		}
+	}
+	// `tokio` is declared in table form; parsing only bare strings would miss it.
+	for name, want := range map[string]string{"serde": "1.0.150", "tokio": "1.28.0", "proptest": "1.2.0"} {
+		if byName[name] != want {
+			t.Errorf("cargo %s = %q, want %q", name, byName[name], want)
+		}
+	}
+	if _, ok := byName["libc"]; ok {
+		t.Error("libc is transitive but was reported as direct")
+	}
+}
+
+func TestDirectDeps_PyPI(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "requirements.txt", `
+# comment
+requests==2.28.1
+flask>=2.0,<3.0
+urllib3 == 1.26.12   # inline comment
+-e .
+`)
+
+	byName := map[string]string{}
+	for _, d := range directDeps(dir) {
+		if d.eco == "pypi" {
+			byName[d.name] = d.version
+		}
+	}
+	if byName["requests"] != "2.28.1" {
+		t.Errorf("requests = %q, want 2.28.1", byName["requests"])
+	}
+	if byName["urllib3"] != "1.26.12" {
+		t.Errorf("urllib3 = %q, want 1.26.12 (whitespace around == must not defeat parsing)", byName["urllib3"])
+	}
+	// A range pin has no single current version; reporting one would invent a
+	// fact. It is listed with an empty version and skipped by the planner.
+	if v := byName["flask"]; v != "" {
+		t.Errorf("flask = %q, want empty — a range gives no exact current version", v)
+	}
+	if _, ok := byName["-e ."]; ok {
+		t.Error("an editable install was parsed as a package name")
+	}
+}
+
+// Each registry answers "what is latest" in its own shape. A wrong field means
+// silently proposing the wrong upgrade, so each is pinned by a test.
+func TestRegistryResolvers(t *testing.T) {
+	cases := []struct {
+		eco, path, body, want string
+	}{
+		{"npm", "/express", `{"dist-tags":{"latest":"4.19.2","next":"5.0.0-beta"}}`, "4.19.2"},
+		{"pypi", "/pypi/requests/json", `{"info":{"version":"2.31.0"}}`, "2.31.0"},
+		{"cargo", "/api/v1/crates/serde", `{"crate":{"max_stable_version":"1.0.197","max_version":"1.1.0-alpha"}}`, "1.0.197"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.eco, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.path {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := resolveLatest(tc.eco, pkgNameForPath(tc.path, tc.eco), srv.URL)
+			if err != nil {
+				t.Fatalf("resolveLatest: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("latest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Prerelease channels must never win. npm's `next`, cargo's `max_version` and
+// PyPI's yanked-but-present releases are all traps: an operator running a
+// currency pass wants the current stable, not a beta.
+func TestRegistryResolvers_IgnorePrereleaseChannels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"crate":{"max_stable_version":"1.0.197","max_version":"2.0.0-rc.1"}}`))
+	}))
+	defer srv.Close()
+
+	got, err := resolveLatest("cargo", "serde", srv.URL)
+	if err != nil {
+		t.Fatalf("resolveLatest: %v", err)
+	}
+	if got != "1.0.197" {
+		t.Errorf("cargo latest = %q — max_version is a prerelease and must not be chosen", got)
+	}
+}
+
+// A registry that is down, rate-limiting, or does not know the package must
+// produce an error rather than an empty string that reads as "no update".
+func TestRegistryResolvers_ErrorsRatherThanReportingCurrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	if got, err := resolveLatest("npm", "express", srv.URL); err == nil {
+		t.Errorf("a 429 produced no error (returned %q); the package would look up to date", got)
+	}
+}
+
+// npm's full packument for a popular package is enormous — typescript and
+// @types/node both exceed 8 MB — which truncated the response body and surfaced
+// as "unexpected end of JSON input" against the real registry. Every dependency
+// in the VS Code extension reported as un-checkable.
+//
+// The fix is to ask for the abbreviated document rather than to keep raising a
+// size ceiling, so this asserts the header is actually sent. Found only by
+// running against the live registry; no stub was ever big enough to catch it.
+func TestNpmResolver_RequestsTheAbbreviatedPackument(t *testing.T) {
+	var gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+		_, _ = w.Write([]byte(`{"dist-tags":{"latest":"1.0.0"}}`))
+	}))
+	defer srv.Close()
+
+	if _, err := resolveLatest("npm", "typescript", srv.URL); err != nil {
+		t.Fatalf("resolveLatest: %v", err)
+	}
+	if gotAccept != "application/vnd.npm.install-v1+json" {
+		t.Errorf("Accept = %q, want the abbreviated-packument media type; "+
+			"the full document is large enough to truncate", gotAccept)
+	}
+}

--- a/cli/outdated_registry_test.go
+++ b/cli/outdated_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -236,5 +237,242 @@ func TestNpmResolver_RequestsTheAbbreviatedPackument(t *testing.T) {
 	if gotAccept != "application/vnd.npm.install-v1+json" {
 		t.Errorf("Accept = %q, want the abbreviated-packument media type; "+
 			"the full document is large enough to truncate", gotAccept)
+	}
+}
+
+// Second batch of ecosystems. Each registry answers "latest" in a different
+// shape, and two of the three actively invite picking a prerelease.
+func TestRegistryResolvers_SecondBatch(t *testing.T) {
+	cases := []struct {
+		name, eco, path, body, want string
+	}{
+		{
+			// RubyGems is the easy one: .version is already the latest stable.
+			name: "rubygems", eco: "rubygems", path: "/api/v1/gems/rails.json",
+			body: `{"name":"rails","version":"8.1.3"}`, want: "8.1.3",
+		},
+		{
+			// Packagist returns versions NEWEST-FIRST, mixed with branch
+			// aliases (dev-master) and prereleases. Taking [0] blindly can
+			// yield "dev-main".
+			name: "packagist", eco: "composer", path: "/p2/monolog/monolog.json",
+			body: `{"packages":{"monolog/monolog":[
+				{"version":"dev-main"},
+				{"version":"3.11.0-RC1"},
+				{"version":"3.10.0"},
+				{"version":"3.9.0"}]}}`,
+			want: "3.10.0",
+		},
+		{
+			// NuGet returns ASCENDING versions INCLUDING prereleases, so the
+			// last element is frequently a beta. Verified against the live API:
+			// newtonsoft.json ends 13.0.4, 13.0.5-beta1 — versions[-1] is the
+			// beta and 13.0.4 is the answer.
+			name: "nuget", eco: "nuget", path: "/v3-flatcontainer/newtonsoft.json/index.json",
+			body: `{"versions":["13.0.3-beta1","13.0.3","13.0.4-beta1","13.0.4","13.0.5-beta1"]}`,
+			want: "13.0.4",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.path {
+					t.Errorf("requested %q, want %q", r.URL.Path, tc.path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := resolveLatest(tc.eco, pkgNameForPath(tc.path, tc.eco), srv.URL)
+			if err != nil {
+				t.Fatalf("resolveLatest: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("latest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// NuGet ids are case-insensitive but the flat-container path must be lowercase,
+// so a manifest saying `Newtonsoft.Json` has to become `newtonsoft.json` or the
+// request 404s and the package reports as un-checkable.
+func TestNugetResolver_LowercasesThePackageID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"versions":["13.0.4"]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := resolveLatest("nuget", "Newtonsoft.Json", srv.URL); err != nil {
+		t.Fatalf("resolveLatest: %v", err)
+	}
+	if gotPath != "/v3-flatcontainer/newtonsoft.json/index.json" {
+		t.Errorf("path = %q; the NuGet id must be lowercased", gotPath)
+	}
+}
+
+// A package with only prereleases published has no stable version. Returning
+// the prerelease anyway would push a beta into someone's manifest; returning
+// nothing is the honest answer and the planner treats it as "no update".
+func TestRegistryResolvers_NoStableRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"versions":["1.0.0-alpha","1.0.0-beta"]}`))
+	}))
+	defer srv.Close()
+
+	got, err := resolveLatest("nuget", "somepkg", srv.URL)
+	if err != nil {
+		t.Fatalf("resolveLatest: %v", err)
+	}
+	if got != "" {
+		t.Errorf("latest = %q — no stable release exists, so there is nothing to propose", got)
+	}
+}
+
+func TestDirectDeps_RubyGems(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "Gemfile", `
+source "https://rubygems.org"
+gem "rails", "~> 8.1"
+gem 'puma'
+gem "rspec", require: false
+`)
+	writeManifest(t, dir, "Gemfile.lock", `
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (8.1.3)
+    puma (6.4.2)
+    rspec (3.13.0)
+    concurrent-ruby (1.2.3)
+`)
+
+	byName := map[string]string{}
+	for _, d := range directDeps(dir) {
+		if d.eco == "rubygems" {
+			byName[d.name] = d.version
+		}
+	}
+	for name, want := range map[string]string{"rails": "8.1.3", "puma": "6.4.2", "rspec": "3.13.0"} {
+		if byName[name] != want {
+			t.Errorf("rubygems %s = %q, want %q", name, byName[name], want)
+		}
+	}
+	if _, ok := byName["concurrent-ruby"]; ok {
+		t.Error("concurrent-ruby is transitive but was reported as direct")
+	}
+}
+
+func TestDirectDeps_Composer(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "composer.json", `{
+	  "require":     { "monolog/monolog": "^3.0", "php": ">=8.1" },
+	  "require-dev": { "phpunit/phpunit": "^10.0" }
+	}`)
+	writeManifest(t, dir, "composer.lock", `{
+	  "packages":     [{"name":"monolog/monolog","version":"3.10.0"},
+	                   {"name":"psr/log","version":"3.0.0"}],
+	  "packages-dev": [{"name":"phpunit/phpunit","version":"10.5.0"}]
+	}`)
+
+	byName := map[string]string{}
+	for _, d := range directDeps(dir) {
+		if d.eco == "composer" {
+			byName[d.name] = d.version
+		}
+	}
+	if byName["monolog/monolog"] != "3.10.0" {
+		t.Errorf("monolog = %q, want 3.10.0", byName["monolog/monolog"])
+	}
+	if byName["phpunit/phpunit"] != "10.5.0" {
+		t.Errorf("phpunit = %q, want 10.5.0", byName["phpunit/phpunit"])
+	}
+	// "php" is a platform requirement, not a package — Packagist has no such
+	// entry and querying it would produce a spurious degraded line.
+	if _, ok := byName["php"]; ok {
+		t.Error("the php platform requirement was treated as a package")
+	}
+	if _, ok := byName["psr/log"]; ok {
+		t.Error("psr/log is transitive but was reported as direct")
+	}
+}
+
+// A resolver without an applier plans an upgrade nox cannot perform: the plan
+// prints, the operator agrees, and applyUpgrade then fails with "ecosystem not
+// supported". Worse, planRegistryCurrency reads the command name out of
+// supportedFixEcosystems, so a missing entry renders a plan line with an empty
+// command.
+//
+// This is the same declared-but-dead shape as the fail-on-degraded action input
+// and the GITHUB_TOKEN that action.yml never mapped: two halves that must agree
+// and nothing connecting them. Fail the build instead.
+func TestEveryCurrencyEcosystemCanAlsoApply(t *testing.T) {
+	for eco := range registryBase {
+		if supportedFixEcosystems[eco] == "" {
+			t.Errorf("ecosystem %q has a currency resolver but no entry in "+
+				"supportedFixEcosystems, so --outdated would plan an upgrade it cannot apply", eco)
+		}
+	}
+	// Go resolves through the toolchain rather than a registry, so it is absent
+	// from registryBase but must still be appliable.
+	if supportedFixEcosystems["go"] == "" {
+		t.Error("go lost its applier")
+	}
+}
+
+// NuGet declares direct dependencies as <PackageReference> in the project file,
+// and there is no lockfile in a default project — the Include/Version pair IS
+// the resolved version, so unlike npm or Cargo there is no second file to read.
+func TestDirectDeps_NuGet(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "App.csproj", `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <ProjectReference Include="../Other/Other.csproj" />
+  </ItemGroup>
+</Project>`)
+
+	byName := map[string]string{}
+	for _, d := range directDeps(dir) {
+		if d.eco == "nuget" {
+			byName[d.name] = d.version
+		}
+	}
+	if byName["Newtonsoft.Json"] != "13.0.3" {
+		t.Errorf("Newtonsoft.Json = %q, want 13.0.3", byName["Newtonsoft.Json"])
+	}
+	if byName["Serilog"] != "3.1.1" {
+		t.Errorf("Serilog = %q, want 3.1.1", byName["Serilog"])
+	}
+	// A ProjectReference is a sibling project, not a package.
+	if _, ok := byName["../Other/Other.csproj"]; ok {
+		t.Error("a ProjectReference was treated as a NuGet package")
+	}
+}
+
+// crates.io answers HTTP 403 to requests without a descriptive User-Agent, and
+// Go's http.Client sends none by default. Every cargo lookup failed against the
+// live registry while passing against every stub here — the second bug in this
+// file that only a real request could surface.
+func TestResolvers_SendAUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte(`{"crate":{"max_stable_version":"1.0.0"}}`))
+	}))
+	defer srv.Close()
+
+	if _, err := resolveLatest("cargo", "serde", srv.URL); err != nil {
+		t.Fatalf("resolveLatest: %v", err)
+	}
+	if !strings.Contains(gotUA, "nox") {
+		t.Errorf("User-Agent = %q; crates.io 403s anonymous clients", gotUA)
 	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -543,21 +543,25 @@ currency upgrades are reported as `OUTDATED`, never as `VULN-001`.
 
 Scope and guarantees:
 
-- **Go, npm, PyPI and Cargo.** Go resolves through `go list -m -u -json all`,
-  which already understands replace directives, retractions and the module
-  graph. The others query their own registry (`registry.npmjs.org`, `pypi.org`,
-  `crates.io`) directly, so planning needs no toolchain — only *applying* an
-  upgrade shells out to `npm`/`pip`/`cargo`. Maven, Gradle, NuGet, Composer and
-  RubyGems are parsed by the scanner but have no currency resolver yet; they are
-  reported as such rather than silently ignored.
-- **Latest STABLE, never a prerelease.** npm publishes channels under
-  `dist-tags` where only `latest` is stable, and crates.io reports both
-  `max_version` (which includes prereleases) and `max_stable_version`. Picking
-  the wrong field would quietly propose a beta.
+- **Seven ecosystems:** Go, npm, PyPI, Cargo, RubyGems, Composer and NuGet. Go
+  resolves through `go list -m -u -json all`, which already understands replace
+  directives, retractions and the module graph. The rest query their own
+  registry directly, so planning needs no toolchain — only *applying* an upgrade
+  shells out to `npm` / `pip` / `cargo` / `bundle` / `composer` / `dotnet`.
+  Maven and Gradle are parsed by the scanner but have no currency resolver:
+  `maven-metadata.xml` has no single "latest stable" and Gradle has no canonical
+  upgrade command, so they are reported as unresolved rather than guessed at.
+- **Latest STABLE, never a prerelease.** Every registry expresses this
+  differently and most of them invite the wrong answer: npm publishes channels
+  under `dist-tags` where only `latest` is stable; crates.io reports
+  `max_version` (including prereleases) beside `max_stable_version`; Packagist
+  returns newest-first but mixes in `dev-<branch>` aliases; and NuGet returns an
+  *ascending* list with prereleases interleaved, so its last element is often a
+  beta. A package with no stable release yields no suggestion at all.
 - **Direct dependencies only.** Indirect ones belong to the lockfile resolver —
   bumping them writes explicit requirements for packages you do not import.
   Directness comes from the *manifest* (`go.mod`, `package.json`, `Cargo.toml`,
-  `requirements.txt`); the resolved current version comes from the lockfile,
+  `requirements.txt`, `Gemfile`, `composer.json`, `*.csproj`); the resolved current version comes from the lockfile,
   because a manifest range like `^4.18.0` is not a version. A range with no
   lockfile entry is skipped rather than assigned a version it does not have.
 - **Never downgrades.** A replace directive or retracted version can make

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -543,14 +543,30 @@ currency upgrades are reported as `OUTDATED`, never as `VULN-001`.
 
 Scope and guarantees:
 
-- **Go only.** `go list -m -u -json all` is an authoritative answer to "what is
-  newer"; other ecosystems are not guessed at.
-- **Direct dependencies only.** Indirect ones are `go mod tidy`'s business —
+- **Go, npm, PyPI and Cargo.** Go resolves through `go list -m -u -json all`,
+  which already understands replace directives, retractions and the module
+  graph. The others query their own registry (`registry.npmjs.org`, `pypi.org`,
+  `crates.io`) directly, so planning needs no toolchain — only *applying* an
+  upgrade shells out to `npm`/`pip`/`cargo`. Maven, Gradle, NuGet, Composer and
+  RubyGems are parsed by the scanner but have no currency resolver yet; they are
+  reported as such rather than silently ignored.
+- **Latest STABLE, never a prerelease.** npm publishes channels under
+  `dist-tags` where only `latest` is stable, and crates.io reports both
+  `max_version` (which includes prereleases) and `max_stable_version`. Picking
+  the wrong field would quietly propose a beta.
+- **Direct dependencies only.** Indirect ones belong to the lockfile resolver —
   bumping them writes explicit requirements for packages you do not import.
+  Directness comes from the *manifest* (`go.mod`, `package.json`, `Cargo.toml`,
+  `requirements.txt`); the resolved current version comes from the lockfile,
+  because a manifest range like `^4.18.0` is not a version. A range with no
+  lockfile entry is skipped rather than assigned a version it does not have.
 - **Never downgrades.** A replace directive or retracted version can make
   `go list` report an "update" that is not newer; those are dropped.
 - **Major bumps held** unless `--include-major`, and counted so you can see
   something is waiting.
+- **A registry that cannot answer is reported, not assumed current.** An
+  unreachable or rate-limiting registry produces a `degraded:` line, never a
+  silent "up to date" — the same contract as scan degradations.
 - **Reaches the network.** This is the one thing that cannot be answered
   offline. It runs only behind this flag, never as part of a scan, so nox's
   offline-first scanning guarantee is unaffected.


### PR DESCRIPTION
`--outdated` shipped Go-only in 1.20.0. This brings it to the three ecosystems `applyUpgrade` already drives, so the flag covers everything `nox fix` could already upgrade instead of a quarter of it.

## Why the deps analyzer couldn't just be reused

**Directness.** `deps.Package` is parsed from *lockfiles* — flat, and containing the whole transitive closure. There is no `Direct` field. Upgrading a transitive package writes an explicit requirement for something the project never imports.

So names come from the **manifest** (`package.json`, `Cargo.toml`, `requirements.txt`) and resolved versions from the **lockfile** — because a manifest range like `^4.18.0` is not a version. A range with no lockfile entry is skipped rather than assigned a version it doesn't have.

**Latest version**, which only a registry can answer. Queried directly rather than shelling out, so planning needs no toolchain; *applying* still uses the native command, which is where a toolchain belongs.

## The traps, each pinned by a test

- **Prereleases.** npm publishes channels under `dist-tags` where only `latest` is stable; crates.io reports `max_version` (including prereleases) *and* `max_stable_version`. Picking the wrong field silently proposes a beta.
- **Silence-as-success.** A registry that 429s or is unreachable produces a `degraded:` line, never `""` — an empty string is indistinguishable from "already current", so one rate-limited registry would report a whole project as up to date. The "all current" message is suppressed when any check failed.

## The bug that only a live run found

npm's full packument for `typescript` and `@types/node` each exceed 8 MB, truncating the read:

```
degraded: … npm/@types/node: parsing npm response: unexpected end of JSON input
degraded: … npm/typescript:  parsing npm response: unexpected end of JSON input
```

Every dependency in `editors/vscode` reported un-checkable. No stub was ever big enough to catch it. Fixed by requesting the **abbreviated** document rather than by raising a size ceiling — with a test asserting the header is actually sent, since the failure mode is a size no test will reproduce.

## Verification

Against the real `editors/vscode`: all four dependencies resolve, and I confirmed the "current" verdict by hand rather than trusting it — lockfile vs npm `dist-tags`:

```
typescript           7.0.2   == latest 7.0.2
@types/node         26.1.1   == latest 26.1.1
vscode-languageclient 10.1.0 == latest 10.1.0
```

Nine tests. Three guards mutation-checked: dropping the abbreviated header, treating non-200 as empty, and using cargo's `max_version`.

## Not yet covered

Maven, Gradle, NuGet, Composer and RubyGems are parsed by the scanner but have **no** currency resolver — and no `applyUpgrade` support either, so adding a resolver alone would plan upgrades it cannot apply. Documented rather than silently absent.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj