### PR TITLE
feat(hardening): detect TLS misconfiguration in Go source (HARDEN-001/002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   must be a literal in the call — a named constant needs `go/types` and is not
   reported, which is the correct direction to fail.
 
+### Added
+
+- **`HARDEN-001` / `HARDEN-002` — TLS misconfiguration in Go source.** Nothing in
+  nox modelled `tls.Config`. Certificate validation could be switched off
+  anywhere in a Go codebase and no rule said a word — a gap that matters now that
+  teams are dropping gosec from their golangci config and running nox as the only
+  code-level security tool. `HARDEN-001` reports `InsecureSkipVerify: true`
+  (**high** — verification off means the connection is authenticated against
+  nobody, and only critical/high fails a typical CI gate); `HARDEN-002` reports a
+  `MinVersion` below TLS 1.2 (**medium** — RFC 8996 deprecates TLS 1.0/1.1, but
+  the peer is still authenticated and a legacy floor is sometimes a defensible
+  choice). Both cover the composite-literal and the post-construction assignment
+  forms, resolve an aliased `crypto/tls` import, and carry `gosec: G402` in
+  metadata. (#405)
+
+  **This one is parsed, not pattern-matched.** `InsecureSkipVerify:\s*true` also
+  matches a comment — grpc's xds credentials contain "InsecureSkipVerify needs to
+  be set to true because …" — and no regex can tell `true` from a variable. The
+  rule uses `go/parser`, which nox already depends on for Go taint extraction, so
+  the check is exact and adds no dependency. Measured over 117,731 real Go files
+  in a module cache: 72 findings, every sampled one a genuine assignment; a loose
+  regex over the same corpus returns 82, of which 12 are comments.
+
+  **Deliberately not reported**, so nobody has to discover it the hard way:
+  `InsecureSkipVerify: skipVerify` (a variable's value is not resolvable without
+  `go/types`, and reporting it anyway would fire on every config-driven client),
+  and `_test.go` files (tests legitimately dial httptest servers with self-signed
+  certificates; a high-severity finding on each would get the rule suppressed
+  wholesale). A struct that is not provably a `crypto/tls.Config` — a wrapper
+  with its own `InsecureSkipVerify` field, or an assignment whose receiver type
+  needs `go/types` — is still reported, at medium confidence.
+
+- Findings from `HARDEN-*` and `CRYPTO-*` now carry a family label in the scan
+  summary ("Transport Security", "Weak Crypto") instead of falling into "Other",
+  where a broken primitive was invisible at a glance. (#405)
+
 ## [1.23.0] - 2026-07-26
 
 ### Changed

--- a/cli/ux.go
+++ b/cli/ux.go
@@ -49,6 +49,12 @@ func familyOf(ruleID string) string {
 		return "Reachability"
 	case strings.HasPrefix(ruleID, "TAINT-"):
 		return "Taint Flow"
+	case strings.HasPrefix(ruleID, "HARDEN-"):
+		return "Transport Security"
+	// CRYPTO- shipped without a label and fell into "Other", where a broken
+	// primitive is invisible in the summary line. Same fix, one line.
+	case strings.HasPrefix(ruleID, "CRYPTO-"):
+		return "Weak Crypto"
 	default:
 		return "Other"
 	}

--- a/core/analyzers/hardening/tls.go
+++ b/core/analyzers/hardening/tls.go
@@ -1,0 +1,486 @@
+// Package hardening detects transport-security misconfiguration in Go source:
+// TLS settings that are syntactically fine and semantically dangerous.
+//
+// WHY THIS EXISTS. Nothing in core modelled `tls.Config`. Certificate
+// validation could be switched off anywhere in a Go codebase and no nox rule
+// would say a word — measured against gosec's G402 on a 38-repo Go fleet where
+// gosec had just been removed from the shared golangci config, leaving nox as
+// the only code-level security tool. That is the highest-severity coverage gap
+// found, so it gets a rule.
+//
+// WHY IT IS NOT A TAINT RULE. There is no source to track. `InsecureSkipVerify:
+// true` is dangerous on its own, independent of where any value came from — the
+// same reason weakcrypto is its own analyzer rather than a taint sink.
+//
+// WHY AN AST AND NOT A REGEX. This is the one detection where a regex is
+// actively misleading. `InsecureSkipVerify:\s*true` also matches the string
+// inside a comment, and — worse — cannot distinguish `true` from a variable, so
+// the only regex that "handles" `InsecureSkipVerify: skipVerify` is one that
+// pretends a variable is a literal. nox is written in Go, so go/parser is free,
+// precise, deterministic and adds no dependency; the taint engine already
+// depends on it for exactly this reason (see docs/design/go-taint.md). The AST
+// answers "is this a keyed field of a composite literal whose value is the
+// identifier true" exactly, with no heuristics.
+//
+// SCOPE, deliberately narrow — the weakcrypto rule for the same reason:
+// over-flagging is how a rule gets globally suppressed, which costs more than
+// the rule is worth. Only literal `true` and literal below-1.2 version
+// constants are reported. See the KNOWN LIMITS block on Analyzer for what this
+// deliberately does not see.
+package hardening
+
+import (
+	"bytes"
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// Rule IDs emitted by this analyzer. HARDEN-* is a new namespace: these are
+// not broken primitives (CRYPTO-*), not infrastructure config (IAC-*) and not
+// a data flow (TAINT-*) — they are dangerous transport-security options in
+// application code. Neither ID collides with an existing rule.
+const (
+	// ruleInsecureSkipVerify: certificate validation switched off.
+	ruleInsecureSkipVerify = "HARDEN-001"
+	// ruleWeakTLSVersion: negotiated floor below TLS 1.2.
+	ruleWeakTLSVersion = "HARDEN-002"
+)
+
+// Analyzer reports TLS misconfiguration in Go source.
+//
+// KNOWN LIMITS — stated here rather than discovered by a user:
+//
+//  1. VARIABLE VALUES ARE NOT RESOLVED. `InsecureSkipVerify: skipVerify` is not
+//     reported. This analyzer walks the AST only; it does not run go/types or
+//     constant propagation, so it cannot tell whether `skipVerify` is a
+//     constant true, a --insecure flag that defaults to false, or a value that
+//     is only ever true in a dev branch. Reporting it anyway would fire on the
+//     config-driven pattern that most real codebases use, at the cost of the
+//     rule being suppressed wholesale. This is a real blind spot, and the
+//     dishonest alternative — a regex that "matches" the variable form without
+//     knowing its value — is worse than the gap.
+//
+//  2. TEST FILES ARE SKIPPED. gosec flags `_test.go`; this does not. Tests
+//     legitimately dial httptest TLS servers with self-signed certificates, and
+//     `InsecureSkipVerify: true` is the documented way to do that. The rule is
+//     High severity precisely so a CI gate can fail on it, which means every
+//     such test would either block a legitimate PR or teach the team to
+//     blanket-suppress HARDEN-001 — and a suppressed rule protects nothing. The
+//     accepted cost: production behaviour that lives in a _test.go file is not
+//     covered.
+//
+//  3. NO CROSS-FILE OR CROSS-PACKAGE VIEW. A helper that returns a
+//     misconfigured *tls.Config is reported where the literal is written, not
+//     where it is used.
+//
+//  4. GO ONLY. The equivalent in other languages (Python `verify=False`, Node
+//     `rejectUnauthorized: false`) is a separate detection with separate
+//     precision problems, and is not in this rule.
+type Analyzer struct{}
+
+// NewAnalyzer constructs the hardening analyzer.
+func NewAnalyzer() *Analyzer { return &Analyzer{} }
+
+// Rules returns the rules this analyzer can emit, for the rule catalogue.
+func (a *Analyzer) Rules() *rules.RuleSet {
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID:      ruleInsecureSkipVerify,
+		Version: "1.0",
+		Description: "TLS certificate verification disabled " +
+			"(InsecureSkipVerify: true)",
+		// High, not Medium. Disabling certificate verification removes
+		// authentication from the connection entirely: any party that can
+		// answer the DNS name or sit on the path can present any certificate
+		// and read and rewrite the traffic. TLS without verification provides
+		// no more security than plaintext against an active attacker, so it
+		// belongs on the same line as a hardcoded credential — and, concretely,
+		// gates that fail on net-new critical/high are the ones that stop it
+		// reaching production. A Medium finding here would be decorative.
+		Severity: findings.SeverityHigh,
+		// High: the AST proves the field is set to the literal true. There is
+		// no interpretation left — unlike CRYPTO-001, where the call site is
+		// unambiguous but its purpose is not.
+		Confidence: findings.ConfidenceHigh,
+		Tags:       []string{"tls", "transport-security", "owasp-a02", "gosec-g402"},
+		Remediation: "This disables TLS certificate verification, so the connection is authenticated against nobody: " +
+			"any host that can answer for the address — an on-path attacker, a hijacked DNS record, a malicious proxy — " +
+			"can present a self-signed certificate and read and modify everything sent over it. " +
+			"Remove the field and let the platform trust store validate the peer. " +
+			"If the peer uses a private or self-signed CA, do not skip verification — pin the CA instead by setting RootCAs to an x509.CertPool containing it, " +
+			"and set ServerName when the certificate does not match the dial address. " +
+			"If this is a deliberate, scoped exception (a local development target, a health probe against a host with no usable certificate), " +
+			"suppress it with a nox:ignore comment recording that reason so the decision is reviewable.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/295.html",
+			"https://pkg.go.dev/crypto/tls#Config",
+			"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/",
+		},
+		Metadata: map[string]string{"cwe": "CWE-295", "gosec": "G402"},
+	})
+	rs.Add(&rules.Rule{
+		ID:          ruleWeakTLSVersion,
+		Version:     "1.0",
+		Description: "TLS minimum version set below TLS 1.2",
+		// Medium, not High, and the difference from HARDEN-001 is deliberate.
+		// A TLS 1.0/1.1 floor is a real weakness — RFC 8996 deprecates both,
+		// PCI DSS forbids them, and they carry cipher suites broken by BEAST
+		// and by RC4 and 3DES weaknesses — but the peer is still
+		// authenticated, and exploiting it requires an active on-path
+		// attacker rather than merely a certificate. It is also, unlike
+		// HARDEN-001, sometimes a defensible decision: a server that must
+		// still serve identified legacy clients. Rating it High would put
+		// "negotiates an old protocol" on the same gate line as "does not
+		// check who it is talking to", which devalues the High tier and is how
+		// severity inflation starts. Medium reports it without blocking.
+		Severity: findings.SeverityMedium,
+		// High: the value is a literal constant naming the version.
+		Confidence: findings.ConfidenceHigh,
+		Tags:       []string{"tls", "transport-security", "owasp-a02", "gosec-g402"},
+		Remediation: "This pins the TLS floor below 1.2. TLS 1.0 and 1.1 are deprecated by RFC 8996 and disallowed by PCI DSS; " +
+			"they permit cipher suites with known weaknesses (RC4, 3DES) and are vulnerable to downgrade and record-protocol attacks that TLS 1.2 and 1.3 are not. " +
+			"Set MinVersion to tls.VersionTLS12, or tls.VersionTLS13 where every peer supports it. " +
+			"Note that omitting MinVersion entirely is not equivalent to setting it high: it takes the Go default, which has changed between releases. Set it explicitly. " +
+			"If a specific legacy peer genuinely requires an older protocol, keep the exception on the one client config that talks to it — not on a shared default — and record the reason in a nox:ignore comment.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/327.html",
+			"https://datatracker.ietf.org/doc/html/rfc8996",
+			"https://pkg.go.dev/crypto/tls#Config",
+		},
+		Metadata: map[string]string{"cwe": "CWE-327", "gosec": "G402"},
+	})
+	return rs
+}
+
+// triggers are the identifiers that any finding requires literally in the
+// source. Files containing neither are skipped without parsing — the AST is
+// only worth its cost on the small fraction of files that mention TLS options
+// at all.
+var triggers = [][]byte{
+	[]byte("InsecureSkipVerify"),
+	[]byte("MinVersion"),
+}
+
+// ScanArtifacts reports TLS misconfiguration across discovered Go sources.
+func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
+	fs := findings.NewFindingSet()
+
+	for _, art := range artifacts {
+		if err := ctx.Err(); err != nil {
+			return fs, err
+		}
+		if !strings.EqualFold(filepath.Ext(art.Path), ".go") {
+			continue
+		}
+		// See KNOWN LIMITS (2) on Analyzer for why test code is out of scope.
+		if isTestPath(art.Path) {
+			continue
+		}
+		content, err := os.ReadFile(art.AbsPath)
+		if err != nil {
+			// Unreadable file is not a finding; discovery already surfaced it.
+			continue
+		}
+		if !hasTrigger(content) {
+			continue
+		}
+		for _, f := range scanGoSource(art.Path, content) {
+			fs.Add(f)
+		}
+	}
+	return fs, nil
+}
+
+// hasTrigger reports whether the source mentions any option this analyzer can
+// report on.
+func hasTrigger(content []byte) bool {
+	for _, t := range triggers {
+		if bytes.Contains(content, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanGoSource parses one Go file and returns its findings.
+func scanGoSource(path string, content []byte) []findings.Finding {
+	fset := token.NewFileSet()
+	// SkipObjectResolution: identifier-object linking is not needed and
+	// skipping it is faster and more tolerant. Comments are deliberately NOT
+	// parsed — a comment cannot contain a composite literal, so mentioning
+	// InsecureSkipVerify in prose can never reach the checks below. On a parse
+	// error the partial AST the parser recovers is still walked, so a
+	// non-compiling file degrades gracefully instead of being silently skipped.
+	file, _ := parser.ParseFile(fset, path, content, parser.SkipObjectResolution)
+	if file == nil {
+		return nil
+	}
+
+	s := &scanner{
+		path:    path,
+		fset:    fset,
+		tlsPkgs: tlsImportNames(file),
+		elided:  map[ast.Node]bool{},
+	}
+	ast.Inspect(file, s.visit)
+	return s.out
+}
+
+// scanner accumulates findings for one file.
+type scanner struct {
+	path string
+	fset *token.FileSet
+	// tlsPkgs holds the local names bound to crypto/tls in this file — "tls"
+	// normally, or an alias. Empty when the file does not import crypto/tls,
+	// in which case no expression in it can be a crypto/tls constant.
+	tlsPkgs map[string]bool
+	// elided holds inner composite literals whose type Go elides because the
+	// enclosing slice, array or map declares it: the `{...}` in
+	// `[]tls.Config{{...}}` has a nil Type of its own. ast.Inspect visits the
+	// parent first, so the parent records its children here and they are still
+	// recognised as tls.Config when their turn comes.
+	elided map[ast.Node]bool
+	out    []findings.Finding
+}
+
+func (s *scanner) visit(n ast.Node) bool {
+	switch node := n.(type) {
+	case *ast.CompositeLit:
+		s.checkCompositeLit(node)
+	case *ast.AssignStmt:
+		s.checkAssign(node)
+	}
+	return true
+}
+
+// checkCompositeLit handles the `tls.Config{...}` construction form, including
+// `&tls.Config{...}` (the & is a UnaryExpr wrapping this node) and configs
+// nested inside another literal such as `&http.Transport{TLSClientConfig: ...}`.
+func (s *scanner) checkCompositeLit(lit *ast.CompositeLit) {
+	isTLSConfig := s.elided[lit] || s.isTLSConfigType(lit.Type)
+	s.markElidedElements(lit)
+
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "InsecureSkipVerify":
+			// Only the literal true. A variable is not resolvable here and is
+			// deliberately not reported — KNOWN LIMITS (1).
+			if isTrueLiteral(kv.Value) {
+				s.add(ruleInsecureSkipVerify, kv, isTLSConfig)
+			}
+		case "MinVersion":
+			// MinVersion is a generic-sounding field name that other libraries
+			// use for unrelated things (API versions, protocol revisions), so
+			// a bare integer only counts inside a literal known to be a
+			// tls.Config. A tls.VersionTLS10 constant anchors itself to
+			// crypto/tls and is reported wherever it appears.
+			if s.isWeakTLSVersion(kv.Value, isTLSConfig) {
+				s.add(ruleWeakTLSVersion, kv, isTLSConfig)
+			}
+		}
+	}
+}
+
+// checkAssign handles the post-construction form, which is how the setting is
+// most often slipped in later:
+//
+//	cfg := &tls.Config{}
+//	cfg.InsecureSkipVerify = true
+func (s *scanner) checkAssign(as *ast.AssignStmt) {
+	for i, lhs := range as.Lhs {
+		sel, ok := lhs.(*ast.SelectorExpr)
+		if !ok || i >= len(as.Rhs) {
+			continue
+		}
+		rhs := as.Rhs[i]
+		switch sel.Sel.Name {
+		case "InsecureSkipVerify":
+			if isTrueLiteral(rhs) {
+				// The receiver's type is unknown without go/types, so this is
+				// reported at Medium confidence — see add().
+				s.add(ruleInsecureSkipVerify, as, false)
+			}
+		case "MinVersion":
+			// Only the named crypto/tls constants: an assignment gives no type
+			// context at all, so a bare integer here would be a guess.
+			if s.isWeakTLSVersion(rhs, false) {
+				s.add(ruleWeakTLSVersion, as, true)
+			}
+		}
+	}
+}
+
+// isTLSConfigType reports whether a composite-literal type expression denotes
+// crypto/tls.Config, resolving the local import name.
+func (s *scanner) isTLSConfigType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := t.X.(*ast.Ident)
+		return ok && s.tlsPkgs[pkg.Name] && t.Sel.Name == "Config"
+	case *ast.StarExpr:
+		return s.isTLSConfigType(t.X)
+	}
+	return false
+}
+
+// markElidedElements records the children of a `[]tls.Config{{...}}`-style
+// literal so they are recognised as tls.Config despite carrying no type of
+// their own.
+func (s *scanner) markElidedElements(lit *ast.CompositeLit) {
+	var elem ast.Expr
+	switch t := lit.Type.(type) {
+	case *ast.ArrayType:
+		elem = t.Elt
+	case *ast.MapType:
+		elem = t.Value
+	default:
+		return
+	}
+	if !s.isTLSConfigType(elem) {
+		return
+	}
+	for _, elt := range lit.Elts {
+		// A map literal's elements are key/value pairs; the value is the one
+		// with the elided type.
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			elt = kv.Value
+		}
+		if inner, ok := elt.(*ast.CompositeLit); ok && inner.Type == nil {
+			s.elided[inner] = true
+		}
+	}
+}
+
+// weakVersionConsts are the crypto/tls version constants below TLS 1.2.
+var weakVersionConsts = map[string]bool{
+	"VersionTLS10": true,
+	"VersionTLS11": true,
+	// SSL 3.0 is worse still (POODLE) and Go has removed support, but the
+	// constant remains and legacy code still names it.
+	"VersionSSL30": true,
+}
+
+// weakVersionValues are the same versions written as raw numbers, in both the
+// hex form the RFCs use and the decimal form a linter-shy codebase sometimes
+// substitutes. Only trusted inside a known tls.Config.
+var weakVersionValues = map[string]bool{
+	"0x0300": true, "768": true, // SSL 3.0
+	"0x0301": true, "769": true, // TLS 1.0
+	"0x0302": true, "770": true, // TLS 1.1
+}
+
+// isWeakTLSVersion reports whether an expression names a TLS version below 1.2.
+// Raw numeric literals only count when the surrounding literal is known to be a
+// tls.Config; a named crypto/tls constant is self-identifying.
+func (s *scanner) isWeakTLSVersion(expr ast.Expr, allowRawNumber bool) bool {
+	switch v := expr.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := v.X.(*ast.Ident)
+		return ok && s.tlsPkgs[pkg.Name] && weakVersionConsts[v.Sel.Name]
+	case *ast.BasicLit:
+		if !allowRawNumber || v.Kind != token.INT {
+			return false
+		}
+		return weakVersionValues[strings.ToLower(v.Value)]
+	}
+	return false
+}
+
+// isTrueLiteral reports whether an expression is the identifier true.
+//
+// Only the literal counts. `false` is an *ast.Ident too, and this is where it
+// is rejected — the whole point of parsing rather than pattern-matching.
+func isTrueLiteral(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "true"
+}
+
+// add records a finding at the node's position.
+//
+// confirmedType carries whether the enclosing type was proven to be
+// crypto/tls.Config. When it was not, the detection rests on the field name
+// alone: a wrapper struct with its own InsecureSkipVerify field, or a
+// post-construction assignment whose receiver type needs go/types to resolve.
+// Those are still reported — a Go field named InsecureSkipVerify set to true
+// has one meaning, and library wrappers pass it straight through to
+// crypto/tls — but at Medium confidence, so a reviewer can tell the two apart.
+func (s *scanner) add(ruleID string, node ast.Node, confirmedType bool) {
+	pos := s.fset.Position(node.Pos())
+	end := s.fset.Position(node.End())
+
+	confidence := findings.ConfidenceHigh
+	message := "TLS certificate verification is disabled (InsecureSkipVerify: true)"
+	cwe := "CWE-295"
+	severity := findings.SeverityHigh
+	if ruleID == ruleWeakTLSVersion {
+		message = "TLS minimum version is set below TLS 1.2"
+		cwe = "CWE-327"
+		severity = findings.SeverityMedium
+	}
+	if !confirmedType {
+		confidence = findings.ConfidenceMedium
+		message += " on a struct that could not be confirmed to be a crypto/tls.Config"
+	}
+
+	s.out = append(s.out, findings.Finding{
+		RuleID:     ruleID,
+		Severity:   severity,
+		Confidence: confidence,
+		Message:    message,
+		Location: findings.Location{
+			FilePath:    s.path,
+			StartLine:   pos.Line,
+			EndLine:     end.Line,
+			StartColumn: pos.Column,
+			EndColumn:   end.Column,
+		},
+		Metadata: map[string]string{"cwe": cwe, "gosec": "G402"},
+	})
+}
+
+// tlsImportNames returns the local names bound to crypto/tls in a file.
+func tlsImportNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range file.Imports {
+		if imp.Path == nil || strings.Trim(imp.Path.Value, `"`) != "crypto/tls" {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			names["tls"] = true
+		case imp.Name.Name == "_" || imp.Name.Name == ".":
+			// A blank import binds nothing; a dot-import puts Config in file
+			// scope with no package qualifier, which this analyzer does not
+			// model (and which no real code does for crypto/tls).
+		default:
+			names[imp.Name.Name] = true
+		}
+	}
+	return names
+}
+
+// isTestPath reports whether a path is Go test code or a test fixture tree.
+func isTestPath(p string) bool {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(p)), "_test.go") {
+		return true
+	}
+	lower := filepath.ToSlash(strings.ToLower(p))
+	return strings.Contains(lower, "/testdata/") || strings.HasPrefix(lower, "testdata/")
+}

