### PR TITLE
fix(vex): accept OpenVEX v0.2.0, and smoke-test the binary before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,143 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
+      # Smoke-test the built binary before publishing it.
+      #
+      # WHY: twice this month a release shipped in which `nox scan` did not run
+      # AT ALL, rather than running and reporting something wrong:
+      #
+      #   - `nox plugin install nox/taint-analysis@*` began 404ing, and the
+      #     install step precedes the scan, so 15 downstream repos ran a dead
+      #     security job for a week before anyone noticed;
+      #   - `-vex` rejected a spec-current OpenVEX v0.2.0 document (#389),
+      #     failing at load time with exit 2 before scanning anything.
+      #
+      # Neither produced a wrong finding. Both produced NO findings — which is
+      # strictly worse, because an empty report is indistinguishable from a
+      # clean one at a glance, and both surfaced only on upgrade, when a user is
+      # least likely to suspect the scanner itself.
+      #
+      # Every assertion below therefore names a rule family that MUST fire on a
+      # fixture built to trigger it. Asserting merely that findings.json is
+      # non-empty would pass on `{"findings":[]}` — a binary with its entire
+      # rule engine removed would ship green. Each family is a separate code
+      # path (secrets = local regex, VULN-001 = OSV network lookup, IaC =
+      # Dockerfile parser), so one dead subsystem cannot hide behind another.
+      - name: Smoke-test the built binary
+        run: |
+          set -euo pipefail
+          go build -o /tmp/nox-smoke ./cli
+          work="$(mktemp -d)"
+          # Results and the VEX document live OUTSIDE the fixture. With
+          # `-output "$work/out"` the second scan ingests the first scan's own
+          # findings.json, which silently defeats the suppression assertion
+          # below (and is the same self-corrupting-tree bug that once had the
+          # release tarball overwriting the checkout it was scanning).
+          res="$(mktemp -d)"
+
+          # Fixture: one hardcoded credential, one dependency with a known
+          # advisory, one insecure Dockerfile.
+          cat > "$work/main.go" <<'GO'
+          package main
+
+          import "fmt"
+
+          const awsKey = "AKIAIOSFODNN7EXAMPLE"
+          const awsSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+          func main() { fmt.Println(awsKey, awsSecret) }
+          GO
+          printf 'module smoke\n\ngo 1.21\n\nrequire github.com/gin-gonic/gin v1.6.0\n' > "$work/go.mod"
+          cat > "$work/Dockerfile" <<'DOCKER'
+          FROM alpine:latest
+          USER root
+          RUN chmod 777 /tmp
+          DOCKER
+
+          # A plugin the scan must not DEPEND on: a registry outage should cost
+          # the taint rules, never the scan. This is the 2026-07-19 failure.
+          /tmp/nox-smoke plugin install nox/taint-analysis@0.7.0 || \
+            echo "::warning title=Plugin unavailable::continuing; the scan must not depend on it"
+
+          set +e
+          /tmp/nox-smoke scan "$work" -format json -output "$res/base"
+          code=$?
+          set -e
+          f="$res/base/findings.json"
+          if [ "$code" -gt 1 ]; then
+            echo "::error title=Smoke test failed::nox scan exited $code — it did not run to completion. Releasing this would ship a binary that cannot scan."
+            exit 1
+          fi
+          if [ ! -s "$f" ]; then
+            echo "::error title=Smoke test failed::no findings.json was written."
+            exit 1
+          fi
+
+          fail=0
+          assert_rule() {
+            n=$(jq --arg p "$1" '[.findings[]? | select(.RuleID | startswith($p))] | length' "$f")
+            if [ "$n" -eq 0 ]; then
+              echo "::error title=Smoke test failed::no $1* findings on a fixture built to trigger them — the $2 detector is not running."
+              fail=1
+            else
+              echo "  ok: $1* fired ($n findings) — $2"
+            fi
+          }
+          assert_rule SEC  "secret detection"
+          assert_rule VULN "dependency advisories (OSV)"
+          assert_rule IAC  "IaC/Dockerfile analysis"
+
+          deps=$(jq '.summary.dependencies // .dependencies // 0' "$f" 2>/dev/null || echo 0)
+          echo "  dependencies resolved: $deps"
+
+          # VEX, in the CURRENT spec version, where `vulnerability` and
+          # `products` are objects rather than strings (#389). Built from a
+          # finding the scan just produced, so it cannot rot when advisories
+          # change. Asserting that something was SUPPRESSED proves the document
+          # was parsed *and* applied — merely loading it would regress silently.
+          vuln=$(jq -r '[.findings[]? | select(.RuleID=="VULN-001") | .Metadata.vuln_id] | first // empty' "$f")
+          if [ -n "$vuln" ]; then
+            jq -n --arg v "$vuln" '{
+              "@context": "https://openvex.dev/ns/v0.2.0",
+              "@id": "https://example.com/vex/smoke",
+              "author": "smoke-test",
+              "timestamp": "2026-01-01T00:00:00Z",
+              "version": 1,
+              "statements": [{
+                "vulnerability": {"@id": $v, "name": $v},
+                "products": [{"@id": "pkg:golang/github.com/gin-gonic/gin@v1.6.0"}],
+                "status": "not_affected",
+                "justification": "vulnerable_code_not_present"
+              }]
+            }' > "$res/vex.json"
+
+            set +e
+            /tmp/nox-smoke scan "$work" -format json -output "$res/vexed" -vex "$res/vex.json"
+            vcode=$?
+            set -e
+            if [ "$vcode" -gt 1 ]; then
+              echo "::error title=Smoke test failed::scan with -vex exited $vcode — a spec-current OpenVEX v0.2.0 document was rejected (regression of #389)."
+              fail=1
+            else
+              # Suppressed findings REMAIN in findings.json, tagged with a
+              # vex_* Status -- so comparing array lengths before/after would
+              # always see zero change and quietly assert nothing.
+              sup=$(jq '[.findings[]? | select(.Status? // "" | startswith("vex_"))] | length' "$res/vexed/findings.json")
+              if [ "$sup" -eq 0 ]; then
+                echo "::error title=Smoke test failed::-vex suppressed nothing though the document targets $vuln. It loaded but was not applied."
+                fail=1
+              else
+                echo "  ok: VEX applied — $sup finding(s) suppressed as vex_not_affected"
+              fi
+            fi
+          else
+            echo "::error title=Smoke test failed::no VULN-001 finding to build a VEX document from; the VEX path went untested."
+            fail=1
+          fi
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "smoke test passed: scan ran, every detector family fired, VEX applied"
+
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'

