### PR TITLE
feat(secrets): add `nox verify-secrets` — is the credential still live?

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -256,6 +256,8 @@ func run(args []string) int {
 		return runInstallHook(remaining[1:])
 	case "fix":
 		return runFix(remaining[1:])
+	case "verify-secrets":
+		return runVerifySecrets(remaining[1:])
 	case "variants":
 		return runVariants(remaining[1:])
 	case "doctor":

--- a/cli/verify_secrets.go
+++ b/cli/verify_secrets.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Secret validity checking: does a detected credential still work?
+//
+// A detected secret and a LIVE secret are different findings. "This looks like
+// a GitHub token" is a backlog item; "this is a working token for account X" is
+// an incident, because the credential is already public and the only fix is
+// rotation. Only the issuer can tell those apart — and, usefully, the check
+// needs no privilege beyond the leaked credential itself.
+//
+// This is deliberately NOT revocation. Revoking requires a credential more
+// privileged than the one that leaked, which would make nox a holder of admin
+// credentials for every provider in the stack and a better target than the leak
+// it defends against. See docs/usage.md.
+//
+// TWO PROPERTIES HOLD THIS FEATURE TOGETHER, and both are enforced by tests:
+//
+//  1. ENDPOINTS ARE COMPILED IN. Verification transmits a live credential to a
+//     third party, which is defensible only because that party is the issuer.
+//     A configurable endpoint would make `--verify-secrets` an exfiltration
+//     primitive built into a security scanner: point it at a host you control
+//     and every secret in the repository is delivered to you. There is no flag,
+//     config key or environment variable that redirects these.
+//
+//  2. THE SECRET NEVER APPEARS IN OUTPUT. Not in a log line, a message, or a
+//     report. The point is to report that a credential works, not to reproduce
+//     it somewhere new.
+//
+// nox does not keep secrets in findings.json — a finding carries a file and a
+// column range, nothing more — so verification re-reads the file at the
+// recorded location. That keeps findings.json shareable, which is worth not
+// losing.
+
+type validity int
+
+const (
+	validityUnknown validity = iota
+	validityLive
+	validityDead
+)
+
+func (v validity) String() string {
+	switch v {
+	case validityLive:
+		return "LIVE"
+	case validityDead:
+		return "revoked"
+	}
+	return "unknown"
+}
+
+var verifyClient = &http.Client{Timeout: 15 * time.Second}
+
+// extractSecretAt re-reads the literal a finding points at.
+//
+// Returns an error rather than a best guess when the location does not fit the
+// file: a stale scan, or a file edited since, would otherwise have whatever text
+// now occupies those columns sent to a third party as if it were the secret.
+func extractSecretAt(path string, line, startCol, endCol int) (string, error) {
+	if line < 1 || startCol < 1 || endCol < startCol {
+		return "", fmt.Errorf("invalid location %s:%d:%d-%d", path, line, startCol, endCol)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8<<20)
+	for n := 1; sc.Scan(); n++ {
+		if n != line {
+			continue
+		}
+		text := sc.Text()
+		if startCol > len(text) || endCol > len(text)+1 {
+			return "", fmt.Errorf("%s:%d has %d columns, finding names %d-%d", path, line, len(text), startCol, endCol)
+		}
+		return text[startCol-1 : endCol-1], nil
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("%s has fewer than %d lines", path, line)
+}
+
+// verifyGitHubToken asks GitHub whether a token still authenticates.
+//
+// GET /user is the cheapest authenticated call: 200 means the credential works,
+// 401 means it does not. Anything else — rate limiting, an outage — is NOT
+// evidence in either direction and must report unknown. Reporting "revoked" on
+// a 403 would tell someone a live, public credential is safe to ignore.
+//
+// The base URL parameter exists for tests. It is not reachable from any flag or
+// configuration; callers in production pass githubAPI.
+func verifyGitHubToken(token, base string) (result validity, detail string) {
+	if base == "" {
+		base = githubAPI
+	}
+	req, err := http.NewRequest(http.MethodGet, base+"/user", http.NoBody)
+	if err != nil {
+		return validityUnknown, "could not build request"
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "nox (+https://github.com/nox-hq/nox)")
+
+	resp, err := verifyClient.Do(req)
+	if err != nil {
+		// Deliberately not %w or %v on anything holding the token: a URL error
+		// can carry the request, and the request carries the credential.
+		return validityUnknown, "could not reach the GitHub API"
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return validityLive, "authenticates against the GitHub API"
+	case http.StatusUnauthorized:
+		return validityDead, "rejected by the GitHub API"
+	default:
+		return validityUnknown, fmt.Sprintf("GitHub API answered HTTP %d — not evidence either way", resp.StatusCode)
+	}
+}
+
+// githubAPI is compiled in. See property (1) in the file comment: this must not
+// become configurable.
+const githubAPI = "https://api.github.com"
+
+// verifiableRules maps a rule to the provider that can confirm its findings.
+// Only rules whose pattern identifies a single issuer belong here — a generic
+// "high entropy string" rule has nobody to ask.
+var verifiableRules = map[string]string{
+	"SEC-003": "github",
+	"SEC-213": "github",
+	"SEC-435": "github",
+	"SEC-495": "github",
+	"SEC-496": "github",
+}
+
+// verifySecret dispatches to the issuer for a rule nox knows how to check.
+func verifySecret(ruleID, secret string) (result validity, detail string) {
+	if verifiableRules[ruleID] == "github" {
+		return verifyGitHubToken(secret, "")
+	}
+	return validityUnknown, "no verifier for this rule"
+}
+
+// redactedPrefix renders a secret for human output without reproducing enough
+// of it to be useful. Kept short deliberately: the first few characters of a
+// GitHub token are a fixed provider prefix and carry no entropy.
+func redactedPrefix(secret string) string {
+	if i := strings.IndexByte(secret, '_'); i > 0 && i < 6 {
+		return secret[:i+1] + "…"
+	}
+	if len(secret) > 4 {
+		return secret[:4] + "…"
+	}
+	return "…"
+}
+
+// runVerifySecrets is the `nox verify-secrets` entry point.
+//
+// Opt-in as a separate command rather than a scan flag, because it does
+// something a scan never does: sends a credential over the network. That should
+// require typing, not inherit from a habit.
+func runVerifySecrets(args []string) int {
+	fs := flag.NewFlagSet("verify-secrets", flag.ContinueOnError)
+	var inputPath, root string
+	fs.StringVar(&inputPath, "input", "findings.json", "path to findings.json from a previous scan")
+	fs.StringVar(&root, "root", ".", "directory the scan was run against, used to resolve finding paths")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	raw, err := os.ReadFile(inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: reading %s: %v\n", inputPath, err)
+		return 2
+	}
+	var doc struct {
+		Findings []findings.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "error: parsing %s: %v\n", inputPath, err)
+		return 2
+	}
+
+	var checked, live int
+	var unverifiable int
+	for i := range doc.Findings {
+		f := &doc.Findings[i]
+		if verifiableRules[f.RuleID] == "" {
+			if strings.HasPrefix(f.RuleID, "SEC-") {
+				unverifiable++
+			}
+			continue
+		}
+		path := f.Location.FilePath
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, path)
+		}
+		secret, err := extractSecretAt(path, f.Location.StartLine, f.Location.StartColumn, f.Location.EndColumn)
+		if err != nil {
+			fmt.Printf("  %-8s %-30s could not re-read the secret: %v\n", f.RuleID, f.Location.FilePath, err)
+			continue
+		}
+		checked++
+		v, detail := verifySecret(f.RuleID, secret)
+		if v == validityLive {
+			live++
+		}
+		fmt.Printf("  %-8s %-30s %-8s %s (%s)\n",
+			f.RuleID, fmt.Sprintf("%s:%d", f.Location.FilePath, f.Location.StartLine),
+			v, detail, redactedPrefix(secret))
+	}
+
+	fmt.Printf("\nchecked %d credential(s); %d still authenticate\n", checked, live)
+	if unverifiable > 0 {
+		fmt.Printf("%d secret finding(s) have no issuer nox can ask — detection only\n", unverifiable)
+	}
+	// A live credential in a repository is already public. Exit non-zero so a
+	// pipeline can act on it without parsing output.
+	if live > 0 {
+		fmt.Println("\nA live credential in version control is compromised. Rotate it at the provider;")
+		fmt.Println("removing the file does not invalidate the key.")
+		return 1
+	}
+	return 0
+}

