### PR TITLE
feat(crypto): CRYPTO-002 — predictable randomness in security contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   must be a literal in the call — a named constant needs `go/types` and is not
   reported, which is the correct direction to fail.
 
-### Added
-
 - **`HARDEN-001` / `HARDEN-002` — TLS misconfiguration in Go source.** Nothing in
   nox modelled `tls.Config`. Certificate validation could be switched off
   anywhere in a Go codebase and no rule said a word — a gap that matters now that
@@ -71,6 +69,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Findings from `HARDEN-*` and `CRYPTO-*` now carry a family label in the scan
   summary ("Transport Security", "Weak Crypto") instead of falling into "Other",
   where a broken primitive was invisible at a glance. (#405)
+
+- **`CRYPTO-002`** — predictable randomness (CWE-338): a `math/rand` or
+  `math/rand/v2` draw used for a security-bearing value in Go. High severity,
+  medium confidence. This is the class gosec reports as G404, which Go
+  codebases lost when they dropped gosec from their lint config. (#405)
+
+  **It does not flag `math/rand`.** `math/rand` is the *correct* tool for retry
+  jitter, backoff spread, load balancing, sampling, shuffling and test
+  fixtures, and those call sites outnumber the dangerous ones. The rule fires
+  only where the names around the draw say the value is security-bearing — the
+  variable, struct field, buffer, called function or enclosing generator
+  function resolves to a word like `token`, `secret`, `key`, `nonce`, `salt`,
+  `password`, `session`, `iv`, `apikey`, `csrf`, `otp` or `auth` — and a word
+  like `jitter`, `backoff`, `retry`, `sample`, `shuffle` or `cache` anywhere in
+  that context vetoes it outright. `crypto/rand` is never flagged: the file is
+  parsed and the import path resolved, so `rand.Read` from `crypto/rand` (the
+  fix this rule recommends, and identical in text) is distinguished from
+  `rand.Read` from `math/rand`.
+
+  **Measured before shipping, on real code.** Across the Go module cache, 851
+  non-test files that import `math/rand` produce 4 findings; a fleet of 23 Go
+  repositories (7,720 files) produces 0, and every one of gosec's 9 G404
+  reports in that same fleet is a documented-benign jitter, chaos-test or
+  simulation call that this rule correctly stays silent on.
+
+  **It misses things, by construction.** A generator whose variables and
+  function are named neutrally is not caught, nor is a value that reaches a
+  security name a statement later, nor a dot-imported `math/rand`. Recall was
+  traded away for silence on purpose: this rule is intended to be safe to gate
+  on, and the absence of a finding is not evidence that a file generates its
+  secrets safely.
 
 ## [1.23.0] - 2026-07-26
 

--- a/core/analyzers/weakcrypto/crypto.go
+++ b/core/analyzers/weakcrypto/crypto.go
@@ -86,6 +86,7 @@ func (a *Analyzer) Rules() *rules.RuleSet {
 		},
 		Metadata: map[string]string{"cwe": "CWE-327"},
 	})
+	rs.Add(randRule())
 	return rs
 }
 
@@ -97,13 +98,17 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 		if err := ctx.Err(); err != nil {
 			return fs, err
 		}
-		re, ok := weakByExt[strings.ToLower(filepath.Ext(art.Path))]
-		if !ok {
+		ext := strings.ToLower(filepath.Ext(art.Path))
+		re, weakOK := weakByExt[ext]
+		// Insecure randomness (CRYPTO-002) is Go-only; see rand.go.
+		randOK := ext == ".go"
+		if !weakOK && !randOK {
 			continue
 		}
 		// Test files are skipped: fixtures deliberately exercise weak
 		// primitives (including this analyzer's own tests), and flagging them
-		// is noise that trains people to ignore the rule.
+		// is noise that trains people to ignore the rule. The same holds for
+		// predictable randomness, where determinism in a test is a feature.
 		if isTestPath(art.Path) {
 			continue
 		}
@@ -114,7 +119,14 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			continue
 		}
 