--- a/core/analyzers/hardening/tls_test.go
+++ b/core/analyzers/hardening/tls_test.go
@@ -1,0 +1,369 @@
+package hardening
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanSource runs the analyzer over a single synthetic file.
+func scanSource(t *testing.T, name, content string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, filepath.Base(name))
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := (&Analyzer{}).ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+// only asserts that a source produced exactly one finding of the given rule and
+// returns it, so a case can go on to check severity or confidence.
+func only(t *testing.T, ruleID, src string) findings.Finding {
+	t.Helper()
+	got := scanSource(t, "a.go", src)
+	if len(got) != 1 || got[0].RuleID != ruleID {
+		t.Fatalf("want exactly one %s, got %d findings %v for:\n%s",
+			ruleID, len(got), ruleIDs(got), src)
+	}
+	return got[0]
+}
+
+func ruleIDs(fs []findings.Finding) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.RuleID)
+	}
+	return out
+}
+
+func TestFlagsInsecureSkipVerify(t *testing.T) {
+	for name, src := range map[string]string{
+		"composite literal": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: true} }`,
+
+		"value literal": `package m
+import "crypto/tls"
+func f() tls.Config { return tls.Config{InsecureSkipVerify: true} }`,
+
+		// The shape that actually appears in the wild: the config is nested in
+		// the transport that uses it.
+		"nested in http.Transport": `package m
+import ("crypto/tls"; "net/http")
+func f() *http.Transport {
+	return &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+}`,
+
+		// Set after construction. This is how the setting is most often slipped
+		// in later, and a rule that only looked at composite literals would
+		// miss it entirely.
+		"assignment after construction": `package m
+import "crypto/tls"
+func f() *tls.Config {
+	c := &tls.Config{MinVersion: tls.VersionTLS12}
+	c.InsecureSkipVerify = true
+	return c
+}`,
+
+		"aliased import": `package m
+import cryptotls "crypto/tls"
+func f() *cryptotls.Config { return &cryptotls.Config{InsecureSkipVerify: true} }`,
+
+		// The element type is declared once by the slice, so the inner literal
+		// carries no type of its own.
+		"slice element with elided type": `package m
+import "crypto/tls"
+func f() []tls.Config { return []tls.Config{{InsecureSkipVerify: true}} }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := only(t, ruleInsecureSkipVerify, src)
+			// High is the whole point: the fleet gate this rule exists for
+			// fails on net-new critical/high only, so a lower severity would
+			// make the rule decorative.
+			if f.Severity != findings.SeverityHigh {
+				t.Errorf("severity = %s, want high", f.Severity)
+			}
+			if f.Metadata["cwe"] != "CWE-295" {
+				t.Errorf("cwe = %q, want CWE-295", f.Metadata["cwe"])
+			}
+		})
+	}
+}
+
+// The negative half of the rule. Every case here is code that a pattern-match
+// on the field name would report and that is not a vulnerability. A rule that
+// fires on these is worse than no rule: it gets suppressed wholesale, and then
+// the true positives go with it.
+func TestDoesNotFlagSafeOrUnprovableForms(t *testing.T) {
+	for name, src := range map[string]string{
+		"explicitly false": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: false} }`,
+
+		"assigned false": `package m
+import "crypto/tls"
+func f(c *tls.Config) { c.InsecureSkipVerify = false }`,
+
+		// KNOWN LIMITS (1): the value is not resolvable from the AST, so it is
+		// not reported. This test pins that decision so it cannot be changed
+		// silently — reporting here would fire on every config-driven client.
+		"variable value": `package m
+import "crypto/tls"
+func f(skip bool) *tls.Config { return &tls.Config{InsecureSkipVerify: skip} }`,
+
+		"computed value": `package m
+import ("crypto/tls"; "os")
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: os.Getenv("DEV") == "1"} }`,
+
+		"value from a call": `package m
+import "crypto/tls"
+func skip() bool { return true }
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: skip()} }`,
+
+		"value forwarded from another struct": `package m
+import "crypto/tls"
+type opts struct{ InsecureSkipVerify bool }
+func f(o opts) *tls.Config { return &tls.Config{InsecureSkipVerify: o.InsecureSkipVerify} }`,
+
+		// Real code contains exactly this: grpc's xds credentials carry the
+		// comment "InsecureSkipVerify needs to be set to true because ...".
+		"line comment": `package m
+import "crypto/tls"
+// InsecureSkipVerify: true would disable verification; do not do it.
+func f() *tls.Config { return &tls.Config{} }`,
+
+		"block comment": `package m
+/*
+	c.InsecureSkipVerify = true
+*/
+func f() {}`,
+
+		"string literal": `package m
+const doc = "InsecureSkipVerify: true"`,
+
+		"struct field declaration": `package m
+type config struct {
+	// InsecureSkipVerify disables verification when true.
+	InsecureSkipVerify bool
+}`,
+
+		"read, not written": `package m
+import ("crypto/tls"; "fmt")
+func f(c *tls.Config) { fmt.Println(c.InsecureSkipVerify) }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := scanSource(t, "a.go", src); len(got) != 0 {
+				t.Errorf("got %d findings %v, want 0 for:\n%s", len(got), ruleIDs(got), src)
+			}
+		})
+	}
+}
+
+func TestFlagsWeakTLSVersion(t *testing.T) {
+	for name, src := range map[string]string{
+		"TLS 1.0 constant": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: tls.VersionTLS10} }`,
+
+		"TLS 1.1 constant": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: tls.VersionTLS11} }`,
+
+		"SSL 3.0 constant": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: tls.VersionSSL30} }`,
+
+		"raw hex inside a tls.Config": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: 0x0301} }`,
+
+		"raw decimal inside a tls.Config": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: 770} }`,
+
+		// Taken from real code: thrift's socket helper does exactly this.
+		"assignment of a tls constant": `package m
+import "crypto/tls"
+func f(c *tls.Config) {
+	if c.MinVersion == 0 {
+		c.MinVersion = tls.VersionTLS10
+	}
+}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := only(t, ruleWeakTLSVersion, src)
+			// Medium, deliberately: the peer is still authenticated, and a
+			// legacy floor is sometimes a defensible decision. See the rule
+			// comment for why inflating this to High would devalue High.
+			if f.Severity != findings.SeverityMedium {
+				t.Errorf("severity = %s, want medium", f.Severity)
+			}
+		})
+	}
+}
+
+func TestDoesNotFlagAcceptableTLSVersions(t *testing.T) {
+	for name, src := range map[string]string{
+		"TLS 1.2": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: tls.VersionTLS12} }`,
+
+		"TLS 1.3": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MinVersion: tls.VersionTLS13} }`,
+
+		"MaxVersion is not MinVersion": `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{MaxVersion: tls.VersionTLS10, MinVersion: tls.VersionTLS12} }`,
+
+		// MinVersion is a generic field name. A bare integer only means a TLS
+		// version inside something known to be a tls.Config; anywhere else it
+		// is an API version, a schema revision, or a protocol number.
+		"unrelated struct with a MinVersion field": `package m
+type api struct{ MinVersion int }
+func f() api { return api{MinVersion: 0x0301} }`,
+
+		"unrelated assignment of a raw number": `package m
+type api struct{ MinVersion int }
+func f(a *api) { a.MinVersion = 769 }`,
+
+		"variable version": `package m
+import "crypto/tls"
+func f(v uint16) *tls.Config { return &tls.Config{MinVersion: v} }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := scanSource(t, "a.go", src); len(got) != 0 {
+				t.Errorf("got %d findings %v, want 0 for:\n%s", len(got), ruleIDs(got), src)
+			}
+		})
+	}
+}
+
+// Confidence separates "the AST proved this is a crypto/tls.Config" from "the
+// field name says so and nothing else does". Both are reported; a reviewer can
+// tell them apart.
+func TestConfidenceReflectsTypeConfirmation(t *testing.T) {
+	confirmed := only(t, ruleInsecureSkipVerify, `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: true} }`)
+	if confirmed.Confidence != findings.ConfidenceHigh {
+		t.Errorf("confirmed tls.Config confidence = %s, want high", confirmed.Confidence)
+	}
+
+	// A wrapper struct with its own InsecureSkipVerify field: reported,
+	// because a Go field with that name set to true has one meaning and such
+	// wrappers pass it straight through to crypto/tls — but the type is not
+	// proven without go/types, so confidence drops.
+	wrapper := only(t, ruleInsecureSkipVerify, `package m
+type clientOpts struct{ InsecureSkipVerify bool }
+func f() clientOpts { return clientOpts{InsecureSkipVerify: true} }`)
+	if wrapper.Confidence != findings.ConfidenceMedium {
+		t.Errorf("unconfirmed struct confidence = %s, want medium", wrapper.Confidence)
+	}
+	if !strings.Contains(wrapper.Message, "could not be confirmed") {
+		t.Errorf("message %q does not say the type is unconfirmed", wrapper.Message)
+	}
+}
+
+// KNOWN LIMITS (2). gosec flags test files; this does not. Tests legitimately
+// dial httptest servers with self-signed certificates, and a High finding on
+// every such test would either block legitimate PRs or teach the team to
+// suppress HARDEN-001 outright.
+func TestSkipsTestCode(t *testing.T) {
+	src := `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: true} }`
+	for _, name := range []string{"a_test.go", "testdata/a.go", "core/testdata/a.go"} {
+		if got := scanSource(t, name, src); len(got) != 0 {
+			t.Errorf("%s: got %d findings, want 0 (test code)", name, len(got))
+		}
+	}
+}
+
+func TestSkipsNonGoFiles(t *testing.T) {
+	for _, name := range []string{"notes.md", "config.yaml", "app.py"} {
+		if got := scanSource(t, name, "InsecureSkipVerify: true"); len(got) != 0 {
+			t.Errorf("%s: got %d findings, want 0", name, len(got))
+		}
+	}
+}
+
+// A file that does not compile still yields a partial AST. Degrading to silence
+// here would mean a scan of a work-in-progress branch quietly reports nothing.
+func TestPartialParseStillReports(t *testing.T) {
+	src := `package m
+import "crypto/tls"
+func f() *tls.Config { return &tls.Config{InsecureSkipVerify: true}` // unclosed
+	if got := scanSource(t, "a.go", src); len(got) != 1 {
+		t.Errorf("got %d findings, want 1 from a partial parse", len(got))
+	}
+}
+
+func TestBothFieldsInOneConfigReportSeparately(t *testing.T) {
+	got := scanSource(t, "a.go", `package m
+import "crypto/tls"
+func f() *tls.Config {
+	return &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS10}
+}`)
+	if len(got) != 2 {
+		t.Fatalf("got %d findings %v, want 2", len(got), ruleIDs(got))
+	}
+	seen := map[string]bool{}
+	for _, f := range got {
+		seen[f.RuleID] = true
+	}
+	if !seen[ruleInsecureSkipVerify] || !seen[ruleWeakTLSVersion] {
+		t.Errorf("want both rules, got %v", ruleIDs(got))
+	}
+}
+
+func TestRulesAreRegistered(t *testing.T) {
+	byID := map[string]bool{}
+	for _, r := range (&Analyzer{}).Rules().Rules() {
+		byID[r.ID] = true
+		switch r.ID {
+		case ruleInsecureSkipVerify:
+			if r.Severity != findings.SeverityHigh {
+				t.Errorf("%s severity = %s, want high", r.ID, r.Severity)
+			}
+			if r.Metadata["cwe"] != "CWE-295" {
+				t.Errorf("%s cwe = %q, want CWE-295", r.ID, r.Metadata["cwe"])
+			}
+		case ruleWeakTLSVersion:
+			if r.Severity != findings.SeverityMedium {
+				t.Errorf("%s severity = %s, want medium", r.ID, r.Severity)
+			}
+		default:
+			t.Errorf("unexpected rule %s", r.ID)
+		}
+		if r.Remediation == "" || len(r.References) == 0 {
+			t.Errorf("%s is missing remediation or references", r.ID)
+		}
+	}
+	if !byID[ruleInsecureSkipVerify] || !byID[ruleWeakTLSVersion] {
+		t.Errorf("missing rules, got %v", byID)
+	}
+}
+
+// Files that mention neither option are never parsed. This is the pre-filter
+// that keeps the analyzer off the critical path for the ~99% of Go files with
+// no TLS configuration in them.
+func TestNonTLSFilesAreNotParsed(t *testing.T) {
+	if hasTrigger([]byte("package m\nfunc main() {}\n")) {
+		t.Error("a file with no TLS option was not filtered out")
+	}
+	if !hasTrigger([]byte("InsecureSkipVerify")) || !hasTrigger([]byte("MinVersion")) {
+		t.Error("a file mentioning a TLS option was filtered out")
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/data"
 	"github.com/nox-hq/nox/core/analyzers/deps"
 	"github.com/nox-hq/nox/core/analyzers/fileperms"
+	"github.com/nox-hq/nox/core/analyzers/hardening"
 	"github.com/nox-hq/nox/core/analyzers/iac"
 	"github.com/nox-hq/nox/core/analyzers/provenance"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
@@ -270,6 +271,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	slopAnalyzer := slop.NewAnalyzer(slopOpts...)
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
 	filepermsAnalyzer := fileperms.NewAnalyzer()
+	hardeningAnalyzer := hardening.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
 	// A signature database that fails to parse leaves every VARIANT-* rule
 	// unable to match. The scan would otherwise report zero variant findings
@@ -368,6 +370,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			return nil
 		},
 		func(c context.Context) error {
+			fs, err := hardeningAnalyzer.ScanArtifacts(c, artifacts)
+			if err != nil {
+				return err
+			}
+			addFindings(fs)
+			return nil
+		},
+		func(c context.Context) error {
 			fs, err := slopAnalyzer.ScanArtifacts(c, artifacts)
 			if err != nil {
 				return err
@@ -458,6 +468,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		allRules.Add(r)
 	}
 	for _, r := range filepermsAnalyzer.Rules().Rules() {
+		allRules.Add(r)
+	}
+	for _, r := range hardeningAnalyzer.Rules().Rules() {
 		allRules.Add(r)
 	}
 	for _, r := range slopAnalyzer.Rules().Rules() {


### PR DESCRIPTION
Closes the `tls.Config` gap in #405.

Nothing in nox modelled TLS configuration. Certificate validation could be switched off anywhere in a Go codebase and no rule reported it — gosec catches this as G402, and the fleet that prompted #405 had just removed gosec from its shared golangci config, leaving nox as the only code-level security tool. This adds a `core/analyzers/hardening` analyzer with two rules.

## What fires

| rule | condition | rating |
|---|---|---|
| `HARDEN-001` | certificate verification disabled | **high** / high confidence |
| `HARDEN-002` | `MinVersion` below TLS 1.2 | **medium** / high confidence |

`HARDEN-001` fires on:

- `tls.Config{InsecureSkipVerify: true}` and `&tls.Config{...}`, including nested in the thing that uses it (`&http.Transport{TLSClientConfig: &tls.Config{…}}`)
- the post-construction form `cfg.InsecureSkipVerify = true`, which is how the setting is most often slipped in later and which a composite-literal-only rule would miss entirely
- an aliased import (`import cryptotls "crypto/tls"`)
- an element of `[]tls.Config{{…}}`, where Go elides the inner literal's type

`HARDEN-002` fires on `MinVersion` set to `tls.VersionTLS10`, `tls.VersionTLS11`, `tls.VersionSSL30`, or the raw constants `0x0300`/`0x0301`/`0x0302` (and their decimal forms) — raw numbers **only** inside a literal proven to be a `tls.Config`, since `MinVersion` is a generic field name that elsewhere means an API or schema version.

## What deliberately does not fire

Every one of these has a test pinning it, so the decision cannot be changed silently.

- **`InsecureSkipVerify: false`**, and `x.InsecureSkipVerify = false`.
- **A variable-valued field** — `InsecureSkipVerify: skipVerify`, `os.Getenv("DEV") == "1"`, `skip()`. This is a real blind spot and is documented as one on the analyzer rather than hidden. The AST cannot tell whether the variable is a constant `true`, a `--insecure` flag defaulting to false, or a value only ever true in a dev branch; resolving it needs `go/types` plus constant propagation. Flagging it anyway would fire on the config-driven pattern most codebases use, and the honest alternative to a blind spot is not a regex that pretends to handle it.
- **`_test.go` files and `testdata/` trees.** gosec flags them; this does not. Tests legitimately dial `httptest` TLS servers with self-signed certificates, and `InsecureSkipVerify: true` is the documented way to do it. Because `HARDEN-001` is high severity — deliberately, so a CI gate fails on it — flagging test code would either block legitimate PRs or teach a team to suppress the rule wholesale, and a suppressed rule protects nothing. Accepted cost: production behaviour living in a `_test.go` file is not covered. This also matches the existing `weakcrypto` precedent.
- **Comments and strings**, including the block-comment and struct-field-declaration forms.
- **A read** (`fmt.Println(c.InsecureSkipVerify)`) and **a forwarded value** (`InsecureSkipVerify: o.InsecureSkipVerify`).
- **`MinVersion` on an unrelated struct**, and `MaxVersion` of any value.

A struct that is not *provably* a `crypto/tls.Config` — a library wrapper with its own `InsecureSkipVerify` field, or an assignment whose receiver type needs `go/types` — **is** still reported, but at **medium confidence** with the message saying so. A Go field with that name set to `true` has one meaning, and such wrappers pass it straight to `crypto/tls`; the confidence tier is what lets a reviewer tell the two apart.

## Why an AST, not a regex

This is the one detection where a regex is actively misleading, so the rule uses `go/parser` — which nox already depends on for Go taint extraction (`core/taint/engine/extract_go.go`), so it is precise, deterministic, and adds no dependency.

Measured over **117,731 real Go files** (a populated module cache):

- the analyzer reports **72 findings** — 70 × `HARDEN-001`, 2 × `HARDEN-002` — in docker, etcd, consul, lib/pq, pgx, mongo-driver, quic-go, testcontainers, spiffe and others. Every sampled one is a genuine literal `true` or `= true`.
- a tight regex (`InsecureSkipVerify:\s*true|InsecureSkipVerify\s*=\s*true`) returns the **exact same 70 lines** on this corpus — so the AST is not buying recall here, and that is worth saying plainly.
- a *loose* regex (`InsecureSkipVerify.*true`) returns **82** — the extra 12 are comments, e.g. grpc's `// InsecureSkipVerify needs to be set to true because we need to perform …`. That is the failure mode the parser makes structurally impossible rather than tuned away.

