### PR TITLE
fix(release): smoke test reported a hardcoded zero for dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,12 @@ jobs:
           assert_rule VULN "dependency advisories (OSV)"
           assert_rule IAC  "IaC/Dockerfile analysis"
 
-          deps=$(jq '.summary.dependencies // .dependencies // 0' "$f" 2>/dev/null || echo 0)
-          echo "  dependencies resolved: $deps"
+          # Distinct vulnerable packages. findings.json carries no dependency
+          # total (top-level keys are meta/findings only), so the previous
+          # `.summary.dependencies` read printed a flat 0 while the scan
+          # reported 2 -- a misleading zero in an otherwise green log.
+          pkgs=$(jq -r '[.findings[]? | .Metadata.package? // empty] | unique | length' "$f")
+          echo "  distinct vulnerable packages: $pkgs"
 
           # VEX, in the CURRENT spec version, where `vulnerability` and
           # `products` are objects rather than strings (#389). Built from a


### PR DESCRIPTION
Follow-up to #391, from watching the v1.22.1 release run.

The smoke test printed `dependencies resolved: 0` while the scan reported `2 dependencies`. `findings.json` has no dependency total — its top-level keys are `meta` and `findings` — so `.summary.dependencies` never matched and the `// 0` fallback printed zero on every run.

Informational only, so no assertion was weakened. But a flat zero sitting in a green log is the same species of misleading signal the smoke test was written to catch, so it should not stay.

Now counts distinct `.Metadata.package` values. Verified locally: `distinct vulnerable packages: 1`, with all other assertions still passing.