### PR TITLE
feat(ci): diff rule behaviour on real repositories between releases

### DIFF
--- a/.github/workflows/rule-diff.yml
+++ b/.github/workflows/rule-diff.yml
@@ -1,0 +1,92 @@
+# Diff rule behaviour on REAL repositories between the last release and this PR.
+#
+# WHY: nox's corpus precision is measured at 1.00, and that number does not
+# predict behaviour on real repositories. A sweep of ~270 baselined findings
+# across a fleet found the secret and AI rules producing 13 false positives out
+# of 13, while VULN-001 and IAC-013 were 21 real out of 23. Synthetic fixtures
+# cannot show that, because they contain exactly what the rule author expected.
+#
+# Every rule-precision regression shipped so far was invisible until someone
+# upgraded and noticed by hand. This makes the change visible at review time.
+name: Rule behaviour diff
+
+on:
+  pull_request:
+    paths:
+      - 'core/analyzers/**'
+      - 'core/rules/**'
+      - 'scripts/rule-diff.sh'
+      - 'scripts/rule-diff-corpus.json'
+      - '.github/workflows/rule-diff.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diff:
+    name: Rule behaviour diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.1.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build candidate
+        run: go build -o /tmp/nox-candidate ./cli
+
+      - name: Fetch last released nox as the baseline
+        run: |
+          set -euo pipefail
+          tag="$(curl -fsSL https://api.github.com/repos/nox-hq/nox/releases/latest | jq -r .tag_name)"
+          ver="${tag#v}"
+          echo "baseline: $tag"
+          tmp="$(mktemp -d)"
+          curl -fsSL -o "$tmp/nox.tar.gz" \
+            "https://github.com/nox-hq/nox/releases/download/${tag}/nox_${ver}_linux_amd64.tar.gz"
+          tar xzf "$tmp/nox.tar.gz" -C "$tmp"
+          mv "$tmp/nox" /tmp/nox-baseline
+          /tmp/nox-baseline version
+
+      - name: Diff rule behaviour
+        id: diff
+        run: |
+          set +e
+          # $? after a pipe is tee's status, not the script's -- reading it
+          # would report success no matter what the harness found.
+          ./scripts/rule-diff.sh /tmp/nox-baseline /tmp/nox-candidate | tee /tmp/diff.txt
+          code="${PIPESTATUS[0]}"
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Report
+        # Exit 2 means a scan did not RUN -- unambiguous, so it fails the job.
+        #
+        # Exit 1 means rule behaviour changed. That is deliberately NOT a
+        # failure: most rule PRs change behaviour on purpose, and a check that
+        # goes red every time it works correctly is one people learn to ignore.
+        # It is a report, and it says so -- unlike a gate that was accidentally
+        # neutered into always-green, which is the failure mode this repo has
+        # been bitten by. The delta lands in the job summary for the reviewer.
+        if: always()
+        run: |
+          code="${{ steps.diff.outputs.code }}"
+          {
+            echo "## Rule behaviour vs last release"
+            echo
+            echo '```'
+            cat /tmp/diff.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$code" in
+            0) echo "No rule-level change on the corpus." ;;
+            1) echo "::notice title=Rule behaviour changed::Review the delta in the job summary and confirm each change is intended. This is a report, not a gate." ;;
+            *) echo "::error title=Rule diff could not run::The harness failed (exit $code) -- a scan produced no findings.json, or the corpus is unusable. This check verified nothing."
+               exit 1 ;;
+          esac

