### PR TITLE
feat(rules): report world-writable file and directory modes (PERM-001/002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **World-writable file and directory modes are now reported (`PERM-001`,
+  `PERM-002`).** A fleet that drops gosec in favour of nox loses G301
+  (`MkdirAll`), G302 (`Chmod`) and G306 (`WriteFile`) outright — 22 findings
+  across 14 Go repositories with no nox equivalent. `os.WriteFile`,
+  `os.OpenFile`, `os.Chmod`, `os.Mkdir`, `os.MkdirAll` and `ioutil.WriteFile`
+  are matched on the Go AST, so a permission literal in a comment, a string, or
+  a same-named project helper is not a finding. Both octal spellings, mode
+  conversions (`os.FileMode(0777)`, `fs.FileMode(…)`) and OR chains are
+  evaluated. (#405)
+
+  **The threshold is the world-write bit (`0o002`), not gosec's 0600/0750.**
+  Under gosec's defaults `0o644` and `0o755` are findings, which in this
+  repository alone would be 503 of them — those modes are Go's own idiomatic
+  defaults, so reporting them is a preference rather than a vulnerability
+  signal, and it is why gosec's permission rules are among the most-suppressed
+  in the fleet. World-writable is different in kind: any local user can rewrite
+  the contents, no idiom requires it, and the finding is actionable without
+  knowing what the file holds. World-readable and group-writable are
+  deliberately not reported. A world-writable directory carrying
+  `os.ModeSticky` is the /tmp model and is not reported either.
+
+  Medium severity at high confidence, matching gosec's own rating for the
+  family. Note that a gate keyed on net-new critical/high will not fail on
+  these; lower the threshold or key on `PERM-*` to make them blocking. The mode
+  must be a literal in the call — a named constant needs `go/types` and is not
+  reported, which is the correct direction to fail.
+
 ## [1.23.0] - 2026-07-26
 
 ### Changed

--- a/core/analyzers/fileperms/fileperms.go
+++ b/core/analyzers/fileperms/fileperms.go
@@ -238,12 +238,19 @@ func scanSource(path string, content []byte) []findings.Finding {
 		if spec.kind == kindDir {
 			ruleID, what = ruleDir, "directory"
 		}
+		// Chmod does not create anything, it re-modes an existing path; saying
+		// "creates" there would misdescribe the call the reader is looking at.
+		msg := fmt.Sprintf("%s creates a world-writable %s (mode %s)",
+			name, what, formatMode(mode.bits))
+		if name == "os.Chmod" {
+			msg = fmt.Sprintf("%s makes a %s world-writable (mode %s)",
+				name, what, formatMode(mode.bits))
+		}
 		out = append(out, findings.Finding{
 			RuleID:     ruleID,
 			Severity:   findings.SeverityMedium,
 			Confidence: findings.ConfidenceHigh,
-			Message: fmt.Sprintf("%s creates a world-writable %s (mode %s)",
-				name, what, formatMode(mode.bits)),
+			Message:    msg,
 			Location: findings.Location{
 				FilePath:  path,
 				StartLine: pos.Line,

--- a/core/analyzers/fileperms/fileperms.go
+++ b/core/analyzers/fileperms/fileperms.go
@@ -1,0 +1,378 @@
+// Package fileperms detects files and directories created with a
+// world-writable permission mode.
+//
+// WHY THIS IS ITS OWN ANALYZER. Like weakcrypto, this is dangerous *API usage*
+// rather than a taint flow: `os.WriteFile(p, b, 0o777)` is wrong regardless of
+// where `p` or `b` came from, so there is no source to track and the taint
+// engine has nothing to say about it. It covers the gosec families G301
+// (MkdirAll), G302 (Chmod) and G306 (WriteFile), which a fleet that has dropped
+// gosec in favour of nox otherwise loses entirely (#405).
+//
+// SCOPE, deliberately narrow — this analyzer follows weakcrypto's stated
+// philosophy, because file modes are exactly the kind of ubiquitous stdlib call
+// that gets a rule globally suppressed when it over-fires.
+//
+// THRESHOLD: the world-writable bit (mode & 0o002) only.
+//
+// gosec's defaults are 0600 for files and 0750 for directories, so under gosec
+// `os.WriteFile(p, b, 0o644)` and `os.MkdirAll(p, 0o755)` are both findings.
+// Those two modes are the normal, correct, idiomatic defaults in Go code — they
+// are what `go` itself writes — so a rule that reports them reports most of the
+// file writes in most repositories. That is not a vulnerability signal, it is a
+// preference, and it is measurably the reason gosec's permission rules are
+// among the most-suppressed in the fleet.
+//
+// World-writable is different in kind. Any local user — any other container in
+// a shared mount, any compromised low-privilege process — can rewrite the
+// contents. If the file is a script, a config, a plugin, a lockfile or a
+// credential, that is straightforward code or policy injection; for a directory
+// it also means an attacker can replace entries underneath a path your code
+// trusts. There is no idiom that needs it, so unlike 0644 there is no
+// legitimate-majority case to weigh against, and the finding is actionable
+// without knowing anything about the file's contents.
+//
+// World-READABLE (0o004) is therefore deliberately NOT flagged. Whether
+// 0o644 is wrong depends entirely on what is in the file, which this analyzer
+// cannot see; flagging it would put the rule back in the suppress-it-globally
+// category for no gain. Group-writable (0o020) is likewise left alone: it is a
+// deliberate, common pattern for a shared service group.
+//
+// STICKY. A world-writable directory carrying os.ModeSticky is the /tmp
+// pattern: anyone may create entries, but only an entry's owner may remove or
+// rename it. That is a deliberate design, not an oversight, so an explicit
+// `| os.ModeSticky` suppresses the finding.
+//
+// WHAT IT CANNOT SEE. The mode must be a literal in the call. A named constant
+// (`os.MkdirAll(p, dirPerm)`) needs go/types to resolve and is not reported —
+// under-reporting is the correct failure direction here. Methods are not
+// matched either: `f.Chmod(0o777)` on an *os.File would need the receiver's
+// type, and matching a bare `.Chmod(` would flag every unrelated Chmod-shaped
+// method in the tree.
+package fileperms
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// Analyzer reports world-writable file and directory modes in Go source.
+type Analyzer struct{}
+
+// NewAnalyzer constructs the file-permission analyzer.
+func NewAnalyzer() *Analyzer { return &Analyzer{} }
+
+// Rule IDs this analyzer emits. Files and directories are separate IDs so a
+// team can waive one without waiving the other — the remediation differs, and
+// so does the exposure.
+const (
+	ruleFile = "PERM-001"
+	ruleDir  = "PERM-002"
+)
+
+// worldWrite is the permission bit that decides every finding here.
+const worldWrite = 0o002
+
+// kind distinguishes what the flagged call creates, which selects the rule ID
+// and the remediation.
+type kind int
+
+const (
+	kindFile kind = iota
+	kindDir
+)
+
+// call describes one stdlib entry point that takes a permission mode.
+//
+// arity is checked exactly. It is what keeps a same-named helper in the scanned
+// project — a local `os` shadow, or a wrapper with a different signature — from
+// being read as the stdlib call with the mode in a different position.
+type call struct {
+	kind   kind
+	modeAt int // index of the permission argument
+	arity  int // exact number of arguments the stdlib function takes
+}
+
+// modeCalls maps `pkg.Func` to where its permission argument lives.
+//
+// io/ioutil is included because it is deprecated, not gone: it remains common
+// in fleet code that predates Go 1.16, and ioutil.WriteFile's mode argument is
+// as real as os.WriteFile's.
+var modeCalls = map[string]call{
+	"os.WriteFile":     {kindFile, 2, 3},
+	"ioutil.WriteFile": {kindFile, 2, 3},
+	"os.OpenFile":      {kindFile, 2, 3},
+	"os.Chmod":         {kindFile, 1, 2},
+	"os.Mkdir":         {kindDir, 1, 2},
+	"os.MkdirAll":      {kindDir, 1, 2},
+}
+
+// Rules returns the rules this analyzer can emit, for the rule catalogue.
+func (a *Analyzer) Rules() *rules.RuleSet {
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID:          ruleFile,
+		Version:     "1.0",
+		Description: "File created or chmod'd with a world-writable permission mode",
+		// Medium, matching gosec's own rating for this family. A world-writable
+		// file is a genuine defect, but exploiting it requires an attacker to
+		// already have local access, and on a single-tenant container there may
+		// be no second principal at all. High is reserved for conditions that
+		// are exploitable from outside.
+		Severity: findings.SeverityMedium,
+		// High: unlike weakcrypto, there is no ambiguity about intent. The mode
+		// is a literal in the call, and no correct use of these APIs needs the
+		// world-write bit.
+		Confidence: findings.ConfidenceHigh,
+		Tags:       []string{"permissions", "hardening", "gosec-g302", "gosec-g306", "owasp-a01"},
+		Remediation: "This writes a file that any local user can modify. If the file holds configuration, credentials, a script, or anything else the process later trusts, an attacker with any local account can replace its contents. " +
+			"Drop the world-write bit: 0o600 for data only this process should read, 0o644 where other users legitimately need to read it. " +
+			"If a second process genuinely needs write access, grant it through group ownership (0o660) rather than to everyone.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/732.html",
+			"https://owasp.org/Top10/A01_2021-Broken_Access_Control/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-732"},
+	})
+	rs.Add(&rules.Rule{
+		ID:          ruleDir,
+		Version:     "1.0",
+		Description: "Directory created with a world-writable permission mode and no sticky bit",
+		Severity:    findings.SeverityMedium,
+		Confidence:  findings.ConfidenceHigh,
+		Tags:        []string{"permissions", "hardening", "gosec-g301", "owasp-a01"},
+		Remediation: "This creates a directory any local user can write to, so an attacker can add, replace, or delete entries under a path this program treats as its own — including swapping a file the program later reads or executes. " +
+			"Use 0o700 for a private directory or 0o755 where others need to list it. " +
+			"If the directory is deliberately a shared drop point, add os.ModeSticky (the /tmp model) so only an entry's owner can remove or rename it.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/732.html",
+			"https://owasp.org/Top10/A01_2021-Broken_Access_Control/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-732"},
+	})
+	return rs
+}
+
+// ScanArtifacts reports world-writable modes across discovered Go sources.
+func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
+	fs := findings.NewFindingSet()
+
+	for _, art := range artifacts {
+		if err := ctx.Err(); err != nil {
+			return fs, err
+		}
+		if !strings.EqualFold(filepath.Ext(art.Path), ".go") {
+			continue
+		}
+		// Test files and fixtures are skipped, as in weakcrypto. Test trees are
+		// where deliberate 0o777 lives — a scanner's own permission fixtures
+		// included — and flagging them trains people to ignore the rule.
+		if isTestPath(art.Path) {
+			continue
+		}
+
+		content, err := os.ReadFile(art.AbsPath)
+		if err != nil {
+			// Unreadable file is not a finding; discovery already surfaced it.
+			continue
+		}
+		for _, f := range scanSource(art.Path, content) {
+			fs.Add(f)
+		}
+	}
+	return fs, nil
+}
+
+// scanSource parses one Go file and returns its findings.
+func scanSource(path string, content []byte) []findings.Finding {
+	fset := token.NewFileSet()
+	// A parse error still leaves a partial AST, which is walked as-is: a file
+	// that does not compile degrades to fewer findings rather than crashing the
+	// scan. Comments are not parsed, and string literals are never call
+	// expressions, so `// 0777` and `"0777"` cannot match structurally — the
+	// whole reason this analyzer uses the AST instead of a regex.
+	file, _ := parser.ParseFile(fset, filepath.Base(path), content, parser.SkipObjectResolution)
+	if file == nil {
+		return nil
+	}
+
+	var out []findings.Finding
+	ast.Inspect(file, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name, ok := calleeName(ce.Fun)
+		if !ok {
+			return true
+		}
+		spec, ok := modeCalls[name]
+		if !ok || len(ce.Args) != spec.arity {
+			return true
+		}
+		mode, ok := evalMode(ce.Args[spec.modeAt])
+		if !ok || mode.bits&worldWrite == 0 {
+			return true
+		}
+		// Sticky is the deliberate /tmp pattern: world-writable by design, with
+		// removal still restricted to the entry's owner. Only os.ModeSticky
+		// counts — a raw 0o1777 literal does NOT set it, because os.Mkdir masks
+		// the numeric mode with Perm() (0o777) and takes the sticky bit solely
+		// from Go's ModeSticky (1<<20). So 0o1777 is still a finding, correctly.
+		if mode.sticky {
+			return true
+		}
+
+		pos := fset.Position(ce.Args[spec.modeAt].Pos())
+		ruleID, what := ruleFile, "file"
+		if spec.kind == kindDir {
+			ruleID, what = ruleDir, "directory"
+		}
+		out = append(out, findings.Finding{
+			RuleID:     ruleID,
+			Severity:   findings.SeverityMedium,
+			Confidence: findings.ConfidenceHigh,
+			Message: fmt.Sprintf("%s creates a world-writable %s (mode %s)",
+				name, what, formatMode(mode.bits)),
+			Location: findings.Location{
+				FilePath:  path,
+				StartLine: pos.Line,
+				EndLine:   pos.Line,
+			},
+			Metadata: map[string]string{
+				"cwe":  "CWE-732",
+				"call": name,
+				"mode": formatMode(mode.bits),
+			},
+		})
+		return true
+	})
+	return out
+}
+
+// calleeName renders a `pkg.Func` callee as "pkg.Func". Anything else — a bare
+// identifier, a method on a value, a deeper selector chain — returns false, so
+// only package-qualified stdlib calls are ever considered.
+func calleeName(fun ast.Expr) (string, bool) {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return pkg.Name + "." + sel.Sel.Name, true
+}
+
+// mode is a partially-evaluated permission expression.
+type mode struct {
+	bits   uint64
+	sticky bool
+}
+
+// evalMode evaluates a permission argument far enough to decide whether the
+// world-write bit is set.
+//
+// It handles the forms that actually appear: an octal literal in either
+// spelling (0777, 0o777), a conversion (os.FileMode(0777), fs.FileMode(0o777)),
+// and an OR chain combining a literal with mode constants. It reports ok=false
+// whenever the value cannot be pinned down, which is the safe direction: an
+// unknown mode produces no finding.
+func evalMode(e ast.Expr) (mode, bool) {
+	switch v := e.(type) {
+	case *ast.ParenExpr:
+		return evalMode(v.X)
+
+	case *ast.BasicLit:
+		if v.Kind != token.INT {
+			return mode{}, false
+		}
+		// Base 0 honours Go's own literal syntax, so 0777, 0o777, 0x1ff and a
+		// plain decimal are each read as the compiler reads them. A decimal
+		// literal is not a mistake to correct here: `os.Chmod(p, 666)` really
+		// does request 0o1232, which really is world-writable.
+		n, err := strconv.ParseUint(strings.ReplaceAll(v.Value, "_", ""), 0, 64)
+		if err != nil {
+			return mode{}, false
+		}
+		return mode{bits: n}, true
+
+	case *ast.SelectorExpr:
+		// os.ModeSticky / fs.ModeSticky. Other Mode* constants (ModeDir,
+		// ModeSetuid, …) carry no permission bits, so they contribute nothing
+		// but must still count as "known" or an OR chain containing one would
+		// be discarded.
+		if !strings.HasPrefix(v.Sel.Name, "Mode") {
+			return mode{}, false
+		}
+		return mode{sticky: v.Sel.Name == "ModeSticky"}, true
+
+	case *ast.CallExpr:
+		// A conversion: os.FileMode(0777), fs.FileMode(0o777), FileMode(0777).
+		if len(v.Args) != 1 || !isFileModeConversion(v.Fun) {
+			return mode{}, false
+		}
+		return evalMode(v.Args[0])
+
+	case *ast.BinaryExpr:
+		if v.Op != token.OR {
+			// &^ and & can CLEAR the world-write bit (0o777 &^ 0o022), so any
+			// operator other than OR is treated as unknown rather than guessed.
+			return mode{}, false
+		}
+		l, lok := evalMode(v.X)
+		r, rok := evalMode(v.Y)
+		if !lok && !rok {
+			return mode{}, false
+		}
+		// OR only ever adds bits, so a known side is still conclusive when the
+		// other side is opaque: if the literal half already sets world-write,
+		// the result does too whatever the unknown half holds.
+		//
+		// The converse does NOT hold — an opaque operand may carry the bit
+		// itself, as in the tar-extraction idiom `hdr.Mode&0o777|0o755`, whose
+		// result is world-writable exactly when the archive entry was. Staying
+		// silent there is a deliberate under-report: the alternative flags every
+		// use of a hardening idiom whose whole point is to clamp the mode.
+		return mode{bits: l.bits | r.bits, sticky: l.sticky || r.sticky}, true
+	}
+	return mode{}, false
+}
+
+// isFileModeConversion reports whether fun is os.FileMode / fs.FileMode or a
+// bare FileMode identifier (dot-imported io/fs).
+func isFileModeConversion(fun ast.Expr) bool {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name == "FileMode"
+	case *ast.SelectorExpr:
+		return f.Sel.Name == "FileMode"
+	}
+	return false
+}
+
+// formatMode renders the permission bits the way the source spelled them, so
+// the message can be matched against the code by eye.
+func formatMode(bits uint64) string {
+	return "0" + strconv.FormatUint(bits&0o7777, 8)
+}
+
+// isTestPath reports whether a path is Go test code or a fixture tree.
+func isTestPath(p string) bool {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(p)), "_test.go") {
+		return true
+	}
+	lower := filepath.ToSlash(strings.ToLower(p))
+	return strings.Contains(lower, "/testdata/") || strings.HasPrefix(lower, "testdata/")
+}

--- a/core/analyzers/fileperms/fileperms_test.go
+++ b/core/analyzers/fileperms/fileperms_test.go
@@ -1,0 +1,246 @@
+package fileperms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanGo runs the analyzer over a single named source file and returns its
+// findings. It goes through ScanArtifacts rather than scanSource so the path
+// filtering (extension, test trees) is exercised too.
+func scanGo(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, filepath.Base(name))
+	if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := (&Analyzer{}).ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+// body wraps statements in a compilable file so fixtures stay readable.
+func body(stmts string) string {
+	return "package m\n\nimport (\n\t\"io/fs\"\n\t\"os\"\n)\n\nvar _ = fs.ModeSticky\n\nfunc f(p string, b []byte) {\n" + stmts + "\n}\n"
+}
+
+func TestFlagsWorldWritableFiles(t *testing.T) {
+	for _, c := range []struct{ name, stmt, wantMode string }{
+		{"WriteFile 0666", `_ = os.WriteFile(p, b, 0666)`, "0666"},
+		{"WriteFile 0o777", `_ = os.WriteFile(p, b, 0o777)`, "0777"},
+		{"WriteFile 0646", `_ = os.WriteFile(p, b, 0646)`, "0646"},
+		{"Chmod 0777", `_ = os.Chmod(p, 0777)`, "0777"},
+		{"Chmod FileMode conversion", `_ = os.Chmod(p, os.FileMode(0777))`, "0777"},
+		{"Chmod fs.FileMode conversion", `_ = os.Chmod(p, fs.FileMode(0o666))`, "0666"},
+		{"OpenFile 0666", `_, _ = os.OpenFile(p, os.O_RDWR|os.O_CREATE, 0666)`, "0666"},
+		{"underscored literal", `_ = os.Chmod(p, 0o7_77)`, "0777"},
+		// A decimal literal is not a typo to forgive: 666 decimal IS 0o1232,
+		// which really does carry the world-write bit.
+		{"decimal literal", `_ = os.Chmod(p, 666)`, "01232"},
+	} {
+		got := scanGo(t, "a.go", body(c.stmt))
+		if len(got) != 1 {
+			t.Errorf("%s: got %d findings, want 1 for %q", c.name, len(got), c.stmt)
+			continue
+		}
+		if got[0].RuleID != ruleFile {
+			t.Errorf("%s: rule = %s, want %s", c.name, got[0].RuleID, ruleFile)
+		}
+		if got[0].Metadata["mode"] != c.wantMode {
+			t.Errorf("%s: mode = %q, want %q", c.name, got[0].Metadata["mode"], c.wantMode)
+		}
+	}
+}
+
+func TestFlagsWorldWritableDirectories(t *testing.T) {
+	for _, c := range []struct{ name, stmt string }{
+		{"MkdirAll 0777", `_ = os.MkdirAll(p, 0777)`},
+		{"MkdirAll 0o777", `_ = os.MkdirAll(p, 0o777)`},
+		{"Mkdir 0777", `_ = os.Mkdir(p, 0777)`},
+		// 0o1777 does NOT set Go's ModeSticky (os.Mkdir masks the numeric mode
+		// with Perm(), 0o777, and reads sticky only from ModeSticky), so this is
+		// a world-writable directory with no sticky protection.
+		{"raw 1777 is not sticky", `_ = os.Mkdir(p, 0o1777)`},
+	} {
+		got := scanGo(t, "a.go", body(c.stmt))
+		if len(got) != 1 {
+			t.Errorf("%s: got %d findings, want 1 for %q", c.name, len(got), c.stmt)
+			continue
+		}
+		if got[0].RuleID != ruleDir {
+			t.Errorf("%s: rule = %s, want %s", c.name, got[0].RuleID, ruleDir)
+		}
+	}
+}
+
+// The threshold is the world-write bit, and nothing else. 0644 and 0755 are the
+// idiomatic Go defaults; reporting them is how a permission rule earns a
+// project-wide suppression.
+func TestIgnoresNonWorldWritableModes(t *testing.T) {
+	for _, stmt := range []string{
+		`_ = os.WriteFile(p, b, 0600)`,
+		`_ = os.WriteFile(p, b, 0644)`,
+		`_ = os.WriteFile(p, b, 0o644)`,
+		`_ = os.Chmod(p, 0755)`,
+		`_ = os.Chmod(p, 0640)`,
+		`_ = os.MkdirAll(p, 0750)`,
+		`_ = os.MkdirAll(p, 0755)`,
+		`_ = os.Mkdir(p, 0700)`,
+		`_, _ = os.OpenFile(p, os.O_RDWR|os.O_CREATE, 0600)`,
+		// Group-writable is a deliberate shared-service pattern, not a defect.
+		`_ = os.WriteFile(p, b, 0660)`,
+		`_ = os.Chmod(p, os.FileMode(0644))`,
+	} {
+		if got := scanGo(t, "a.go", body(stmt)); len(got) != 0 {
+			t.Errorf("got %d findings, want 0 for %q: %+v", len(got), stmt, got)
+		}
+	}
+}
+
+// A world-writable directory with the sticky bit is the /tmp model: anyone may
+// create entries, only an entry's owner may remove them. That is a design, not
+// an oversight.
+func TestStickyDirectoryIsNotFlagged(t *testing.T) {
+	for _, stmt := range []string{
+		`_ = os.MkdirAll(p, 0777|os.ModeSticky)`,
+		`_ = os.MkdirAll(p, os.ModeSticky|0o777)`,
+		`_ = os.Mkdir(p, os.FileMode(0777)|os.ModeSticky)`,
+		`_ = os.MkdirAll(p, fs.ModeSticky|0777)`,
+	} {
+		if got := scanGo(t, "a.go", body(stmt)); len(got) != 0 {
+			t.Errorf("got %d findings, want 0 for sticky %q: %+v", len(got), stmt, got)
+		}
+	}
+}
+
+// Structural matching is the entire reason this analyzer parses instead of
+// grepping: a permission literal in prose or in a string is not a call.
+func TestIgnoresLiteralsThatAreNotModes(t *testing.T) {
+	for _, name := range []string{"comment", "string", "unrelated"} {
+		var stmt string
+		switch name {
+		case "comment":
+			stmt = "\t// historically this was os.MkdirAll(p, 0777)\n\t_ = os.MkdirAll(p, 0755)"
+		case "string":
+			stmt = "\t_ = os.WriteFile(p, []byte(\"chmod 0777 /srv\"), 0600)\n\tconst doc = \"os.Chmod(p, 0777)\"\n\t_ = doc"
+		case "unrelated":
+			// Not a mode argument at all: an exit code, a bitmask, a wrapper
+			// with a different signature, and a method on a value.
+			stmt = "\tconst mask = 0777\n\t_ = mask\n\t_ = os.Chtimes\n\t_ = write(p, b, 0777)"
+		}
+		if got := scanGo(t, "a.go", body(stmt)+"\nfunc write(string, []byte, int) error { return nil }\n"); len(got) != 0 {
+			t.Errorf("%s: got %d findings, want 0: %+v", name, len(got), got)
+		}
+	}
+}
+
+// The mode must be pinned down in the call. A named constant needs go/types to
+// resolve, and guessing is the wrong failure direction for a rule like this.
+func TestUnresolvableModeIsNotFlagged(t *testing.T) {
+	for _, stmt := range []string{
+		`_ = os.MkdirAll(p, dirPerm)`,
+		`_ = os.Chmod(p, modeFor(p))`,
+		// &^ clears bits, so the result cannot be read off the left operand.
+		`_ = os.Chmod(p, 0777&^0o022)`,
+	} {
+		src := body(stmt) + "\nconst dirPerm = 0o777\n\nfunc modeFor(string) os.FileMode { return 0o777 }\n"
+		if got := scanGo(t, "a.go", src); len(got) != 0 {
+			t.Errorf("got %d findings, want 0 for %q: %+v", len(got), stmt, got)
+		}
+	}
+}
+
+// An OR against an opaque operand is still conclusive when the literal half
+// already sets world-write: OR only ever adds bits.
+func TestOrWithOpaqueOperandStillFlags(t *testing.T) {
+	src := body(`_ = os.Chmod(p, 0666|extra)`) + "\nvar extra os.FileMode\n"
+	if got := scanGo(t, "a.go", src); len(got) != 1 {
+		t.Errorf("got %d findings, want 1: %+v", len(got), got)
+	}
+}
+
+// The tar-extraction idiom clamps an archive entry's mode and forces a floor.
+// Both lines are real code from registry/oci/extract.go; flagging a hardening
+// idiom is precisely how a permission rule earns a repo-wide suppression.
+func TestArchiveModeClampIdiomIsNotFlagged(t *testing.T) {
+	src := "package m\n\nimport \"os\"\n\nfunc f(target, tmp string, hdrMode int64, mode os.FileMode) {\n" +
+		"\t_ = os.MkdirAll(target, os.FileMode(hdrMode)&0o777|0o755)\n" +
+		"\t_, _ = os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode&0o777|0o644)\n}\n"
+	if got := scanGo(t, "a.go", src); len(got) != 0 {
+		t.Errorf("got %d findings, want 0: %+v", len(got), got)
+	}
+}
+
+// Arity is checked exactly so a project's own helper cannot be read as the
+// stdlib call with the mode in a different position.
+func TestWrongArityIsNotFlagged(t *testing.T) {
+	src := "package m\n\ntype pkg struct{}\n\nfunc (pkg) WriteFile(a string, b []byte, c, d int) error { return nil }\n\nvar os pkg\n\nfunc f() { _ = os.WriteFile(\"p\", nil, 0777, 0) }\n"
+	if got := scanGo(t, "a.go", src); len(got) != 0 {
+		t.Errorf("got %d findings, want 0: %+v", len(got), got)
+	}
+}
+
+// Test trees are where deliberate 0777 lives, this analyzer's own fixtures
+// included. Flagging them trains people to ignore the rule.
+func TestSkipsTestAndFixtureTrees(t *testing.T) {
+	for _, name := range []string{"a_test.go", "testdata/a.go", "core/testdata/x/a.go"} {
+		if got := scanGo(t, name, body(`_ = os.MkdirAll(p, 0777)`)); len(got) != 0 {
+			t.Errorf("%s: got %d findings, want 0", name, len(got))
+		}
+	}
+}
+
+func TestNonGoFileIsSkipped(t *testing.T) {
+	if got := scanGo(t, "notes.md", "os.MkdirAll(p, 0777)"); len(got) != 0 {
+		t.Errorf("got %d findings for markdown, want 0", len(got))
+	}
+}
+
+// A file that does not compile must degrade to fewer findings, never panic.
+func TestUnparseableSourceDoesNotPanic(t *testing.T) {
+	scanGo(t, "a.go", "package m\nfunc f( { os.Chmod(p, 0777) }")
+}
+
+func TestReportsTheModeArgumentLine(t *testing.T) {
+	src := "package m\n\nimport \"os\"\n\nfunc f(p string) {\n\t_ = os.Chmod(\n\t\tp,\n\t\t0777,\n\t)\n}\n"
+	got := scanGo(t, "a.go", src)
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+	if got[0].Location.StartLine != 8 {
+		t.Errorf("line = %d, want 8 (the mode argument)", got[0].Location.StartLine)
+	}
+	if !strings.Contains(got[0].Message, "os.Chmod") || !strings.Contains(got[0].Message, "0777") {
+		t.Errorf("message = %q, want it to name the call and the mode", got[0].Message)
+	}
+}
+
+func TestRulesAreRegistered(t *testing.T) {
+	rs := (&Analyzer{}).Rules().Rules()
+	if len(rs) != 2 {
+		t.Fatalf("got %d rules, want 2: %+v", len(rs), rs)
+	}
+	seen := map[string]bool{}
+	for _, r := range rs {
+		seen[r.ID] = true
+		if r.Metadata["cwe"] != "CWE-732" {
+			t.Errorf("%s: cwe = %q, want CWE-732", r.ID, r.Metadata["cwe"])
+		}
+		if r.Severity != findings.SeverityMedium || r.Confidence != findings.ConfidenceHigh {
+			t.Errorf("%s: severity/confidence = %s/%s, want medium/high", r.ID, r.Severity, r.Confidence)
+		}
+	}
+	if !seen[ruleFile] || !seen[ruleDir] {
+		t.Errorf("missing rule IDs: %+v", seen)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/ai"
 	"github.com/nox-hq/nox/core/analyzers/data"
 	"github.com/nox-hq/nox/core/analyzers/deps"
+	"github.com/nox-hq/nox/core/analyzers/fileperms"
 	"github.com/nox-hq/nox/core/analyzers/iac"
 	"github.com/nox-hq/nox/core/analyzers/provenance"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
@@ -268,6 +269,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	}
 	slopAnalyzer := slop.NewAnalyzer(slopOpts...)
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
+	filepermsAnalyzer := fileperms.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
 	// A signature database that fails to parse leaves every VARIANT-* rule
 	// unable to match. The scan would otherwise report zero variant findings
@@ -351,6 +353,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		},
 		func(c context.Context) error {
 			fs, err := cryptoAnalyzer.ScanArtifacts(c, artifacts)
+			if err != nil {
+				return err
+			}
+			addFindings(fs)
+			return nil
+		},
+		func(c context.Context) error {
+			fs, err := filepermsAnalyzer.ScanArtifacts(c, artifacts)
 			if err != nil {
 				return err
 			}
@@ -445,6 +455,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		allRules.Add(r)
 	}
 	for _, r := range cryptoAnalyzer.Rules().Rules() {
+		allRules.Add(r)
+	}
+	for _, r := range filepermsAnalyzer.Rules().Rules() {
 		allRules.Add(r)
 	}
 	for _, r := range slopAnalyzer.Rules().Rules() {


### PR DESCRIPTION
Closes part of #405 — the permissive-file-mode third of the proposed `hardening`
work (G301 / G302 / G306). TLS misconfiguration (G402) and insecure randomness
(G404) are not in this PR.

A new `core/analyzers/fileperms` analyzer, built on `weakcrypto`'s model:
dangerous *API usage*, no taint source to track, and deliberately narrow.

## What fires

Matched on the Go AST (`go/parser` + `go/ast`, the same choice `core/taint/engine/extract_go.go` makes), never on lines:

| call | mode arg | rule |
|---|---|---|
| `os.WriteFile(p, b, mode)` | 2 | `PERM-001` (G306) |
| `ioutil.WriteFile(p, b, mode)` | 2 | `PERM-001` |
| `os.OpenFile(p, flags, mode)` | 2 | `PERM-001` |
| `os.Chmod(p, mode)` | 1 | `PERM-001` (G302) |
| `os.Mkdir(p, mode)` | 1 | `PERM-002` (G301) |
| `os.MkdirAll(p, mode)` | 1 | `PERM-002` (G301) |

Mode forms evaluated: `0777` and `0o777`, digit separators (`0o7_77`),
`os.FileMode(0777)` / `fs.FileMode(0o666)` / bare `FileMode(…)` conversions, and
OR chains (`0666|extra` still fires — OR only ever adds bits). Decimal is read as
Go reads it, so `os.Chmod(p, 666)` fires reporting `01232`, which is what that
literal actually requests.

Arity is checked exactly, so a project's own `WriteFile`-shaped helper with a
different signature is not read as the stdlib call with the mode in another slot.

## The threshold: world-writable (`0o002`), not gosec's 0600/0750

This is the substantive design choice, and it is where I diverge from gosec.

gosec's defaults make `os.WriteFile(p, b, 0o644)` and `os.MkdirAll(p, 0o755)`
findings. **In this repository alone that is 503 call sites** (387 × `0o644`,
116 × `0o755`). Those two modes are the normal, correct, idiomatic Go defaults —
they are what `go` itself writes. A rule that reports them is reporting a
preference, not a vulnerability signal, and per the issue's own data the
permission families are among the most-suppressed in the fleet. Over-flagging a
ubiquitous stdlib call is how a rule gets globally suppressed, which costs more
than the rule is worth — `weakcrypto`'s header, and it applies squarely here.

World-writable is different in kind. Any local user — any other container on a
shared mount, any compromised low-privilege process — can rewrite the contents.
If the file is a script, a config, a plugin or a lockfile, that is direct code or
policy injection; for a directory it also means entries can be swapped underneath
a path the program trusts. No idiom needs it, so there is no legitimate-majority
case to weigh against, and the finding is actionable without knowing what the
file holds.

## What deliberately does NOT fire, and why

Every one of these is an asserted negative in the tests, not an accident:

- **`0600`, `0644`, `0o644`, `0755`, `0640`, `0700`, `os.MkdirAll(p, 0750)`** —
  the threshold above. Group-writable `0660` is also left alone: a deliberate,
  common shared-service-group pattern.
- **World-readable (`0o004`)** — whether `0644` is wrong depends entirely on
  what is in the file, which this analyzer cannot see.
- **`0777` in a comment or a string literal** — structurally impossible to match:
  comments aren't parsed and a string is not a `CallExpr`. This is the whole
  reason for the AST rather than a regex, and there is a mutation test proving
  the fixture catches a grep-shaped implementation (below).
- **Sticky directories** — `os.MkdirAll(p, 0777|os.ModeSticky)` is the /tmp
  model: anyone may create entries, only an entry's owner may remove or rename
  them. A design, not an oversight. Note that a *raw* `0o1777` literal does
  **not** get this exemption and is correctly still flagged: `os.Mkdir` masks the
  numeric mode with `Perm()` (`0o777`) and takes sticky solely from Go's
  `ModeSticky` (`1<<20`), so `0o1777` sets no sticky bit at all.
- **Unresolvable modes** — `os.MkdirAll(p, dirPerm)` (a named constant needs
  `go/types`), `os.Chmod(p, modeFor(p))`, and anything using `&^` or `&`, which
  can *clear* the world-write bit. Under-reporting is the correct failure
  direction here.
- **The tar-extraction clamp idiom** — `os.MkdirAll(t, os.FileMode(hdr.Mode)&0o777|0o755)`.
  Both lines in that test are real code from `registry/oci/extract.go`. Flagging a
  hardening idiom whose whole point is to clamp the mode is exactly how a
  permission rule earns a repo-wide suppression. Honest caveat, documented in the
  code: this is a genuine under-report, since the opaque operand could itself
  carry the bit.
- **Methods** — `f.Chmod(0o777)` on an `*os.File` needs the receiver's type;
  matching a bare `.Chmod(` would flag every unrelated Chmod-shaped method.
- **Test files and `testdata/` trees**, as `weakcrypto` does. Fixtures are where
  deliberate `0777` lives.

## Severity — and whether it gates

**Medium at high confidence**, matching gosec's own rating for G301/G302/G306.
A world-writable file is a genuine defect, but exploiting it requires an attacker
to already hold local access, and on a single-tenant container there may be no
second principal at all. High is reserved here for conditions exploitable from
outside — `InsecureSkipVerify` in the same issue is the example that does deserve
it. Confidence is High rather than `CRYPTO-001`'s Low because there is no
ambiguity of intent: the mode is a literal in the call.

**Stated plainly: at Medium this will NOT fail a gate keyed on net-new
critical/high.** It reports, it baselines, and it shows in the diff, but it does
not block. A fleet that wants gosec's blocking behaviour back has to lower the
threshold or key the gate on `PERM-*`. Inflating the severity to force gating
would be misrepresenting the risk to work around the gate's shape, and it would
also make every net-new `0666` in a build tool a release blocker.

## What it reports on nox's own tree

**Zero.** Both with the repo's `.nox.yaml` (full `nox scan .`, 79 findings, none
`PERM-*`) and with a raw sweep of **all 635 `.go` files with the test/fixture
skip disabled** — nothing in this repository, test trees included, creates a
world-writable file or directory. The two `0o777` literals in `os.*` permission
calls (`registry/oci/extract.go`) are the clamp idiom above and are correctly
silent.

That is the check the threshold was chosen against: at gosec's defaults the same
tree yields 503.

## Verification

- New fixtures were run before the assertions were written; nothing was assumed
  to match.
- **The tests were verified to fail when they should.** Six mutations, each
  reverted after: (1) threshold `0o002`→`0o004` — negatives and the decimal case
  fail; (2) sticky exemption removed — all four sticky fixtures fail; (3) arity
  `!=`→`<` — the helper-shadowing fixture fails; (4) test-tree skip disabled —
  the fixture-tree test fails; (5) `&^` treated like OR — the unresolvable-mode
  test fails; (6) AST matching swapped for a line regex, i.e. what a grep rule
  would do — the comment and string fixtures fail, 1 and 2 findings respectively.
- `go test ./...` clean, `go vet ./...` clean, `gofmt -l` clean (the one file it
  lists, `core/analyzers/secrets/testdata/benign/config.go`, is unformatted on
  `main` already).

Please do not merge without a look at the threshold argument — that is the part
worth disagreeing with.
