### PR TITLE
test(config): contract-test flag-over-config precedence; fix --staged dropping CLI flags

### DIFF
--- a/cli/config_precedence_test.go
+++ b/cli/config_precedence_test.go
@@ -315,8 +315,8 @@ func TestStagedScanOptionsPreservesFlags(t *testing.T) {
 	got := stagedScanOptions(root, in)
 
 	for _, c := range []struct{ name, got, want string }{
-		{"CustomRulesPath", got.CustomRulesPath, filepath.Join(root, "rules/custom.yaml")},
-		{"VEXPath", got.VEXPath, filepath.Join(root, "waivers/vex.json")},
+		{"CustomRulesPath", got.CustomRulesPath, filepath.Join(root, "rules", "custom.yaml")},
+		{"VEXPath", got.VEXPath, filepath.Join(root, "waivers", "vex.json")},
 		{"BaselinePath", got.BaselinePath, filepath.Join(root, "baseline.json")},
 		{"TerraformPlanPath", got.TerraformPlanPath, filepath.Join(root, "plan.json")},
 	} {

--- a/cli/config_precedence_test.go
+++ b/cli/config_precedence_test.go
@@ -1,0 +1,429 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	nox "github.com/nox-hq/nox/core"
+)
+
+// Contract tests for every setting that can be supplied BOTH on the command
+// line and in .nox.yaml. The rule under test, for all of them:
+//
+//	explicit CLI flag  >  .nox.yaml  >  built-in default
+//
+// Config supplies a value when the flag is ABSENT. It must never override one
+// the operator actually typed.
+//
+// This exists because of #362: `output.format` in .nox.yaml silently overrode an
+// explicit `-format` on the command line. The check compared the flag's VALUE to
+// its default, so `-format json` — deliberately typed — was indistinguishable
+// from "flag absent", and config won. CI ran `nox scan . -format json,sarif` and
+// gated on findings.json; two repos set `output.format: sarif`, findings.json was
+// never written, the gate step skipped on the missing file, and a skipped step is
+// a green check. 20 and 63 findings went ungated, for a long time, with a passing
+// build.
+//
+// The defining case for this bug class is therefore NOT "flag differs from
+// config" — it is "flag was explicitly passed with a value that happens to equal
+// its own default, and config says something else". A resolver that compares
+// against the zero or default value cannot tell those apart. Every table below
+// carries that case, marked `explicit == default`.
+//
+// Coverage map for the dual-source settings, so the gaps are visible:
+//
+//	output.format      / scan -format        resolveOutputFormat  — output_precedence_test.go
+//	output.directory   / scan -output        resolveOutputDir     — output_precedence_test.go
+//	scan.rules_dir     / scan -rules         core/scan.go         — core/config_precedence_test.go
+//	policy.baseline_path / scan -baseline    core/scan.go         — core/config_precedence_test.go
+//	policy.vex_path    / scan -vex           core/scan.go         — core/config_precedence_test.go
+//	explain.model      / explain -model      applyExplainDefaults — below
+//	explain.base_url   / explain -base-url   applyExplainDefaults — below
+//	explain.timeout    / explain -timeout    applyExplainDefaults — below
+//	explain.batch_size / explain -batch-size applyExplainDefaults — below
+//	explain.output     / explain -output     applyExplainDefaults — below
+//	explain.enrich     / explain -enrich     applyExplainDefaults — below
+//	explain.plugin_dir / explain -plugin-dir applyExplainDefaults — below
+//	plugins.trust_policy / plugin install --trust-policy, --require-verified,
+//	                       --require-signature, --allow-unverified
+//	                                         resolveTrustPolicy   — below
+//
+// Two further pairs are one-way and cannot invert, because no flag re-enables
+// what either source turns off — there is no --osv and no --auto-install:
+//
+//	scan.osv.disabled     / scan --no-osv, --offline   (disjunction)
+//	plugins.auto_install  / scan --no-auto-install     (conjunction)
+//
+// If such a flag is ever added, those two become two-sided and need tables here.
+//
+// explain.api_key_env is config-only (no flag). compliance.framework and the
+// whole cache block (cache.disabled/ttl/dir) parse from .nox.yaml and are read
+// by nothing — dead config, not a precedence question.
+
+// ---------------------------------------------------------------------------
+// explain: seven dual-source settings, resolved by applyExplainDefaults
+// ---------------------------------------------------------------------------
+
+// explainConfigFor builds a ScanConfig whose `explain:` block sets exactly one
+// field, so each table row isolates a single setting. An empty value means the
+// key is absent from .nox.yaml.
+func explainConfigFor(t *testing.T, field, value string) *nox.ScanConfig {
+	t.Helper()
+	var ec nox.ExplainSettings
+	switch field {
+	case "model":
+		ec.Model = value
+	case "base-url":
+		ec.BaseURL = value
+	case "timeout":
+		ec.Timeout = value
+	case "batch-size":
+		if value != "" {
+			n, err := strconv.Atoi(value)
+			if err != nil {
+				t.Fatalf("batch-size config value %q: %v", value, err)
+			}
+			ec.BatchSize = n
+		}
+	case "output":
+		ec.Output = value
+	case "enrich":
+		ec.Enrich = value
+	case "plugin-dir":
+		ec.PluginDir = value
+	default:
+		t.Fatalf("unknown explain field %q", field)
+	}
+	return &nox.ScanConfig{Explain: ec}
+}
+
+func TestExplainSettingPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// Each flag's registered default, restated so the third tier is asserted
+	// against a literal rather than against whatever the code happens to do.
+	builtin := map[string]string{
+		"model":      "gpt-4o",
+		"base-url":   "",
+		"timeout":    "2m0s",
+		"batch-size": "10",
+		"output":     "explanations.json",
+		"enrich":     "",
+		"plugin-dir": "",
+	}
+
+	cases := []struct {
+		name string
+		// flagName is the CLI flag and, implicitly, the .nox.yaml explain key.
+		flagName string
+		// explicit says whether the flag was passed at all; flagValue is what it
+		// was passed. The two are separate on purpose — an explicit flag whose
+		// value equals the default is the #362 case, and it cannot be expressed
+		// by value alone.
+		explicit  bool
+		flagValue string
+		configVal string // "" means the key is absent from .nox.yaml
+		want      string
+	}{
+		// model — default "gpt-4o"
+		{"model: neither, built-in default", "model", false, "", "", "gpt-4o"},
+		{"model: config fills an absent flag", "model", false, "", "claude-3-opus", "claude-3-opus"},
+		{"model: explicit flag beats config", "model", true, "gpt-4o-mini", "claude-3-opus", "gpt-4o-mini"},
+		{"model: explicit == default still beats config", "model", true, "gpt-4o", "claude-3-opus", "gpt-4o"},
+
+		// base-url — default ""
+		{"base-url: neither", "base-url", false, "", "", ""},
+		{"base-url: config fills an absent flag", "base-url", false, "", "http://localhost:11434", "http://localhost:11434"},
+		{"base-url: explicit flag beats config", "base-url", true, "http://proxy:8080", "http://localhost:11434", "http://proxy:8080"},
+
+		// timeout — default 2m, Duration-typed. A resolver comparing against the
+		// zero Duration would read an explicit -timeout 2m as absent.
+		{"timeout: neither", "timeout", false, "", "", "2m0s"},
+		{"timeout: config fills an absent flag", "timeout", false, "", "5m", "5m0s"},
+		{"timeout: explicit flag beats config", "timeout", true, "30s", "5m", "30s"},
+		{"timeout: explicit == default still beats config", "timeout", true, "2m", "5m", "2m0s"},
+
+		// batch-size — default 10, int-typed. Same hazard against 0 and against 10.
+		{"batch-size: neither", "batch-size", false, "", "", "10"},
+		{"batch-size: config fills an absent flag", "batch-size", false, "", "20", "20"},
+		{"batch-size: explicit flag beats config", "batch-size", true, "5", "20", "5"},
+		{"batch-size: explicit == default still beats config", "batch-size", true, "10", "20", "10"},
+
+		// output — default "explanations.json". This is #362's exact shape: a
+		// well-known artifact path that a later pipeline step reads.
+		{"output: neither", "output", false, "", "", "explanations.json"},
+		{"output: config fills an absent flag", "output", false, "", "custom.json", "custom.json"},
+		{"output: explicit flag beats config", "output", true, "mine.json", "custom.json", "mine.json"},
+		{"output: explicit == default still beats config", "output", true, "explanations.json", "custom.json", "explanations.json"},
+
+		// enrich — default ""
+		{"enrich: neither", "enrich", false, "", "", ""},
+		{"enrich: config fills an absent flag", "enrich", false, "", "tool1,tool2", "tool1,tool2"},
+		{"enrich: explicit flag beats config", "enrich", true, "only-this", "tool1,tool2", "only-this"},
+
+		// plugin-dir — default ""
+		{"plugin-dir: neither", "plugin-dir", false, "", "", ""},
+		{"plugin-dir: config fills an absent flag", "plugin-dir", false, "", "/opt/plugins", "/opt/plugins"},
+		{"plugin-dir: explicit flag beats config", "plugin-dir", true, "/tmp/p", "/opt/plugins", "/tmp/p"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Real registration, not a hand-rolled copy: the flag names, types
+			// and defaults under test are the ones runExplain uses. A private
+			// copy of the flag set had already drifted from production (it
+			// declared -timeout as a string where production registers a
+			// Duration), and a test built on a different flag set cannot catch
+			// a precedence bug in the real one.
+			fs := flag.NewFlagSet("explain", flag.ContinueOnError)
+			registerExplainFlags(fs)
+
+			var args []string
+			if tc.explicit {
+				args = []string{"-" + tc.flagName, tc.flagValue}
+			}
+			if err := fs.Parse(args); err != nil {
+				t.Fatalf("parsing %v: %v", args, err)
+			}
+
+			applyExplainDefaults(fs, explainConfigFor(t, tc.flagName, tc.configVal))
+
+			got := fs.Lookup(tc.flagName).Value.String()
+			if got != tc.want {
+				t.Errorf("-%s explicit=%v value=%q, config %q -> %q, want %q",
+					tc.flagName, tc.explicit, tc.flagValue, tc.configVal, got, tc.want)
+			}
+			// Third tier, asserted independently: with neither source supplying
+			// a value the result must be the registered built-in.
+			if !tc.explicit && tc.configVal == "" && got != builtin[tc.flagName] {
+				t.Errorf("-%s with no flag and no config = %q, want the built-in default %q",
+					tc.flagName, got, builtin[tc.flagName])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// plugin install: plugins.trust_policy vs the four trust flags
+// ---------------------------------------------------------------------------
+
+// TestTrustPolicyPrecedence covers plugins.trust_policy in .nox.yaml against the
+// flags that override it. resolveTrustPolicy reads .nox.yaml from the process
+// working directory, so each row runs in its own temp dir.
+//
+// The asymmetry is deliberate and worth pinning: a project pinning
+// `trust_policy: enterprise` asserts that unsigned plugins must not install, and
+// an operator flag may relax that — the documented order puts flags first. What
+// must not happen is config silently re-tightening or re-loosening a flag that
+// was passed.
+func TestTrustPolicyPrecedence(t *testing.T) {
+	cases := []struct {
+		name             string
+		configVal        string // "" means no plugins.trust_policy key
+		override         string // --trust-policy
+		requireVerified  bool   // --require-verified
+		requireSignature bool   // --require-signature
+		allowUnverified  bool   // --allow-unverified
+		want             string
+	}{
+		{name: "neither: built-in default", want: "default"},
+		{name: "config fills absent flags", configVal: "enterprise", want: "enterprise"},
+		{name: "config permissive with no flags", configVal: "permissive", want: "permissive"},
+
+		{name: "explicit --trust-policy beats config", configVal: "enterprise", override: "permissive", want: "permissive"},
+		// The #362 case. "default" is both a legal --trust-policy value and the
+		// built-in fallback: an implementation comparing the override against
+		// its own fallback would read this row as "flag not passed" and let
+		// config win, silently tightening an operator who asked to relax.
+		{name: "explicit --trust-policy == built-in default still beats config", configVal: "enterprise", override: "default", want: "default"},
+		{name: "explicit --trust-policy == config value", configVal: "permissive", override: "permissive", want: "permissive"},
+
+		{name: "--allow-unverified beats config", configVal: "enterprise", allowUnverified: true, want: "permissive"},
+		{name: "--require-verified beats config", configVal: "permissive", requireVerified: true, want: "enterprise"},
+		{name: "--require-signature beats config", configVal: "permissive", requireSignature: true, want: "default"},
+		// --require-signature resolves to "default", weaker than the configured
+		// "enterprise". The flag still wins: flags come first, and silently
+		// upgrading it would be config beating a flag.
+		{name: "--require-signature beats a stricter config", configVal: "enterprise", requireSignature: true, want: "default"},
+
+		{name: "config value is normalised", configVal: "  ENTERPRISE  ", want: "enterprise"},
+		{name: "flag value is normalised", override: "  PERMISSIVE  ", configVal: "enterprise", want: "permissive"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Chdir is incompatible with t.Parallel; resolveTrustPolicy reads
+			// .nox.yaml from the working directory.
+			dir := t.TempDir()
+			if tc.configVal != "" {
+				body := "plugins:\n  trust_policy: \"" + tc.configVal + "\"\n"
+				if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(body), 0o644); err != nil {
+					t.Fatalf("writing .nox.yaml: %v", err)
+				}
+			}
+			t.Chdir(dir)
+
+			got := resolveTrustPolicy(tc.override, tc.requireVerified, tc.requireSignature, tc.allowUnverified)
+			if got != tc.want {
+				t.Errorf("resolveTrustPolicy(override=%q, verified=%v, signature=%v, unverified=%v) with config %q = %q, want %q",
+					tc.override, tc.requireVerified, tc.requireSignature, tc.allowUnverified, tc.configVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scan --staged: flags must survive the temp-directory round trip
+// ---------------------------------------------------------------------------
+
+// TestStagedScanOptionsPreservesFlags pins the wiring that gives
+// `nox scan --staged` the operator's flags at all.
+//
+// The CLI called nox.RunStagedScan(target), which passes ScanOptions{}. The core
+// had already been fixed to thread options through RunStagedScanWithOptions, but
+// this call site was never updated — so under --staged every flag was dropped
+// while .nox.yaml was still copied into the temp directory and honoured. Config
+// beat an explicit flag, exactly as in #362, on the path `nox protect` installs
+// as a pre-commit hook.
+//
+// Path-valued options are anchored to the scan target because the staged scan
+// runs against a temp copy; a relative path left alone would resolve there and
+// silently match nothing.
+func TestStagedScanOptionsPreservesFlags(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	in := nox.ScanOptions{
+		CustomRulesPath:    "rules/custom.yaml",
+		VEXPath:            "waivers/vex.json",
+		BaselinePath:       "baseline.json",
+		TerraformPlanPath:  "plan.json",
+		DisableOSV:         true,
+		Offline:            true,
+		TrackedOnly:        true,
+		NoRespectGitignore: true,
+		ChangedSince:       "main",
+	}
+
+	got := stagedScanOptions(root, in)
+
+	for _, c := range []struct{ name, got, want string }{
+		{"CustomRulesPath", got.CustomRulesPath, filepath.Join(root, "rules/custom.yaml")},
+		{"VEXPath", got.VEXPath, filepath.Join(root, "waivers/vex.json")},
+		{"BaselinePath", got.BaselinePath, filepath.Join(root, "baseline.json")},
+		{"TerraformPlanPath", got.TerraformPlanPath, filepath.Join(root, "plan.json")},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want it anchored to the scan target: %q", c.name, c.got, c.want)
+		}
+	}
+
+	// Booleans must survive untouched. --offline and --no-osv are the
+	// zero-network guarantee: dropping them under --staged makes a hook-time
+	// scan reach the network after the operator forbade it.
+	if !got.DisableOSV || !got.Offline || !got.TrackedOnly || !got.NoRespectGitignore {
+		t.Errorf("boolean flags were dropped: %+v", got)
+	}
+	if got.ChangedSince != "main" {
+		t.Errorf("ChangedSince = %q, want %q — clearing it is RunStagedScanWithOptions's job, not the CLI's",
+			got.ChangedSince, "main")
+	}
+}
+
+func TestStagedScanOptionsLeavesAbsoluteAndEmptyPaths(t *testing.T) {
+	t.Parallel()
+
+	abs := filepath.Join(t.TempDir(), "rules.yaml")
+	got := stagedScanOptions(t.TempDir(), nox.ScanOptions{CustomRulesPath: abs})
+	if got.CustomRulesPath != abs {
+		t.Errorf("absolute path rewritten: got %q, want %q", got.CustomRulesPath, abs)
+	}
+
+	// Empty must stay empty: "" is the sentinel meaning "flag absent", and
+	// turning it into the scan root would make every absent path flag look
+	// explicitly set — reintroducing #362 from the other direction.
+	got = stagedScanOptions(t.TempDir(), nox.ScanOptions{})
+	if got.CustomRulesPath != "" || got.VEXPath != "" || got.BaselinePath != "" || got.TerraformPlanPath != "" {
+		t.Errorf("absent path flags were given a value: %+v", got)
+	}
+}
+
+// TestScanStagedHonoursRulesFlagOverConfig is the end-to-end proof, driven
+// through run() the way CI drives the binary: the custom rule from --rules must
+// fire under --staged, and the rule from .nox.yaml's scan.rules_dir — which the
+// staged pipeline copies into its temp directory — must not.
+//
+// Before the fix this failed with both assertions inverted: CONFIG-001 present,
+// CLI-001 absent.
+func TestScanStagedHonoursRulesFlagOverConfig(t *testing.T) {
+	dir := t.TempDir()
+	gitInitOrSkip(t, dir)
+
+	writeFile(t, dir, "app.txt", "CONFIG_PATTERN_aaaaaaaaaaaaaaaa\nCLI_PATTERN_deadbeefcafebabe\n")
+
+	cfgRules := filepath.Join(dir, "config-rules")
+	if err := os.Mkdir(cfgRules, 0o755); err != nil {
+		t.Fatalf("creating config-rules: %v", err)
+	}
+	writeFile(t, cfgRules, "rules.yaml", `rules:
+  - id: "CONFIG-001"
+    version: "1.0"
+    description: "Config rule (must not run when --rules is passed)"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "CONFIG_PATTERN_[0-9a-z]{16}"
+`)
+	writeFile(t, dir, ".nox.yaml", "scan:\n  rules_dir: config-rules\n")
+
+	cliRules := writeFile(t, dir, "cli-rules.yaml", `rules:
+  - id: "CLI-001"
+    version: "1.0"
+    description: "CLI rule"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "CLI_PATTERN_[0-9a-f]{16}"
+`)
+
+	runGitOrSkip(t, dir, "add", "-A")
+
+	outDir := filepath.Join(dir, "out")
+	run([]string{"--quiet", "--rules", cliRules, "--output", outDir, "scan", "--staged", dir})
+
+	body, err := os.ReadFile(filepath.Join(outDir, "findings.json"))
+	if err != nil {
+		t.Fatalf("reading findings.json: %v", err)
+	}
+	got := string(body)
+
+	if !strings.Contains(got, "CLI-001") {
+		t.Error("--staged dropped the explicit --rules flag: CLI-001 is missing from findings.json")
+	}
+	if strings.Contains(got, "CONFIG-001") {
+		t.Error("--staged let .nox.yaml scan.rules_dir override an explicit --rules flag (#362 shape): CONFIG-001 fired")
+	}
+}
+
+func gitInitOrSkip(t *testing.T, dir string) {
+	t.Helper()
+	runGitOrSkip(t, dir, "init")
+	runGitOrSkip(t, dir, "config", "user.email", "test@example.com")
+	runGitOrSkip(t, dir, "config", "user.name", "Test User")
+}
+
+func runGitOrSkip(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/cli/explain_cmd.go
+++ b/cli/explain_cmd.go
@@ -34,24 +34,7 @@ func runExplain(args []string) int {
 	}
 
 	fs := flag.NewFlagSet("explain", flag.ContinueOnError)
-
-	var (
-		model     string
-		baseURL   string
-		batchSize int
-		output    string
-		pluginDir string
-		enrich    string
-		timeout   time.Duration
-	)
-
-	fs.StringVar(&model, "model", "gpt-4o", "LLM model name")
-	fs.StringVar(&baseURL, "base-url", "", "custom OpenAI-compatible API base URL")
-	fs.IntVar(&batchSize, "batch-size", 10, "findings per LLM request")
-	fs.StringVar(&output, "output", "explanations.json", "output file path")
-	fs.StringVar(&pluginDir, "plugin-dir", "", "directory containing plugin binaries for enrichment")
-	fs.StringVar(&enrich, "enrich", "", "comma-separated list of read-only plugin tools to invoke for enrichment")
-	fs.DurationVar(&timeout, "timeout", 2*time.Minute, "timeout per LLM request")
+	ef := registerExplainFlags(fs)
 
 	if err := fs.Parse(flagArgs); err != nil {
 		return 2
@@ -71,6 +54,11 @@ func runExplain(args []string) int {
 		return 2
 	}
 	applyExplainDefaults(fs, cfg)
+
+	// Read the settled values only after config has filled in the flags left
+	// absent — flag > config > default is complete at this point.
+	model, baseURL, batchSize := ef.model, ef.baseURL, ef.batchSize
+	output, pluginDir, enrich, timeout := ef.output, ef.pluginDir, ef.enrich, ef.timeout
 
 	// Check for API key.
 	apiKeyEnv := "OPENAI_API_KEY"
@@ -175,6 +163,36 @@ func runExplain(args []string) int {
 	}
 	fmt.Println("[done]")
 	return 0
+}
+
+// explainFlags holds the explain command's flag-backed settings. Every field is
+// dual-source: settable on the command line and under `explain:` in .nox.yaml.
+type explainFlags struct {
+	model     string
+	baseURL   string
+	batchSize int
+	output    string
+	pluginDir string
+	enrich    string
+	timeout   time.Duration
+}
+
+// registerExplainFlags binds the explain flags onto fs and returns their
+// destinations. Registration is a single function so the precedence contract
+// tests exercise the real flag names, types and defaults instead of a
+// hand-rolled copy — a copy had already drifted (it declared -timeout as a
+// string where production registers a Duration), and a test built on a
+// different flag set cannot catch a precedence bug in the real one.
+func registerExplainFlags(fs *flag.FlagSet) *explainFlags {
+	f := &explainFlags{}
+	fs.StringVar(&f.model, "model", "gpt-4o", "LLM model name")
+	fs.StringVar(&f.baseURL, "base-url", "", "custom OpenAI-compatible API base URL")
+	fs.IntVar(&f.batchSize, "batch-size", 10, "findings per LLM request")
+	fs.StringVar(&f.output, "output", "explanations.json", "output file path")
+	fs.StringVar(&f.pluginDir, "plugin-dir", "", "directory containing plugin binaries for enrichment")
+	fs.StringVar(&f.enrich, "enrich", "", "comma-separated list of read-only plugin tools to invoke for enrichment")
+	fs.DurationVar(&f.timeout, "timeout", 2*time.Minute, "timeout per LLM request")
+	return f
 }
 
 // applyExplainDefaults applies .nox.yaml explain settings as defaults for any

--- a/cli/main.go
+++ b/cli/main.go
@@ -345,6 +345,40 @@ func resolveOutputDir(flagValue, configValue string) string {
 	return "."
 }
 
+// stagedScanOptions adapts the scan options for a --staged run.
+//
+// `nox scan --staged` reconstructs the git index into a temporary directory and
+// scans that, copying .nox.yaml across so project config still applies. The CLI
+// used to call nox.RunStagedScan(target), which passes ScanOptions{} — so every
+// flag the operator typed (--rules, --vex, --baseline, --offline, --no-osv,
+// --tf-plan, --tracked-only, --no-respect-gitignore) was silently dropped while
+// the config file was still honoured. That is #362's inversion again: config
+// beat an explicit flag, with no error and no warning. It sat on the pre-commit
+// hook path, which is `nox scan --staged`.
+//
+// Path-valued options are resolved here rather than in the scan pipeline: the
+// pipeline joins relative paths against the scan root, which under --staged is
+// the temp directory, so a relative --rules/--vex/--baseline would resolve to a
+// file that does not exist there. Anchoring them to the real target preserves
+// the same "relative to the scan target" meaning a non-staged run has.
+func stagedScanOptions(target string, opts nox.ScanOptions) nox.ScanOptions {
+	root := nox.ConfigRoot(target)
+	opts.CustomRulesPath = absAgainst(root, opts.CustomRulesPath)
+	opts.VEXPath = absAgainst(root, opts.VEXPath)
+	opts.BaselinePath = absAgainst(root, opts.BaselinePath)
+	opts.TerraformPlanPath = absAgainst(root, opts.TerraformPlanPath)
+	return opts
+}
+
+// absAgainst anchors a relative path to root. Empty and absolute paths are
+// returned unchanged so "flag absent" stays representable as "".
+func absAgainst(root, p string) string {
+	if p == "" || filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(root, p)
+}
+
 func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verbose bool) int {
 	// Parse scan-specific flags.
 	scanFS := flag.NewFlagSet("scan", flag.ContinueOnError)
@@ -474,10 +508,22 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		fmt.Println("[discover] walking directory...")
 	}
 
+	opts := nox.ScanOptions{
+		CustomRulesPath:    rulesPath,
+		DisableOSV:         noOSVFlag,
+		Offline:            offlineFlag,
+		VEXPath:            vexFlag,
+		TerraformPlanPath:  tfPlanFlag,
+		ChangedSince:       changedSinceFlag,
+		NoRespectGitignore: noRespectGitignoreFlg,
+		TrackedOnly:        trackedOnlyFlag,
+		BaselinePath:       baselineFlag,
+	}
+
 	var result *nox.ScanResult
 	switch {
 	case stagedFlag:
-		result, err = nox.RunStagedScan(target)
+		result, err = nox.RunStagedScanWithOptions(target, stagedScanOptions(target, opts))
 	case historyFlag:
 		historyOpts := nox.HistoryScanOptions{
 			MaxDepth:    historyDepthFlag,
@@ -485,17 +531,6 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		}
 		result, err = nox.RunHistoryScan(target, &historyOpts)
 	default:
-		opts := nox.ScanOptions{
-			CustomRulesPath:    rulesPath,
-			DisableOSV:         noOSVFlag,
-			Offline:            offlineFlag,
-			VEXPath:            vexFlag,
-			TerraformPlanPath:  tfPlanFlag,
-			ChangedSince:       changedSinceFlag,
-			NoRespectGitignore: noRespectGitignoreFlg,
-			TrackedOnly:        trackedOnlyFlag,
-			BaselinePath:       baselineFlag,
-		}
 		result, err = nox.RunScanWithOptions(target, opts)
 	}
 	if err != nil {

--- a/core/config_precedence_test.go
+++ b/core/config_precedence_test.go
@@ -1,0 +1,395 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/baseline"
+)
+
+// Contract tests for the settings the scan pipeline resolves from two sources:
+// a ScanOptions field (set by a CLI flag) and a .nox.yaml key. The rule for all
+// of them is
+//
+//	explicit CLI flag  >  .nox.yaml  >  built-in default
+//
+// and it is asserted here through real scans, because the resolution is inline
+// in RunScanContext rather than behind a helper a unit test could call.
+//
+// See #362 for why this is worth pinning: `output.format` in .nox.yaml overrode
+// an explicit `-format` because the resolver compared the flag's VALUE against
+// its default, so an explicitly-typed `-format json` looked identical to an
+// absent flag. findings.json stopped being written, the CI gate step skipped on
+// the missing file, and a skipped step is a green check.
+//
+// The three settings below are structurally immune to that specific mistake:
+// each flag defaults to "", so "absent" has its own representation and config
+// fills it in without ever inspecting the value. These tests exist to keep it
+// that way — a future default of "." or ".nox/baseline.json" on any of these
+// flags would silently reintroduce #362, and would fail here.
+
+// ---------------------------------------------------------------------------
+// scan.rules_dir  /  ScanOptions.CustomRulesPath  (--rules)
+// ---------------------------------------------------------------------------
+
+const cliRuleYAML = `rules:
+  - id: "PREC-CLI"
+    version: "1.0"
+    description: "rule supplied via --rules"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "CLI_PATTERN_[0-9a-f]{16}"
+    file_patterns:
+      - "*.txt"
+`
+
+const configRuleYAML = `rules:
+  - id: "PREC-CONFIG"
+    version: "1.0"
+    description: "rule supplied via .nox.yaml scan.rules_dir"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "CONFIG_PATTERN_[0-9a-z]{16}"
+    file_patterns:
+      - "*.txt"
+`
+
+// bothPatternsFile contains one line each rule can match, so which rule set was
+// loaded is decided purely by precedence, not by the input.
+const bothPatternsFile = "CLI_PATTERN_deadbeefcafebabe\nCONFIG_PATTERN_aaaaaaaaaaaaaaaa\n"
+
+func TestCustomRulesPathPrecedence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// useFlag sets ScanOptions.CustomRulesPath (what --rules does);
+		// useConfig writes scan.rules_dir into .nox.yaml.
+		useFlag    bool
+		useConfig  bool
+		wantCLI    bool
+		wantConfig bool
+	}{
+		{"neither: no custom rules load", false, false, false, false},
+		{"config fills an absent flag", false, true, false, true},
+		{"explicit flag, no config", true, false, true, false},
+		{"explicit flag beats config", true, true, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			mustWrite(t, filepath.Join(dir, "app.txt"), bothPatternsFile)
+
+			cfgRulesDir := filepath.Join(dir, "config-rules")
+			if err := os.Mkdir(cfgRulesDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			mustWrite(t, filepath.Join(cfgRulesDir, "rules.yaml"), configRuleYAML)
+
+			cliRules := filepath.Join(dir, "cli-rules.yaml")
+			mustWrite(t, cliRules, cliRuleYAML)
+
+			if tc.useConfig {
+				mustWrite(t, filepath.Join(dir, ".nox.yaml"), "scan:\n  rules_dir: config-rules\n")
+			}
+
+			opts := ScanOptions{Offline: true}
+			if tc.useFlag {
+				opts.CustomRulesPath = cliRules
+			}
+
+			res, err := RunScanWithOptions(dir, opts)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			got := res.Findings.Findings()
+
+			if hasRule(got, "PREC-CLI") != tc.wantCLI {
+				t.Errorf("PREC-CLI present = %v, want %v (flag=%v config=%v)",
+					hasRule(got, "PREC-CLI"), tc.wantCLI, tc.useFlag, tc.useConfig)
+			}
+			if hasRule(got, "PREC-CONFIG") != tc.wantConfig {
+				t.Errorf("PREC-CONFIG present = %v, want %v (flag=%v config=%v)",
+					hasRule(got, "PREC-CONFIG"), tc.wantConfig, tc.useFlag, tc.useConfig)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// policy.vex_path  /  ScanOptions.VEXPath  (--vex)
+// ---------------------------------------------------------------------------
+
+const validVEX = `{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://example.com/vex/precedence",
+  "author": "test",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "statements": []
+}`
+
+// TestVEXPathPrecedence decides precedence by which path the pipeline tries to
+// load: an explicitly-supplied VEX document that is missing is a hard error,
+// while a valid one loads silently. Pointing the two sources at a valid and a
+// missing file respectively makes "which source won" observable without needing
+// a real vulnerable dependency to waive.
+func TestVEXPathPrecedence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		flagPath    string // "" means --vex absent
+		configPath  string // "" means policy.vex_path absent
+		wantErrPath string // substring of the path the error must name; "" means no error
+	}{
+		{"neither: no VEX applied", "", "", ""},
+		{"config fills an absent flag (valid)", "", "valid.json", ""},
+		{"config fills an absent flag (missing → error names the config path)", "", "missing.json", "missing.json"},
+		{"explicit flag beats config: flag valid, config missing", "valid.json", "missing.json", ""},
+		{"explicit flag beats config: flag missing, config valid", "missing.json", "valid.json", "missing.json"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			mustWrite(t, filepath.Join(dir, "app.txt"), "nothing interesting\n")
+			mustWrite(t, filepath.Join(dir, "valid.json"), validVEX)
+			// missing.json is deliberately never created.
+
+			if tc.configPath != "" {
+				mustWrite(t, filepath.Join(dir, ".nox.yaml"),
+					"policy:\n  vex_path: \""+tc.configPath+"\"\n")
+			}
+
+			opts := ScanOptions{Offline: true, VEXPath: tc.flagPath}
+			_, err := RunScanWithOptions(dir, opts)
+
+			switch {
+			case tc.wantErrPath == "" && err != nil:
+				t.Fatalf("unexpected error (flag=%q config=%q): %v", tc.flagPath, tc.configPath, err)
+			case tc.wantErrPath != "" && err == nil:
+				t.Fatalf("expected the scan to fail loading %q (flag=%q config=%q), got nil",
+					tc.wantErrPath, tc.flagPath, tc.configPath)
+			case tc.wantErrPath != "" && !strings.Contains(err.Error(), tc.wantErrPath):
+				t.Fatalf("error names the wrong VEX path — the losing source was used.\n got: %v\nwant a path containing %q", err, tc.wantErrPath)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// policy.baseline_path  /  ScanOptions.BaselinePath  (--baseline)
+// ---------------------------------------------------------------------------
+
+const baselineRuleYAML = `rules:
+  - id: "PREC-BL"
+    version: "1.0"
+    description: "deterministic finding for baseline precedence"
+    severity: "high"
+    confidence: "high"
+    matcher_type: "regex"
+    pattern: "TODO"
+    file_patterns:
+      - "*.go"
+`
+
+// TestBaselinePathPrecedence covers the one setting here that CAN express
+// "explicit flag whose value equals the built-in default": the baseline path
+// falls back to .nox/baseline.json when neither source sets it, and that same
+// path can also be passed explicitly on --baseline.
+//
+// That is #362's shape exactly. A resolver comparing the flag against the
+// default path would read `--baseline .nox/baseline.json` as "flag absent" and
+// let policy.baseline_path win — suppressing findings the operator had just
+// asked to see, silently.
+func TestBaselinePathPrecedence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// flagPath / configPath are repo-relative; "" means that source is unset.
+		flagPath   string
+		configPath string
+		// wantSuppressed says whether PREC-BL must come back marked baselined.
+		// The two baseline files differ precisely in that: "full.json" contains
+		// the finding's fingerprint, "empty.json" and ".nox/baseline.json"
+		// contain none.
+		wantSuppressed bool
+	}{
+		{"neither: default .nox/baseline.json (empty) applies, nothing suppressed", "", "", false},
+		{"config fills an absent flag", "", "full.json", true},
+		{"explicit flag, no config", "full.json", "", true},
+		{"explicit flag beats config (flag suppresses)", "full.json", "empty.json", true},
+		{"explicit flag beats config (flag does NOT suppress)", "empty.json", "full.json", false},
+		// The #362 case: the explicitly-passed path IS the built-in default.
+		// It must still win over a config path that would have suppressed.
+		{"explicit flag == built-in default path still beats config", ".nox/baseline.json", "full.json", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			rulesFile := filepath.Join(dir, "rules.yaml")
+			mustWrite(t, rulesFile, baselineRuleYAML)
+			mustWrite(t, filepath.Join(dir, "main.go"), "// TODO: fix\n")
+
+			// Probe scan with no baseline anywhere, to capture the fingerprint.
+			probe, err := RunScanWithOptions(dir, ScanOptions{CustomRulesPath: rulesFile, Offline: true})
+			if err != nil {
+				t.Fatalf("probe scan: %v", err)
+			}
+			found := probe.Findings.Findings()
+			if !hasRule(found, "PREC-BL") {
+				t.Fatal("probe scan did not produce PREC-BL")
+			}
+			if isBaselined(found, "PREC-BL") {
+				t.Fatal("probe scan baselined PREC-BL with no baseline in play")
+			}
+
+			writeBaseline(t, filepath.Join(dir, "full.json"), baseline.FromFindings(found))
+			writeBaseline(t, filepath.Join(dir, "empty.json"), nil)
+			// The built-in default location, deliberately empty: reaching it
+			// must suppress nothing.
+			if err := os.MkdirAll(filepath.Join(dir, ".nox"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeBaseline(t, filepath.Join(dir, ".nox", "baseline.json"), nil)
+
+			if tc.configPath != "" {
+				mustWrite(t, filepath.Join(dir, ".nox.yaml"),
+					"policy:\n  baseline_path: \""+tc.configPath+"\"\n")
+			}
+
+			opts := ScanOptions{CustomRulesPath: rulesFile, Offline: true}
+			if tc.flagPath != "" {
+				opts.BaselinePath = filepath.Join(dir, tc.flagPath)
+			}
+
+			res, err := RunScanWithOptions(dir, opts)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			got := res.Findings.Findings()
+			if !hasRule(got, "PREC-BL") {
+				t.Fatal("PREC-BL disappeared")
+			}
+			if isBaselined(got, "PREC-BL") != tc.wantSuppressed {
+				t.Errorf("PREC-BL baselined = %v, want %v (--baseline %q, policy.baseline_path %q)",
+					isBaselined(got, "PREC-BL"), tc.wantSuppressed, tc.flagPath, tc.configPath)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// --staged: the options a staged scan must honour, and the two it must clear
+// ---------------------------------------------------------------------------
+
+// TestStagedScanHonoursCustomRulesOverConfig is the core-side half of the
+// --staged fix. RunStagedScanWithOptions rebuilds the git index into a temp
+// directory and copies .nox.yaml across, so config applies there; the caller's
+// options must apply too, and must win.
+func TestStagedScanHonoursCustomRulesOverConfig(t *testing.T) {
+	t.Parallel()
+
+	// initGitRepo commits what it writes, and a staged scan sees only the
+	// index, so the interesting files are written and staged afterwards.
+	dir := initGitRepo(t, map[string]string{"README.md": "placeholder\n"})
+	stageFiles(t, dir, map[string]string{
+		"app.txt":                 bothPatternsFile,
+		"config-rules/rules.yaml": configRuleYAML,
+		"cli-rules.yaml":          cliRuleYAML,
+		".nox.yaml":               "scan:\n  rules_dir: config-rules\n",
+	})
+
+	res, err := RunStagedScanWithOptions(dir, ScanOptions{
+		CustomRulesPath: filepath.Join(dir, "cli-rules.yaml"),
+		Offline:         true,
+	})
+	if err != nil {
+		t.Fatalf("staged scan: %v", err)
+	}
+	got := res.Findings.Findings()
+
+	if !hasRule(got, "PREC-CLI") {
+		t.Error("staged scan dropped the explicit CustomRulesPath: PREC-CLI missing")
+	}
+	if hasRule(got, "PREC-CONFIG") {
+		t.Error("staged scan let .nox.yaml scan.rules_dir beat an explicit CustomRulesPath (#362 shape)")
+	}
+}
+
+// TestStagedScanClearsGitScopedOptions pins the two options that must NOT be
+// forwarded verbatim. Both name git state that does not exist in the temp
+// directory the staged scan builds, and both are already implied by --staged:
+// the staged set is a changed set and a subset of the tracked set. Forwarding
+// them would turn `--staged --tracked-only` into a hard "requires a git
+// repository" error about a directory the operator never named.
+func TestStagedScanClearsGitScopedOptions(t *testing.T) {
+	t.Parallel()
+
+	dir := initGitRepo(t, map[string]string{"README.md": "placeholder\n"})
+	stageFiles(t, dir, map[string]string{"app.go": "package main\n"})
+
+	for _, tc := range []struct {
+		name string
+		opts ScanOptions
+	}{
+		{"--tracked-only", ScanOptions{TrackedOnly: true, Offline: true}},
+		{"--changed-since", ScanOptions{ChangedSince: "HEAD~1", Offline: true}},
+		{"both", ScanOptions{TrackedOnly: true, ChangedSince: "HEAD~1", Offline: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := RunStagedScanWithOptions(dir, tc.opts); err != nil {
+				t.Errorf("staged scan with %s failed: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// stageFiles writes files under dir and stages them without committing, so a
+// staged scan has something in the index to look at.
+func stageFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		mustWrite(t, full, body)
+	}
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add -A: %v\n%s", err, out)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+func writeBaseline(t *testing.T, path string, entries []baseline.Entry) {
+	t.Helper()
+	data, err := json.Marshal(baseline.Baseline{SchemaVersion: "1.0.0", Entries: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, path, string(data))
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -1112,8 +1112,15 @@ func RunStagedScanWithOptions(repoRoot string, opts ScanOptions) (*ScanResult, e
 	// ChangedSince is cleared because the temp directory is not a git
 	// repository — a staged scan already IS a changed-files scan, and leaving
 	// the ref set would make discovery fail.
+	//
+	// TrackedOnly is cleared for the same reason, and it costs nothing: the
+	// staged set is by definition a subset of the tracked set, so the flag's
+	// guarantee already holds. Leaving it set would make --staged --tracked-only
+	// fail with "requires a git repository", which is true of the temp directory
+	// and false of what the operator asked for.
 	stagedOpts := opts
 	stagedOpts.ChangedSince = ""
+	stagedOpts.TrackedOnly = false
 
 	result, err := RunScanWithOptions(tmpDir, stagedOpts)
 	if err != nil {


### PR DESCRIPTION
Refs #362.

#362 was a precedence inversion: `output.format` in a repo's `.nox.yaml` silently overrode an explicit `-format` on the command line. The resolver compared the flag's **value** against its default, so a deliberately-typed `-format json` was indistinguishable from an absent flag and config won. CI ran `nox scan . -format json,sarif` and gated on `findings.json`; two repos set `output.format: sarif`, `findings.json` was never written, the gate step skipped on the missing file — and a skipped step is a green check. 20 and 63 findings went ungated with a passing build.

That fix landed for `output.format` / `output.directory`, but nothing systematically checked the **other** settings that can be set from both sources. This PR enumerates them from the code, adds contract tables for each, and fixes one live instance of the same inversion.

## The defining test case

The bug class is not "flag differs from config" — that case works even in broken implementations. It is **"flag passed explicitly with a value equal to its own default, config says something different"**. A resolver comparing against the zero/default value cannot tell that from an omitted flag. Every table below carries that row, marked `explicit == default`.

## Dual-source settings found

| Config key | CLI flag | Resolver | Precedence | Covered |
|---|---|---|---|---|
| `output.format` | `scan -format` | `resolveOutputFormat` | correct | pre-existing (`output_precedence_test.go`) |
| `output.directory` | `scan -output` | `resolveOutputDir` | correct | pre-existing (`output_precedence_test.go`) |
| `scan.rules_dir` | `scan -rules` | inline, `core/scan.go` | correct | **new** — `TestCustomRulesPathPrecedence` |
| `policy.baseline_path` | `scan -baseline` | inline, `core/scan.go` | correct | **new** — `TestBaselinePathPrecedence` |
| `policy.vex_path` | `scan -vex` | inline, `core/scan.go` | correct | **new** — `TestVEXPathPrecedence` |
| `explain.model` | `explain -model` | `applyExplainDefaults` | correct | **new** |
| `explain.base_url` | `explain -base-url` | `applyExplainDefaults` | correct | **new** |
| `explain.timeout` | `explain -timeout` | `applyExplainDefaults` | correct | **new** |
| `explain.batch_size` | `explain -batch-size` | `applyExplainDefaults` | correct | **new** |
| `explain.output` | `explain -output` | `applyExplainDefaults` | correct | **new** |
| `explain.enrich` | `explain -enrich` | `applyExplainDefaults` | correct | **new** |
| `explain.plugin_dir` | `explain -plugin-dir` | `applyExplainDefaults` | correct | **new** |
| `plugins.trust_policy` | `plugin install --trust-policy`, `--require-verified`, `--require-signature`, `--allow-unverified` | `resolveTrustPolicy` | correct | **new** — `TestTrustPolicyPrecedence` |
| *(all of the above)* | **`scan --staged`** | — | **BROKEN — fixed here** | **new** |

Excluded from the tables, with reasons:

- **`scan.osv.disabled`** / `--no-osv`, `--offline` and **`plugins.auto_install`** / `--no-auto-install` are one-way. Either source can turn the behaviour off; no flag turns it back on, because no `--osv` or `--auto-install` exists. Config cannot override an explicit flag when there is no explicit flag meaning "on". Documented in the test file so a reader does not assume they were forgotten — if such a flag is ever added they become two-sided and need real tables.
- **`explain.api_key_env`** is config-only (no flag).
- **`compliance.framework`** and the whole **`cache`** block (`cache.disabled` / `ttl` / `dir`) parse from `.nox.yaml` and are read by nothing. Dead config, not a precedence question — flagged here as a separate cleanup.

## Precedence bug found and fixed: `nox scan --staged`

`nox scan --staged` rebuilds the git index into a temp directory and scans that, **copying `.nox.yaml` across so project config still applies**. The CLI called `nox.RunStagedScan(target)`, which passes `ScanOptions{}` — so every flag the operator typed (`--rules`, `--vex`, `--baseline`, `--offline`, `--no-osv`, `--tf-plan`, `--no-respect-gitignore`) was silently dropped, while config was still honoured.

That is #362's inversion exactly: **config beat an explicit flag, with no error and no warning.** Reproduced before the fix — a rule from `--rules` did not fire, while the rule from `.nox.yaml`'s `scan.rules_dir` did:

```
CLI-001 present: false
CONFIG-001 present: true
```

Blast radius: `nox protect` and `nox install-hook` both generate pre-commit hooks that run `nox scan --staged`. `--offline` and `--no-osv` being dropped also means a hook-time scan could reach the network after the operator forbade it.

The core had already been fixed to thread options through `RunStagedScanWithOptions` (its comment says so explicitly); this CLI call site was simply never updated when that landed.

The fix passes the options through, anchoring path-valued options to the real scan target — the staged scan runs against a temp copy, so a relative `--rules`/`--vex`/`--baseline` would otherwise resolve inside the temp directory and silently match nothing. `TrackedOnly` is cleared alongside the existing `ChangedSince` clearing in `RunStagedScanWithOptions`: both name git state absent from the temp directory, both are already implied by `--staged` (the staged set is a subset of the tracked set), and forwarding `TrackedOnly` would turn `--staged --tracked-only` into a spurious "requires a git repository" error.

**Not fixed, reported:** `nox scan --history` forwards only `--rules` and drops `--vex`, `--baseline` and the rest. It is *not* the same inversion — `RunHistoryScan` reads no config either, so nothing overrides the flags, they are simply ignored. Applying baselines and VEX to a history scan is a feature, not a small fix, so it is left alone here.

## Evidence the tests fail when precedence breaks

Every table was verified by breaking the production logic and confirming the test caught it, then restoring. Six mutations:

1. **Invert baseline resolution** (`core/scan.go`, config-wins) → `TestBaselinePathPrecedence` fails 3 rows, including `explicit flag == built-in default path still beats config`.
2. **Swap `rules_dir` resolution** (`core/scan.go`) → `TestCustomRulesPathPrecedence/explicit_flag_beats_config` fails both assertions (`PREC-CLI` absent, `PREC-CONFIG` present).
3. **Reintroduce the #362 defect verbatim in `applyExplainDefaults`** — replace the `fs.Visit` "was it passed?" check with "is it at its default value?":
   ```go
   if fs.Lookup("model").Value.String() == "gpt-4o" && ec.Model != "" {
   ```
   → **exactly and only** the four `explicit == default` rows fail:
   ```
   --- FAIL: .../model:_explicit_==_default_still_beats_config
       -model explicit=true value="gpt-4o", config "claude-3-opus" -> "claude-3-opus", want "gpt-4o"
   --- FAIL: .../timeout:_explicit_==_default_still_beats_config
   --- FAIL: .../batch-size:_explicit_==_default_still_beats_config
   --- FAIL: .../output:_explicit_==_default_still_beats_config
   ```
   The "explicit flag beats config" rows still passed. **That is the whole point:** a table that only checks differing values cannot see this bug, which is how #362 shipped.
4. **Revert the `--staged` fix** → `TestScanStagedHonoursRulesFlagOverConfig` fails with both messages: flag dropped, config won.
5. **Move the config lookup above the `override` check in `resolveTrustPolicy`** → 3 rows fail, including `explicit --trust-policy == built-in default still beats config`.
6. **Drop the `TrackedOnly` clearing** → `TestStagedScanClearsGitScopedOptions` fails with `--tracked-only requires a git repository`.

## Checks

`go build ./...`, `go vet ./...`, `gofmt -l` and `go test ./...` all clean — 55 packages ok, exit 0. (`gofmt -l` reports only the pre-existing, deliberately-unformatted `core/analyzers/secrets/testdata/benign/config.go` fixture.)

## Note on `registerExplainFlags`

The explain flags are now registered in one function shared by production and tests. The tests previously hand-rolled their own `FlagSet`, and it had already drifted — it declared `-timeout` as a **string** where production registers a **Duration**. A precedence test built on a different flag set than the one that ships cannot catch a precedence bug in the real one.
