### PR TITLE
fix(outdated): report what was not checked instead of implying it was

### DIFF
--- a/cli/fix_outdated.go
+++ b/cli/fix_outdated.go
@@ -144,7 +144,7 @@ func runOutdatedFix(manifestRoot string, dryRun, includeMajor bool) int {
 	if _, statErr := os.Stat(filepath.Join(manifestRoot, "go.mod")); statErr == nil {
 		mods, err := goListModules(manifestRoot)
 		if err != nil {
-			degraded = append(degraded, fmt.Sprintf("go: %v", err))
+			degraded = append(degraded, fmt.Sprintf("could not enumerate Go modules: %v", err))
 		} else {
 			goPlan := planCurrencyUpgrades(mods, includeMajor)
 			plan.actions = append(plan.actions, goPlan.actions...)
@@ -164,7 +164,7 @@ func runOutdatedFix(manifestRoot string, dryRun, includeMajor bool) int {
 	// short list is never mistaken for a clean bill of health. This is the same
 	// contract as the scan degradations model.
 	for _, d := range degraded {
-		fmt.Fprintf(os.Stderr, "degraded: could not determine the latest version — %s\n", d)
+		fmt.Fprintf(os.Stderr, "degraded: %s\n", d)
 	}
 
 	if len(plan.actions) == 0 {

--- a/cli/outdated_registry.go
+++ b/cli/outdated_registry.go
@@ -244,14 +244,85 @@ func pkgNameForPath(path, eco string) string {
 // rather than failing: a repo with a broken package.json should still get its
 // Cargo dependencies checked.
 func directDeps(root string) []directDep {
-	var out []directDep
-	out = append(out, npmDirectDeps(root)...)
-	out = append(out, cargoDirectDeps(root)...)
-	out = append(out, pypiDirectDeps(root)...)
-	out = append(out, rubygemsDirectDeps(root)...)
-	out = append(out, composerDirectDeps(root)...)
-	out = append(out, nugetDirectDeps(root)...)
-	return out
+	deps, _ := directDepsWithNotes(root)
+	return deps
+}
+
+// manifestForEco names the file that declares direct dependencies for each
+// registry-resolved ecosystem, so their presence can be reported on.
+var manifestForEco = map[string]string{
+	"npm":      "package.json",
+	"cargo":    "Cargo.toml",
+	"pypi":     "requirements.txt",
+	"rubygems": "Gemfile",
+	"composer": "composer.json",
+}
+
+// directDepsWithNotes enumerates direct dependencies and returns notes about
+// anything it could NOT check.
+//
+// Both notes matter for the same reason. A manifest that exists but does not
+// parse drops its whole ecosystem from the run, and a tree with no manifests at
+// all was never checked in the first place — reporting either as "all
+// dependencies are current" is the reassuring-but-empty result this project has
+// had to dig out of CI repeatedly. "Report what you could not check" is the
+// scan degradations contract; it applies here too.
+func directDepsWithNotes(root string) (deps []directDep, notes []string) {
+	deps = append(deps, npmDirectDeps(root)...)
+	deps = append(deps, cargoDirectDeps(root)...)
+	deps = append(deps, pypiDirectDeps(root)...)
+	deps = append(deps, rubygemsDirectDeps(root)...)
+	deps = append(deps, composerDirectDeps(root)...)
+	deps = append(deps, nugetDirectDeps(root)...)
+
+	// A manifest on disk that yielded nothing is either empty or unparseable.
+	// Either way the operator should hear about it rather than lose the
+	// ecosystem silently.
+	found := 0
+	for eco, file := range manifestForEco {
+		if readIfPresent(filepath.Join(root, file)) == nil {
+			continue
+		}
+		found++
+		sawEco := false
+		for _, d := range deps {
+			if d.eco == eco {
+				sawEco = true
+				break
+			}
+		}
+		if !sawEco {
+			notes = append(notes, fmt.Sprintf("%s exists but no dependencies could be read from it", file))
+		}
+	}
+	if hasGoMod(root) || hasProjectFile(root) {
+		found++
+	}
+	if found == 0 {
+		notes = append(notes, fmt.Sprintf("no supported manifest found in %s — nothing was checked", root))
+	}
+	return deps, notes
+}
+
+func hasGoMod(root string) bool {
+	_, err := os.Stat(filepath.Join(root, "go.mod"))
+	return err == nil
+}
+
+// hasProjectFile reports whether a .NET project file is present. NuGet has no
+// single canonical manifest name, so it is detected by extension.
+func hasProjectFile(root string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		n := e.Name()
+		if !e.IsDir() && (strings.HasSuffix(n, ".csproj") || strings.HasSuffix(n, ".fsproj") || strings.HasSuffix(n, ".vbproj")) {
+			return true
+		}
+	}
+	return false
 }
 
 func readIfPresent(path string) []byte {
@@ -396,7 +467,9 @@ func pypiDirectDeps(root string) []directDep {
 // degradation string so the caller can print them, matching nox's "report what
 // you could not check" model.
 func planRegistryCurrency(root string, includeMajor bool, base map[string]string) (plan upgradePlan, degraded []string) {
-	for _, d := range directDeps(root) {
+	deps, notes := directDepsWithNotes(root)
+	degraded = append(degraded, notes...)
+	for _, d := range deps {
 		if d.version == "" {
 			// A range pin with no lockfile entry: there is no single current
 			// version to compare, so there is nothing honest to say.
@@ -405,7 +478,7 @@ func planRegistryCurrency(root string, includeMajor bool, base map[string]string
 		}
 		latest, err := resolveLatest(d.eco, d.name, base[d.eco])
 		if err != nil {
-			degraded = append(degraded, fmt.Sprintf("%s/%s: %v", d.eco, d.name, err))
+			degraded = append(degraded, fmt.Sprintf("could not determine the latest version of %s %s: %v", d.eco, d.name, err))
 			continue
 		}
 		if latest == "" || !versionLess(d.version, latest) {

--- a/cli/outdated_registry_test.go
+++ b/cli/outdated_registry_test.go
@@ -476,3 +476,47 @@ func TestResolvers_SendAUserAgent(t *testing.T) {
 		t.Errorf("User-Agent = %q; crates.io 403s anonymous clients", gotUA)
 	}
 }
+
+// "all direct dependencies are current" on a tree with no manifests is the
+// exact failure this project keeps finding elsewhere: a reassuring message
+// where nothing was actually checked. There is a real difference between
+// "checked seven ecosystems, everything current" and "found nothing to check".
+func TestDirectDeps_ReportsWhenNoManifestExists(t *testing.T) {
+	_, notes := directDepsWithNotes(t.TempDir())
+	if len(notes) == 0 {
+		t.Fatal("an empty directory produced no note; --outdated would report it as all-current")
+	}
+	joined := strings.Join(notes, " ")
+	if !strings.Contains(joined, "no supported manifest") {
+		t.Errorf("note does not say a manifest was missing: %q", joined)
+	}
+}
+
+// A manifest that exists but cannot be parsed must be reported, not skipped.
+// Silently dropping it means the ecosystem disappears from the run while the
+// summary still reads as a clean result.
+func TestDirectDeps_ReportsUnparseableManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "package.json", `{ this is not json`)
+	// A valid second ecosystem, to prove one broken manifest does not stop the
+	// others being checked.
+	writeManifest(t, dir, "Cargo.toml", "[package]\nname=\"x\"\n\n[dependencies]\nserde = \"1.0.100\"\n")
+	writeManifest(t, dir, "Cargo.lock", "[[package]]\nname = \"serde\"\nversion = \"1.0.100\"\n")
+
+	deps, notes := directDepsWithNotes(dir)
+
+	var sawCargo bool
+	for _, d := range deps {
+		if d.eco == "cargo" && d.name == "serde" {
+			sawCargo = true
+		}
+	}
+	if !sawCargo {
+		t.Error("a broken package.json stopped Cargo from being checked")
+	}
+
+	joined := strings.Join(notes, " ")
+	if !strings.Contains(joined, "package.json") {
+		t.Errorf("the unparseable package.json was dropped silently: %q", joined)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -568,9 +568,13 @@ Scope and guarantees:
   `go list` report an "update" that is not newer; those are dropped.
 - **Major bumps held** unless `--include-major`, and counted so you can see
   something is waiting.
-- **A registry that cannot answer is reported, not assumed current.** An
-  unreachable or rate-limiting registry produces a `degraded:` line, never a
-  silent "up to date" — the same contract as scan degradations.
+- **Anything unchecked is reported, not assumed current.** An unreachable or
+  rate-limiting registry, a manifest that exists but cannot be parsed, and a
+  directory with no supported manifest at all each produce a `degraded:` line —
+  and the "all dependencies are current" message is suppressed whenever one
+  appears. There is a real difference between "checked seven ecosystems and
+  everything is current" and "found nothing to check", and only one of them is
+  good news. Same contract as scan degradations.
 - **Reaches the network.** This is the one thing that cannot be answered
   offline. It runs only behind this flag, never as part of a scan, so nox's
   offline-first scanning guarantee is unaffected.


### PR DESCRIPTION
Two cases where `--outdated` printed **"all direct dependencies are current"** having checked nothing. Found while exercising it on real trees before cutting 1.21.0.

## 1. No manifest at all

```
$ nox fix --outdated --root /tmp/empty
nox fix --outdated: all direct dependencies are current.
```

Nothing was examined. There were no dependencies to examine. This is the reassuring-but-empty result this project keeps finding in its own CI — a green line standing in for an absent check.

## 2. An unparseable manifest disappears silently

A deliberately broken `package.json` beside a valid `Cargo.toml`:

```
plan: cargo update serde 1.0.100 -> 1.0.229  (OUTDATED)
```

Correct Cargo plan, and **no mention of npm at all**. The output looks like a complete run of a smaller project.

## After

```
degraded: no supported manifest found in /tmp/empty — nothing was checked
nox fix --outdated: no upgrades found, but 1 dependency check(s) could not complete (see above).

degraded: package.json exists but no dependencies could be read from it
plan: cargo update serde 1.0.100 -> 1.0.229  (OUTDATED)
```

The all-current message is suppressed whenever any check failed. One broken manifest still doesn't stop the other ecosystems — the point is to report the loss, not fail the run.

Also reworded the degraded prefix, which hard-coded "could not determine the latest version" and read as nonsense for a missing manifest.

## On the mutation checks

Both guards are mutation-checked, but the first attempt at the second one is worth recording: deleting the block left an unused variable and **failed to compile**. A mutation that doesn't build proves nothing about the test. Inverting the condition (`if !sawEco` → `if sawEco`) is the mutation that actually exercises the assertion, and that one does fail the test.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj