### PR TITLE
fix(iac): retire ten duplicate rule IDs, aliasing them so existing waivers keep matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Ten duplicate IaC rule IDs retired; one condition, one finding.** Fourteen
+  pairs of IaC rules fired on the same condition, so a single misconfiguration
+  was reported twice — often at two different severities, which made a
+  severity-keyed gate depend on which ID it happened to read. `continue-on-error:
+  true` was both low (IAC-018) and medium (IAC-310); `privileged: true` was
+  covered three times over. IAC-237, IAC-283, IAC-287, IAC-291, IAC-292,
+  IAC-310, IAC-312, IAC-321, IAC-333 and IAC-337 are retired into the older rule
+  that already reported their condition. Two of the fourteen were not duplicates
+  but generic patterns swallowing specific ones (`encrypt\w*` over
+  `storage_encrypted`, `replicas` over `minReplicas`); both rules survive, with
+  the generic one bounded so the two no longer overlap. (#394)
+
+  **Existing waivers keep working.** A retired ID stays valid in baselines, VEX
+  statements, `nox:ignore` comments and `scan.rules.disable` — the rule that
+  absorbed it reproduces its fingerprints, bounded by the retired rule's own
+  pattern so no waiver is widened. Nothing needs to be rewritten. What changes
+  is the count and the ID: gates or dashboards keyed on a retired ID should move
+  to the surviving one (see "Retired rule IDs" in docs/usage.md).
+
 ## [1.22.1] - 2026-07-26
 
 ### Fixed

--- a/core/analyzers/iac/iac_test.go
+++ b/core/analyzers/iac/iac_test.go
@@ -616,8 +616,11 @@ func TestDetect_CustomDockerfileExtension(t *testing.T) {
 
 func TestAllIaCRules_Count(t *testing.T) {
 	rules := builtinIaCRules()
-	if got := len(rules); got != 500 {
-		t.Errorf("expected 500 IaC rules, got %d", got)
+	// 490, not 500: ten duplicate IDs were retired in #394 (see
+	// knownDuplicateRulePairs). Each lives on as an alias on the rule that
+	// absorbed it, so the drop is in rule COUNT only, not in coverage.
+	if got := len(rules); got != 490 {
+		t.Errorf("expected 490 IaC rules, got %d", got)
 	}
 }
 

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -25,6 +25,12 @@ type iacRule struct {
 	// Used e.g. by IAC-013 to declare a trusted-publisher allowlist that the
 	// regex matcher consumes via a post-filter.
 	extraMetadata map[string]string
+	// retires lists rule IDs this rule absorbed, with the pattern each of them
+	// carried at retirement. It is what keeps baselines, VEX statements and
+	// nox:ignore comments written against the retired ID matching — see
+	// rules.RetiredRule. Retiring an ID without it un-waives, in every
+	// consuming repo, findings an operator explicitly accepted.
+	retires []rules.RetiredRule
 	// absence* fields, when set, switch the rule to the block-scoped absence
 	// matcher (matcher_type "absence") instead of a plain regex. They replace
 	// the RE2-incompatible negative-lookahead patterns that never compiled: the
@@ -128,7 +134,25 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-005", severity: findings.SeverityHigh, confidence: findings.ConfidenceLow,
-			pattern:     `(?i)encrypt\w*\s*=\s*(false|"false")`,
+			// `\b` keeps this generic rule off attributes that a specific rule
+			// owns. Without it `encrypt\w*` matched the tail of
+			// `storage_encrypted = false`, so IAC-037 (RDS storage encryption,
+			// high confidence) and this rule (low confidence, generic message)
+			// both reported one line. The boundary makes the split legible:
+			// this rule covers attributes NAMED encrypt* (`encrypted = false`
+			// on an EBS volume), a prefixed attribute belongs to the rule that
+			// knows the resource. Surviving matches keep their exact matched
+			// text, so their fingerprints — and any baseline entry — are
+			// unchanged.
+			//
+			// The cost is prefixed attributes that no specific rule covers yet
+			// (`at_rest_encryption_enabled = false`, `transit_encryption_enabled
+			// = false` on ElastiCache): they are no longer reported. RE2 has no
+			// negative lookbehind, so a boundary is the only way to keep this
+			// pattern off the specific rules' ground, and a low-confidence
+			// generic message was never the right home for them — a rule per
+			// resource is.
+			pattern:     `(?i)\bencrypt\w*\s*=\s*(false|"false")`,
 			description: "Terraform resource has encryption disabled",
 			cwe:         "CWE-311", keywords: []string{"encrypt"},
 			filePatterns: []string{"*.tf", "*.tfvars"},
@@ -153,6 +177,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-284", keywords: []string{"publicly_accessible"},
 			filePatterns: []string{"*.tf", "*.tfvars"},
 			tags:         []string{"iac", "terraform", "database", "network"},
+			retires:      []rules.RetiredRule{{ID: "IAC-283", Pattern: `(?i)publicly_accessible\s*=\s*true`}},
 			remediation:  "Set publicly_accessible = false and access the database through a VPC, bastion host, or VPN. Public database instances are a common attack vector.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/284.html"},
 		},
@@ -213,6 +238,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-319", keywords: []string{"enable_https_traffic_only"},
 			filePatterns: []string{"*.tf"},
 			tags:         []string{"iac", "terraform", "azure", "encryption"},
+			retires:      []rules.RetiredRule{{ID: "IAC-321", Pattern: `(?i)enable_https_traffic_only\s*=\s*false`}},
 			remediation:  "Set enable_https_traffic_only = true to enforce HTTPS on Azure storage accounts. HTTP traffic exposes data to eavesdropping and tampering.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/319.html"},
 		},
@@ -252,13 +278,25 @@ func builtinBaseIaCRules() []rules.Rule {
 		// =================================================================
 		{
 			id: "IAC-007", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
-			pattern:     `(?i)privileged\s*:\s*true`,
-			description: "Kubernetes pod running as privileged",
+			// The single rule for `privileged: true`. IAC-065 (CloudFormation
+			// ECS) and IAC-237 (Kustomize) reported the same condition, so one
+			// line produced three findings at two severities. Absorbing them
+			// costs two things they could do that this could not: the quoted
+			// `Privileged: "true"` form, and *.template files. Both are
+			// covered here now, and `retires` keeps their waivers working.
+			pattern:     `(?i)privileged\s*:\s*(?:true|"true")`,
+			description: "Container runs in privileged mode",
 			cwe:         "CWE-250", keywords: []string{"privileged"},
-			filePatterns: []string{"*.yaml", "*.yml"},
-			tags:         []string{"iac", "kubernetes", "privilege"},
-			remediation:  "Set privileged: false in the pod security context. If specific capabilities are needed, use securityContext.capabilities.add with only what is required and drop ALL others. Enable readOnlyRootFilesystem: true where possible. Set runAsNonRoot: true and specify a non-root runAsUser. Apply Pod Security Standards.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/250.html", "https://kubernetes.io/docs/concepts/security/pod-security-standards/"},
+			filePatterns: []string{"*.yaml", "*.yml", "*.template"},
+			tags:         []string{"iac", "kubernetes", "cloudformation", "kustomize", "privilege"},
+			retires: []rules.RetiredRule{
+				// Only IAC-065's privileged branch moved here; its root-user
+				// branch stayed behind and IAC-065 still reports it.
+				{ID: "IAC-065", Pattern: `(?i)Privileged\s*:\s*(true|"true")`},
+				{ID: "IAC-237", Pattern: `(?i)privileged:\s*true`},
+			},
+			remediation: "Set privileged: false (Kubernetes securityContext, ECS ContainerDefinitions.Privileged, or the Kustomize patch that sets it). If specific capabilities are needed, use securityContext.capabilities.add with only what is required and drop ALL others. Enable readOnlyRootFilesystem: true where possible. Set runAsNonRoot: true and specify a non-root runAsUser. Apply Pod Security Standards.",
+			references:  []string{"https://cwe.mitre.org/data/definitions/250.html", "https://kubernetes.io/docs/concepts/security/pod-security-standards/"},
 		},
 		{
 			id: "IAC-008", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
@@ -297,6 +335,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-250", keywords: []string{"hostpid"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "privilege"},
+			retires:      []rules.RetiredRule{{ID: "IAC-291", Pattern: `(?i)hostPID:\s*true`}},
 			remediation:  "Remove hostPID: true. Sharing the host PID namespace allows the container to see and signal all processes on the host, breaking process isolation.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
 		},
@@ -307,6 +346,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-250", keywords: []string{"hostipc"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "privilege"},
+			retires:      []rules.RetiredRule{{ID: "IAC-292", Pattern: `(?i)hostIPC:\s*true`}},
 			remediation:  "Remove hostIPC: true. Sharing the host IPC namespace allows containers to access shared memory and IPC resources of other host processes.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
 		},
@@ -337,6 +377,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-269", keywords: []string{"automountserviceaccounttoken"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "privilege"},
+			retires:      []rules.RetiredRule{{ID: "IAC-287", Pattern: `(?i)automountServiceAccountToken:\s*true`}},
 			remediation:  "Set automountServiceAccountToken: false unless the pod requires Kubernetes API access. Mounted tokens can be used for lateral movement if the pod is compromised.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/269.html"},
 		},
@@ -461,11 +502,17 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-017", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:     `::set-output\s+name=`,
+			// Case-insensitive so it covers everything the retired IAC-312
+			// caught. IAC-312 dropped the `::` prefix entirely, which is what
+			// makes the workflow command a command; without it the pattern
+			// also matched prose about set-output. That looseness is not
+			// carried over.
+			pattern:     `(?i)::set-output\s+name=`,
 			description: "Workflow uses deprecated set-output command",
 			cwe:         "CWE-77", keywords: []string{"set-output"},
 			filePatterns: []string{"*.yml", "*.yaml"},
 			tags:         []string{"iac", "github-actions", "deprecated"},
+			retires:      []rules.RetiredRule{{ID: "IAC-312", Pattern: `(?i)set-output\s+name=`}},
 			remediation:  "Replace ::set-output with $GITHUB_OUTPUT environment file. The set-output command is deprecated and vulnerable to log injection attacks.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/77.html", "https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"},
 		},
@@ -476,8 +523,13 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-755", keywords: []string{"continue-on-error"},
 			filePatterns: []string{"*.yml", "*.yaml"},
 			tags:         []string{"iac", "github-actions", "error-handling"},
-			remediation:  "Avoid continue-on-error: true as it can mask security check failures. If needed, check the step outcome explicitly and fail on security-critical errors.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/755.html"},
+			// The retired IAC-310 reported this at medium; keeping the older
+			// ID's low is the conservative half of an arbitrary split — a
+			// deliberately non-blocking step is a hygiene signal, and a gate
+			// keyed on medium should not start failing because of a de-dup.
+			retires:     []rules.RetiredRule{{ID: "IAC-310", Pattern: `(?i)continue-on-error:\s*true`}},
+			remediation: "Avoid continue-on-error: true as it can mask security check failures. If needed, check the step outcome explicitly and fail on security-critical errors.",
+			references:  []string{"https://cwe.mitre.org/data/definitions/755.html"},
 		},
 
 		// =================================================================
@@ -720,12 +772,20 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-065", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?i)(?:Privileged\s*:\s*(true|"true")|User\s*:\s*["']?(?:0|root)["']?)`,
-			description: "CloudFormation ECS task definition runs as privileged or root",
-			cwe:         "CWE-250", keywords: []string{"Privileged", "ContainerDefinitions", "TaskDefinition"},
+			// The privileged branch moved to IAC-007, which reported the same
+			// condition at critical. What is left is this rule's own
+			// contribution — a container definition running as root — and its
+			// matched text is unchanged, so existing findings keep their
+			// fingerprints and their baseline entries.
+			pattern:     `(?i)User\s*:\s*["']?(?:0|root)["']?`,
+			description: "CloudFormation ECS task definition runs as root",
+			// Keywords stay as they were: they gate at file level, so trimming
+			// "Privileged" here would stop scanning files this rule still has
+			// something to say about, for no gain.
+			cwe: "CWE-250", keywords: []string{"Privileged", "ContainerDefinitions", "TaskDefinition"},
 			filePatterns: []string{"*.template", "*.json", "*.yaml", "*.yml"},
 			tags:         []string{"iac", "cloudformation", "aws", "privilege"},
-			remediation:  "Set Privileged to false and avoid running as root (User: 0) in ECS task definitions. Use non-root users and drop unnecessary Linux capabilities.",
+			remediation:  "Avoid running as root (User: 0) in ECS task definitions. Use a non-root user and drop unnecessary Linux capabilities. Privileged mode is reported separately by IAC-007.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
 		},
 		{
@@ -1234,6 +1294,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-693", keywords: []string{"enable_secure_boot", "enableSecureBoot"},
 			filePatterns: []string{"*.tf", "*.yaml", "*.yml", "*.json"},
 			tags:         []string{"iac", "gcp", "integrity"},
+			retires:      []rules.RetiredRule{{ID: "IAC-333", Pattern: `(?i)enable_secure_boot\s*=\s*false`}},
 			remediation:  "Enable Shielded VM features (secure boot, vTPM, integrity monitoring) on compute instances. Shielded VMs protect against rootkits and boot-level malware.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
@@ -1286,6 +1347,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			cwe:         "CWE-319", keywords: []string{"require_ssl", "requireSsl"},
 			filePatterns: []string{"*.tf", "*.yaml", "*.yml", "*.json"},
 			tags:         []string{"iac", "gcp", "database", "encryption"},
+			retires:      []rules.RetiredRule{{ID: "IAC-337", Pattern: `(?i)require_ssl\s*=\s*false`}},
 			remediation:  "Set require_ssl to true to enforce SSL connections to Cloud SQL instances. Unencrypted connections expose database traffic to eavesdropping.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/319.html"},
 		},
@@ -1580,7 +1642,12 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-141", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?im)replicas\s*:\s*1\s*$`,
+			// `\b` stops the Deployment rule from also claiming an HPA's
+			// `minReplicas: 1` (IAC-399) — and `maxReplicas`, `readyReplicas`
+			// and every other *Replicas key. A YAML key is always preceded by
+			// whitespace or a line start, so real `replicas: 1` matches are
+			// unaffected, matched text included.
+			pattern:     `(?im)\breplicas\s*:\s*1\s*$`,
 			description: "Kubernetes Deployment with single replica (no high availability)",
 			cwe:         "CWE-693", keywords: []string{"replicas"},
 			filePatterns: []string{"*.yaml", "*.yml"},
@@ -2101,6 +2168,7 @@ func convertIaCRules(defs []iacRule) []rules.Rule {
 			Metadata:     md,
 			Remediation:  defs[i].remediation,
 			References:   defs[i].references,
+			Retires:      defs[i].retires,
 		}
 		if defs[i].absenceAnchor != "" {
 			r.MatcherType = "absence"

--- a/core/analyzers/iac/rules_dedup_test.go
+++ b/core/analyzers/iac/rules_dedup_test.go
@@ -6,8 +6,46 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
 )
+
+// assertRetiredIntoSurvivor is the check a retirement has to pass: the
+// condition the retired ID reported is still detected, exactly once, by the
+// rule that absorbed it — and the retired ID is still attached to that finding
+// as an alias, which is what keeps a baseline entry, a VEX statement or a
+// nox:ignore comment written against it matching.
+//
+// A retirement that merely deletes a rule passes "no duplicate" and fails here.
+func assertRetiredIntoSurvivor(t *testing.T, results []findings.Finding, retired, survivor string, want findings.Severity) {
+	t.Helper()
+
+	var matches []findings.Finding
+	for i := range results {
+		switch results[i].RuleID {
+		case retired:
+			t.Errorf("%s is retired but was still emitted", retired)
+		case survivor:
+			matches = append(matches, results[i])
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one %s finding (the condition %s used to double-report), got %d",
+			survivor, retired, len(matches))
+	}
+	f := matches[0]
+	if f.Severity != want {
+		t.Errorf("%s severity = %s, want %s", survivor, f.Severity, want)
+	}
+	if !f.MatchesRuleID(retired) {
+		t.Errorf("%s finding does not answer to the retired ID %s (RetiredRuleIDs=%v) — "+
+			"every waiver written against %s stops matching", survivor, retired, f.RetiredRuleIDs, retired)
+	}
+	if len(f.AliasFingerprints) == 0 {
+		t.Errorf("%s finding carries no alias fingerprint for %s — baselines keyed on the "+
+			"retired ID cannot match", survivor, retired)
+	}
+}
 
 // Two rules that fire on the same line for the same condition report one issue
 // twice. IAC-018 ("Workflow step suppresses failures with continue-on-error",
@@ -147,33 +185,94 @@ var allowedOverlap = map[struct{ a, b string }]bool{
 }
 
 // knownDuplicateRulePairs are pairs that DO double-report the same condition and
-// are not yet fixed. Nearly all follow one shape: rules_expanded.go (IAC-266 to
-// IAC-500) re-implements a condition rules.go (IAC-001 to IAC-185) already
+// are not yet fixed. Nearly all followed one shape: rules_expanded.go (IAC-266 to
+// IAC-500) re-implemented a condition rules.go (IAC-001 to IAC-185) already
 // covered, because the files are concatenated by builtinIaCRules with nothing
 // comparing them.
 //
-// Fixing one means retiring an ID and aliasing it, so existing baselines keep
-// matching instead of silently un-waiving; that is a behavioural change with
-// migration consequences, so it is deliberately not bundled into this test.
+// It is EMPTY, and that is the point: the 14 pairs it tracked were retired in
+// #394. Ten IDs (IAC-237, IAC-283, IAC-287, IAC-291, IAC-292, IAC-310, IAC-312,
+// IAC-321, IAC-333, IAC-337) were absorbed by the older rule that already
+// reported their condition, each declaring the retirement in that rule's
+// `retires` list so baselines, VEX statements and nox:ignore comments written
+// against the retired ID keep matching. Two pairs were not duplicates but
+// generic patterns swallowing specific ones — `encrypt\w*` over
+// `storage_encrypted`, `replicas` over `minReplicas` — and were fixed by
+// bounding the generic pattern with `\b` instead, so both rules survive.
 //
-// Like knownUncompilableIaCRules, this set must only ever SHRINK. Remove a pair
-// when it is fixed; the guard below then requires it to stay fixed. A NEW
-// duplicate fails the build.
-var knownDuplicateRulePairs = map[struct{ a, b string }]string{
-	{"IAC-005", "IAC-037"}: "generic `encrypt* = false` also matches the specific `storage_encrypted = false`",
-	{"IAC-007", "IAC-065"}: "privileged: true",
-	{"IAC-007", "IAC-237"}: "privileged: true (three rules cover this one condition)",
-	{"IAC-065", "IAC-237"}: "privileged: true",
-	{"IAC-017", "IAC-312"}: "deprecated ::set-output",
-	{"IAC-018", "IAC-310"}: "continue-on-error: true, reported low AND medium",
-	{"IAC-026", "IAC-291"}: "hostPID: true",
-	{"IAC-027", "IAC-292"}: "hostIPC: true",
-	{"IAC-030", "IAC-287"}: "automountServiceAccountToken: true",
-	{"IAC-036", "IAC-283"}: "publicly_accessible = true",
-	{"IAC-042", "IAC-321"}: "enable_https_traffic_only = false",
-	{"IAC-111", "IAC-333"}: "enable_secure_boot = false",
-	{"IAC-116", "IAC-337"}: "require_ssl = false",
-	{"IAC-141", "IAC-399"}: "minReplicas: 1",
+// Like knownUncompilableIaCRules, this set must only ever SHRINK. Nothing may
+// be added to it: a NEW duplicate fails the build, and the fix is to retire an
+// ID (with its alias) or to narrow the pattern, not to record the overlap here.
+var knownDuplicateRulePairs = map[struct{ a, b string }]string{}
+
+// partiallyRetiredIDs are IDs that survive as rules while ONE branch of what
+// they used to match moved to another rule. IAC-065 is the only one: its
+// `Privileged: true` branch went to IAC-007 (which reported the same condition
+// at critical), while its `User: 0|root` branch — the CloudFormation ECS
+// contribution nothing else makes — stayed.
+//
+// Such an ID is unusual enough to be listed rather than inferred: it means a
+// waiver naming it also reaches the rule that absorbed the moved branch, at the
+// lines where the moved pattern matches. That is deliberate — it is the same
+// condition under a new ID — but it is not something to introduce by accident.
+var partiallyRetiredIDs = map[string]bool{"IAC-065": true}
+
+// TestIaCRuleRetirements_AreWellFormed checks the migration data itself. A
+// retirement whose pattern does not compile, or that names a live rule by
+// mistake, silently stops keeping old waivers alive — the failure mode is
+// invisible in a scan and only shows up as red gates in consuming repos.
+func TestIaCRuleRetirements_AreWellFormed(t *testing.T) {
+	all := builtinIaCRules()
+
+	live := make(map[string]bool, len(all))
+	for _, r := range all {
+		live[r.ID] = true
+	}
+
+	declaredBy := map[string]string{}
+	retirements := 0
+	for _, r := range all {
+		for _, retired := range r.Retires {
+			retirements++
+			if retired.ID == "" {
+				t.Errorf("%s retires a rule with no ID", r.ID)
+			}
+			if retired.ID == r.ID {
+				t.Errorf("%s retires itself", r.ID)
+			}
+			if prev, dup := declaredBy[retired.ID]; dup {
+				t.Errorf("%s is retired by both %s and %s; one finding would answer to it twice",
+					retired.ID, prev, r.ID)
+			}
+			declaredBy[retired.ID] = r.ID
+
+			if retired.Pattern == "" {
+				t.Errorf("%s retires %s with no pattern, so it cannot reproduce that rule's "+
+					"fingerprints and every baseline entry for %s stops matching",
+					r.ID, retired.ID, retired.ID)
+				continue
+			}
+			if _, err := regexp.Compile(retired.Pattern); err != nil {
+				t.Errorf("%s retires %s with an uncompilable pattern %q: %v",
+					r.ID, retired.ID, retired.Pattern, err)
+			}
+			if live[retired.ID] && !partiallyRetiredIDs[retired.ID] {
+				t.Errorf("%s is retired by %s but is still a live rule; either it was never "+
+					"retired or the alias widens %s's waivers to a rule that still fires",
+					retired.ID, r.ID, retired.ID)
+			}
+		}
+	}
+	if retirements == 0 {
+		t.Fatal("no rule declares a retirement; either the retirements were dropped or this " +
+			"test is looking at the wrong rule set")
+	}
+	for id := range partiallyRetiredIDs {
+		if !live[id] {
+			t.Errorf("%s is listed as partially retired but no longer exists; retire it fully "+
+				"and drop it from partiallyRetiredIDs", id)
+		}
+	}
 }
 
 // literalProbe turns a regex into a plain string that the regex matches, or

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -212,17 +212,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Set skip_final_snapshot = false and provide a final_snapshot_identifier. Without a final snapshot, all data is permanently lost when the RDS instance is destroyed.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-283", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)publicly_accessible\s*=\s*true`,
-			description:  "Terraform resource is publicly accessible",
-			cwe:          "CWE-284",
-			keywords:     []string{"publicly_accessible", "true"},
-			filePatterns: tfFilePatterns,
-			tags:         []string{"iac", "terraform", "network"},
-			remediation:  "Set publicly_accessible = false and access the resource through a VPN, bastion host, or VPC endpoint. Public-facing databases and caches are common attack targets.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/284.html"},
-		},
+		// IAC-283 retired into IAC-036, which already reported this condition.
+		// IAC-036's `retires` carries the alias that keeps waivers written
+		// against IAC-283 matching.
 		{
 			id: "IAC-284", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)enable_key_rotation\s*=\s*false`,
@@ -260,17 +252,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Define NetworkPolicy resources to restrict ingress and egress traffic for workloads. Without NetworkPolicies, pods can communicate with any other pod in the cluster.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-287", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)automountServiceAccountToken:\s*true`,
-			description:  "K8s pod automounts service account token",
-			cwe:          "CWE-284",
-			keywords:     []string{"automountServiceAccountToken"},
-			filePatterns: k8sFilePatterns,
-			tags:         []string{"iac", "kubernetes", "privilege"},
-			remediation:  "Set automountServiceAccountToken: false unless the pod needs to access the Kubernetes API. Mounted tokens can be exploited if the pod is compromised.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/284.html"},
-		},
+		// IAC-287 retired into IAC-030, which already reported this condition.
+		// IAC-030's `retires` carries the alias that keeps waivers written
+		// against IAC-287 matching.
 		{
 			id: "IAC-288", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)roleRef:(?:.*\n){0,3}.*name:\s*['"]?cluster-admin`,
@@ -304,28 +288,12 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Replace wildcard verbs with specific verbs (get, list, watch, create, update, delete). Wildcard verbs grant all operations including escalate and impersonate.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
 		},