-		lineComment := lineCommentFor(strings.ToLower(filepath.Ext(art.Path)))
+		if randOK {
+			scanInsecureRandom(fs, art, content)
+		}
+		if !weakOK {
+			continue
+		}
+
+		lineComment := lineCommentFor(ext)
 
 		for i, line := range strings.Split(string(content), "\n") {
 			loc := re.FindStringIndex(line)

--- a/core/analyzers/weakcrypto/crypto_test.go
+++ b/core/analyzers/weakcrypto/crypto_test.go
@@ -84,10 +84,17 @@ func TestUnknownExtensionIsSkipped(t *testing.T) {
 
 func TestRuleIsRegistered(t *testing.T) {
 	rs := (&Analyzer{}).Rules().Rules()
-	if len(rs) != 1 || rs[0].ID != ruleID {
-		t.Fatalf("expected exactly %s, got %+v", ruleID, rs)
+	// Two rules: broken primitives (this file) and insecure randomness
+	// (rand.go). A rule added without a catalogue entry is invisible to
+	// `nox rules`, so the count is asserted rather than only the lookup.
+	if len(rs) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rs))
 	}
-	if rs[0].Metadata["cwe"] != "CWE-327" {
-		t.Errorf("cwe = %q, want CWE-327", rs[0].Metadata["cwe"])
+	r, ok := (&Analyzer{}).Rules().ByID(ruleID)
+	if !ok {
+		t.Fatalf("%s missing from the catalogue", ruleID)
+	}
+	if r.Metadata["cwe"] != "CWE-327" {
+		t.Errorf("cwe = %q, want CWE-327", r.Metadata["cwe"])
 	}
 }

--- a/core/analyzers/weakcrypto/rand.go
+++ b/core/analyzers/weakcrypto/rand.go
@@ -1,0 +1,596 @@
+// Insecure randomness — CRYPTO-002.
+//
+// WHY THIS RULE EXISTS. `math/rand` is a deterministic PRNG. Its output is
+// predictable from a handful of observed values, so a session token, password,
+// nonce, salt or API key produced from it is guessable by anyone who can see a
+// few earlier ones. That is CWE-338, and it is genuinely exploitable — this is
+// not a hygiene rule. gosec has caught it as G404 for years; nox had no
+// equivalent, which is a real gap for Go codebases that dropped gosec.
+//
+// WHY IT IS NOT "FLAG math/rand". This is the crux of the rule, and the reason
+// it looks more complicated than a regex. `math/rand` is CORRECT — the right
+// tool, not a tolerated one — for retry jitter, exponential-backoff spread,
+// load-balancer and shard selection, sampling, shuffling, test fixtures and
+// anything else where an adversary predicting the value costs nothing. Those
+// call sites vastly outnumber the security-bearing ones in real code. A rule
+// that flags all of them is noise, and noise is how a rule gets globally
+// disabled, which leaves the codebase worse off than having no rule at all.
+// CRYPTO-001's header says the same thing about MD5; the asymmetry is even
+// sharper here, because the safe uses are the majority.
+//
+// HOW THE SECURITY CONTEXT IS DECIDED. Without go/types we cannot follow the
+// value to a crypto sink, so the signal comes from the names around the call —
+// what it is assigned to, what it is passed to, and the function it sits in.
+// An identifier that splits into a word like `token`, `secret`, `key`, `nonce`,
+// `salt`, `password`, `session`, `iv`, `apikey`, `credential`, `csrf`, `otp` or
+// `auth` is the developer stating the value is security-bearing. A word like
+// `jitter`, `backoff`, `delay`, `sleep`, `retry`, `sample`, `shuffle`, `pick`
+// or `choose` is the developer stating the opposite, and it VETOES the finding
+// even when a security word is also present — so `authRetryDelay` stays quiet.
+// Benign beating security is deliberate: every ambiguous case resolves to
+// silence.
+//
+// Four further discriminators exist because measurement demanded them, not by
+// anticipation; each is documented at its declaration below:
+//
+//   - the enclosing function's name accuses only alongside a producer verb, so
+//     `newPassword` fires and `handleAuth` does not (producerWords);
+//   - a name that measures rather than holds — `maxTokens`, `keyLen` — does not
+//     accuse (quantityWords);
+//   - a `len(…)`-bounded draw is a choice of element, so a variable name cannot
+//     accuse on it (isIndexDraw);
+//   - a getter, or a string literal beside the call, can exonerate but never
+//     accuse (lookupPrefixes, and the BasicLit branch of contextNames).
+//
+// MEASURED, not assumed. On the Go module cache, 851 non-test files importing
+// math/rand yield 4 findings — before these four discriminators it was 10, and
+// the 6 removed were a cache key, two shard selections, an index draw and a
+// duplicate. On a 23-repository Go fleet (7,720 files) it yields 0, while gosec
+// reports 9 G404 hits there, every one of them a jitter, chaos-test or
+// simulation call already carrying a `//nolint:gosec` explaining why it is
+// fine. That the rule is silent on all 9 is the point of it.
+//
+// KNOWN FALSE NEGATIVES, stated plainly. A generator with no descriptive names
+// (`b := make([]byte, 16); rand.Read(b)` in `func gen()`) is not caught. Nor is
+// a value laundered through a neutrally-named helper in another file, nor an
+// interface-typed RNG, nor a dot-import of math/rand. This rule catches the
+// obvious naming cases and nothing else. That is the intended trade: a rule
+// that finds most of these and never cries wolf is worth more than one that
+// finds nearly all of them and gets suppressed org-wide in its first week.
+// The remediation text says so too, because a finding's ABSENCE must not be
+// read as proof that a file generates its secrets safely.
+
+package weakcrypto
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"unicode"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// randRuleID is the insecure-randomness rule.
+const randRuleID = "CRYPTO-002"
+
+// mathRandPaths are the import paths that bind a predictable PRNG. Both the v1
+// and v2 packages are deterministic; v2 changed the algorithm and the API, not
+// the guarantee. `crypto/rand` is deliberately absent — it is the CORRECT API,
+// and because it is also imported as the identifier `rand`, resolving the
+// import path (rather than matching the text `rand.Read`) is what keeps this
+// rule from flagging the fix it recommends.
+var mathRandPaths = map[string]bool{
+	"math/rand":    true,
+	"math/rand/v2": true,
+}
+
+// securityWords mark a value whose predictability is exploitable. Matching is
+// on WORDS extracted from an identifier, never substrings: `monkey` and
+// `keyboard` do not contain the word `key`, and treating them as if they did is
+// exactly the over-flagging this rule is built to avoid.
+//
+// `seed` is deliberately NOT here, though a seed for key derivation would
+// qualify. In Go the word overwhelmingly names a PRNG's own seed — `seed :=
+// time.Now().UnixNano()`, `rand.New(rand.NewSource(seed))` — so including it
+// would fire on the benign construction of the very generator this rule tracks.
+// The rare key-derivation seed is an accepted false negative.
+var securityWords = map[string]bool{
+	"token": true, "secret": true, "key": true, "nonce": true,
+	"salt": true, "password": true, "passwd": true, "pwd": true,
+	"session": true, "iv": true, "apikey": true, "credential": true,
+	"csrf": true, "xsrf": true, "otp": true, "auth": true,
+	"jwt": true, "hmac": true,
+}
+
+// producerWords mark a function whose JOB is to produce a value. The enclosing
+// function's name is the weakest of the context signals — a random draw can sit
+// anywhere inside a long `handleAuth`, and flagging every one of those is how
+// this rule would earn its suppression. Requiring a producer verb alongside the
+// security noun restricts the signal to functions that generate the secret
+// (`generateToken`, `newPassword`, `randomKey`, `newIV`) rather than functions
+// that merely operate near one. Measured on the fixture set, this is what
+// separates `newPassword` (fires) from `handleAuth` (silent).
+var producerWords = map[string]bool{
+	"new": true, "generate": true, "gen": true, "create": true,
+	"make": true, "random": true, "rand": true, "build": true,
+	"issue": true, "mint": true, "derive": true, "fresh": true,
+}
+
+// quantityWords mark a name that measures or locates something rather than
+// holding it: `maxTokens`, `keyLen`, `sessionCount`, `tokenIndex`. The value is
+// a size or a position, not the secret, so such a name does not supply the
+// security signal — though it does not veto one coming from elsewhere, so a
+// `keyLen` inside `generateKey` is still reported.
+var quantityWords = map[string]bool{
+	"len": true, "length": true, "size": true, "count": true,
+	"num": true, "index": true, "idx": true, "offset": true,
+	"max": true, "min": true, "limit": true, "cap": true,
+	"capacity": true, "total": true, "position": true, "pos": true,
+}
+
+// lookupPrefixes name a call that RETRIEVES rather than stores. An enclosing
+// call is normally good evidence of what a value is for — `SetSessionToken(…)`
+// is damning — but a getter inverts it: in `GetByKey(strconv.Itoa(rand.Int()))`
+// the random value picks an entry, it does not become a secret. Measured on the
+// Go module cache, this single distinction removed a false positive in
+// `go-redis`'s ring shard selection.
+var lookupPrefixes = map[string]bool{
+	"get": true, "find": true, "lookup": true, "load": true,
+	"fetch": true, "select": true, "index": true, "has": true,
+	"contains": true, "exists": true, "at": true,
+}
+
+// benignWords mark a use where predictability is harmless — and where
+// `math/rand` is the right choice, not a lapse. A benign word anywhere in the
+// context vetoes the finding, including when a security word is also present.
+var benignWords = map[string]bool{
+	"jitter": true, "jittered": true, "backoff": true, "delay": true,
+	"sleep": true, "wait": true, "timeout": true, "retry": true,
+	"retries": true, "poll": true, "sample": true, "sampling": true,
+	"shuffle": true, "pick": true, "choose": true, "choice": true,
+	"cache": true, "test": true, "testing": true, "fake": true,
+	"mock": true, "dummy": true, "stub": true, "fixture": true,
+	"example": true, "demo": true, "bench": true, "benchmark": true,
+}
+
+// randRule describes CRYPTO-002 for the rule catalogue.
+//
+// SEVERITY: high, at medium confidence. The alternative — medium — was
+// rejected because it makes the rule decorative in the setup that motivated it:
+// CI gates commonly fail only on net-new critical/high, so a medium rule ships
+// as a report-only line item that nobody actions. The impact when this fires is
+// not medium either: a predictable session token or password-reset token is
+// account takeover, reachable with arithmetic and no privileged position.
+//
+// Gating carries an obligation the rest of this file discharges: the rule must
+// stay quiet unless the surrounding code says the value is security-bearing,
+// and every ambiguous case must resolve to silence. Confidence is medium rather
+// than high because the security context is asserted by naming, not proven by
+// type analysis.
+func randRule() *rules.Rule {
+	return &rules.Rule{
+		ID:          randRuleID,
+		Version:     "1.0",
+		Description: "Predictable randomness (math/rand) used for a security-bearing value",
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Tags:        []string{"crypto", "weak-random", "owasp-a02"},
+		Remediation: "`math/rand` is a deterministic PRNG: its output is predictable from a small number of observed values, so a token, key, nonce, salt, password or session identifier derived from it is guessable. " +
+			"Use `crypto/rand` instead — `crypto/rand.Read` for raw bytes, `crypto/rand.Int` for a bounded integer, or `crypto/rand.Text` (Go 1.24+) for a random string — and encode the bytes with `encoding/hex` or `encoding/base64` rather than deriving characters with a modulo. " +
+			"This rule fires only where the surrounding names say the value is security-bearing, so `math/rand` for jitter, backoff, sampling, shuffling or load balancing is not reported and needs no change; conversely, a security-bearing generator whose variables are named neutrally will NOT be caught, so this finding's absence is not evidence a file is clean. " +
+			"If the value here genuinely is not security-bearing, suppress it with a nox:ignore comment recording that reason.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/338.html",
+			"https://owasp.org/Top10/A02_2021-Cryptographic_Failures/",
+			"https://pkg.go.dev/crypto/rand",
+		},
+		Metadata: map[string]string{"cwe": "CWE-338"},
+	}
+}
+
+// scanInsecureRandom reports math/rand values that flow into a security-bearing
+// name in one Go source file.
+//
+// The file is parsed rather than pattern-matched. A regex cannot tell
+// `crypto/rand.Read` from `math/rand.Read` — both are written `rand.Read` — and
+// flagging the recommended fix would discredit the rule immediately. Parsing
+// also removes comments and string literals from consideration for free.
+func scanInsecureRandom(fs *findings.FindingSet, art discovery.Artifact, content []byte) {
+	fset := token.NewFileSet()
+	// A partial AST from a non-compiling file is still walked, matching the Go
+	// taint extractor's behaviour: degraded input yields fewer findings, never a
+	// crash. SkipObjectResolution — identifier linking is not needed here.
+	file, _ := parser.ParseFile(fset, "src.go", content, parser.SkipObjectResolution)
+	if file == nil {
+		return
+	}
+
+	pkgNames := mathRandImportNames(file)
+	if len(pkgNames) == 0 {
+		return
+	}
+	// Locals holding a *rand.Rand from `rand.New(...)`, so the receiver call
+	// style (`rng.Intn(n)`) is covered as well as the package call style.
+	// File-scoped and name-only: shadowing in an inner block is not modelled,
+	// which can only cost a finding, never invent one.
+	rngVars := seededRandVars(file, pkgNames)
+
+	reported := map[int]bool{}
+	stack := make([]ast.Node, 0, 32)
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		// ast.Inspect pairs every non-nil node with a later nil call, so the
+		// stack stays balanced; the guard is there because a panic inside an
+		// analyzer would take the whole scan down.
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			return true
+		}
+		defer func() { stack = append(stack, n) }()
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		fn, isWeak := weakRandCall(call, pkgNames, rngVars)
+		if !isWeak {
+			return true
+		}
+		line := fset.Position(call.Pos()).Line
+		if reported[line] {
+			return true
+		}
+
+		ctx := contextNames(call, stack)
+		hit, vetoed := classify(ctx, isIndexDraw(call))
+		if vetoed || hit == "" {
+			return true
+		}
+
+		reported[line] = true
+		fs.Add(findings.Finding{
+			RuleID:     randRuleID,
+			Severity:   findings.SeverityHigh,
+			Confidence: findings.ConfidenceMedium,
+			Message: "Predictable randomness: math/rand." + fn +
+				" produces a value named for a security use (" + hit + "); use crypto/rand",
+			Location: findings.Location{
+				FilePath:  art.Path,
+				StartLine: line,
+				EndLine:   line,
+			},
+			Metadata: map[string]string{
+				"cwe":      "CWE-338",
+				"function": fn,
+				"context":  hit,
+			},
+		})
+		return true
+	})
+}
+
+// mathRandImportNames returns the identifiers bound to a math/rand package in
+// this file — the default `rand`, or whatever alias the import gives it. A dot
+// import is not handled: it makes the call indistinguishable from a local
+// function without type information, and it is vanishingly rare.
+func mathRandImportNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		path := strings.Trim(imp.Path.Value, `"`)
+		if !mathRandPaths[path] {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			names["rand"] = true
+		case imp.Name.Name == "_" || imp.Name.Name == ".":
+			// Blank import produces no call sites; dot import is out of scope.
+		default:
+			names[imp.Name.Name] = true
+		}
+	}
+	return names
+}
+
+// seededRandVars collects the names assigned a `*rand.Rand` from `rand.New(…)`,
+// so calls on that receiver are recognised. Both `r := rand.New(…)` and
+// `s.rng = rand.New(…)` are handled; only the final identifier is kept.
+func seededRandVars(file *ast.File, pkgNames map[string]bool) map[string]bool {
+	vars := map[string]bool{}
+	record := func(lhs []ast.Expr, rhs []ast.Expr) {
+		for i, r := range rhs {
+			call, ok := r.(*ast.CallExpr)
+			if !ok || i >= len(lhs) {
+				continue
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "New" {
+				continue
+			}
+			if id, ok := sel.X.(*ast.Ident); !ok || !pkgNames[id.Name] {
+				continue
+			}
+			if name := trailingName(lhs[i]); name != "" {
+				vars[name] = true
+			}
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			record(s.Lhs, s.Rhs)
+		case *ast.ValueSpec:
+			lhs := make([]ast.Expr, 0, len(s.Names))
+			for _, nm := range s.Names {
+				lhs = append(lhs, nm)
+			}
+			record(lhs, s.Values)
+		}
+		return true
+	})
+	return vars
+}
+
+// weakRandCall reports whether a call draws from a math/rand generator, and
+// returns the function name for the message.
+//
+// Constructors and seeding (`New`, `NewSource`, `NewPCG`, `Seed`) are excluded:
+// they configure a generator rather than producing a value, so flagging them
+// would report the setup line instead of the use — and `rand.New` appears in
+// plenty of code whose draws are all benign.
+func weakRandCall(call *ast.CallExpr, pkgNames, rngVars map[string]bool) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	fn := sel.Sel.Name
+	if fn == "Seed" || strings.HasPrefix(fn, "New") {
+		return "", false
+	}
+	switch x := sel.X.(type) {
+	case *ast.Ident:
+		if pkgNames[x.Name] || rngVars[x.Name] {
+			return fn, true
+		}
+	case *ast.SelectorExpr:
+		// A generator held in a field: `s.rng.Intn(n)`.
+		if rngVars[x.Sel.Name] {
+			return fn, true
+		}
+	}
+	return "", false
+}
+
+// ctxName is one identifier describing a random value's use, tagged with the
+// role it plays. Every context name can VETO; what it takes to ACCUSE depends
+// on the role.
+type ctxName struct {
+	name string
+	role role
+}
+
+type role int
+
+const (
+	// roleValue: a name the value itself takes on — an assignment target, a
+	// struct field, a buffer passed to Read, the function it is handed to.
+	roleValue role = iota
+	// roleFunc: the enclosing function's name. Accuses only when it also
+	// carries a producer verb (see producerWords).
+	roleFunc
+	// roleVetoOnly: a name that describes the surroundings without saying the
+	// value is security-bearing — a getter, or a string literal sitting beside
+	// the call. It can exonerate but never accuse.
+	roleVetoOnly
+)
+
+// contextNames gathers the identifiers that describe what a random value is
+// FOR: what it is assigned to, the struct field it initialises, the functions
+// it is passed to, and the function it sits in.
+//
+// `Read` is special-cased: its output is the buffer argument, so `rand.Read(
+// token)` takes its meaning from the argument rather than from an assignment.
+func contextNames(call *ast.CallExpr, stack []ast.Node) []ctxName {
+	var names []ctxName
+	add := func(n string, r role) {
+		if n != "" {
+			names = append(names, ctxName{name: n, role: r})
+		}
+	}
+
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Read" {
+		for _, arg := range call.Args {
+			add(trailingName(arg), roleValue)
+		}
+	}
+
+	for i := len(stack) - 1; i >= 0; i-- {
+		switch node := stack[i].(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range node.Lhs {
+				add(trailingName(lhs), roleValue)
+			}
+		case *ast.ValueSpec:
+			for _, nm := range node.Names {
+				add(nm.Name, roleValue)
+			}
+		case *ast.KeyValueExpr:
+			add(trailingName(node.Key), roleValue)
+		case *ast.CallExpr:
+			// An enclosing call names the destination of the value:
+			// `time.Sleep(…)` is benign, `setSessionKey(…)` is not — unless it
+			// is a lookup, where the value selects rather than becomes.
+			fname := trailingName(node.Fun)
+			r := roleValue
+			if isLookup(fname) {
+				r = roleVetoOnly
+			}
+			add(fname, r)
+			// A string literal in the same call describes the value as surely as
+			// an identifier does: `fmt.Sprintf("cache_key_%d", rand.Intn(50))`
+			// says "cache" even though no variable does. Veto-only, because a
+			// literal is far too weak to accuse on.
+			for _, arg := range node.Args {
+				if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					add(strings.Trim(lit.Value, "`\""), roleVetoOnly)
+				}
+			}
+		case *ast.FuncDecl:
+			// Accuses only for a generator; see producerWords.
+			add(node.Name.Name, roleFunc)
+		}
+	}
+	return names
+}
+
+// isProducer reports whether a function name claims to MAKE something.
+func isProducer(name string) bool {
+	for _, w := range identWords(name) {
+		if producerWords[w] {
+			return true
+		}
+	}
+	return false
+}
+
+// isLookup reports whether a call name retrieves something.
+func isLookup(name string) bool {
+	w := identWords(name)
+	return len(w) > 0 && lookupPrefixes[w[0]]
+}
+
+// isIndexDraw reports whether the draw is bounded by `len(…)` — the shape of
+// picking an element, not of generating a secret. `i := rand.Intn(len(hosts))`
+// is a choice however the variable is named, so a name like `keyInd` must not
+// accuse on its own.
+//
+// It only disqualifies name-derived evidence: a len-bounded draw inside
+// `newPassword` is still reported, because `charset[rand.Intn(len(charset))]`
+// is exactly how a weak password generator is written.
+func isIndexDraw(call *ast.CallExpr) bool {
+	found := false
+	for _, arg := range call.Args {
+		ast.Inspect(arg, func(n ast.Node) bool {
+			if c, ok := n.(*ast.CallExpr); ok {
+				if id, ok := c.Fun.(*ast.Ident); ok && id.Name == "len" {
+					found = true
+				}
+			}
+			return !found
+		})
+	}
+	return found
+}
+
+// trailingName returns the last identifier of a simple expression: `x` for `x`,
+// `Token` for `s.Token`, `buf` for `buf[:]` and `keys` for `keys[i]`. Anything
+// more complex yields "" — an unnamed destination carries no signal either way.
+func trailingName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		if v.Name == "_" {
+			return ""
+		}
+		return v.Name
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	case *ast.IndexExpr:
+		return trailingName(v.X)
+	case *ast.SliceExpr:
+		return trailingName(v.X)
+	case *ast.StarExpr:
+		return trailingName(v.X)
+	case *ast.UnaryExpr:
+		return trailingName(v.X)
+	case *ast.ParenExpr:
+		return trailingName(v.X)
+	}
+	return ""
+}
+
+// classify splits every context identifier into words and reports the
+// security word that justifies a finding, plus whether a benign word vetoes it.
+//
+// The veto is evaluated over ALL names, not just the closest one, and wins
+// outright. `sessionRetryDelay` and a jitter computed inside `refreshAuthToken`
+// both stay silent. Losing those to a false negative is the cheaper error.
+func classify(names []ctxName, indexDraw bool) (hit string, vetoed bool) {
+	for _, c := range names {
+		words := identWords(c.name)
+		quantity := false
+		for _, w := range words {
+			if benignWords[w] || benignWords[singular(w)] {
+				return "", true
+			}
+			if quantityWords[w] || quantityWords[singular(w)] {
+				quantity = true
+			}
+		}
+		accuses := c.role == roleValue && !indexDraw ||
+			c.role == roleFunc && isProducer(c.name)
+		if hit != "" || !accuses || quantity {
+			continue
+		}
+		for _, w := range words {
+			if securityWords[w] || securityWords[singular(w)] {
+				hit = c.name
+				break
+			}
+		}
+	}
+	return hit, false
+}
+
+// singular strips a trailing plural "s" so `keys`, `tokens` and `credentials`
+// match their singular entries. Short words are left alone.
+func singular(w string) string {
+	if len(w) > 3 && strings.HasSuffix(w, "s") {
+		return strings.TrimSuffix(w, "s")
+	}
+	return w
+}
+
+// identWords splits an identifier into lowercase words on camelCase, acronym,
+// underscore and digit boundaries: `sessionToken` and `session_token` and
+// `APIKey` and `csrfToken2` all yield the words a human reads in them.
+//
+// Word-level matching, rather than substring matching, is what keeps `monkey`,
+// `keyboard` and `passthrough` out of the security set.
+func identWords(id string) []string {
+	var out []string
+	var cur []rune
+	flush := func() {
+		if len(cur) > 0 {
+			out = append(out, strings.ToLower(string(cur)))
+			cur = nil
+		}
+	}
+	rs := []rune(id)
+	for i, r := range rs {
+		switch {
+		case r == '_' || r == '-' || r == '.' || unicode.IsDigit(r):
+			flush()
+		case unicode.IsUpper(r):
+			// Start a new word at a lower→upper transition (`apiKey`), or at the
+			// last capital of an acronym run followed by lowercase (`APIKey`).
+			if i > 0 && (!unicode.IsUpper(rs[i-1]) ||
+				(i+1 < len(rs) && unicode.IsLower(rs[i+1]))) {
+				flush()
+			}
+			cur = append(cur, r)
+		default:
+			cur = append(cur, r)
+		}
+	}
+	flush()
+	return out
+}