The second thing the AST buys is the type context that sets confidence, which no regex has.

**Zero findings on nox itself**, and zero on a Go CLI from the rule-diff corpus. The `Rule behaviour diff` job should report `HARDEN-*` appearing where corpus repos genuinely disable verification; that is the rule working, not a regression.

Files mentioning neither `InsecureSkipVerify` nor `MinVersion` are never parsed, so the parser cost is confined to the small fraction of Go files that configure TLS at all.

## Severity choices

`HARDEN-001` is **high**, and this is the load-bearing decision. Disabling certificate verification removes authentication from the connection entirely — any party that can answer for the address can present a self-signed certificate and read and rewrite everything. Against an active attacker that is no better than plaintext. It is also practical: gates commonly fail on net-new critical/high only, so a medium finding here would never gate and the rule would be decorative.

`HARDEN-002` is **medium**, deliberately different. A TLS 1.0/1.1 floor is a real weakness (RFC 8996 deprecates both, PCI DSS forbids them), but the peer is still authenticated, exploiting it needs an on-path attacker, and it is sometimes a defensible decision for identified legacy clients. Rating it high would put "negotiates an old protocol" on the same gate line as "does not check who it is talking to", which is how severity inflation starts.

## Other limitations

- No cross-file or cross-package view: a helper returning a misconfigured `*tls.Config` is reported where the literal is written, not where it is used.
- Go only. Python `verify=False` and Node `rejectUnauthorized: false` are separate detections with separate precision problems; not in this PR.
- A file that does not compile still yields a partial AST and is still reported (tested) — degrading to silence would mean a work-in-progress branch quietly scans clean.