--- a/cli/verify_secrets_test.go
+++ b/cli/verify_secrets_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A detected secret and a LIVE secret are different findings. "This looks like
+// a GitHub token" is a backlog item; "this is a working GitHub token for user
+// X" is an incident. Only the issuer can tell them apart, and the check needs
+// no privilege beyond the leaked credential itself.
+//
+// nox deliberately does not keep the secret in findings.json — a finding
+// carries only a file and column range — so verification re-reads the file at
+// the recorded location. That keeps findings.json shareable, which is a
+// property worth not losing.
+
+func TestExtractSecretAtLocation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cfg.go")
+	body := "package main\n\nconst tok = \"ghp_" + strings.Repeat("A", 36) + "\"\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Columns as the secrets analyzer reports them: 1-based within the LINE,
+	// end exclusive. Verified against a real finding: an AKIA key alone on a
+	// line reports StartColumn 1, EndColumn 21 for 20 characters.
+	line3 := strings.Split(body, "\n")[2]
+	start := strings.Index(line3, "ghp_") + 1
+	got, err := extractSecretAt(p, 3, start, start+40)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if got != "ghp_"+strings.Repeat("A", 36) {
+		t.Errorf("extracted %q, want the token literal", got)
+	}
+}
+
+// A finding whose location no longer matches the file — because the secret was
+// removed, or the scan is stale — must not silently verify whatever text now
+// occupies those columns.
+func TestExtractSecretAtLocation_OutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "small.txt")
+	if err := os.WriteFile(p, []byte("short\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := extractSecretAt(p, 99, 1, 40); err == nil {
+		t.Error("a line past end-of-file produced no error")
+	}
+	if _, err := extractSecretAt(p, 1, 1, 400); err == nil {
+		t.Error("a column past end-of-line produced no error")
+	}
+}
+
+// THE security property of this feature. Verification transmits a live
+// credential to a third party, which is only defensible when that party is the
+// issuer. If the endpoint were configurable, `--verify-secrets` would be an
+// exfiltration primitive built into a security scanner: point it at a host you
+// control and every secret in the repo is delivered to you.
+//
+// So endpoints are compiled in, per provider, and there is no flag, config key
+// or environment variable that redirects them.
+func TestVerifierEndpointsAreNotConfigurable(t *testing.T) {
+	src, err := os.ReadFile("verify_secrets.go")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	text := string(src)
+
+	for _, forbidden := range []string{
+		"os.Getenv", "flag.String", "cfg.", "Endpoint =", "baseURL =",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("verify_secrets.go contains %q — the verification endpoint must not be "+
+				"redirectable, or this becomes a way to exfiltrate every secret in the repo", forbidden)
+		}
+	}
+	// Each provider's host must appear as a literal.
+	for _, host := range []string{"api.github.com"} {
+		if !strings.Contains(text, host) {
+			t.Errorf("no compiled-in endpoint for %s", host)
+		}
+	}
+}
+
+func TestVerifyGitHubToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   validity
+	}{
+		{"live token", http.StatusOK, `{"login":"octocat"}`, validityLive},
+		{"revoked token", http.StatusUnauthorized, `{"message":"Bad credentials"}`, validityDead},
+		// Rate limiting is not evidence either way. Reporting "dead" here would
+		// tell someone a live credential is safe to ignore.
+		{"rate limited", http.StatusForbidden, `{"message":"rate limit"}`, validityUnknown},
+		{"server error", http.StatusInternalServerError, ``, validityUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Authorization"); got != "Bearer ghp_test" {
+					t.Errorf("Authorization = %q, want the token as a bearer credential", got)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, _ := verifyGitHubToken("ghp_test", srv.URL)
+			if got != tc.want {
+				t.Errorf("validity = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A live credential must never reach a log line, a finding message, or stdout.
+// The whole point is to report that a secret works, not to reproduce it.
+func TestVerificationOutputNeverContainsTheSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"login":"octocat"}`))
+	}))
+	defer srv.Close()
+
+	secret := "ghp_" + strings.Repeat("S", 36)
+	_, detail := verifyGitHubToken(secret, srv.URL)
+	if strings.Contains(detail, secret) {
+		t.Errorf("the verification detail echoes the secret: %q", detail)
+	}
+	if strings.Contains(detail, "ghp_SSSS") {
+		t.Errorf("the detail contains a recognisable prefix of the secret: %q", detail)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -532,6 +532,49 @@ not a feature — there is nothing for a scanner to implement. If you want
 automatic revocation, enable GitHub secret scanning alongside nox; the two do
 not overlap on this point.
 
+#### `nox verify-secrets`: is the credential still live?
+
+What nox *can* do is ask the issuer whether a detected credential still works,
+using the leaked credential itself — which needs no privilege beyond what is
+already public.
+
+```bash
+nox scan . -format json -output out
+nox verify-secrets --input out/findings.json
+```
+
+```
+  SEC-003  config/app.js:1   LIVE   authenticates against the GitHub API (ghp_…)
+
+checked 1 credential(s); 1 still authenticate
+```
+
+That distinction is the difference between a backlog item and an incident. "This
+looks like a GitHub token" can wait; "this is a working token" cannot, because
+the credential is already public and removing the file does not invalidate it.
+Exit status is 1 when anything still authenticates, so a pipeline can act on it
+without parsing output.
+
+Two properties are deliberate and enforced by tests:
+
+- **The endpoints are compiled in.** Verification sends a live credential to a
+  third party, which is defensible only because that party is the issuer. If the
+  endpoint were configurable, this command would be a way to exfiltrate every
+  secret in a repository — point it at a host you control and they are delivered
+  to you. No flag, config key or environment variable redirects them.
+- **The secret never appears in output.** Reports show a provider prefix and an
+  ellipsis. The point is to report that a credential works, not to reproduce it
+  somewhere new.
+
+Anything other than a clear yes or no — rate limiting, an outage — reports
+`unknown`. Calling a live credential `revoked` because the issuer was briefly
+unreachable would be worse than not checking at all.
+
+Currently covers GitHub tokens (`SEC-003`, `SEC-213`, `SEC-435`, `SEC-495`,
+`SEC-496`). AWS is absent on purpose: verifying an AWS key requires SigV4
+request signing and the paired secret access key, which is a different shape of
+work rather than another entry in a table.
+
 So: a clean `fix` run means the remediable classes were handled. It is not a
 statement that the SAST findings were.
 


### PR DESCRIPTION
The capability gap found while auditing nox against GitHub's security features. nox detects secrets well — 1,164 `SEC-*` rules, plus `-history` for past commits. What it couldn't say is whether a detected credential **still works**.

That distinction is the difference between a backlog item and an incident. *"This looks like a GitHub token"* can wait. *"This is a working token"* cannot, because the credential is already public and deleting the file doesn't invalidate it.

```bash
nox scan . -format json -output out
nox verify-secrets --input out/findings.json
```

```
  SEC-003  config/app.js:1   LIVE   authenticates against the GitHub API (ghp_…)

checked 1 credential(s); 1 still authenticate
```

Exit 1 when anything authenticates, so a pipeline can act without parsing output.

## Explicitly not revocation

Revoking requires calling the provider's API with *another* credential, usually more privileged than the one that leaked. A nox that could revoke your AWS keys is a nox holding AWS admin credentials — a better target than the leak it defends against. This asks the issuer a question using the already-public credential; it needs no privilege at all.

## Two properties hold this together

**1. Endpoints are compiled in.** Verification sends a live credential to a third party, defensible *only* because that party is the issuer. If the endpoint were configurable, this command would be an exfiltration primitive inside a security scanner — point it at a host you control and every secret in the repo is delivered to you.

A test greps the source for `os.Getenv`, `flag.String`, and assignment to the endpoint, failing the build on any of them.

**2. The secret never appears in output.** Not in a message, not in an error. The transport failure is deliberately *not* wrapped with `%w` — a `url.Error` carries the request, and the request carries the credential.

**Uncertainty is reported as uncertainty.** Rate limiting or an outage reports `unknown`. Treating a 403 as `revoked` would tell someone a live, public credential is safe to ignore — worse than not checking.

## Design note

`findings.json` deliberately contains no secrets — a finding carries a file and column range. Verification re-reads the file at that location, preserving the property that findings are shareable. A location that no longer fits the file is an **error**, not a best guess: otherwise whatever text now occupies those columns gets sent to a third party as if it were the secret.

## Verification

End-to-end against a real scan: `SEC-003` at `app.js:1:16-56` → re-read → submitted → 401 → reported `revoked`, secret redacted to `ghp_…`. That exercises the real column arithmetic against a real finding, which is where I'd expect an off-by-one.

Three guards mutation-checked: non-200-as-dead, echoing the secret, and making the endpoint env-configurable — each fails its test.

**The LIVE path is unit-tested, not end-to-end.** That is a direct consequence of the endpoint being non-redirectable, and I'd rather have the property than the test.

## Scope

GitHub tokens only (`SEC-003`, `SEC-213`, `SEC-435`, `SEC-495`, `SEC-496`). AWS needs SigV4 signing and the paired secret access key — a different shape of work, not another table entry. Slack, Stripe and npm are simple bearer checks and would slot into `verifiableRules` directly.

https://claude.ai/code/session_015gJyQQVf63eTLrzRnsVySj