--- a/core/analyzers/weakcrypto/rand_test.go
+++ b/core/analyzers/weakcrypto/rand_test.go
@@ -1,0 +1,352 @@
+package weakcrypto
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanGo runs the analyzer over one Go source file and returns only the
+// CRYPTO-002 findings, so a fixture that also trips CRYPTO-001 does not
+// silently satisfy an assertion here.
+func scanGo(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, filepath.Base(name))
+	if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := (&Analyzer{}).ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []findings.Finding
+	for _, f := range fs.Findings() {
+		if f.RuleID == randRuleID {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// TestFlagsSecurityUseOfMathRand covers what the rule is FOR: a predictable
+// draw that the surrounding names identify as security-bearing. Each case also
+// asserts the context identifier the finding blames, so a case that starts
+// passing for the wrong reason (a different name matching, or the enclosing
+// function standing in for the variable) fails here.
+func TestFlagsSecurityUseOfMathRand(t *testing.T) {
+	for _, c := range []struct{ name, src, wantCtx string }{
+		{
+			name:    "assignment to a security-named variable",
+			src:     "package m\nimport \"math/rand\"\nfunc f() { token := rand.Int63(); _ = token }",
+			wantCtx: "token",
+		},
+		{
+			name:    "math/rand/v2 is the same predictable generator",
+			src:     "package m\nimport \"math/rand/v2\"\nfunc f() { sessionKey := rand.N(100); _ = sessionKey }",
+			wantCtx: "sessionKey",
+		},
+		{
+			name:    "aliased import",
+			src:     "package m\nimport mrand \"math/rand\"\nfunc f() { apiKey := mrand.Intn(999999); _ = apiKey }",
+			wantCtx: "apiKey",
+		},
+		{
+			name:    "Read takes its meaning from the buffer it fills",
+			src:     "package m\nimport \"math/rand\"\nfunc f() { nonce := make([]byte, 12); rand.Read(nonce) }",
+			wantCtx: "nonce",
+		},
+		{
+			name:    "struct field assignment",
+			src:     "package m\nimport \"math/rand\"\nfunc f(u *User) { u.PasswordResetToken = fmt.Sprintf(\"%d\", rand.Int63()) }",
+			wantCtx: "PasswordResetToken",
+		},
+		{
+			name:    "composite literal field",
+			src:     "package m\nimport \"math/rand\"\nfunc f() { s := Session{Token: rand.Int63()}; _ = s }",
+			wantCtx: "Token",
+		},
+		{
+			name:    "value handed to a setter",
+			src:     "package m\nimport \"math/rand\"\nfunc f(c *C) { c.SetSessionID(rand.Int63()) }",
+			wantCtx: "SetSessionID",
+		},
+		{
+			name:    "seeded *rand.Rand receiver",
+			src:     "package m\nimport \"math/rand\"\nfunc f() { r := rand.New(rand.NewSource(1)); csrf := r.Intn(1 << 31); _ = csrf }",
+			wantCtx: "csrf",
+		},
+		{
+			name:    "generator held in a struct field",
+			src:     "package m\nimport \"math/rand\"\ntype S struct{ rng *rand.Rand }\nfunc (s *S) f() { s.rng = rand.New(rand.NewSource(1)); otp := s.rng.Intn(1000000); _ = otp }",
+			wantCtx: "otp",
+		},
+		{
+			// The classic weak password generator: no variable says "password",
+			// only the function does — and it says it while claiming to produce.
+			name:    "producer function name, neutral variables",
+			src:     "package m\nimport \"math/rand\"\nconst charset = \"abc\"\nfunc newPassword(n int) string {\n\tb := make([]byte, n)\n\tfor i := range b {\n\t\tb[i] = charset[rand.Intn(len(charset))]\n\t}\n\treturn string(b)\n}",
+			wantCtx: "newPassword",
+		},
+		{
+			name:    "producer function with no assignment at all",
+			src:     "package m\nimport \"math/rand\"\nfunc generateToken() string { b := make([]byte, 16); rand.Read(b); return string(b) }",
+			wantCtx: "generateToken",
+		},
+		{
+			name:    "salt from a float draw",
+			src:     "package m\nimport \"math/rand\"\nfunc f() { salt := rand.Float64(); _ = salt }",
+			wantCtx: "salt",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got := scanGo(t, "a.go", c.src)
+			if len(got) != 1 {
+				t.Fatalf("got %d findings, want 1: %s", len(got), c.src)
+			}
+			if got[0].Metadata["context"] != c.wantCtx {
+				t.Errorf("blamed context %q, want %q", got[0].Metadata["context"], c.wantCtx)
+			}
+			if got[0].Severity != findings.SeverityHigh {
+				t.Errorf("severity %q, want high", got[0].Severity)
+			}
+		})
+	}
+}
+
+// TestIgnoresBenignRandomness is the half of this rule that matters most.
+// `math/rand` is CORRECT for every case below; flagging them is what would get
+// CRYPTO-002 suppressed org-wide, which costs more than the rule is worth.
+func TestIgnoresBenignRandomness(t *testing.T) {
+	for _, c := range []struct{ name, src string }{
+		{
+			name: "retry jitter",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { jitter := rand.Intn(1000); _ = jitter }",
+		},
+		{
+			name: "exponential backoff spread",
+			src:  "package m\nimport \"math/rand\"\nfunc backoff(attempt int) time.Duration {\n\tbase := time.Second * time.Duration(1<<attempt)\n\treturn base + time.Duration(rand.Int63n(int64(base/2)))\n}",
+		},
+		{
+			// A benign word vetoes even though "auth" sits in the function name.
+			name: "jittered sleep inside an auth path",
+			src:  "package m\nimport \"math/rand\"\nfunc (c *Client) authRetry() { time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond) }",
+		},
+		{
+			name: "load-balancer selection",
+			src:  "package m\nimport \"math/rand\"\nfunc f(backends []string) { n := rand.Intn(len(backends)); _ = backends[n] }",
+		},
+		{
+			name: "shuffling",
+			src:  "package m\nimport \"math/rand\"\nfunc f(keys []string) { rand.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] }) }",
+		},
+		{
+			name: "sampling helper whose name mentions tokens",
+			src:  "package m\nimport \"math/rand\"\nfunc sampleTokens(n int) int { return rand.Intn(n) }",
+		},
+		{
+			// A random draw somewhere inside an auth handler is not evidence
+			// that the value is a secret; only a producer verb makes the
+			// function name accuse.
+			name: "neutral draw inside a security-named handler",
+			src:  "package m\nimport \"math/rand\"\nfunc handleAuth() { n := rand.Intn(10); _ = n }",
+		},
+		{
+			name: "seeding a generator",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { seed := rand.Int63(); _ = rand.New(rand.NewSource(seed)) }",
+		},
+		{
+			// Word-level matching, not substring: neither of these is a key.
+			name: "identifiers that merely contain security substrings",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { monkey := rand.Intn(10); keyboard := rand.Intn(10); _, _ = monkey, keyboard }",
+		},
+		{
+			name: "quantity named for a secret is not the secret",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { maxTokens := rand.Intn(4096); _ = maxTokens }",
+		},
+		{
+			name: "len-bounded draw is a choice however it is named",
+			src:  "package m\nimport \"math/rand\"\nfunc f(c *C) { keyInd := rand.Intn(len(c.objects)); _ = keyInd }",
+		},
+		{
+			name: "lookup by a random entry",
+			src:  "package m\nimport \"math/rand\"\nfunc f(c *C) { _ = c.GetByKey(strconv.Itoa(rand.Int())) }",
+		},
+		{
+			name: "a benign string literal in the same call exonerates",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { key := fmt.Sprintf(\"cache_key_%d\", rand.Intn(50)); _ = key }",
+		},
+		{
+			name: "commented-out code and string literals are not code",
+			src:  "package m\nimport \"math/rand\"\n// token := rand.Int63() -- removed\nfunc f() { x := \"token = rand.Int63()\"; _ = x; _ = rand.Intn(2) }",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scanGo(t, "a.go", c.src); len(got) != 0 {
+				t.Errorf("got %d findings, want 0 — math/rand is correct here: %s\n%s",
+					len(got), got[0].Message, c.src)
+			}
+		})
+	}
+}
+
+// TestNeverFlagsCryptoRand guards the one false positive that would discredit
+// the rule outright: `crypto/rand` is the API this rule TELLS people to use,
+// and it is spelled `rand.Read` too. Only resolving the import path keeps them
+// apart — a text pattern cannot.
+func TestNeverFlagsCryptoRand(t *testing.T) {
+	for _, c := range []struct{ name, src string }{
+		{
+			name: "crypto/rand filling a token",
+			src:  "package m\nimport \"crypto/rand\"\nfunc f() { token := make([]byte, 32); rand.Read(token); _ = token }",
+		},
+		{
+			name: "crypto/rand inside a key generator",
+			src:  "package m\nimport \"crypto/rand\"\nfunc generateSessionKey() []byte { key := make([]byte, 32); rand.Read(key); return key }",
+		},
+		{
+			// Both packages in one file: the crypto one does the security work,
+			// the math one does jitter. Neither may be reported.
+			name: "both packages imported, each used correctly",
+			src:  "package m\nimport (\n\t\"crypto/rand\"\n\tmrand \"math/rand\"\n)\nfunc f() { token := make([]byte, 32); rand.Read(token); jitter := mrand.Intn(9); _, _ = token, jitter }",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scanGo(t, "a.go", c.src); len(got) != 0 {
+				t.Errorf("got %d findings, want 0 — crypto/rand is the CORRECT API: %s", len(got), c.src)
+			}
+		})
+	}
+}
+
+// TestAliasedCryptoRandStillFlagsMathRand is the mirror image: when the aliases
+// are swapped, the math/rand call must still be found. Together with the test
+// above this proves the decision is made on the import PATH, not on the
+// identifier `rand`.
+func TestAliasedCryptoRandStillFlagsMathRand(t *testing.T) {
+	src := "package m\nimport (\n\tcrand \"crypto/rand\"\n\t\"math/rand\"\n)\nfunc f() { token := rand.Int63(); k := make([]byte, 8); crand.Read(k); _, _ = token, k }"
+	got := scanGo(t, "a.go", src)
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+	if got[0].Metadata["context"] != "token" {
+		t.Errorf("blamed %q, want token", got[0].Metadata["context"])
+	}
+}
+
+// TestDocumentedFalseNegatives pins the limits of a naming heuristic. These
+// ARE insecure, and the rule does not catch them. They are asserted so the
+// boundary is explicit rather than folklore: if a later change starts catching
+// one, this test fails and the remediation text should be updated to match.
+func TestDocumentedFalseNegatives(t *testing.T) {
+	for _, c := range []struct{ name, src string }{
+		{
+			// Nothing in scope is named for what the bytes are.
+			name: "no descriptive names anywhere",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { b := make([]byte, 16); rand.Read(b); _ = b }",
+		},
+		{
+			// Needs value tracking across statements, which is go/types work.
+			name: "value reaches the security name in a later statement",
+			src:  "package m\nimport \"math/rand\"\nfunc f() { a, b := rand.Intn(1), rand.Intn(2); token := a + b; _ = token }",
+		},
+		{
+			// A dot import makes the call indistinguishable from a local
+			// function without type information.
+			name: "dot import",
+			src:  "package m\nimport . \"math/rand\"\nfunc f() { token := Int63(); _ = token }",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scanGo(t, "a.go", c.src); len(got) != 0 {
+				t.Errorf("got %d findings, want 0 — this is a DOCUMENTED false negative; "+
+					"if it is now caught, update the remediation text and this test", len(got))
+			}
+		})
+	}
+}
+
+// TestSkipsTestFiles — fixtures use predictable randomness deliberately, and
+// determinism in a test is a feature.
+func TestRandSkipsTestFiles(t *testing.T) {
+	src := "package m\nimport \"math/rand\"\nfunc f() { token := rand.Int63(); _ = token }"
+	if got := scanGo(t, "a_test.go", src); len(got) != 0 {
+		t.Errorf("got %d findings in a test file, want 0", len(got))
+	}
+}
+
+// TestOneFindingPerLine — several draws on one line are one problem.
+func TestOneFindingPerLine(t *testing.T) {
+	src := "package m\nimport \"math/rand\"\nfunc f() { token, secret := rand.Int63(), rand.Int63(); _, _ = token, secret }"
+	if got := scanGo(t, "a.go", src); len(got) != 1 {
+		t.Fatalf("got %d findings, want 1 per line", len(got))
+	}
+}
+
+// TestNonCompilingFileDegrades — a partial parse must not panic or crash the
+// scan, matching the Go taint extractor's behaviour.
+func TestNonCompilingFileDegrades(t *testing.T) {
+	src := "package m\nimport \"math/rand\"\nfunc f() { token := rand.Int63(); _ = token\n// missing brace"
+	if got := scanGo(t, "a.go", src); len(got) != 1 {
+		t.Fatalf("got %d findings from a partial parse, want 1", len(got))
+	}
+}
+
+func TestIdentWords(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want []string
+	}{
+		{"sessionToken", []string{"session", "token"}},
+		{"session_token", []string{"session", "token"}},
+		{"APIKey", []string{"api", "key"}},
+		{"IV", []string{"iv"}},
+		{"csrfToken2", []string{"csrf", "token"}},
+		{"monkey", []string{"monkey"}},
+		{"keyboard", []string{"keyboard"}},
+	} {
+		got := identWords(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("identWords(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("identWords(%q) = %v, want %v", c.in, got, c.want)
+				break
+			}
+		}
+	}
+}
+
+func TestRandRuleRegistered(t *testing.T) {
+	r, ok := (&Analyzer{}).Rules().ByID(randRuleID)
+	if !ok {
+		t.Fatalf("%s not in the rule catalogue", randRuleID)
+	}
+	if r.Severity != findings.SeverityHigh {
+		t.Errorf("severity %q, want high — a medium rule does not gate in a "+
+			"net-new-critical/high CI policy, which makes the rule decorative", r.Severity)
+	}
+	if r.Confidence != findings.ConfidenceMedium {
+		t.Errorf("confidence %q, want medium", r.Confidence)
+	}
+	if r.Metadata["cwe"] != "CWE-338" {
+		t.Errorf("cwe = %q, want CWE-338", r.Metadata["cwe"])
+	}
+	// The remediation must name crypto/rand and must admit the false negatives;
+	// a naming heuristic that presents itself as exhaustive is worse than one
+	// that says what it misses.
+	if !strings.Contains(r.Remediation, "crypto/rand") {
+		t.Error("remediation does not name the replacement API")
+	}
+	if !strings.Contains(r.Remediation, "will NOT be caught") {
+		t.Error("remediation does not state that the rule misses neutrally-named generators")
+	}
+}