--- a/core/vex/vex.go
+++ b/core/vex/vex.go
@@ -43,6 +43,91 @@ type Statement struct {
 	NoxFingerprint string   `json:"_nox_fingerprint,omitempty"`
 }
 
+// UnmarshalJSON accepts both OpenVEX shapes for `vulnerability` and `products`.
+//
+// The spec changed them from plain strings to objects in v0.2.0:
+//
+//	v0.0.1 / v0.1.0    "vulnerability": "CVE-2024-1234"
+//	v0.2.0             "vulnerability": {"@id": "CVE-2024-1234", "name": "..."}
+//
+//	v0.0.1 / v0.1.0    "products": ["pkg:golang/example"]
+//	v0.2.0             "products": [{"@id": "pkg:golang/example"}]
+//
+// Reading only the older shape made nox reject documents that declare the
+// current spec version, and it failed at LOAD time — before any scanning — so
+// a repo that adopted v0.2.0 got no scan at all rather than a scan with
+// unapplied waivers. Accepting both is the whole fix; nox keeps WRITING the
+// string form, which every reader still understands.
+func (s *Statement) UnmarshalJSON(data []byte) error {
+	// The alias sheds the method set, so the embedded decode does not recurse.
+	type alias Statement
+	aux := struct {
+		Vulnerability json.RawMessage `json:"vulnerability"`
+		Products      json.RawMessage `json:"products"`
+		*alias
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	id, err := scalarOrObjectID(aux.Vulnerability)
+	if err != nil {
+		return fmt.Errorf("vulnerability: %w", err)
+	}
+	s.VulnerabilityID = id
+	products, err := scalarOrObjectIDs(aux.Products)
+	if err != nil {
+		return fmt.Errorf("products: %w", err)
+	}
+	s.Products = products
+	return nil
+}
+
+// scalarOrObjectID reads an identifier written either as a bare string or as an
+// object carrying "@id" / "name". "@id" wins because it is the spec's identity
+// field; "name" is the human-facing label and is only a fallback.
+func scalarOrObjectID(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str, nil
+	}
+	var obj struct {
+		ID   string `json:"@id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return "", fmt.Errorf("expected a string or an object with @id/name: %w", err)
+	}
+	if obj.ID != "" {
+		return obj.ID, nil
+	}
+	return obj.Name, nil
+}
+
+// scalarOrObjectIDs is scalarOrObjectID over a list, tolerating a mixed array.
+func scalarOrObjectIDs(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("expected an array: %w", err)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		id, err := scalarOrObjectID(item)
+		if err != nil {
+			return nil, err
+		}
+		if id != "" {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
 // Document is a simplified OpenVEX document.
 type Document struct {
 	Context    string      `json:"@context,omitempty"`

--- a/core/vex/vex_test.go
+++ b/core/vex/vex_test.go
@@ -1,6 +1,7 @@
 package vex
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -306,5 +307,88 @@ func TestCollectVulnIDs(t *testing.T) {
 	ids2 := collectVulnIDs(&f2)
 	if len(ids2) != 0 {
 		t.Errorf("expected 0 IDs, got %d", len(ids2))
+	}
+}
+
+// TestStatement_AcceptsBothOpenVEXShapes covers the regression where a
+// spec-current v0.2.0 document was rejected outright. It failed at LOAD time,
+// before any scanning, so the practical effect was no scan at all — worse than
+// a scan with unapplied waivers, and indistinguishable from a clean one.
+func TestStatement_AcceptsBothOpenVEXShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantVuln string
+		wantProd []string
+	}{
+		{
+			name:     "v0.1.0 strings",
+			json:     `{"vulnerability":"CVE-2024-1234","products":["pkg:golang/example"],"status":"not_affected"}`,
+			wantVuln: "CVE-2024-1234",
+			wantProd: []string{"pkg:golang/example"},
+		},
+		{
+			name:     "v0.2.0 objects",
+			json:     `{"vulnerability":{"@id":"CVE-2024-1234","name":"CVE-2024-1234","description":"x"},"products":[{"@id":"pkg:golang/example"}],"status":"not_affected"}`,
+			wantVuln: "CVE-2024-1234",
+			wantProd: []string{"pkg:golang/example"},
+		},
+		{
+			name:     "object with only name falls back to it",
+			json:     `{"vulnerability":{"name":"AI-036"},"status":"not_affected"}`,
+			wantVuln: "AI-036",
+		},
+		{
+			name:     "@id wins over name, being the identity field",
+			json:     `{"vulnerability":{"@id":"CVE-2024-1234","name":"friendly label"},"status":"not_affected"}`,
+			wantVuln: "CVE-2024-1234",
+		},
+		{
+			name:     "a mixed array is tolerated rather than rejected",
+			json:     `{"vulnerability":"CVE-1","products":["pkg:a",{"@id":"pkg:b"}],"status":"fixed"}`,
+			wantVuln: "CVE-1",
+			wantProd: []string{"pkg:a", "pkg:b"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Statement
+			if err := json.Unmarshal([]byte(tc.json), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.VulnerabilityID != tc.wantVuln {
+				t.Errorf("VulnerabilityID = %q, want %q", got.VulnerabilityID, tc.wantVuln)
+			}
+			if len(got.Products) != len(tc.wantProd) {
+				t.Fatalf("Products = %v, want %v", got.Products, tc.wantProd)
+			}
+			for i := range tc.wantProd {
+				if got.Products[i] != tc.wantProd[i] {
+					t.Errorf("Products[%d] = %q, want %q", i, got.Products[i], tc.wantProd[i])
+				}
+			}
+			// The other fields must still decode through the alias.
+			if got.Status != Status(map[bool]string{true: "fixed", false: "not_affected"}[tc.wantVuln == "CVE-1"]) {
+				t.Errorf("Status = %q — sibling fields must survive the custom unmarshaller", got.Status)
+			}
+		})
+	}
+}
+
+// TestStatement_RoundTripsThroughNoxsOwnWriter guards the half the issue also
+// flagged: whatever `nox baseline` emits must be readable by `nox scan -vex` in
+// the same release, or the two halves disagree.
+func TestStatement_RoundTripsThroughNoxsOwnWriter(t *testing.T) {
+	orig := Statement{VulnerabilityID: "CVE-2024-9999", Status: StatusNotAffected, Products: []string{"pkg:golang/x"}}
+	blob, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Statement
+	if err := json.Unmarshal(blob, &back); err != nil {
+		t.Fatalf("nox cannot read what nox wrote: %v", err)
+	}
+	if back.VulnerabilityID != orig.VulnerabilityID || len(back.Products) != 1 || back.Products[0] != orig.Products[0] {
+		t.Errorf("round trip lost data: %+v", back)
 	}
 }


### PR DESCRIPTION
Fixes two related failures where `nox scan` did not run **at all**, rather than running and reporting something wrong.

## 1. `-vex` rejects spec-current OpenVEX documents (#389)

OpenVEX **v0.2.0** — the current spec, and what `nox vex init` itself emits downstream — models `vulnerability` and `products` as **objects**:

```json
"vulnerability": {"@id": "CVE-2024-0000", "name": "CVE-2024-0000"},
"products": [{"@id": "pkg:golang/example"}]
```

`core/vex` typed both as strings, so loading such a document failed with exit 2 *before scanning*:

```
error: scan failed: loading VEX document .nox/vex.json: ...
```

`Statement.UnmarshalJSON` now accepts **both** shapes, preferring `@id` over `name`, and tolerating mixed arrays. Round-trip through nox's own writer is covered, so documents nox emits still load.

## 2. Nothing would have caught it (#390)

This is the second time this month a release shipped a binary that could not scan. The first: `nox plugin install nox/taint-analysis@*` began 404ing, and the install step precedes the scan, so 15 downstream repos ran a dead security job for a week.

Neither bug produced a *wrong* finding. Both produced **no** findings — which is strictly worse, because an empty report is indistinguishable from a clean one at a glance, and both surfaced only on upgrade, when a user is least likely to suspect the scanner itself.

So `release.yml` now smoke-tests the built binary before goreleaser runs. It scans a fixture carrying a hardcoded credential, a dependency with a known advisory, and an insecure Dockerfile, and asserts **each rule family fires**.

Asserting merely that `findings.json` is non-empty would pass on `{"findings":[]}` — a binary with its entire rule engine removed would ship green. That is the same class of defect as the bugs above, so the assertions name what must be found. The three families are separate code paths (local regex, OSV network lookup, Dockerfile parser), so one dead subsystem cannot hide behind another.

The VEX document is built **from a finding the scan just produced**, so it cannot rot as advisories change, and the assertion is that something was **suppressed** — proving the document was parsed *and* applied, not merely loaded.

## Verification

Both directions, not just the happy path:

| Binary | Result |
|---|---|
| this branch | **exit 0** — all families fire, 2 findings suppressed as `vex_not_affected` |
| parent commit (pre-fix) | **exit 1** — `scan with -vex exited 2 — a spec-current OpenVEX v0.2.0 document was rejected (regression of #389)` |
| fixture stripped of secret/dep | **exit 1** — `no SEC* findings … the secret detection detector is not running` (and VULN) |

Verified against the real document that surfaced this, from `chronos`:

```
[results] 9 findings (55 suppressed), 61 dependencies, 1 AI components
```

Two things the test itself got wrong first, both caught by running it rather than reasoning about it, and both now commented in place:

- `-output` pointed **inside** the scanned fixture, so the second scan ingested the first scan's own `findings.json` and the suppression assertion silently compared nothing;
- suppressed findings **remain** in `findings.json` tagged `Status: vex_not_affected`, so comparing array lengths before/after always sees zero change.

`go test ./core/vex/...` passes; gofmt and vet clean.

Closes #389
Closes #390