-		{
-			id: "IAC-291", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)hostPID:\s*true`,
-			description:  "K8s pod uses host PID namespace",
-			cwe:          "CWE-250",
-			keywords:     []string{"hostPID"},
-			filePatterns: k8sFilePatterns,
-			tags:         []string{"iac", "kubernetes", "privilege"},
-			remediation:  "Remove hostPID: true unless absolutely required. Sharing the host PID namespace allows the container to see and signal all host processes, enabling privilege escalation.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
-		},
-		{
-			id: "IAC-292", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)hostIPC:\s*true`,
-			description:  "K8s pod uses host IPC namespace",
-			cwe:          "CWE-250",
-			keywords:     []string{"hostIPC"},
-			filePatterns: k8sFilePatterns,
-			tags:         []string{"iac", "kubernetes", "privilege"},
-			remediation:  "Remove hostIPC: true. Sharing the host IPC namespace allows the container to access shared memory segments on the host, which can be exploited for data exfiltration.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
-		},
+		// IAC-291 retired into IAC-026, which already reported this condition.
+		// IAC-026's `retires` carries the alias that keeps waivers written
+		// against IAC-291 matching.
+		// IAC-292 retired into IAC-027, which already reported this condition.
+		// IAC-027's `retires` carries the alias that keeps waivers written
+		// against IAC-292 matching.
 		{
 			id: "IAC-293", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
 			pattern:      `(?i)hostPath:\s*\n\s*path:\s*['"]?/`,
@@ -517,17 +485,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Ensure that cancelling in-progress runs is intentional. For deployment workflows, cancellation may leave infrastructure in a partially applied state.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-310", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)continue-on-error:\s*true`,
-			description:  "GHA step continues on error",
-			cwe:          "CWE-755",
-			keywords:     []string{"continue-on-error"},
-			filePatterns: ghaFilePatterns,
-			tags:         []string{"iac", "github-actions", "error-handling"},
-			remediation:  "Remove continue-on-error: true unless the failure is intentionally non-blocking. Ignoring errors can mask security scan failures and broken tests.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/755.html"},
-		},
+		// IAC-310 retired into IAC-018, which already reported this condition.
+		// IAC-018's `retires` carries the alias that keeps waivers written
+		// against IAC-310 matching.
 		{
 			id: "IAC-311", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)ACTIONS_ALLOW_UNSECURE_COMMANDS`,
@@ -539,17 +499,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Remove ACTIONS_ALLOW_UNSECURE_COMMANDS and migrate to the GITHUB_OUTPUT and GITHUB_ENV file-based alternatives. The old set-env and add-path commands are vulnerable to injection.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/78.html"},
 		},
-		{
-			id: "IAC-312", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)set-output\s+name=`,
-			description:  "GHA uses deprecated set-output command",
-			cwe:          "CWE-693",
-			keywords:     []string{"set-output"},
-			filePatterns: ghaFilePatterns,
-			tags:         []string{"iac", "github-actions", "best-practice"},
-			remediation:  "Replace ::set-output with the $GITHUB_OUTPUT file. The set-output command is deprecated and may be removed in a future runner version.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
-		},
+		// IAC-312 retired into IAC-017, which already reported this condition.
+		// IAC-017's `retires` carries the alias that keeps waivers written
+		// against IAC-312 matching.
 		{
 			id: "IAC-313", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)save-state\s+name=`,
@@ -642,17 +594,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 		// =================================================================
 		// Azure (IAC-321 to IAC-330)
 		// =================================================================
-		{
-			id: "IAC-321", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)enable_https_traffic_only\s*=\s*false`,
-			description:  "Azure storage allows HTTP traffic",
-			cwe:          "CWE-319",
-			keywords:     []string{"enable_https_traffic_only"},
-			filePatterns: tfFilePatterns,
-			tags:         []string{"iac", "terraform", "azure", "transport-security"},
-			remediation:  "Set enable_https_traffic_only = true to enforce HTTPS for all storage account traffic. HTTP traffic is unencrypted and vulnerable to interception.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/319.html"},
-		},
+		// IAC-321 retired into IAC-042, which already reported this condition.
+		// IAC-042's `retires` carries the alias that keeps waivers written
+		// against IAC-321 matching.
 		{
 			id: "IAC-322", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)min_tls_version\s*=\s*['"]?TLS1_0`,
@@ -778,17 +722,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Set enable_integrity_monitoring = true to detect unauthorized changes to the boot sequence and kernel. Disabling it removes a key defense against persistent malware.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-333", severity: findings.SeverityMedium, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)enable_secure_boot\s*=\s*false`,
-			description:  "GCP shielded VM secure boot disabled",
-			cwe:          "CWE-693",
-			keywords:     []string{"enable_secure_boot"},
-			filePatterns: tfFilePatterns,
-			tags:         []string{"iac", "terraform", "gcp", "security"},
-			remediation:  "Set enable_secure_boot = true to ensure only verified boot software runs. Disabling secure boot allows unsigned or modified bootloaders and kernels.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
-		},
+		// IAC-333 retired into IAC-111, which already reported this condition.
+		// IAC-111's `retires` carries the alias that keeps waivers written
+		// against IAC-333 matching.
 		{
 			id: "IAC-334", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
 			pattern:      `(?i)resource\s*['"]google_storage_bucket['"]`,
@@ -822,17 +758,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Enable require_ssl in the ip_configuration settings to enforce encrypted connections to the Cloud SQL instance. Unencrypted connections expose data in transit.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-337", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)require_ssl\s*=\s*false`,
-			description:  "GCP SQL instance without SSL enforcement",
-			cwe:          "CWE-319",
-			keywords:     []string{"require_ssl"},
-			filePatterns: tfFilePatterns,
-			tags:         []string{"iac", "terraform", "gcp", "transport-security"},
-			remediation:  "Set require_ssl = true to enforce SSL/TLS connections to the Cloud SQL instance. Without SSL enforcement, database traffic is transmitted in plain text.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/319.html"},
-		},
+		// IAC-337 retired into IAC-116, which already reported this condition.
+		// IAC-116's `retires` carries the alias that keeps waivers written
+		// against IAC-337 matching.
 		{
 			id: "IAC-338", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
 			pattern:      `(?i)value\s*=\s*['"]?0\.0\.0\.0/0`,

--- a/core/analyzers/iac/rules_expanded_test.go
+++ b/core/analyzers/iac/rules_expanded_test.go
@@ -12,8 +12,11 @@ import (
 
 func TestExpandedRules_Count(t *testing.T) {
 	rules := builtinExpandedIaCRules()
-	if got := len(rules); got != 235 {
-		t.Errorf("expected 235 expanded rules, got %d", got)
+	// 226, not the original 235: nine expanded rules (IAC-283, IAC-287,
+	// IAC-291, IAC-292, IAC-310, IAC-312, IAC-321, IAC-333, IAC-337) were
+	// retired in #394 because a base rule already reported their condition.
+	if got := len(rules); got != 226 {
+		t.Errorf("expected 226 expanded rules, got %d", got)
 	}
 }
 
@@ -218,7 +221,10 @@ func TestExpandedDetect_IAC281_ForceDestroyEnabled(t *testing.T) {
 	}
 }
 
-func TestExpandedDetect_IAC283_PubliclyAccessible(t *testing.T) {
+// IAC-283 was retired into IAC-036, which reported the same condition at
+// critical. The fixture is unchanged: what must not change is that the
+// condition is still detected -- once.
+func TestExpandedDetect_IAC283_RetiredIntoIAC036_PubliclyAccessible(t *testing.T) {
 	a := NewAnalyzer()
 	content := []byte(`resource "aws_db_instance" "default" {
   publicly_accessible = true
@@ -228,18 +234,7 @@ func TestExpandedDetect_IAC283_PubliclyAccessible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	found := false
-	for _, f := range results {
-		if f.RuleID == "IAC-283" {
-			found = true
-			if f.Severity != findings.SeverityHigh {
-				t.Errorf("expected severity high, got %s", f.Severity)
-			}
-		}
-	}
-	if !found {
-		t.Error("expected IAC-283 to be detected")
-	}
+	assertRetiredIntoSurvivor(t, results, "IAC-283", "IAC-036", findings.SeverityCritical)
 }
 
 func TestExpandedDetect_IAC285_MultiAZFalse(t *testing.T) {
@@ -586,15 +581,7 @@ jobs:
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	found := false
-	for _, f := range results {
-		if f.RuleID == "IAC-310" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected IAC-310 to be detected")
-	}
+	assertRetiredIntoSurvivor(t, results, "IAC-310", "IAC-018", findings.SeverityLow)
 }
 
 func TestExpandedDetect_IAC314_ContentsWrite(t *testing.T) {
@@ -687,7 +674,8 @@ jobs:
 // Azure (IAC-321 to IAC-330) -- these use .tf files
 // ---------------------------------------------------------------------------
 
-func TestExpandedDetect_IAC321_AzureHTTPTraffic(t *testing.T) {
+// IAC-321 was retired into IAC-042 (#394), same condition, same severity.
+func TestExpandedDetect_IAC321_RetiredIntoIAC042_AzureHTTPTraffic(t *testing.T) {
 	a := NewAnalyzer()
 	content := []byte(`resource "azurerm_storage_account" "main" {
   name                      = "mystorageaccount"
@@ -698,18 +686,7 @@ func TestExpandedDetect_IAC321_AzureHTTPTraffic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	found := false
-	for _, f := range results {
-		if f.RuleID == "IAC-321" {
-			found = true
-			if f.Severity != findings.SeverityHigh {
-				t.Errorf("expected severity high, got %s", f.Severity)
-			}
-		}
-	}
-	if !found {
-		t.Error("expected IAC-321 to be detected")
-	}
+	assertRetiredIntoSurvivor(t, results, "IAC-321", "IAC-042", findings.SeverityHigh)
 }
 
 func TestExpandedDetect_IAC324_AzureAdminEnabled(t *testing.T) {
@@ -778,18 +755,7 @@ func TestExpandedDetect_IAC337_GCPRequireSSLFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	found := false
-	for _, f := range results {
-		if f.RuleID == "IAC-337" {
-			found = true
-			if f.Severity != findings.SeverityHigh {
-				t.Errorf("expected severity high, got %s", f.Severity)
-			}
-		}
-	}
-	if !found {
-		t.Error("expected IAC-337 to be detected")
-	}
+	assertRetiredIntoSurvivor(t, results, "IAC-337", "IAC-116", findings.SeverityHigh)
 }
 
 func TestExpandedDetect_IAC338_GCPAllIPsAuthorized(t *testing.T) {

--- a/core/analyzers/iac/rules_kustomize.go
+++ b/core/analyzers/iac/rules_kustomize.go
@@ -76,17 +76,9 @@ func builtinKustomizeRules() []rules.Rule {
 			remediation:  "Move sensitive values from configMapGenerator to secretGenerator and use external secret management (e.g., Sealed Secrets, SOPS, or an external secrets operator).",
 			references:   []string{"https://cwe.mitre.org/data/definitions/798.html"},
 		},
-		{
-			id: "IAC-237", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:      `(?i)privileged:\s*true`,
-			description:  "Kustomize patch enables privileged containers",
-			cwe:          "CWE-250",
-			keywords:     []string{"privileged"},
-			filePatterns: kustomizeFilePatterns,
-			tags:         []string{"iac", "kustomize", "privilege"},
-			remediation:  "Avoid running containers in privileged mode. Use specific Linux capabilities (securityContext.capabilities.add) instead of granting full host access.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
-		},
+		// IAC-237 retired into IAC-007, which already reported this condition.
+		// IAC-007's `retires` carries the alias that keeps waivers written
+		// against IAC-237 matching.
 		{
 			id: "IAC-238", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
 			pattern:      `(?i)count:\s*1\b`,

--- a/core/analyzers/iac/rules_kustomize_test.go
+++ b/core/analyzers/iac/rules_kustomize_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestKustomizeRules_Count(t *testing.T) {
 	rules := builtinKustomizeRules()
-	if got := len(rules); got != 15 {
-		t.Errorf("expected 15 Kustomize rules, got %d", got)
+	// 14, not 15: IAC-237 (privileged: true) was retired into IAC-007 in
+	// #394 -- three rules reported that one condition.
+	if got := len(rules); got != 14 {
+		t.Errorf("expected 14 Kustomize rules, got %d", got)
 	}
 }
 
@@ -185,7 +187,7 @@ resources:
 }
 
 // ---------------------------------------------------------------------------
-// IAC-237: privileged: true in Kustomize overlay
+// IAC-237 (retired into IAC-007): privileged: true in Kustomize overlay
 // ---------------------------------------------------------------------------
 
 func TestDetect_KustomizePrivilegedContainer(t *testing.T) {
@@ -212,18 +214,7 @@ patchesStrategicMerge:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	found := false
-	for _, f := range results {
-		if f.RuleID == "IAC-237" {
-			found = true
-			if f.Severity != findings.SeverityHigh {
-				t.Errorf("expected severity high, got %s", f.Severity)
-			}
-		}
-	}
-	if !found {
-		t.Error("expected IAC-237 to be detected")
-	}
+	assertRetiredIntoSurvivor(t, results, "IAC-237", "IAC-007", findings.SeverityCritical)
 }
 
 // ---------------------------------------------------------------------------

--- a/core/analyzers/iac/rules_retired_test.go
+++ b/core/analyzers/iac/rules_retired_test.go
@@ -1,0 +1,208 @@
+package iac
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// The conditions that used to be reported twice, each checked from the outside:
+// one finding, from the rule that kept the ID, still covering everything the
+// retired rule covered.
+
+func scanIaC(t *testing.T, path, content string) []findings.Finding {
+	t.Helper()
+	got, err := NewAnalyzer().ScanFile(path, []byte(content))
+	if err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return got
+}
+
+func rulesFiring(fs []findings.Finding) map[string]int {
+	out := map[string]int{}
+	for i := range fs {
+		out[fs[i].RuleID]++
+	}
+	return out
+}
+
+// TestRetired_OneFindingPerCondition walks the retirements: the condition is
+// reported exactly once, by the surviving ID, and the retired ID is gone.
+func TestRetired_OneFindingPerCondition(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		content  string
+		survivor string
+		retired  string
+	}{
+		{"hostPID", "pod.yaml", "spec:\n  hostPID: true\n", "IAC-026", "IAC-291"},
+		{"hostIPC", "pod.yaml", "spec:\n  hostIPC: true\n", "IAC-027", "IAC-292"},
+		{"automount token", "pod.yaml", "spec:\n  automountServiceAccountToken: true\n", "IAC-030", "IAC-287"},
+		{"privileged", "pod.yaml", "        privileged: true\n", "IAC-007", "IAC-237"},
+		{"set-output", "ci.yml", "      - run: echo \"::set-output name=v::1\"\n", "IAC-017", "IAC-312"},
+		{"continue-on-error", "ci.yml", "      - continue-on-error: true\n", "IAC-018", "IAC-310"},
+		{"publicly accessible", "rds.tf", "  publicly_accessible = true\n", "IAC-036", "IAC-283"},
+		{"azure http", "storage.tf", "  enable_https_traffic_only = false\n", "IAC-042", "IAC-321"},
+		{"secure boot", "vm.tf", "  enable_secure_boot = false\n", "IAC-111", "IAC-333"},
+		{"require ssl", "sql.tf", "  require_ssl = false\n", "IAC-116", "IAC-337"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			firing := rulesFiring(scanIaC(t, tc.path, tc.content))
+			if got := firing[tc.survivor]; got != 1 {
+				t.Errorf("%s fired %d times, want exactly 1 — the condition must still be reported",
+					tc.survivor, got)
+			}
+			if got := firing[tc.retired]; got != 0 {
+				t.Errorf("%s is retired but fired %d times", tc.retired, got)
+			}
+		})
+	}
+}
+
+// TestRetired_IAC065PrivilegedBranchMovedToIAC007 checks the one partial
+// retirement from both ends: the branch that moved is reported by IAC-007
+// (including the quoted form and *.template files, which only IAC-065 used to
+// reach), and the branch that stayed is still reported by IAC-065.
+func TestRetired_IAC065PrivilegedBranchMovedToIAC007(t *testing.T) {
+	t.Run("quoted privileged in a CloudFormation template", func(t *testing.T) {
+		content := "Resources:\n  Task:\n    Properties:\n      ContainerDefinitions:\n        - Privileged: \"true\"\n"
+		fs := scanIaC(t, "ecs.template", content)
+		firing := rulesFiring(fs)
+		if firing["IAC-007"] != 1 {
+			t.Errorf("IAC-007 fired %d times on a *.template with Privileged: \"true\"; "+
+				"absorbing IAC-065 must not lose the quoted form or the file type", firing["IAC-007"])
+		}
+		if firing["IAC-065"] != 0 {
+			t.Errorf("IAC-065 still reports privileged (%d findings) — the branch was supposed to move",
+				firing["IAC-065"])
+		}
+		for i := range fs {
+			if fs[i].RuleID != "IAC-007" {
+				continue
+			}
+			if !fs[i].MatchesRuleID("IAC-065") {
+				t.Errorf("the IAC-007 finding does not answer to IAC-065 (%v); waivers written "+
+					"against IAC-065 for this line stop applying", fs[i].RetiredRuleIDs)
+			}
+		}
+	})
+
+	t.Run("root user stays with IAC-065", func(t *testing.T) {
+		content := "Resources:\n  Task:\n    Properties:\n      ContainerDefinitions:\n        - User: root\n"
+		firing := rulesFiring(scanIaC(t, "ecs.template", content))
+		if firing["IAC-065"] != 1 {
+			t.Errorf("IAC-065 fired %d times on `User: root`, want 1 — narrowing it must not "+
+				"drop the branch nothing else covers", firing["IAC-065"])
+		}
+	})
+}
+
+// TestNarrowed_GenericPatternNoLongerSwallowsTheSpecificOne covers the two pairs
+// that were not duplicates but a generic pattern reaching into a specific one's
+// territory. Both rules survive; each keeps its own ground.
+func TestNarrowed_GenericPatternNoLongerSwallowsTheSpecificOne(t *testing.T) {
+	t.Run("storage_encrypted belongs to IAC-037", func(t *testing.T) {
+		firing := rulesFiring(scanIaC(t, "rds.tf", "  storage_encrypted = false\n"))
+		if firing["IAC-037"] != 1 {
+			t.Errorf("IAC-037 fired %d times, want 1", firing["IAC-037"])
+		}
+		if firing["IAC-005"] != 0 {
+			t.Errorf("the generic IAC-005 still fires on storage_encrypted (%d findings)",
+				firing["IAC-005"])
+		}
+	})
+
+	t.Run("a bare encrypted attribute is still IAC-005", func(t *testing.T) {
+		firing := rulesFiring(scanIaC(t, "ebs.tf", "  encrypted = false\n"))
+		if firing["IAC-005"] != 1 {
+			t.Errorf("IAC-005 fired %d times on `encrypted = false`, want 1 — narrowing it "+
+				"must not cost the attributes it is the only rule for", firing["IAC-005"])
+		}
+	})
+
+	t.Run("minReplicas belongs to IAC-399", func(t *testing.T) {
+		firing := rulesFiring(scanIaC(t, "hpa.yaml", "spec:\n  minReplicas: 1\n"))
+		if firing["IAC-399"] != 1 {
+			t.Errorf("IAC-399 fired %d times, want 1", firing["IAC-399"])
+		}
+		if firing["IAC-141"] != 0 {
+			t.Errorf("the Deployment rule IAC-141 still fires on minReplicas (%d findings)",
+				firing["IAC-141"])
+		}
+	})
+
+	t.Run("a Deployment replica count is still IAC-141", func(t *testing.T) {
+		firing := rulesFiring(scanIaC(t, "deploy.yaml", "spec:\n  replicas: 1\n"))
+		if firing["IAC-141"] != 1 {
+			t.Errorf("IAC-141 fired %d times on `replicas: 1`, want 1", firing["IAC-141"])
+		}
+	})
+}
+
+// TestNarrowed_FingerprintsOfSurvivingMatchesAreUnchanged pins the reason both
+// narrowings use `\b` rather than a leading-whitespace anchor: the matched text
+// is what the fingerprint hashes, so widening the match would invalidate every
+// baseline entry for the rule while "only" tightening its scope.
+func TestNarrowed_FingerprintsOfSurvivingMatchesAreUnchanged(t *testing.T) {
+	cases := []struct {
+		name, path, content, ruleID, patternBefore string
+	}{
+		{
+			name: "IAC-005 on a bare encrypted attribute", path: "ebs.tf",
+			content: "  encrypted = false\n", ruleID: "IAC-005",
+			patternBefore: `(?i)encrypt\w*\s*=\s*(false|"false")`,
+		},
+		{
+			name: "IAC-141 on a Deployment replica count", path: "deploy.yaml",
+			content: "spec:\n  replicas: 1\n", ruleID: "IAC-141",
+			patternBefore: `(?im)replicas\s*:\s*1\s*$`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := scanWithPattern(t, tc.ruleID, tc.patternBefore, tc.path, tc.content)
+
+			var found bool
+			for _, f := range scanIaC(t, tc.path, tc.content) {
+				if f.RuleID != tc.ruleID {
+					continue
+				}
+				found = true
+				if f.Fingerprint != before.Fingerprint {
+					t.Errorf("%s fingerprint changed (%s -> %s): the narrowed pattern matches "+
+						"different text, so every baseline entry for this rule stops matching",
+						tc.ruleID, before.Fingerprint[:12], f.Fingerprint[:12])
+				}
+			}
+			if !found {
+				t.Errorf("%s did not fire on %q at all", tc.ruleID, tc.content)
+			}
+		})
+	}
+}
+
+// scanWithPattern runs one rule, defined by ID and pattern alone, over content —
+// used to reproduce what a rule produced BEFORE its pattern was narrowed.
+func scanWithPattern(t *testing.T, ruleID, pattern, path, content string) findings.Finding {
+	t.Helper()
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID: ruleID, Version: "1.0", Description: "before",
+		Severity: findings.SeverityHigh, Confidence: findings.ConfidenceHigh,
+		MatcherType: "regex", Pattern: pattern,
+	})
+	got, err := rules.NewEngine(rs).ScanFile(path, []byte(content))
+	if err != nil {
+		t.Fatalf("scan with the pre-change pattern: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("the pre-change %s produced %d findings, want 1", ruleID, len(got))
+	}
+	return got[0]
+}

--- a/core/baseline/baseline.go
+++ b/core/baseline/baseline.go
@@ -110,11 +110,34 @@ func (b *Baseline) Save(path string) error {
 
 // Match returns the matching baseline entry for a finding, or nil if none.
 // Expired entries are not matched.
+//
+// A finding that inherited a retired rule ID is also looked up under the
+// fingerprint that retired rule would have produced (see
+// findings.Finding.AliasFingerprints). Without that fallback, retiring a
+// duplicate rule ID would silently un-baseline every finding accepted under it:
+// the fingerprint hashes the rule ID, so the entry an operator committed would
+// simply stop matching and the finding would resurface as new.
 func (b *Baseline) Match(f *findings.Finding) *Entry {
 	if f == nil {
 		return nil
 	}
-	e, ok := b.index[f.Fingerprint]
+	if e := b.lookup(f.Fingerprint); e != nil {
+		return e
+	}
+	for _, fp := range f.AliasFingerprints {
+		if e := b.lookup(fp); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// lookup returns the unexpired entry for a fingerprint, or nil.
+func (b *Baseline) lookup(fingerprint string) *Entry {
+	if fingerprint == "" {
+		return nil
+	}
+	e, ok := b.index[fingerprint]
 	if !ok {
 		return nil
 	}

--- a/core/baseline/baseline_test.go
+++ b/core/baseline/baseline_test.go
@@ -274,3 +274,45 @@ func TestBuildIndex_RebuildsCorrectly(t *testing.T) {
 		t.Fatal("expected match for fp2 after rebuild")
 	}
 }
+
+// TestMatch_AliasFingerprintFromARetiredRuleID: a baseline entry written when
+// the condition was reported under a now-retired rule ID must keep matching.
+// Anything else silently un-baselines findings an operator accepted.
+func TestMatch_AliasFingerprintFromARetiredRuleID(t *testing.T) {
+	bl := &Baseline{}
+	bl.Add(&Entry{Fingerprint: "legacy-fp", RuleID: "IAC-310", CreatedAt: time.Now()})
+
+	f := findings.Finding{
+		RuleID:            "IAC-018",
+		Fingerprint:       "current-fp",
+		RetiredRuleIDs:    []string{"IAC-310"},
+		AliasFingerprints: []string{"legacy-fp"},
+	}
+	if bl.Match(&f) == nil {
+		t.Fatal("the entry written against the retired IAC-310 no longer matches")
+	}
+
+	// The alias is not a wildcard: a finding that inherited nothing is unmatched.
+	plain := findings.Finding{RuleID: "IAC-018", Fingerprint: "current-fp"}
+	if bl.Match(&plain) != nil {
+		t.Error("a finding with no alias matched an unrelated entry")
+	}
+}
+
+// TestMatch_ExpiredAliasEntryDoesNotMatch: expiry is a property of the entry,
+// not of the lookup path it was found through.
+func TestMatch_ExpiredAliasEntryDoesNotMatch(t *testing.T) {
+	past := time.Now().Add(-24 * time.Hour)
+	bl := &Baseline{}
+	bl.Add(&Entry{Fingerprint: "legacy-fp", RuleID: "IAC-310", CreatedAt: past, ExpiresAt: &past})
+
+	f := findings.Finding{
+		RuleID:            "IAC-018",
+		Fingerprint:       "current-fp",
+		RetiredRuleIDs:    []string{"IAC-310"},
+		AliasFingerprints: []string{"legacy-fp"},
+	}
+	if bl.Match(&f) != nil {
+		t.Error("an expired entry matched through the alias path")
+	}
+}

--- a/core/catalog/catalog_test.go
+++ b/core/catalog/catalog_test.go
@@ -29,8 +29,12 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	// already cover connection strings carrying userinfo credentials.
 	// 1529 = 1528 plus SLOP-002 (predictive slopsquat-target match, emitted by
 	// the slop analyzer when a verified blocklist feed is loaded).
-	if got := len(cat); got != 1529 {
-		t.Errorf("Catalog() returned %d rules, want 1529", got)
+	// 1519 = 1529 minus the ten duplicate IaC rules retired in #394 (IAC-237,
+	// IAC-283, IAC-287, IAC-291, IAC-292, IAC-310, IAC-312, IAC-321, IAC-333,
+	// IAC-337): each reported a condition an older rule already reported, and
+	// each lives on as an alias on that rule so existing waivers keep matching.
+	if got := len(cat); got != 1519 {
+		t.Errorf("Catalog() returned %d rules, want 1519", got)
 	}
 }
 
@@ -67,7 +71,9 @@ func TestCatalogLookup(t *testing.T) {
 		{"SEC-001", "AWS Access Key ID detected"},
 		{"SEC-002", "AWS Secret Access Key detected"},
 		{"AI-004", "MCP server exposes file system write tool without restrictions"},
-		{"IAC-007", "Kubernetes pod running as privileged"},
+		// Reworded when IAC-007 absorbed IAC-065's privileged branch (ECS)
+		// and IAC-237 (Kustomize) in #394 -- it is no longer k8s-only.
+		{"IAC-007", "Container runs in privileged mode"},
 	}
 
 	for _, tt := range tests {

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -131,6 +131,48 @@ type Finding struct {
 	Fingerprint string
 	Metadata    map[string]string
 	Status      Status `json:"Status,omitempty"`
+
+	// RetiredRuleIDs are the IDs of retired rules that reported THIS finding's
+	// condition at THIS location before they were retired, and AliasFingerprints
+	// are the fingerprints those rules would have produced here.
+	//
+	// They exist so a waiver written before the retirement keeps working. A
+	// baseline entry is keyed on a fingerprint that hashes the rule ID, and a
+	// VEX statement or nox:ignore comment names the rule ID outright, so
+	// retiring a duplicate ID would otherwise un-waive every finding accepted
+	// under it — turning gates red across every consuming repo for a change
+	// that fixed a double-report.
+	//
+	// Both are populated only where the retired rule's own pattern actually
+	// matches, so an alias never reaches a location the retired rule never
+	// reported. That is what keeps an ID-level waiver from widening: it still
+	// covers exactly the conditions it used to cover.
+	//
+	// Nil for the overwhelming majority of findings; omitted from JSON when
+	// empty, but serialized when present so the scan cache round-trips them
+	// (a cache hit must not quietly drop a waiver).
+	RetiredRuleIDs    []string `json:",omitempty"`
+	AliasFingerprints []string `json:",omitempty"`
+}
+
+// MatchesRuleID reports whether id addresses this finding — either its current
+// rule ID or one of the retired IDs it inherited (see RetiredRuleIDs). Use it
+// wherever an operator names a rule in a waiver, so waivers written against a
+// retired ID keep applying. Comparison is case-insensitive, matching the VEX
+// path's existing behaviour.
+func (f *Finding) MatchesRuleID(id string) bool {
+	if id == "" {
+		return false
+	}
+	if strings.EqualFold(f.RuleID, id) {
+		return true
+	}
+	for _, retired := range f.RetiredRuleIDs {
+		if strings.EqualFold(retired, id) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewFinding constructs a Finding with a normalized location. It is the
@@ -475,19 +517,26 @@ func (fs *FindingSet) SortByPriority() {
 	})
 }
 
-// RemoveByRuleIDs removes all findings whose RuleID matches any of the given IDs.
+// RemoveByRuleIDs removes all findings whose RuleID matches any of the given
+// IDs. A retired ID a finding inherited counts as a match (see RetiredRuleIDs):
+// `rules.disable: [IAC-310]` in a config written before IAC-310 was retired is
+// still an instruction to drop that condition, and honouring it is what stops a
+// rule merge from re-enabling a rule the operator switched off.
 func (fs *FindingSet) RemoveByRuleIDs(ids []string) {
 	if len(ids) == 0 {
 		return
 	}
-	disabled := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		disabled[id] = struct{}{}
-	}
 	kept := make([]Finding, 0, len(fs.items))
 	for i := range fs.items {
 		finding := fs.items[i]
-		if _, skip := disabled[finding.RuleID]; !skip {
+		skip := false
+		for _, id := range ids {
+			if finding.MatchesRuleID(id) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
 			kept = append(kept, finding)
 		}
 	}

--- a/core/rules/engine.go
+++ b/core/rules/engine.go
@@ -114,6 +114,15 @@ func (e *Engine) ScanFile(path string, content []byte) ([]findings.Finding, erro
 			// here so callers who do not use FindingSet still get a stable
 			// fingerprint.
 			f.Fingerprint = findings.ComputeFingerprint(f.RuleID, f.Location, mr.MatchText)
+			// A rule that absorbed a retired ID also carries that ID's
+			// identity here, so waivers written before the retirement keep
+			// matching. See RetiredRule.
+			if len(rule.Retires) > 0 {
+				if lines == nil {
+					lines = splitLines(content)
+				}
+				f.RetiredRuleIDs, f.AliasFingerprints = retiredIdentities(rule, lineAt(lines, mr.Line), f.Location)
+			}
 			fpShort := f.Fingerprint
 			if len(fpShort) > 12 {
 				fpShort = fpShort[:12]
@@ -133,6 +142,15 @@ const contextWindow = 4
 // splitLines splits content into lines without a trailing-newline empty entry.
 func splitLines(content []byte) []string {
 	return strings.Split(string(content), "\n")
+}
+
+// lineAt returns the 1-based line, or "" when it is out of range.
+func lineAt(lines []string, line1 int) string {
+	idx := line1 - 1
+	if idx < 0 || idx >= len(lines) {
+		return ""
+	}
+	return lines[idx]
 }
 
 // commentPrefixes are the leading tokens that mark a line as a comment across

--- a/core/rules/retired.go
+++ b/core/rules/retired.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"regexp"
+	"sync"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// RetiredRule is an ID that a surviving rule absorbed, together with the
+// pattern the retired rule used to carry.
+//
+// Two rules that fire on one condition report it twice, so one of the IDs has
+// to go. Deleting it outright is not safe: baselines key on a fingerprint that
+// hashes the rule ID, and VEX statements and nox:ignore comments name the rule
+// ID directly, so every waiver written against the deleted ID would stop
+// matching. The finding would come back as new under the surviving ID —
+// un-waiving, in every consuming repo, something an operator explicitly
+// accepted.
+//
+// Declaring the retirement here instead keeps those waivers working. The
+// pattern is what makes it exact: the retired rule's fingerprint hashed the
+// text ITS pattern matched, which is not always the text the survivor matches
+// (IAC-312's `set-output name=` against IAC-017's `::set-output name=`, for
+// one). Re-running the retired pattern over the matched line reproduces the
+// retired rule's own match text, and therefore its exact fingerprint.
+//
+// It also bounds the alias: a retired ID is attached to a finding only where
+// its pattern really matches, so an ID-level waiver keeps covering exactly the
+// conditions that ID used to report and no more.
+type RetiredRule struct {
+	// ID is the retired rule's identifier, e.g. "IAC-310".
+	ID string `yaml:"id"`
+	// Pattern is the regex the retired rule carried at retirement. It is
+	// frozen: editing it after the fact invalidates the fingerprints it
+	// reproduces, which is the whole point of keeping it.
+	Pattern string `yaml:"pattern"`
+}
+
+// retiredPatterns caches compiled retirement patterns. Compilation happens once
+// per pattern per process rather than once per match.
+var retiredPatterns sync.Map // string -> *regexp.Regexp (nil for uncompilable)
+
+func compiledRetiredPattern(pattern string) *regexp.Regexp {
+	if pattern == "" {
+		return nil
+	}
+	if v, ok := retiredPatterns.Load(pattern); ok {
+		re, _ := v.(*regexp.Regexp)
+		return re
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		// An uncompilable retirement pattern yields no alias rather than a
+		// panic: the survivor still reports the finding, and the loss is
+		// limited to legacy waivers for that one ID. TestRetiredRulePatterns
+		// keeps this from happening silently.
+		re = nil
+	}
+	retiredPatterns.Store(pattern, re)
+	return re
+}
+
+// retiredIdentities returns the retired rule IDs that also matched on line, and
+// the fingerprints those rules would have produced at loc. Both slices are
+// index-aligned and nil when the rule retires nothing.
+func retiredIdentities(rule *Rule, line string, loc findings.Location) (ids, fingerprints []string) {
+	for i := range rule.Retires {
+		retired := rule.Retires[i]
+		if retired.ID == "" {
+			continue
+		}
+		re := compiledRetiredPattern(retired.Pattern)
+		if re == nil {
+			continue
+		}
+		matchText := re.FindString(line)
+		if matchText == "" {
+			// The retired rule would not have fired here, so nothing it
+			// waived applies to this finding.
+			continue
+		}
+		ids = append(ids, retired.ID)
+		fingerprints = append(fingerprints, findings.ComputeFingerprint(retired.ID, loc, matchText))
+	}
+	return ids, fingerprints
+}

--- a/core/rules/retired_test.go
+++ b/core/rules/retired_test.go
@@ -1,0 +1,151 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// survivorRule is a rule that absorbed a retired one: same condition, different
+// pattern text (the retired rule wrote the colon without optional space).
+func survivorRule() *Rule {
+	return &Rule{
+		ID:          "TEST-SURVIVOR",
+		Version:     "1.0",
+		Description: "step continues on error",
+		Severity:    findings.SeverityLow,
+		Confidence:  findings.ConfidenceMedium,
+		MatcherType: "regex",
+		Pattern:     `(?i)continue-on-error\s*:\s*true`,
+		Retires:     []RetiredRule{{ID: "TEST-RETIRED", Pattern: `(?i)continue-on-error:\s*true`}},
+	}
+}
+
+func scanOne(t *testing.T, rule *Rule, path, content string) findings.Finding {
+	t.Helper()
+	rs := NewRuleSet()
+	rs.Add(rule)
+	got, err := NewEngine(rs).ScanFile(path, []byte(content))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding from %s, got %d", rule.ID, len(got))
+	}
+	return got[0]
+}
+
+// TestRetires_AliasFingerprintEqualsTheRetiredRulesOwn is the property the whole
+// migration rests on: the alias fingerprint is not merely *a* fingerprint, it is
+// byte-for-byte the one the retired rule produced here — which is what a
+// committed baseline holds.
+func TestRetires_AliasFingerprintEqualsTheRetiredRulesOwn(t *testing.T) {
+	const path = ".github/workflows/ci.yml"
+	const content = "jobs:\n  test:\n    steps:\n      - continue-on-error: true\n"
+
+	survivor := scanOne(t, survivorRule(), path, content)
+	retired := scanOne(t, &Rule{
+		ID:          "TEST-RETIRED",
+		Version:     "1.0",
+		Description: "step continues on error",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceHigh,
+		MatcherType: "regex",
+		Pattern:     `(?i)continue-on-error:\s*true`,
+	}, path, content)
+
+	if len(survivor.AliasFingerprints) != 1 {
+		t.Fatalf("AliasFingerprints = %v, want exactly one", survivor.AliasFingerprints)
+	}
+	if survivor.AliasFingerprints[0] != retired.Fingerprint {
+		t.Errorf("alias fingerprint %q != the retired rule's own %q — a baseline entry "+
+			"written before the retirement will not match",
+			survivor.AliasFingerprints[0], retired.Fingerprint)
+	}
+	if !survivor.MatchesRuleID("TEST-RETIRED") {
+		t.Errorf("RetiredRuleIDs = %v, want it to answer to TEST-RETIRED", survivor.RetiredRuleIDs)
+	}
+	if survivor.Fingerprint == retired.Fingerprint {
+		t.Error("the two fingerprints are equal, so this test proves nothing about aliasing")
+	}
+}
+
+// TestRetires_DifferentMatchTextStillReproducesTheFingerprint covers the case
+// that rules out the naive implementation: IAC-312 matched `set-output name=`
+// where the surviving IAC-017 matches `::set-output name=`. Hashing the
+// SURVIVOR's matched text under the retired ID would produce a fingerprint that
+// never existed.
+func TestRetires_DifferentMatchTextStillReproducesTheFingerprint(t *testing.T) {
+	const path = ".github/workflows/ci.yml"
+	const content = "      - run: echo \"::set-output name=version::1.2.3\"\n"
+
+	survivor := scanOne(t, &Rule{
+		ID:          "TEST-SETOUTPUT",
+		Version:     "1.0",
+		Description: "deprecated set-output",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceHigh,
+		MatcherType: "regex",
+		Pattern:     `(?i)::set-output\s+name=`,
+		Retires:     []RetiredRule{{ID: "TEST-SETOUTPUT-OLD", Pattern: `(?i)set-output\s+name=`}},
+	}, path, content)
+
+	retired := scanOne(t, &Rule{
+		ID:          "TEST-SETOUTPUT-OLD",
+		Version:     "1.0",
+		Description: "deprecated set-output",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceHigh,
+		MatcherType: "regex",
+		Pattern:     `(?i)set-output\s+name=`,
+	}, path, content)
+
+	if len(survivor.AliasFingerprints) != 1 || survivor.AliasFingerprints[0] != retired.Fingerprint {
+		t.Errorf("alias fingerprints %v do not include the retired rule's own %q; the two rules "+
+			"matched different text (%q vs %q), which is exactly the case a naive alias gets wrong",
+			survivor.AliasFingerprints, retired.Fingerprint, "::set-output name=", "set-output name=")
+	}
+}
+
+// TestRetires_NoAliasWhereTheRetiredRuleWouldNotHaveFired keeps an ID-level
+// waiver from widening. The survivor matches `continue-on-error : true` (space
+// before the colon); the retired rule did not, so nothing about that line was
+// ever waived under the retired ID.
+func TestRetires_NoAliasWhereTheRetiredRuleWouldNotHaveFired(t *testing.T) {
+	f := scanOne(t, survivorRule(), "ci.yml", "      - continue-on-error : true\n")
+
+	if len(f.RetiredRuleIDs) != 0 || len(f.AliasFingerprints) != 0 {
+		t.Errorf("finding inherited %v / %v on a line the retired rule never matched — "+
+			"a waiver for the retired ID would now suppress a condition it never covered",
+			f.RetiredRuleIDs, f.AliasFingerprints)
+	}
+}
+
+// TestRetires_UncompilablePatternIsInert: a broken retirement pattern costs the
+// alias, not the finding.
+func TestRetires_UncompilablePatternIsInert(t *testing.T) {
+	rule := survivorRule()
+	rule.Retires = []RetiredRule{{ID: "TEST-RETIRED", Pattern: `(?!nope)`}}
+
+	f := scanOne(t, rule, "ci.yml", "      - continue-on-error: true\n")
+	if len(f.AliasFingerprints) != 0 {
+		t.Errorf("AliasFingerprints = %v, want none", f.AliasFingerprints)
+	}
+	if f.Fingerprint == "" {
+		t.Error("the finding lost its own fingerprint")
+	}
+}
+
+// TestRetires_UnrelatedRuleIsUnaffected: findings from rules that retire nothing
+// carry no alias fields, so the JSON artifact and the cache are unchanged for
+// every rule but the handful that absorbed an ID.
+func TestRetires_UnrelatedRuleIsUnaffected(t *testing.T) {
+	rule := survivorRule()
+	rule.Retires = nil
+
+	f := scanOne(t, rule, "ci.yml", "      - continue-on-error: true\n")
+	if f.RetiredRuleIDs != nil || f.AliasFingerprints != nil {
+		t.Errorf("RetiredRuleIDs=%v AliasFingerprints=%v, want both nil",
+			f.RetiredRuleIDs, f.AliasFingerprints)
+	}
+}

--- a/core/rules/rules.go
+++ b/core/rules/rules.go
@@ -81,6 +81,11 @@ type Rule struct {
 	// AbsenceRequire, when non-empty, additionally requires its pattern to be
 	// present in the span before the rule fires (e.g. an IAM statement that
 	// grants "Resource": "*"). All four are RE2 regexes and must compile.
+	// Retires lists rule IDs this rule absorbed. See RetiredRule: it is the
+	// migration half of retiring a duplicate ID, without which every baseline
+	// entry and VEX statement written against the retired ID stops matching.
+	Retires []RetiredRule `yaml:"retires"`
+
 	AbsenceAnchor   string `yaml:"absence_anchor"`
 	AbsenceProperty string `yaml:"absence_property"`
 	AbsenceRequire  string `yaml:"absence_require"`

--- a/core/scan.go
+++ b/core/scan.go
@@ -1428,6 +1428,26 @@ func sweepWaiversInCleanFiles(byFile map[string][]int, target string, deg *degra
 	}
 }
 
+// suppressionCovers reports whether an inline directive waives a finding,
+// under the finding's own rule ID or under a retired ID it inherited.
+//
+// The retired-ID leg is what keeps `# nox:ignore IAC-310` working after
+// IAC-310 was retired into IAC-018: the comment names an ID the scanner no
+// longer emits, and without this the waived finding would come back reported
+// under the surviving ID. See findings.Finding.RetiredRuleIDs.
+func suppressionCovers(s suppress.Suppression, f *findings.Finding) bool {
+	now := timeNow()
+	if s.MatchesFinding(f.RuleID, f.Location.StartLine, now) {
+		return true
+	}
+	for _, id := range f.RetiredRuleIDs {
+		if s.MatchesFinding(id, f.Location.StartLine, now) {
+			return true
+		}
+	}
+	return false
+}
+
 // applySuppressions reads files that have findings and marks suppressed
 // findings. scanned lists every file the scan looked at, so waivers in files
 // that produced no finding are still checked — see sweepWaiversInCleanFiles.
@@ -1505,7 +1525,7 @@ func applySuppressions(fs *findings.FindingSet, target string, deg *degrade.Degr
 			f := items[idx]
 			suppressed := false
 			for si := range suppressions {
-				if suppressions[si].MatchesFinding(f.RuleID, f.Location.StartLine, timeNow()) {
+				if suppressionCovers(suppressions[si], &f) {
 					used[si] = true
 					suppressed = true
 				}

--- a/core/scan_retired_rule_waiver_test.go
+++ b/core/scan_retired_rule_waiver_test.go
@@ -1,0 +1,300 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+	"github.com/nox-hq/nox/core/vex"
+)
+
+// Retiring a duplicate rule ID is only safe if the waivers written against it
+// keep working. These tests are the proof, and they are deliberately end-to-end:
+// a repo on disk, a waiver file an operator could have committed months ago, and
+// a real scan.
+//
+// The legacy waiver is not hand-written. It is produced by running the RETIRED
+// rule — its ID, its pattern, its file patterns, exactly as they stood before
+// this change — through the normal engine, which is what an older nox did. So
+// the fingerprint under test is the fingerprint that nox actually shipped, not
+// one re-derived from the alias code the tests are checking.
+//
+// IAC-310 ("GHA step continues on error", medium) is the case that started
+// #394: it and IAC-018 (low) both fired on every `continue-on-error: true`.
+
+const continueOnErrorWorkflow = `name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flaky integration suite
+        continue-on-error: true
+        run: make integration
+`
+
+// retiredIAC310 is IAC-310 as it stood at retirement, verbatim.
+func retiredIAC310() *rules.Rule {
+	return &rules.Rule{
+		ID:          "IAC-310",
+		Version:     "1.0",
+		Description: "GHA step continues on error",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceHigh,
+		MatcherType: "regex",
+		Pattern:     `(?i)continue-on-error:\s*true`,
+		Keywords:    []string{"continue-on-error"},
+		FilePatterns: []string{
+			".github/workflows/*.yml", ".github/workflows/*.yaml", "*.yml", "*.yaml",
+		},
+		Metadata: map[string]string{"cwe": "CWE-755"},
+	}
+}
+
+// legacyIAC310Finding returns the finding the retired rule produced for path,
+// as an older nox would have recorded it in a baseline or VEX document.
+func legacyIAC310Finding(t *testing.T, path string, content []byte) findings.Finding {
+	t.Helper()
+	rs := rules.NewRuleSet()
+	rs.Add(retiredIAC310())
+	got, err := rules.NewEngine(rs).ScanFile(path, content)
+	if err != nil {
+		t.Fatalf("reproducing the retired IAC-310: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("retired IAC-310 produced %d findings for %s, want 1", len(got), path)
+	}
+	return got[0]
+}
+
+// writeWorkflowRepo lays out a repo whose only content is a workflow with one
+// continue-on-error step, and returns the repo root and the workflow's
+// repo-relative path.
+func writeWorkflowRepo(t *testing.T) (root, rel string) {
+	t.Helper()
+	root = t.TempDir()
+	rel = filepath.Join(".github", "workflows", "ci.yml")
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(continueOnErrorWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, rel
+}
+
+// findingFor returns the single finding with the given rule ID.
+func findingFor(t *testing.T, fs []findings.Finding, ruleID string) findings.Finding {
+	t.Helper()
+	var out []findings.Finding
+	for i := range fs {
+		if fs[i].RuleID == ruleID {
+			out = append(out, fs[i])
+		}
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected exactly one %s finding, got %d", ruleID, len(out))
+	}
+	return out[0]
+}
+
+// TestRetiredRuleID_BaselineWrittenBeforeRetirementStillSuppresses is the
+// central guarantee: a .nox/baseline.json entry recorded when the condition was
+// reported as IAC-310 still suppresses it now that IAC-018 reports it alone.
+//
+// Without the alias the entry's fingerprint — which hashes the rule ID — simply
+// stops matching, and a finding an operator explicitly accepted comes back as
+// new in every repo that baselined one.
+func TestRetiredRuleID_BaselineWrittenBeforeRetirementStillSuppresses(t *testing.T) {
+	t.Parallel()
+
+	root, rel := writeWorkflowRepo(t)
+	content, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Control: with no baseline the surviving rule reports the condition.
+	res, err := RunScan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	live := findingFor(t, res.Findings.Findings(), "IAC-018")
+	if live.Status == findings.StatusBaselined {
+		t.Fatal("finding was baselined before any baseline was written")
+	}
+
+	// The waiver an older nox would have written, keyed on the retired ID.
+	legacy := legacyIAC310Finding(t, live.Location.FilePath, content)
+	if legacy.Fingerprint == live.Fingerprint {
+		t.Fatal("the retired rule's fingerprint equals the surviving rule's — " +
+			"this test would pass without any alias at all")
+	}
+	writeBaselineEntries(t, root, baseline.Entry{
+		Fingerprint: legacy.Fingerprint,
+		RuleID:      "IAC-310",
+		FilePath:    live.Location.FilePath,
+		Severity:    findings.SeverityMedium,
+		Reason:      "flaky integration suite, accepted",
+		CreatedAt:   time.Now().UTC(),
+	})
+
+	res2, err := RunScan(root)
+	if err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	got := findingFor(t, res2.Findings.Findings(), "IAC-018")
+	if got.Status != findings.StatusBaselined {
+		t.Errorf("finding status = %q, want %q — the baseline entry written against the "+
+			"retired IAC-310 no longer suppresses it, so retiring the ID un-waived it",
+			got.Status, findings.StatusBaselined)
+	}
+}
+
+// TestRetiredRuleID_UnrelatedBaselineEntryDoesNotSuppress is the control for the
+// test above: the alias must match the retired rule's OWN fingerprint, not
+// anything that happens to name the retired ID.
+func TestRetiredRuleID_UnrelatedBaselineEntryDoesNotSuppress(t *testing.T) {
+	t.Parallel()
+
+	root, _ := writeWorkflowRepo(t)
+	writeBaselineEntries(t, root, baseline.Entry{
+		Fingerprint: "0000000000000000000000000000000000000000000000000000000000000000",
+		RuleID:      "IAC-310",
+		FilePath:    filepath.Join(".github", "workflows", "ci.yml"),
+		Severity:    findings.SeverityMedium,
+		CreatedAt:   time.Now().UTC(),
+	})
+
+	res, err := RunScan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := findingFor(t, res.Findings.Findings(), "IAC-018")
+	if got.Status == findings.StatusBaselined {
+		t.Error("a baseline entry naming the retired ID but a different occurrence " +
+			"suppressed the finding — the alias is matching by rule ID, not by fingerprint")
+	}
+}
+
+// TestRetiredRuleID_VEXStatementStillApplies covers the other waiver surface:
+// OpenVEX statements name the rule ID outright.
+func TestRetiredRuleID_VEXStatementStillApplies(t *testing.T) {
+	t.Parallel()
+
+	root, _ := writeWorkflowRepo(t)
+	vexPath := filepath.Join(root, "vex.json")
+	doc := vex.Document{
+		Context: "https://openvex.dev/ns/v0.2.0",
+		ID:      "legacy-waiver",
+		Author:  "platform-team",
+		Statements: []vex.Statement{{
+			VulnerabilityID: "IAC-310",
+			Status:          vex.StatusNotAffected,
+			Justification:   "vulnerable_code_not_in_execute_path",
+		}},
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vexPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RunScanWithOptions(root, ScanOptions{VEXPath: vexPath})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := findingFor(t, res.Findings.Findings(), "IAC-018")
+	if got.Status != findings.StatusVEXNotAffected {
+		t.Errorf("finding status = %q, want %q — the VEX statement written against the "+
+			"retired IAC-310 no longer applies", got.Status, findings.StatusVEXNotAffected)
+	}
+}
+
+// TestRetiredRuleID_InlineSuppressionStillApplies covers the third waiver
+// surface: a nox:ignore comment naming an ID the scanner no longer emits.
+func TestRetiredRuleID_InlineSuppressionStillApplies(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	rel := filepath.Join(".github", "workflows", "ci.yml")
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := `name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flaky integration suite
+        # nox:ignore IAC-310 -- accepted, reported by a job summary instead
+        continue-on-error: true
+        run: make integration
+`
+	if err := os.WriteFile(full, []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RunScan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := findingFor(t, res.Findings.Findings(), "IAC-018")
+	if got.Status != findings.StatusSuppressed {
+		t.Errorf("finding status = %q, want %q — `nox:ignore IAC-310` stopped waiving the "+
+			"condition it was written for", got.Status, findings.StatusSuppressed)
+	}
+}
+
+// TestRetiredRuleID_DisabledInConfigStaysDisabled covers the fourth surface: a
+// config that switched the rule off by ID.
+func TestRetiredRuleID_DisabledInConfigStaysDisabled(t *testing.T) {
+	t.Parallel()
+
+	root, _ := writeWorkflowRepo(t)
+	cfg := `version: "1"
+scan:
+  rules:
+    disable:
+      - IAC-310
+`
+	if err := os.WriteFile(filepath.Join(root, ".nox.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RunScan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hasRule(res.Findings.Findings(), "IAC-018") {
+		t.Error("`rules.disable: [IAC-310]` no longer switches the condition off — " +
+			"retiring the ID silently re-enabled a rule the operator turned off")
+	}
+}
+
+// writeBaselineEntries commits a baseline containing exactly the given entries.
+func writeBaselineEntries(t *testing.T, root string, entries ...baseline.Entry) {
+	t.Helper()
+	bl := baseline.Baseline{SchemaVersion: "1.0.0", Entries: entries}
+	data, err := json.Marshal(bl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := baseline.DefaultPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/core/vex/vex.go
+++ b/core/vex/vex.go
@@ -161,7 +161,11 @@ func LoadVEX(path string) (*Document, error) {
 //  2. The finding's Fingerprint, when the VEX statement carries a
 //     matching _nox_fingerprint aux field — pins a waiver to a
 //     specific occurrence rather than a whole rule class.
-//  3. (VULN-001 only) The CVE / GHSA identifiers in the finding's
+//  3. A retired rule ID the finding inherited, or the fingerprint that
+//     retired rule would have produced here (see
+//     findings.Finding.RetiredRuleIDs). Retiring a duplicate rule ID
+//     must not un-waive what an operator already accepted under it.
+//  4. (VULN-001 only) The CVE / GHSA identifiers in the finding's
 //     vuln_id and aliases metadata. Operators can keep waiving by
 //     CVE without learning nox-specific rule IDs.
 //
@@ -197,7 +201,25 @@ func ApplyVEX(fs *findings.FindingSet, doc *Document) int {
 				matched = &stmt
 			}
 		}
-		// 3. CVE / GHSA aliases for VULN-001 findings.
+		// 3. Waivers written against a rule ID that has since been retired
+		//    into this one, by ID or by pinned fingerprint.
+		if matched == nil {
+			for _, id := range f.RetiredRuleIDs {
+				if stmt, ok := stmtByID[strings.ToUpper(id)]; ok {
+					matched = &stmt
+					break
+				}
+			}
+		}
+		if matched == nil {
+			for _, fp := range f.AliasFingerprints {
+				if stmt, ok := stmtByFingerprint[fp]; ok {
+					matched = &stmt
+					break
+				}
+			}
+		}
+		// 4. CVE / GHSA aliases for VULN-001 findings.
 		if matched == nil && f.RuleID == "VULN-001" {
 			for _, id := range collectVulnIDs(f) {
 				if stmt, ok := stmtByID[strings.ToUpper(id)]; ok {

--- a/core/vex/vex_test.go
+++ b/core/vex/vex_test.go
@@ -392,3 +392,72 @@ func TestStatement_RoundTripsThroughNoxsOwnWriter(t *testing.T) {
 		t.Errorf("round trip lost data: %+v", back)
 	}
 }
+
+// TestApplyVEX_RetiredRuleID: a statement naming a rule ID that has since been
+// retired into another rule still applies to the surviving finding — otherwise
+// retiring a duplicate ID re-opens everything waived under it.
+func TestApplyVEX_RetiredRuleID(t *testing.T) {
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{
+		RuleID:         "IAC-018",
+		Fingerprint:    "current-fp",
+		Message:        "Workflow step suppresses failures with continue-on-error",
+		RetiredRuleIDs: []string{"IAC-310"},
+	})
+
+	doc := &Document{Statements: []Statement{{
+		VulnerabilityID: "IAC-310",
+		Status:          StatusNotAffected,
+		Justification:   "deliberately non-blocking step",
+	}}}
+	if applied := ApplyVEX(fs, doc); applied != 1 {
+		t.Fatalf("ApplyVEX applied %d statements, want 1", applied)
+	}
+	if got := fs.Findings()[0].Status; got != findings.StatusVEXNotAffected {
+		t.Errorf("status = %q, want %q", got, findings.StatusVEXNotAffected)
+	}
+}
+
+// TestApplyVEX_RetiredFingerprintPin: the same for an occurrence-pinned
+// statement, whose _nox_fingerprint was recorded under the retired ID.
+func TestApplyVEX_RetiredFingerprintPin(t *testing.T) {
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{
+		RuleID:            "IAC-018",
+		Fingerprint:       "current-fp",
+		Message:           "Workflow step suppresses failures with continue-on-error",
+		AliasFingerprints: []string{"legacy-fp"},
+	})
+
+	doc := &Document{Statements: []Statement{{
+		VulnerabilityID: "IAC-310",
+		Status:          StatusFixed,
+		NoxFingerprint:  "legacy-fp",
+	}}}
+	if applied := ApplyVEX(fs, doc); applied != 1 {
+		t.Fatalf("ApplyVEX applied %d statements, want 1", applied)
+	}
+	if got := fs.Findings()[0].Status; got != findings.StatusVEXFixed {
+		t.Errorf("status = %q, want %q", got, findings.StatusVEXFixed)
+	}
+}
+
+// TestApplyVEX_UnrelatedRetiredIDIsNotMatched: the alias is an exact ID list,
+// not a family match.
+func TestApplyVEX_UnrelatedRetiredIDIsNotMatched(t *testing.T) {
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{
+		RuleID:         "IAC-018",
+		Fingerprint:    "current-fp",
+		Message:        "Workflow step suppresses failures with continue-on-error",
+		RetiredRuleIDs: []string{"IAC-310"},
+	})
+
+	doc := &Document{Statements: []Statement{{
+		VulnerabilityID: "IAC-311",
+		Status:          StatusNotAffected,
+	}}}
+	if applied := ApplyVEX(fs, doc); applied != 0 {
+		t.Errorf("ApplyVEX applied %d statements for an unrelated ID, want 0", applied)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1187,6 +1187,18 @@ Nox's canonical findings format. Contains all findings with fingerprints, severi
 }
 ```
 
+A finding reported by a rule that absorbed a retired rule ID carries two extra
+fields, omitted everywhere else (see [Retired rule IDs](#retired-rule-ids)):
+
+```json
+      "RetiredRuleIDs": ["IAC-310"],
+      "AliasFingerprints": ["faae53ee..."]
+```
+
+`RetiredRuleIDs` are the IDs this finding also answers to, and
+`AliasFingerprints` the fingerprints those rules would have produced for it —
+what a baseline or VEX document written before the retirement holds.
+
 ### results.sarif
 
 SARIF 2.1.0 format, compatible with GitHub Code Scanning. Upload directly:
@@ -1618,7 +1630,43 @@ nox scan . -q || exit 1
 
 ## Built-in Rules Reference
 
-Nox ships with **1506 built-in rules** across five analyzer suites: Secrets (938), AI Security (50), IAC (500), Data Protection (12), and Dependencies (6).
+Nox ships with **1496 built-in rules** across five analyzer suites: Secrets (938), AI Security (50), IAC (490), Data Protection (12), and Dependencies (6).
+
+### Retired rule IDs
+
+When two rules turn out to report the same condition, one ID is retired and the
+other keeps reporting it. Your waivers do not need to be rewritten: a retired ID
+stays valid everywhere it was already accepted.
+
+- a `.nox/baseline.json` entry written against the retired ID keeps matching;
+- an OpenVEX statement naming it — by ID or by `_nox_fingerprint` — still applies;
+- a `# nox:ignore <retired-id>` comment still suppresses;
+- `scan.rules.disable: [<retired-id>]` still switches the condition off.
+
+The alias is bounded by the retired rule's own pattern, so it only ever covers
+the lines that rule actually matched. It never widens a waiver to a condition
+the retired ID never reported.
+
+What does change is the count: one finding per condition instead of two, under
+the surviving ID and at that rule's severity. If you gate or report on a retired
+ID specifically, switch to the surviving one.
+
+| Retired | Now reported as | Condition |
+|---------|-----------------|-----------|
+| IAC-237 | IAC-007 | `privileged: true` |
+| IAC-283 | IAC-036 | `publicly_accessible = true` |
+| IAC-287 | IAC-030 | `automountServiceAccountToken: true` |
+| IAC-291 | IAC-026 | `hostPID: true` |
+| IAC-292 | IAC-027 | `hostIPC: true` |
+| IAC-310 | IAC-018 | `continue-on-error: true` |
+| IAC-312 | IAC-017 | deprecated `::set-output` |
+| IAC-321 | IAC-042 | `enable_https_traffic_only = false` |
+| IAC-333 | IAC-111 | `enable_secure_boot = false` |
+| IAC-337 | IAC-116 | `require_ssl = false` |
+
+IAC-065 (CloudFormation ECS task definition) is a partial case: it still reports
+`User: 0` / `User: root`, while the `Privileged: true` half it shared with
+IAC-007 is now reported by IAC-007 alone.
 
 ### Secrets Rules (938 rules)
 
@@ -1855,7 +1903,7 @@ IaC rules detect security misconfigurations in container definitions, cloud infr
 
 | Rule | Severity | Confidence | CWE | Description |
 |------|----------|------------|-----|-------------|
-| IAC-007 | Critical | High | CWE-250 | Kubernetes pod running as privileged |
+| IAC-007 | Critical | High | CWE-250 | Container runs in privileged mode |
 | IAC-008 | High | High | CWE-284 | Kubernetes pod uses host network |
 | IAC-009 | Critical | High | CWE-250 | Kubernetes pod allows privilege escalation |
 | IAC-010 | High | High | CWE-250 | Kubernetes pod running as root (runAsUser: 0) |

--- a/testdata/metamorphic-corpus/README.md
+++ b/testdata/metamorphic-corpus/README.md
@@ -32,15 +32,16 @@ the vulnerable and the safe shape of a pattern to tell "precise" from "overfit".
 ## Coverage (rules exercised on current `main`)
 
 The sweep reports `rules_exercised` and a full per-rule coverage map in
-`triage_report.json`. As of the current corpus it exercises **38 distinct
-rules** across six families:
+`triage_report.json`. As of the current corpus it exercises **37 distinct
+rules** across six families (IAC-283 was retired into IAC-036 in #394, which
+the corpus already exercises, so the same construct is still covered):
 
 ```
 AI-002, AI-006,
 CONT-001,
 IAC-001, IAC-003, IAC-004, IAC-005, IAC-006, IAC-012, IAC-013, IAC-014,
 IAC-024, IAC-036, IAC-037, IAC-040, IAC-121, IAC-122, IAC-123, IAC-124,
-IAC-126, IAC-127, IAC-167, IAC-282, IAC-283, IAC-315, IAC-317, IAC-318,
+IAC-126, IAC-127, IAC-167, IAC-282, IAC-315, IAC-317, IAC-318,
 SEC-001, SEC-003, SEC-023, SEC-030, SEC-080, SEC-086, SEC-508,
 SLOP-001,
 TAINT-001, TAINT-002, TAINT-006


### PR DESCRIPTION
Retires the fourteen duplicate IaC rule pairs tracked by `knownDuplicateRulePairs`, and empties that set. Refs #394.

## What survived, what was retired

Ten IDs are retired into the older rule that already reported their condition. The lower ID wins in every case: it is older, so more likely to appear in an existing baseline, and its message and severity are no worse.

| Retired | Survivor | Condition | Note |
|---|---|---|---|
| IAC-237 (high) | **IAC-007** (critical) | `privileged: true` | Kustomize file patterns are a subset of IAC-007's |
| IAC-283 (high) | **IAC-036** (critical) | `publicly_accessible = true` | identical pattern |
| IAC-287 (medium) | **IAC-030** (medium) | `automountServiceAccountToken: true` | identical condition |
| IAC-291 (high) | **IAC-026** (high) | `hostPID: true` | identical condition |
| IAC-292 (high) | **IAC-027** (high) | `hostIPC: true` | identical condition |
| IAC-310 (medium) | **IAC-018** (low) | `continue-on-error: true` | the split that started #394 |
| IAC-312 (medium) | **IAC-017** (medium) | deprecated `::set-output` | IAC-017 made case-insensitive |
| IAC-321 (high) | **IAC-042** (high) | `enable_https_traffic_only = false` | identical pattern |
| IAC-333 (medium) | **IAC-111** (medium) | `enable_secure_boot = false` | IAC-111 is strictly broader |
| IAC-337 (high) | **IAC-116** (high) | `require_ssl = false` | IAC-116 is strictly broader |

Where a retiree could reach something the survivor could not, the survivor absorbed it rather than losing it:

- **IAC-007** now matches the quoted `Privileged: "true"` form and `*.template` files — IAC-065's reach. Its description becomes "Container runs in privileged mode"; it is no longer Kubernetes-only.
- **IAC-017** is now case-insensitive, covering everything IAC-312 caught. IAC-312's dropped `::` prefix is deliberately *not* carried over: without it the pattern also matched prose about set-output.

**IAC-065 is the one partial case.** Its `Privileged: true` branch moved to IAC-007 (same condition, reported at critical); its `User: 0|root` branch — the CloudFormation ECS contribution nothing else covers — stayed. Its matched text for root findings is unchanged, so those fingerprints and their baseline entries are untouched.

### IAC-005 + IAC-037 and IAC-141 + IAC-399: narrowed, not retired

These two are different in kind — a generic pattern reaching into a specific one's territory — so both rules survive and the generic one is bounded:

- `(?i)encrypt\w*…` → `(?i)\bencrypt\w*…`, so it no longer claims the tail of `storage_encrypted = false` (IAC-037, high confidence, RDS-specific message).
- `(?im)replicas\s*:\s*1\s*$` → `(?im)\breplicas…`, so it no longer claims an HPA's `minReplicas: 1` (IAC-399) — or `maxReplicas`, `readyReplicas`.

`\b` and not a leading-whitespace anchor, because **the fingerprint hashes the matched text**: anchoring would have made every match a character longer and invalidated every baseline entry for a rule that merely got stricter. A test asserts the surviving matches keep byte-identical fingerprints, comparing against the pre-change pattern run through the engine.

Cost, stated plainly: prefixed encryption attributes no specific rule covers (`at_rest_encryption_enabled = false`, `transit_encryption_enabled = false` on ElastiCache) are no longer reported by IAC-005. RE2 has no negative lookbehind, so a boundary is the only way to keep the generic pattern off the specific rule's ground; a rule per resource is the right follow-up, and adding one is a deliberate new-findings change rather than part of a de-dup.

## How aliasing works

There was no alias mechanism, so this adds a minimal one. Deleting an ID outright would un-waive, in every consuming repo, findings that were explicitly accepted: a baseline fingerprint hashes the rule ID, and VEX statements, `nox:ignore` comments and `scan.rules.disable` name it outright.

A rule now declares what it absorbed:

```go
retires: []rules.RetiredRule{{ID: "IAC-310", Pattern: `(?i)continue-on-error:\s*true`}},
```

`core/rules/engine.go` then attaches, to each finding, the retired IDs and the fingerprints those rules would have produced — `Finding.RetiredRuleIDs` / `Finding.AliasFingerprints`, both `omitempty` and nil for every rule that retires nothing (they *are* serialized when present, so a scan-cache hit cannot quietly drop a waiver).

Two design points:

- **The retired pattern is stored, not just the ID.** IAC-312 matched `set-output name=` where IAC-017 matches `::set-output name=`; hashing the *survivor's* matched text under the retired ID would produce a fingerprint that never existed. Re-running the retired pattern over the matched line reproduces the retired rule's own match text and therefore its exact fingerprint.
- **The alias is bounded by that pattern.** A retired ID is attached only where its own pattern really matches, so an ID-level waiver keeps covering exactly the conditions that ID reported — it cannot widen to lines the retired rule never saw.

Resolution points, all four waiver surfaces:

| Surface | Where |
|---|---|
| `.nox/baseline.json` | `Baseline.Match` falls back to the alias fingerprints |
| OpenVEX (by ID and by `_nox_fingerprint`) | `vex.ApplyVEX`, after the RuleID leg |
| `# nox:ignore <id>` | `suppressionCovers` in `core/scan.go` |
| `scan.rules.disable` | `FindingSet.RemoveByRuleIDs` via `Finding.MatchesRuleID` |

## Evidence that old baselines still match

Not only unit tests — the pre-change binary produced the waiver.

```console
$ nox-before scan .            # binary built at the base commit
BEFORE IAC-018 low    bc549bd83bda47b0
BEFORE IAC-310 medium faae53eee5aab123   # one line, reported twice

$ nox-before baseline write . # then trimmed to ONLY the IAC-310 entry
{"fingerprint": "faae53ee…", "rule_id": "IAC-310", "reason": "flaky integration suite, accepted"}

$ nox-after scan .            # this branch
AFTER  IAC-018 low bc549bd83bda47b0 status=baselined retired=['IAC-310']
```

The surviving finding's own fingerprint (`bc549bd8…`) is **not** in the baseline; the retired rule's (`faae53ee…`) is, and it still suppresses.

Controls:

```console
# same entry, different fingerprint → NOT suppressed (occurrence-exact, not rule-wide)
CONTROL (IAC-310 entry, wrong fingerprint): IAC-018 status=new

# OpenVEX statement naming the retired ID
VEX (statement names retired IAC-310): IAC-018 status=vex_not_affected
```

Real-repo deltas, before vs after:

- **nox itself**: 82 → 78 findings. The only rule that changed is `IAC-310: 4 → 0`; the IAC-018 findings on those same lines were already there.
- **CI's own "Rule behaviour diff" job**, run against real repositories, reports one change and nothing else: `IAC-310: 2 -> 0`.
- **testdata/metamorphic-corpus**: 78 → 76. `IAC-283 → 0` (IAC-036 already reported that line at critical) and `IAC-005 → 0` on `storage_encrypted = false`, still reported by IAC-037. No condition lost its last reporter.

## Tests

- `knownDuplicateRulePairs` is now empty; the guard fails the build on any new duplicate, and refuses to let a fixed pair stay listed.
- `TestIaCRuleRetirements_AreWellFormed` — retirement patterns compile, no ID is retired twice or by itself, and a retired ID that is still live must be a declared partial retirement (only IAC-065).
- `TestRetires_*` (`core/rules`) — the alias fingerprint equals the retired rule's own; the different-matched-text case (`set-output`) is covered explicitly; no alias where the retired rule would not have fired; a broken retirement pattern costs the alias, not the finding.
- `TestRetiredRuleID_*` (`core/`) — end-to-end over a real repo for baseline, VEX, `nox:ignore` and `rules.disable`, with the legacy fingerprint produced by running the retired rule definition through the engine.
- `TestRetired_OneFindingPerCondition` / `TestNarrowed_*` — one finding per condition for all ten retirements, both halves of the IAC-065 split, and the fingerprint-stability check for the two narrowed patterns.
- Rule counts updated: IaC 500 → 490, catalog 1529 → 1519, each with the reason inline.

`go test ./...`, `go vet ./...`, `gofmt -l` and `golangci-lint run ./...` are clean.

## Operator impact

Nothing to rewrite. Waivers keyed on a retired ID keep applying, documented under "Retired rule IDs" in `docs/usage.md`. What changes is the count and the ID: one finding per condition, under the surviving rule at that rule's severity — so a gate or dashboard keyed on a retired ID specifically should move to the survivor. `continue-on-error: true` is now low only (IAC-018), the conservative half of an arbitrary split.