### PR DESCRIPTION
Part of #405 (the weak-RNG quarter of it; TLS, file perms and overflow are separate PRs — this one must not auto-close the umbrella issue).

`math/rand` is a deterministic PRNG. A session token, password, nonce, salt or key derived from it is guessable from a handful of observed values — CWE-338, and genuinely exploitable rather than a hygiene issue. gosec reports this as G404. nox had no equivalent, which is a live gap for the Go codebases that dropped gosec from their shared lint config.

## What fires

A `math/rand` or `math/rand/v2` draw whose surrounding **names** say the value is security-bearing. Both import paths, both call styles (`rand.Intn`, `rand.Read`, a seeded `*rand.Rand` receiver, a generator held in a struct field), and aliased imports.

The context comes from the AST around the call: the assignment target, the struct field, the buffer passed to `Read`, the function the value is handed to, and the enclosing function. An identifier that splits into `token`, `secret`, `key`, `nonce`, `salt`, `password`, `session`, `iv`, `apikey`, `credential`, `csrf`, `otp`, `auth`, `jwt` or `hmac` accuses.

```go
token := rand.Int63()                       // CRYPTO-002
nonce := make([]byte, 12); rand.Read(nonce) // CRYPTO-002
u.PasswordResetToken = fmt.Sprint(rand.Int63())
func newPassword(n int) string { … charset[rand.Intn(len(charset))] … }
```

Matching is on **words**, not substrings, so `monkey` and `keyboard` are not keys.

## What deliberately does not fire, and why

This is the half that decides whether the rule survives. `math/rand` is *correct* — the right tool, not a tolerated one — for retry jitter, backoff spread, load-balancer and shard selection, sampling, shuffling and fixtures. Those call sites vastly outnumber the dangerous ones, and flagging them is how a rule gets globally suppressed, leaving the codebase worse off than with no rule at all.

- **A benign word anywhere in the context vetoes**, even alongside a security word: `jitter`, `backoff`, `delay`, `sleep`, `retry`, `sample`, `shuffle`, `pick`, `choose`, `cache`, `test`, `mock`… So a jittered sleep inside `authRetry()` is silent.
- **`crypto/rand` is never flagged.** It is the API this rule recommends, and it is *also* spelled `rand.Read`. Files are parsed with `go/parser` and the import path resolved, so the fix can never be reported as the bug — including a file that imports both packages under swapped aliases. A text pattern cannot make this distinction; that is why this rule parses.
- **The enclosing function accuses only with a producer verb.** `newPassword`, `generateToken`, `randomKey` fire; `handleAuth`, `rotateKeys`, `validateSession` do not. A draw sitting somewhere inside an auth handler is not evidence the value is a secret.
- **A quantity is not the secret.** `maxTokens`, `keyLen`, `sessionCount` do not accuse.
- **A `len(…)`-bounded draw is a choice of element**, however the variable is named — `keyInd := rand.Intn(len(objs))` is silent. (The producer-function signal survives it, because `charset[rand.Intn(len(charset))]` inside `newPassword` is exactly how a weak password generator is written.)
- **Getters exonerate**: in `GetByKey(strconv.Itoa(rand.Int()))` the value selects an entry, it does not become one.
- **A string literal beside the call can exonerate**: `fmt.Sprintf("cache_key_%d", rand.Intn(50))` says "cache" even though no variable does.
- Comments and string literals are not code (free from parsing), and `_test.go` files are skipped — determinism in a test is a feature.

The last four discriminators were **not anticipated**; each was added in response to a measured false positive, and each is documented at its declaration.

## Measurement

I wrote the fixtures, ran the scanner, and then fixed what actually fired — assertions were written against observed behaviour, not assumed behaviour.

| Corpus | Files | CRYPTO-002 |
|---|---|---|
| Go module cache, non-test files importing `math/rand` | 851 | **4** (10 before the four discriminators) |
| 23-repository Go fleet | 7,720 `.go` | **0** |

The 4 module-cache hits: `gorilla/websocket`'s `newMaskKey` (RFC 6455 requires unpredictable masking keys — a genuine G404), two Google Spanner in-memory fakes generating session IDs and tokens via `rand.Read`, and a badger benchmark tool filling DB keys. One clear true positive, two borderline (test doubles, but the exact vuln shape), one noise. The 6 removed by the discriminators were a cache key, two shard selections, an index draw and a duplicate.

In that same 23-repo fleet, gosec reports **9 G404 findings — all 9 benign**: retry jitter, chaos-test fault injection, latency simulation, each already carrying a `//nolint:gosec` explaining why. CRYPTO-002 is silent on all of them. That is the strongest evidence I have for the design: an unconditional `math/rand` rule would have produced 9 false positives and 0 true positives on this fleet.