## Testing

- 11 tests / 29 subtests in `core/analyzers/hardening/tls_test.go`, roughly half of them negative.
- **The tests were verified to fail when they should.** Six mutations were applied to the analyzer and the suite re-run each time: `isTrueLiteral` accepting any identifier — the regex-equivalent naivety — (caught: `explicitly false`, `assigned false`, `variable value`); removing the test-file skip (caught); accepting raw numbers outside a `tls.Config` (caught, 2 subtests); removing the confidence downgrade (caught); ignoring the version constant's value (caught, 6 subtests). One unrealistic mutation — treating a string literal as `true` — was *not* caught, and is reported here rather than papered over with a fixture nobody would write. The file was restored and diffed byte-identical afterwards.
- Fixtures were run through the scanner and the real output inspected **before** the assertions were written, not assumed. That is what caught `[]tls.Config{{…}}` reporting at the wrong confidence, since Go elides the inner literal's type.
- `go test ./...`, `gofmt -l`, `go vet ./...` and `golangci-lint run` are clean. End-to-end `nox scan` verified: both rules surface in `findings.json` with distinct fingerprints (they land on the same line, so the column range separates them).

## Drive-by

`CRYPTO-*` shipped without a family label and fell into `Other` in the scan summary, where a broken primitive is invisible at a glance. Added alongside `HARDEN-*` ("Weak Crypto" / "Transport Security") — one line each, display only, no effect on gating.

Refs #405