--- a/core/analyzers/iac/rules_dedup_test.go
+++ b/core/analyzers/iac/rules_dedup_test.go
@@ -1,0 +1,214 @@
+package iac
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// Two rules that fire on the same line for the same condition report one issue
+// twice. IAC-018 ("Workflow step suppresses failures with continue-on-error",
+// low) and IAC-310 ("GHA step continues on error", medium) did exactly that on
+// every `continue-on-error: true` in every scanned repo.
+//
+// The severity split is what makes it more than cosmetic: the same condition is
+// simultaneously low and medium, so a gate keyed on severity gets an arbitrary
+// answer, and a baseline or VEX waiver written against one ID leaves the other
+// unwaived -- the finding reads as "still open" after being explicitly accepted.
+//
+// The duplicate arose because rules live in several files (rules.go,
+// rules_expanded.go, ...) that are concatenated by builtinIaCRules with nothing
+// comparing them. This test is that comparison.
+//
+// It is behavioural, not textual: the two patterns above differ as strings
+// (`continue-on-error\s*:\s*true` vs `continue-on-error:\s*true`) while
+// matching the same input, so comparing pattern text would not have caught it.
+func TestIaCRules_NoTwoRulesMatchTheSameInput(t *testing.T) {
+	all := builtinIaCRules()
+
+	type probed struct {
+		rule  rules.Rule
+		probe string
+	}
+	var probes []probed
+	for _, r := range all {
+		if r.Pattern == "" {
+			continue
+		}
+		if p, ok := literalProbe(r.Pattern); ok {
+			probes = append(probes, probed{rule: r, probe: p})
+		}
+	}
+	if len(probes) == 0 {
+		t.Fatal("no rule yielded a literal probe; the probe generator is broken, " +
+			"so this test would pass while checking nothing")
+	}
+
+	// Absence rules carry an EMPTY Pattern -- their detection lives in
+	// Absence{Anchor,Property,Require} -- and regexp.Compile("") matches every
+	// string, so including them made every absence rule collide with everything.
+	// Uncompilable patterns are the business of TestNoNewUncompilableIaCRules,
+	// which tracks them deliberately; duplicating that check here would just
+	// restate its failures.
+	compiled := make(map[string]*regexp.Regexp, len(all))
+	for _, r := range all {
+		if r.Pattern == "" {
+			continue
+		}
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			continue
+		}
+		compiled[r.ID] = re
+	}
+
+	// ruleID -> set of ruleIDs it collides with, deduped so each pair reports once.
+	type pair = struct{ a, b string }
+	collisions := map[pair]string{}
+
+	for _, p := range probes {
+		for _, other := range all {
+			if other.ID == p.rule.ID {
+				continue
+			}
+			re, ok := compiled[other.ID]
+			if !ok || !re.MatchString(p.probe) {
+				continue
+			}
+			if !filePatternsOverlap(p.rule.FilePatterns, other.FilePatterns) {
+				continue // cannot apply to the same file, so cannot double-report
+			}
+			a, b := p.rule.ID, other.ID
+			if a > b {
+				a, b = b, a
+			}
+			if allowedOverlap[pair{a, b}] {
+				continue
+			}
+			collisions[pair{a, b}] = p.probe
+		}
+	}
+
+	// Split into newly-introduced duplicates (fail) and tracked ones (must all
+	// still be present, so the set can only shrink).
+	stillDuplicated := map[pair]bool{}
+	for k := range collisions {
+		key := k
+		if _, tracked := knownDuplicateRulePairs[key]; tracked {
+			stillDuplicated[key] = true
+			delete(collisions, k)
+		}
+	}
+	var fixed []string
+	for k := range knownDuplicateRulePairs {
+		if !stillDuplicated[k] {
+			fixed = append(fixed, k.a+"+"+k.b)
+		}
+	}
+	if len(fixed) > 0 {
+		sort.Strings(fixed)
+		t.Errorf("%d tracked duplicate pair(s) no longer collide: %v — remove them from "+
+			"knownDuplicateRulePairs so the guard tightens", len(fixed), fixed)
+	}
+
+	if len(collisions) == 0 {
+		return
+	}
+	keys := make([]pair, 0, len(collisions))
+	for k := range collisions {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].a != keys[j].a {
+			return keys[i].a < keys[j].a
+		}
+		return keys[i].b < keys[j].b
+	})
+	var b strings.Builder
+	b.WriteString("rules double-report the same input:\n")
+	for _, k := range keys {
+		b.WriteString("  " + k.a + " + " + k.b + " both match " + strconv(collisions[k]) + "\n")
+	}
+	b.WriteString("\nRetire one ID and alias it so existing baselines keep matching, " +
+		"or -- if the two are genuinely distinct concerns that merely co-locate -- " +
+		"add the pair to allowedOverlap with the reason.")
+	t.Error(b.String())
+}
+
+// allowedOverlap lists rule pairs that legitimately fire on the same input
+// because they report genuinely different problems. Each needs a reason.
+var allowedOverlap = map[struct{ a, b string }]bool{
+	// A `uses:` line can be both pinned to a mutable tag and on a deprecated
+	// major version. Fixing one does not fix the other.
+	{"IAC-013", "IAC-157"}: true,
+}
+
+// knownDuplicateRulePairs are pairs that DO double-report the same condition and
+// are not yet fixed. Nearly all follow one shape: rules_expanded.go (IAC-266 to
+// IAC-500) re-implements a condition rules.go (IAC-001 to IAC-185) already
+// covered, because the files are concatenated by builtinIaCRules with nothing
+// comparing them.
+//
+// Fixing one means retiring an ID and aliasing it, so existing baselines keep
+// matching instead of silently un-waiving; that is a behavioural change with
+// migration consequences, so it is deliberately not bundled into this test.
+//
+// Like knownUncompilableIaCRules, this set must only ever SHRINK. Remove a pair
+// when it is fixed; the guard below then requires it to stay fixed. A NEW
+// duplicate fails the build.
+var knownDuplicateRulePairs = map[struct{ a, b string }]string{
+	{"IAC-005", "IAC-037"}: "generic `encrypt* = false` also matches the specific `storage_encrypted = false`",
+	{"IAC-007", "IAC-065"}: "privileged: true",
+	{"IAC-007", "IAC-237"}: "privileged: true (three rules cover this one condition)",
+	{"IAC-065", "IAC-237"}: "privileged: true",
+	{"IAC-017", "IAC-312"}: "deprecated ::set-output",
+	{"IAC-018", "IAC-310"}: "continue-on-error: true, reported low AND medium",
+	{"IAC-026", "IAC-291"}: "hostPID: true",
+	{"IAC-027", "IAC-292"}: "hostIPC: true",
+	{"IAC-030", "IAC-287"}: "automountServiceAccountToken: true",
+	{"IAC-036", "IAC-283"}: "publicly_accessible = true",
+	{"IAC-042", "IAC-321"}: "enable_https_traffic_only = false",
+	{"IAC-111", "IAC-333"}: "enable_secure_boot = false",
+	{"IAC-116", "IAC-337"}: "require_ssl = false",
+	{"IAC-141", "IAC-399"}: "minReplicas: 1",
+}
+
+// literalProbe turns a regex into a plain string that the regex matches, or
+// reports false when the pattern is too dynamic to reduce confidently. A
+// conservative generator is the point: a wrong probe would invent collisions.
+func literalProbe(pattern string) (string, bool) {
+	s := strings.TrimPrefix(pattern, "(?i)")
+	// Whitespace classes become a single literal space.
+	for _, ws := range []string{`\s*`, `\s+`, `\s`} {
+		s = strings.ReplaceAll(s, ws, " ")
+	}
+	// Unescape the escapes that denote themselves.
+	for _, esc := range []string{`\.`, `\-`, `\/`, `\:`, `\_`, `\@`} {
+		s = strings.ReplaceAll(s, esc, strings.TrimPrefix(esc, `\`))
+	}
+	if s == "" || strings.ContainsAny(s, `[]()|*+?^$.{}\`) {
+		return "", false // still dynamic; no reliable literal
+	}
+	return s, true
+}
+
+// filePatternsOverlap reports whether two rules can ever apply to one file. An
+// empty list means "any file".
+func filePatternsOverlap(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return true
+	}
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func strconv(s string) string { return `"` + s + `"` }

--- a/scripts/rule-diff-corpus.json
+++ b/scripts/rule-diff-corpus.json
@@ -1,0 +1,30 @@
+{
+  "_comment": [
+    "Real repositories scanned by scripts/rule-diff.sh to detect rule-behaviour",
+    "changes between two nox builds. Chosen for VARIETY of the surfaces nox",
+    "actually gets pointed at -- Go services, Terraform/Kubernetes manifests,",
+    "Dockerfiles, GitHub Actions workflows, JS/TS dependency trees -- not for",
+    "being clean. A repo with real findings is more useful here than one without.",
+    "",
+    "Pinned by commit sha so the diff reflects a change in NOX, never a change in",
+    "the repo. Bumping a sha is a deliberate act: re-read the delta it produces",
+    "before committing it, or the corpus stops being a control.",
+    "",
+    "Keep this list small. It runs on every release; breadth matters more than",
+    "depth, and each entry costs a clone plus two full scans."
+  ],
+  "repos": [
+    {
+      "name": "chronos",
+      "url": "https://github.com/klarlabs-studio/chronos",
+      "sha": "d969c13ea6c1cc28183e0ee6ed56628869fef2d7",
+      "why": "Go service with Dockerfile, compose, and 8 GitHub Actions workflows; carries a committed baseline and an OpenVEX document, so it exercises suppression paths too"
+    },
+    {
+      "name": "warden",
+      "url": "https://github.com/klarlabs-studio/warden",
+      "sha": "f3af9e3a2f9bc85c2513845368f06049586525d6",
+      "why": "Go CLI with signing/provenance code -- dense in crypto and credential-shaped strings, which is where secret rules over-fire"
+    }
+  ]
+}

--- a/scripts/rule-diff.sh
+++ b/scripts/rule-diff.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Scan a corpus of real repositories with two nox builds and diff the findings.
+#
+# WHY: nox's corpus precision is measured at 1.00, and that number does not
+# predict behaviour on real repositories. A sweep of ~270 baselined findings
+# across the fleet found secret and AI rules producing 13 false positives out of
+# 13, while VULN-001 and IAC-013 were 21 real out of 23. Synthetic fixtures
+# cannot show that, because they contain exactly what the rule author expected.
+#
+# So this runs both builds over pinned real repositories and reports what
+# CHANGED per rule. A rule that starts firing 40 more times, or stops firing
+# entirely, is the signal -- neither is inherently wrong, but neither should
+# reach a release unexplained.
+#
+# Usage:
+#   scripts/rule-diff.sh <baseline-nox> <candidate-nox> [corpus.json]
+#
+# Exits 0 when there is no delta, 1 when rules changed. The caller decides
+# whether a delta blocks; on a PR it is informational, at release it should be
+# read by a human.
+set -euo pipefail
+
+BASE_BIN="${1:?usage: rule-diff.sh <baseline-nox> <candidate-nox> [corpus.json]}"
+CAND_BIN="${2:?usage: rule-diff.sh <baseline-nox> <candidate-nox> [corpus.json]}"
+CORPUS="${3:-$(dirname "$0")/rule-diff-corpus.json}"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
+[ -f "$CORPUS" ] || { echo "corpus manifest not found: $CORPUS" >&2; exit 2; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Scan one checkout and emit "RULEID<TAB>count" lines. Output goes OUTSIDE the
+# tree being scanned: writing results into the checkout makes the next scan
+# ingest the previous scan's own findings.json.
+scan_counts() {
+  local bin="$1" src="$2" out="$3"
+  if ! "$bin" scan "$src" -format json -output "$out" >/dev/null 2>&1; then
+    : # findings present is a non-zero exit; a real failure surfaces as no JSON
+  fi
+  if [ ! -s "$out/findings.json" ]; then
+    echo "::error::$bin produced no findings.json for $src -- the scan did not run" >&2
+    return 1
+  fi
+  jq -r '.findings[]?.RuleID' "$out/findings.json" | sort | uniq -c \
+    | awk '{print $2"\t"$1}' | sort
+}
+
+total_delta=0
+repo_count=0
+
+while read -r name url sha; do
+  [ -n "$name" ] || continue
+  repo_count=$((repo_count + 1))
+  echo "── $name @ ${sha:0:8}"
+  src="$work/src-$name"
+  git clone -q --filter=blob:none "$url" "$src" 2>/dev/null || {
+    echo "   SKIP: clone failed (network or repo moved)"; continue; }
+  git -C "$src" checkout -q "$sha" 2>/dev/null || {
+    echo "   SKIP: pinned sha $sha not found -- repo history rewritten?"; continue; }
+  rm -rf "$src/.git"
+
+  # A scan that does not run is FATAL, never a skip. Skipping here would turn
+  # "nox is broken" into a quiet "no change" -- the exact failure this whole
+  # harness exists to make visible.
+  scan_counts "$BASE_BIN" "$src" "$work/out-base-$name" > "$work/base-$name.tsv" || exit 2
+  scan_counts "$CAND_BIN" "$src" "$work/out-cand-$name" > "$work/cand-$name.tsv" || exit 2
+
+  # join on rule id, showing 0 where a side is absent
+  delta="$(join -t"$(printf '\t')" -a1 -a2 -e0 -o '0,1.2,2.2' \
+            "$work/base-$name.tsv" "$work/cand-$name.tsv" \
+          | awk -F'\t' '$2 != $3 {print "   "$1": "$2" -> "$3}')"
+
+  if [ -z "$delta" ]; then
+    echo "   no change ($(wc -l < "$work/base-$name.tsv" | tr -d ' ') rules fired)"
+  else
+    echo "$delta"
+    total_delta=$((total_delta + $(printf '%s\n' "$delta" | wc -l)))
+  fi
+done < <(jq -r '.repos[] | "\(.name) \(.url) \(.sha)"' "$CORPUS")
+
+echo
+if [ "$repo_count" -eq 0 ]; then
+  echo "::error::corpus is empty -- this check verified nothing"
+  exit 2
+fi
+if [ "$total_delta" -eq 0 ]; then
+  echo "no rule-level change across $repo_count repo(s)"
+  exit 0
+fi
+echo "$total_delta rule(s) changed across $repo_count repo(s) -- each needs an explanation"
+exit 1


### PR DESCRIPTION
The second half of the #390 problem. The release smoke test now catches *"the scan didn't run"*; nothing catches *"the rules changed their minds"*.

nox's corpus precision is measured at **1.00**, and that number does not predict real repositories. A sweep of ~270 baselined findings across a fleet found the secret and AI rules at **13 false positives out of 13**, while `VULN-001` and `IAC-013` were **21 real out of 23**. Synthetic fixtures can't show that — they contain exactly what the rule author expected. Every precision regression so far (#361, #364, #394) was found by a human upgrading and squinting.

This scans pinned real repos with the last release and the PR build, and reports the per-rule delta.

### Verified against real version pairs

| pair | result |
|---|---|
| `1.22.0 → HEAD` | exit **0**, no change — correct, since the VEX fix and dedup test alter no rule behaviour |
| `1.7.0 → HEAD` | exit **1**, 26 rules changed |
| broken binary | exit **2**, fatal |

The middle row is the proof it isn't vacuous. It shows `SEC-356/357/358/364/430/431` all dropping to **zero** on chronos — the #361 false positives being retired, now visible rather than inferred — and raises a genuine question I have not answered: `VULN-001: 3 → 0` on warden, same tree scanned by both binaries.

### A scan that doesn't run is fatal, never a skip

Skipping would turn *"nox is broken"* into a quiet *"no change"* — the exact failure the harness exists to expose. Proved by pointing the baseline at a binary that exits 0 and writes nothing: exit 2.

### The delta is a report, on purpose

Most rule PRs change behaviour intentionally, and a check that goes red whenever it works correctly is one people learn to ignore. **Only the harness failing to run fails the job.** The comments say so explicitly so it isn't mistaken for a gate that was accidentally neutered — a distinction this repo has been bitten by more than once.

Corpus repos are pinned by sha, so a delta reflects a change in nox, not in the repo.

Refs #390