## Severity: high, medium confidence

Argued in a comment at `randRule()`. Medium was rejected because it makes the rule decorative where it is needed: CI gates commonly fail only on net-new critical/high, so a medium rule ships as a report-only line nobody actions. The impact when it fires is not medium either — a predictable session or password-reset token is account takeover with arithmetic and no privileged position. Confidence is medium, not high, because the security context is asserted by naming rather than proven by type analysis.

Gating carries an obligation, and the precision work above is how it is discharged: every ambiguous case resolves to silence.

## Honest limitations

Stated in the rule's own remediation text, in the package doc, and pinned by `TestDocumentedFalseNegatives` so the boundary is explicit rather than folklore:

- a generator whose variables *and* function are named neutrally (`b := make([]byte, 16); rand.Read(b)` in `func gen()`) is **missed**;
- a value that reaches a security name a statement later is **missed** (that needs `go/types` value tracking);
- a dot-imported `math/rand` is **missed**;
- an interface-typed RNG is **missed**;
- `seed` is excluded from the security words on purpose — in Go it overwhelmingly names a PRNG's own seed, so including it would fire on the benign construction of the very generator this rule tracks.

Recall was traded for silence deliberately. **The absence of a CRYPTO-002 finding is not evidence that a file generates its secrets safely**, and the remediation text says exactly that so nobody reads a clean scan as an assurance.

Scope is Go only. The heuristic depends on Go's package-qualified call syntax and Go naming conventions; `Math.random()` and Python's `random` deserve their own measurement before they get a rule, and breadth without that measurement is how the negatives get wrong.

## Verification

- `go test ./...` — 55 packages pass; `gofmt -l`, `go vet ./...`, `golangci-lint run` clean.
- **Mutation-tested.** Nine independent mutations, each applied to a clean baseline, each confirmed to fail the test that guards it: adding `crypto/rand` to the math paths → `TestNeverFlagsCryptoRand` fails; disabling the benign veto, the producer gate, the index-draw exemption, the lookup demotion, the literal veto, the quantity guard → the matching `TestIgnoresBenignRandomness` subtest fails; dropping receiver tracking → the `*rand.Rand` positive fails; removing the test-file skip → both skip tests fail. Baseline restored and re-verified green after each.
- End-to-end through the CLI on a fixture with a token generator, a jittered backoff and a `crypto/rand` key: exactly one finding, the token.

Implementation lives in `core/analyzers/weakcrypto/rand.go`, alongside CRYPTO-001 — same analyzer, already registered in `core/scan.go`, so no wiring change was needed.
