### PR TITLE
feat(memsafe): integer truncation that sizes memory (MEMSAFE-001), not a G115 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The rule reports **zero findings on nox's own repository**, before and after.
   (#405)
 
+- **`MEMSAFE-001` — integer truncation that sizes memory.** A value narrowed to
+  a smaller integer type, or flipped signed→unsigned, and then used as a
+  `make()` size or a slice bound. A wire-decoded length converted
+  `uint32`→`int32` goes negative above 2³¹ and panics the allocation; a length
+  truncated to `uint8` silently mis-frames anything longer than 255 bytes. Both
+  were found in widely deployed networking libraries while validating the rule.
+  Medium severity, so it reports rather than gates. (#405)
+
+  **This is deliberately not gosec's `G115`.** Measured before implementation,
+  gosec's own rule produced 96 findings across sixteen fleet repositories plus
+  nox itself, with **zero** true positives — `int32(len(out))` filling protobuf
+  count fields, `byte(addr>>24)` extracting an IPv4 octet, `byte(nano%10)`
+  formatting a digit. That is how a rule earns 63 blanket suppressions. Nox
+  reports only the shape where truncation is a memory-safety bug, and stays
+  silent on all 96. On `segmentio/kafka-go`, gosec reports 156 findings of which
+  two are a real bug; this rule reports one, and it is the bug.
+
+  Masks, modulo, logical shifts on unsigned values, comparison guards written
+  through a conversion (`if uint32(r) <= MaxLatin1`), and `len`-derived values
+  narrowed to 32 bits or more are all suppressed — each one a class observed
+  firing on correct code. A bare index `s[i]` is not treated as a sink: it is
+  syntactically indistinguishable from a map lookup, and Go bounds-checks slice
+  indexes anyway.
+
+  **`go/types` was evaluated and rejected**, with the cost written down in
+  `docs/design/go-integer-overflow.md`. Full `G115` parity needs type
+  resolution, every Go importer needs a resolvable module graph and a toolchain,
+  and nox scans checked-out trees offline in containers that have neither. The
+  measured price is 64% of gosec's findings on nox's own source — all of which
+  were false positives anyway. Conversions whose operand type is not provable
+  from the enclosing function are not reported.
+
+  `G103` (`unsafe`), `G602` (slice bounds) and `G104` (unhandled errors) are
+  **not** implemented, with reasons: all 20 fleet `G103` findings are in
+  generated protobuf code, `G602`'s useful half is this rule's slice-bound sink,
+  and `G104` is already covered by `errcheck` in the fleet's golangci config —
+  duplicating it would reintroduce exactly the double-reporting that retired
+  `nox-plugin-sast`.
+
 ## [1.23.0] - 2026-07-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ Detects personally identifiable information (PII) and sensitive data patterns in
 | Infrastructure | DATA-005 | Hardcoded public IP addresses |
 | Personal | DATA-006 | Date of birth fields |
 
+### Memory safety (Go)
+
+| Rule | Description |
+|------|-------------|
+| MEMSAFE-001 | Integer truncation reaching a `make()` size or a slice bound — a narrowed or sign-flipped length that wraps (CWE-190) |
+
+Deliberately much narrower than gosec's `G115`, which reports every narrowing
+conversion: measured across sixteen Go repositories, that produced 96 findings
+and no real bugs. This rule reports only truncation that sizes memory, and
+suppresses masks, modulo, unsigned shifts, guarded values and length-derived
+values. Conversions whose operand type is not provable from the enclosing
+function are not reported — nox parses Go with `go/ast`, not `go/types`. See
+[`docs/design/go-integer-overflow.md`](docs/design/go-integer-overflow.md).
+
 ## Configuration
 
 Create a `.nox.yaml` in your project root to customize scan behavior:

--- a/core/analyzers/memsafe/memsafe.go
+++ b/core/analyzers/memsafe/memsafe.go
@@ -1,0 +1,986 @@
+// Package memsafe detects integer-overflow truncation that reaches a memory
+// sizing operation in Go source.
+//
+// WHY THIS IS ITS OWN ANALYZER. It is not a taint flow — the danger is the
+// arithmetic, not the provenance, and the value need not come from a tracked
+// source to wrap. It is not weak crypto and it is not a secret. It is a
+// property of a *conversion expression and what it feeds*, which nothing in
+// core previously modelled.
+//
+// SCOPE, DELIBERATELY MUCH NARROWER THAN gosec G115. This rule exists because
+// gosec was removed from the fleet's shared golangci config, leaving integer
+// conversions uncovered. Measuring gosec's own G115 across sixteen Go
+// repositories plus nox itself produced 96 findings and, on inspection, zero
+// true positives: `int32(len(out))` and `int32(total)` filling protobuf count
+// fields, `uint64(t.Unix())` in an HOTP counter, `byte(addr>>24)` extracting an
+// IPv4 octet, `byte(nano%10)` formatting a digit. Truncation is very often the
+// programmer's intent, and a rule that cannot tell intent from accident gets
+// globally suppressed — which is exactly what happened: 63 `#nosec G115`
+// suppressions already exist in that fleet.
+//
+// So this analyzer does NOT report every narrowing conversion. It reports the
+// one shape where truncation is a memory-safety bug rather than a style
+// question: a value that is narrowed (or flipped signed→unsigned) and then used
+// to SIZE AN ALLOCATION or BOUND A SLICE — `make([]byte, n)`, `buf[n]`,
+// `buf[:n]`. That is CWE-190 turning into CWE-680/CWE-789: the wrapped length
+// either panics or, worse, allocates and indexes a buffer that does not match
+// the length the rest of the code believes in. A truncated counter in a
+// response message is not that, and is not reported.
+//
+// The conversion must also be UNGUARDED: a preceding bounds comparison, a bit
+// mask, or a modulo that provably fits the destination all suppress it, because
+// each of those is the correct fix and code that already applies one is not
+// vulnerable.
+//
+// TYPE INFORMATION. nox parses Go with go/ast only — no go/types — because
+// type checking requires a resolvable module graph and a Go toolchain, neither
+// of which nox can assume when it scans a checked-out tree offline. Source
+// types are therefore inferred from declarations visible in the same function:
+// parameters, results, `var` declarations, explicit conversions, and a small
+// table of standard-library functions with fixed integer return types. A
+// conversion whose operand type cannot be established locally is NOT reported.
+// That is a deliberate false-negative trade: silence beats a guess.
+// See docs/design/go-integer-overflow.md.
+package memsafe
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// Analyzer reports unvalidated narrowing integer conversions that size memory.
+type Analyzer struct{}
+
+// NewAnalyzer constructs the memory-safety analyzer.
+func NewAnalyzer() *Analyzer { return &Analyzer{} }
+
+// ruleID is the single rule this analyzer emits.
+const ruleID = "MEMSAFE-001"
+
+// Rules returns the rule this analyzer can emit, for the rule catalogue.
+func (a *Analyzer) Rules() *rules.RuleSet {
+	rs := rules.NewRuleSet()
+	rs.Add(&rules.Rule{
+		ID:          ruleID,
+		Version:     "1.0",
+		Description: "Integer truncation reaching an allocation size or slice bound (CWE-190)",
+		Severity:    findings.SeverityMedium,
+		// Medium: the conversion and the sink are both established
+		// syntactically and the guard analysis suppresses the safe forms, but
+		// whether the operand can actually exceed the destination's range
+		// depends on callers this analyzer does not see.
+		Confidence: findings.ConfidenceMedium,
+		Tags:       []string{"go", "integer-overflow", "memory-safety", "cwe-190"},
+		Remediation: "A value is narrowed to a smaller integer type — or converted from signed to unsigned — and the result is then used to size an allocation or bound a slice. " +
+			"If the original value exceeds the destination's range it wraps: a large length becomes a small one, and a negative length becomes an enormous unsigned one. " +
+			"The consequence is a panic at best and a buffer whose size disagrees with the length the surrounding code assumes at worst. " +
+			"Fix it by range-checking before the conversion (`if n < 0 || n > math.MaxInt32 { return err }`), by masking to the destination width when truncation is intended (`v & 0xFF`), or by keeping the wider type all the way to the allocation. " +
+			"If the value is provably bounded by something this analyzer cannot see, suppress with a nox:ignore comment recording the bound.",
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/190.html",
+			"https://cwe.mitre.org/data/definitions/680.html",
+		},
+		Metadata: map[string]string{"cwe": "CWE-190"},
+	})
+	return rs
+}
+
+// ScanArtifacts reports truncating conversions that size memory, across
+// discovered Go sources.
+func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
+	fs := findings.NewFindingSet()
+
+	for _, art := range artifacts {
+		if err := ctx.Err(); err != nil {
+			return fs, err
+		}
+		if !strings.EqualFold(filepath.Ext(art.Path), ".go") {
+			continue
+		}
+		// Test files are skipped: fixtures deliberately construct overflowing
+		// conversions (including this analyzer's own tests), and flagging them
+		// trains people to ignore the rule.
+		if isTestPath(art.Path) {
+			continue
+		}
+
+		content, err := os.ReadFile(art.AbsPath)
+		if err != nil {
+			// Unreadable file is not a finding; discovery already surfaced it.
+			continue
+		}
+		// Generated code is skipped. Every one of the twenty gosec `unsafe`
+		// findings measured across this fleet sat in protoc-gen-go output, and
+		// a rule that reports code nobody writes is pure noise. The marker is
+		// the convention from https://go.dev/s/generatedcode.
+		if isGenerated(content) {
+			continue
+		}
+
+		for _, f := range scanFile(art.Path, content) {
+			fs.Add(f)
+		}
+	}
+	return fs, nil
+}
+
+// scanFile parses one Go source and returns its findings. A file that does not
+// parse yields whatever the recovered partial AST supports rather than an
+// error: a non-compiling snippet must degrade, never crash the scan.
+func scanFile(path string, content []byte) []findings.Finding {
+	fset := token.NewFileSet()
+	// SkipObjectResolution: this analyzer does its own function-scoped name
+	// tracking, and skipping resolution is faster and more error-tolerant.
+	file, _ := parser.ParseFile(fset, path, content, parser.SkipObjectResolution)
+	if file == nil {
+		return nil
+	}
+
+	var out []findings.Finding
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		out = append(out, (&funcScan{fset: fset, path: path, fn: fn}).run()...)
+	}
+	return out
+}
+
+// funcScan holds the per-function analysis state. Everything this analyzer
+// knows is function-local by construction: package-level and cross-package
+// types are not resolvable without go/types (see the package comment).
+type funcScan struct {
+	fset *token.FileSet
+	path string
+	fn   *ast.FuncDecl
+
+	// types maps a local name to the integer type it was declared or inferred
+	// to have. Absent means "unknown", which suppresses reporting.
+	types map[string]intKind
+	// guarded holds names that are compared against a bound somewhere in this
+	// function. Presence suppresses reporting for that name: the code already
+	// does the thing the rule would ask for.
+	guarded map[string]bool
+	// bounds holds, for names that are masked or reduced modulo a constant
+	// somewhere in this function, the tightest magnitude bound observed. It is
+	// checked against the DESTINATION type at report time, so `x & 0xFF`
+	// suppresses a conversion to uint8 but `x & 0xFFFF` does not. Where a name
+	// is bounded more than once the smallest bound wins: this rule errs toward
+	// silence, and a mask in one branch is nearly always the same mask in all.
+	bounds map[string]uint64
+	// sinks holds names that appear in an allocation-size or slice-bound
+	// position somewhere in this function.
+	sinks map[string]bool
+}
+
+func (s *funcScan) run() []findings.Finding {
+	s.types = map[string]intKind{}
+	s.guarded = map[string]bool{}
+	s.bounds = map[string]uint64{}
+	s.sinks = map[string]bool{}
+
+	s.collectDeclaredTypes()
+	s.collectGuards()
+	s.collectSinks()
+	return s.report()
+}
+
+// ---------------------------------------------------------------------------
+// Integer type lattice
+// ---------------------------------------------------------------------------
+
+// intKind is a Go integer type reduced to the only two properties that decide
+// whether a conversion can lose information.
+type intKind struct {
+	bits   int  // 8, 16, 32 or 64
+	signed bool // true for intN / int, false for uintN / uint / uintptr
+}
+
+// intTypes maps every predeclared integer type name to its kind. `int`, `uint`
+// and `uintptr` are taken as 64-bit: that is true on every platform the fleet
+// builds for, and assuming 64 is the conservative choice — it makes int→int32
+// a narrowing (reportable) rather than a no-op.
+var intTypes = map[string]intKind{
+	"int8":    {8, true},
+	"int16":   {16, true},
+	"int32":   {32, true},
+	"rune":    {32, true},
+	"int64":   {64, true},
+	"int":     {64, true},
+	"uint8":   {8, false},
+	"byte":    {8, false},
+	"uint16":  {16, false},
+	"uint32":  {32, false},
+	"uint64":  {64, false},
+	"uint":    {64, false},
+	"uintptr": {64, false},
+}
+
+// lossy reports whether converting a value of kind from to kind to can change
+// its value, and returns a short human-readable reason.
+//
+// Three ways to lose information, and one deliberate non-case:
+//   - narrowing: fewer bits in the destination, same signedness.
+//   - signed → unsigned: a negative value becomes an enormous positive one,
+//     at any width. This is the form that turns a length check inside out.
+//   - unsigned → signed at the same or smaller width: the top half of the
+//     source range becomes negative.
+//
+// Widening with the same signedness, and unsigned → signed into strictly more
+// bits (uint8 → int16, uint32 → int64), are exact and never reported.
+func lossy(from, to intKind) (string, bool) {
+	switch {
+	case from == to:
+		return "", false
+	case from.signed && !to.signed:
+		return "signed to unsigned", true
+	case !from.signed && to.signed:
+		if to.bits > from.bits {
+			return "", false // uint8 -> int16 and friends are exact
+		}
+		return "unsigned to signed", true
+	case to.bits < from.bits:
+		return "truncating", true
+	default:
+		return "", false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local type inference
+// ---------------------------------------------------------------------------
+
+// stdReturns maps a standard-library call, rendered as a dotted chain, to the
+// integer type it returns. Only functions whose return type is fixed by the
+// language or the standard library appear here, so a match is a fact rather
+// than a heuristic. Method-suffix keys are deliberately absent: `.Size()` and
+// `.Len()` exist on unrelated types with unrelated widths, and guessing there
+// is how a rule starts lying.
+var stdReturns = map[string]intKind{
+	"len":                 {64, true}, // int
+	"cap":                 {64, true}, // int
+	"strconv.Atoi":        {64, true}, // int
+	"strconv.ParseInt":    {64, true}, // int64
+	"strconv.ParseUint":   {64, false},
+	"os.Getpid":           {64, true},
+	"os.Getppid":          {64, true},
+	"rand.Int":            {64, true},
+	"rand.Int63":          {64, true},
+	"rand.Int63n":         {64, true},
+	"rand.Uint64":         {64, false},
+	"rand.Uint32":         {32, false},
+	"rand.Int31":          {32, true},
+	"rand.Int31n":         {32, true},
+	"BigEndian.Uint16":    {16, false},
+	"BigEndian.Uint32":    {32, false},
+	"BigEndian.Uint64":    {64, false},
+	"LittleEndian.Uint16": {16, false},
+	"LittleEndian.Uint32": {32, false},
+	"LittleEndian.Uint64": {64, false},
+	"NativeEndian.Uint16": {16, false},
+	"NativeEndian.Uint32": {32, false},
+	"NativeEndian.Uint64": {64, false},
+	"time.Now.Unix":       {64, true},
+	"time.Now.UnixNano":   {64, true},
+	"time.Now.UnixMilli":  {64, true},
+	"time.Now.UnixMicro":  {64, true},
+}
+
+// collectDeclaredTypes records the integer type of every function-scoped name
+// whose type is written down or directly inferable.
+func (s *funcScan) collectDeclaredTypes() {
+	record := func(names []*ast.Ident, typ ast.Expr) {
+		k, ok := identKind(typ)
+		if !ok {
+			return
+		}
+		for _, n := range names {
+			if n != nil && n.Name != "_" {
+				s.types[n.Name] = k
+			}
+		}
+	}
+
+	// Receiver, parameters and named results: their types are written in the
+	// signature, so they are the most reliable source there is.
+	for _, fl := range []*ast.FieldList{s.fn.Recv, s.fn.Type.Params, s.fn.Type.Results} {
+		if fl == nil {
+			continue
+		}
+		for _, f := range fl.List {
+			record(f.Names, f.Type)
+		}
+	}
+
+	ast.Inspect(s.fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.DeclStmt:
+			gd, ok := v.Decl.(*ast.GenDecl)
+			if !ok {
+				return true
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				if vs.Type != nil {
+					record(vs.Names, vs.Type)
+					continue
+				}
+				// `var x = <expr>` and `x := <expr>` share the inference path.
+				for i, name := range vs.Names {
+					if i < len(vs.Values) {
+						s.inferAssign(name, vs.Values[i])
+					}
+				}
+			}
+		case *ast.AssignStmt:
+			if len(v.Lhs) == len(v.Rhs) {
+				for i, lhs := range v.Lhs {
+					if id, ok := lhs.(*ast.Ident); ok {
+						s.inferAssign(id, v.Rhs[i])
+					}
+				}
+				return true
+			}
+			// `n, err := strconv.ParseInt(...)` — one call feeding several
+			// names. Every entry in stdReturns returns its integer FIRST
+			// (`(int64, error)`, `(int, error)`), so the first name takes the
+			// tabled kind and the rest stay unknown. Any other multi-value
+			// call would need the callee's full signature, which is exactly
+			// what go/types would provide and this does not have.
+			if len(v.Rhs) != 1 || len(v.Lhs) == 0 {
+				return true
+			}
+			call, ok := v.Rhs[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if k, ok := stdReturns[chainOf(call.Fun)]; ok {
+				if id, ok := v.Lhs[0].(*ast.Ident); ok && id.Name != "_" {
+					s.types[id.Name] = k
+				}
+			}
+		}
+		return true
+	})
+}
+
+// inferAssign records the type of name when the right-hand side determines it.
+func (s *funcScan) inferAssign(name *ast.Ident, rhs ast.Expr) {
+	if name == nil || name.Name == "_" {
+		return
+	}
+	if k, ok := s.exprKind(rhs); ok {
+		s.types[name.Name] = k
+	}
+}
+
+// identKind maps a type expression to an integer kind, for the predeclared
+// integer types only. A named type (`os.FileMode`, `time.Duration`, a local
+// `type ID uint32`) returns false: resolving its underlying type is precisely
+// what needs go/types.
+func identKind(e ast.Expr) (intKind, bool) {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return intKind{}, false
+	}
+	k, ok := intTypes[id.Name]
+	return k, ok
+}
+
+// exprKind infers the integer kind of an expression from local information.
+// The second result is false whenever the type cannot be established, which is
+// the common case and always means "do not report".
+func (s *funcScan) exprKind(e ast.Expr) (intKind, bool) {
+	switch v := e.(type) {
+	case *ast.ParenExpr:
+		return s.exprKind(v.X)
+	case *ast.Ident:
+		k, ok := s.types[v.Name]
+		return k, ok
+	case *ast.CallExpr:
+		// A conversion to a predeclared integer type yields that type.
+		if k, ok := identKind(v.Fun); ok {
+			return k, true
+		}
+		if k, ok := stdReturns[chainOf(v.Fun)]; ok {
+			return k, true
+		}
+		return intKind{}, false
+	case *ast.BinaryExpr:
+		// Both operands of a Go binary op share one type, so either side that
+		// is known determines the result. Shifts are the exception: the result
+		// takes the LEFT operand's type regardless of the right.
+		if v.Op == token.SHL || v.Op == token.SHR {
+			return s.exprKind(v.X)
+		}
+		if k, ok := s.exprKind(v.X); ok {
+			return k, true
+		}
+		return s.exprKind(v.Y)
+	case *ast.UnaryExpr:
+		return s.exprKind(v.X)
+	}
+	return intKind{}, false
+}
+
+// chainOf renders a selector expression as the dotted string the stdReturns
+// table is keyed on, dropping call parentheses — the same convention the Go
+// taint extractor uses. `binary.BigEndian.Uint32` renders as
+// `BigEndian.Uint32` after the leading package qualifier is dropped by the
+// two-segment suffix rule below, and `time.Now().Unix()` renders as
+// `time.Now.Unix`.
+func chainOf(e ast.Expr) string {
+	var parts []string
+	var walk func(ast.Expr) bool
+	walk = func(x ast.Expr) bool {
+		switch v := x.(type) {
+		case *ast.Ident:
+			parts = append(parts, v.Name)
+			return true
+		case *ast.SelectorExpr:
+			if !walk(v.X) {
+				return false
+			}
+			parts = append(parts, v.Sel.Name)
+			return true
+		case *ast.CallExpr:
+			return walk(v.Fun)
+		case *ast.ParenExpr:
+			return walk(v.X)
+		}
+		return false
+	}
+	if !walk(e) {
+		return ""
+	}
+	full := strings.Join(parts, ".")
+	if _, ok := stdReturns[full]; ok {
+		return full
+	}
+	// Fall back to the last two segments so `binary.BigEndian.Uint32` matches
+	// `BigEndian.Uint32` whatever the import is aliased to.
+	if len(parts) >= 2 {
+		return strings.Join(parts[len(parts)-2:], ".")
+	}
+	return full
+}
+
+// ---------------------------------------------------------------------------
+// Guard detection
+// ---------------------------------------------------------------------------
+
+// collectGuards marks every name the function already bounds. This runs over
+// the WHOLE function rather than only the statements that dominate the
+// conversion: a coarse over-approximation whose only failure mode is silence,
+// which is the direction this rule errs in on purpose.
+func (s *funcScan) collectGuards() {
+	ast.Inspect(s.fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.BinaryExpr:
+			switch v.Op {
+			case token.LSS, token.GTR, token.LEQ, token.GEQ:
+				// A comparison bounds whichever side is a plain name.
+				s.markName(v.X)
+				s.markName(v.Y)
+			case token.AND:
+				// `x & 0xFF` bounds the RESULT. Record the magnitude rather
+				// than a boolean, so the suppression can be checked against
+				// the destination width at report time. Only a constant
+				// right-hand side counts; `x & y` bounds nothing this
+				// analyzer can see.
+				s.markBound(v.X, v.Y, v.Op)
+			case token.REM:
+				// Modulo bounds unconditionally, whatever the divisor is.
+				// `h % buckHashSize` is the universal idiom for confining a
+				// value to a table, and the divisor is very often a named
+				// constant this analyzer cannot evaluate. Requiring a literal
+				// there reported `runtime/mprof.go` and code like it; a
+				// remainder is smaller than its divisor by definition, and the
+				// divisor is almost always the size of the thing being
+				// indexed, so treat any modulo as a bound.
+				s.markName(v.X)
+				s.markBound(v.X, v.Y, v.Op)
+			}
+		case *ast.SwitchStmt:
+			// A type/value switch on a name is a bound in the same spirit as
+			// a comparison; treat the tag as guarded.
+			if v.Tag != nil {
+				s.markName(v.Tag)
+			}
+		}
+		return true
+	})
+}
+
+// markName records a guard against a plain identifier, seeing through an
+// integer conversion wrapped around it.
+//
+// The conversion case matters: `if uint32(r) <= MaxLatin1` is how the standard
+// library range-checks a rune before narrowing it, and reading only the bare
+// identifier misses every guard written that way. Anything more complex than a
+// name — a field, an index, a call to something that is not a conversion — is
+// not tracked, because the conversion side does not track those either.
+func (s *funcScan) markName(e ast.Expr) {
+	switch v := unparen(e).(type) {
+	case *ast.Ident:
+		s.guarded[v.Name] = true
+	case *ast.CallExpr:
+		if _, isConv := identKind(v.Fun); isConv && len(v.Args) == 1 {
+			s.markName(v.Args[0])
+		}
+	}
+}
+
+// markBound records the magnitude a mask or modulo confines a name to.
+func (s *funcScan) markBound(name, lit ast.Expr, op token.Token) {
+	id, ok := unparen(name).(*ast.Ident)
+	if !ok {
+		return
+	}
+	max, ok := literalBound(lit, op)
+	if !ok {
+		return
+	}
+	if prev, seen := s.bounds[id.Name]; !seen || max < prev {
+		s.bounds[id.Name] = max
+	}
+}
+
+// literalBound returns the maximum magnitude `x op lit` can produce, for the
+// masking operators. `x & n` is at most n; `x % n` is at most n-1.
+func literalBound(lit ast.Expr, op token.Token) (uint64, bool) {
+	b, ok := unparen(lit).(*ast.BasicLit)
+	if !ok || b.Kind != token.INT {
+		return 0, false
+	}
+	v, ok := parseUintLit(b.Value)
+	if !ok {
+		return 0, false
+	}
+	if op == token.REM {
+		if v == 0 {
+			return 0, false
+		}
+		v--
+	}
+	return v, true
+}
+
+// isConstantish reports whether an expression is built entirely from integer
+// literals, and therefore cannot overflow at runtime — the compiler would
+// reject it if it did not fit.
+func isConstantish(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.ParenExpr:
+		return isConstantish(v.X)
+	case *ast.UnaryExpr:
+		return isConstantish(v.X)
+	case *ast.BasicLit:
+		return v.Kind == token.INT || v.Kind == token.CHAR
+	case *ast.BinaryExpr:
+		return isConstantish(v.X) && isConstantish(v.Y)
+	}
+	return false
+}
+
+// selfBounded reports whether the operand expression bounds itself, so the
+// conversion cannot lose information regardless of the operand's own type.
+//
+// Three shapes, all of them idioms whose whole point is to make the value fit:
+//   - `x & 0xFF` — a mask no wider than the destination.
+//   - `x % 16` — a modulo whose remainder fits.
+//   - `x >> 24` on an UNSIGNED value — a logical shift leaves at most
+//     (width - shift) bits set, which is how every byte-extraction and
+//     binary-search midpoint in existence is written. The shift must be
+//     logical: on a signed value `>>` propagates the sign bit and bounds
+//     nothing, so the source kind is required to be unsigned.
+func (s *funcScan) selfBounded(e ast.Expr, to intKind) bool {
+	v, ok := unparen(e).(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	switch v.Op {
+	case token.AND, token.REM:
+		max, ok := literalBound(v.Y, v.Op)
+		if !ok {
+			return false
+		}
+		return fitsIn(max, to)
+	case token.SHR:
+		from, ok := s.exprKind(v.X)
+		if !ok || from.signed {
+			return false
+		}
+		shift, ok := literalBound(v.Y, token.SHL) // reuse the literal parser
+		if !ok || shift == 0 || shift >= uint64(from.bits) {
+			return false
+		}
+		remaining := uint64(from.bits) - shift
+		// The result occupies `remaining` bits, so its magnitude is at most
+		// 2^remaining - 1.
+		if remaining >= 64 {
+			return false
+		}
+		return fitsIn((uint64(1)<<remaining)-1, to)
+	}
+	return false
+}
+
+// nonNegative reports whether an expression is provably ≥ 0 — which, for a
+// signed source, removes the entire signed→unsigned hazard.
+//
+// Only `len` and `cap` qualify, plus arithmetic built from them and integer
+// literals. Both are defined to return a non-negative count, and in a real Go
+// process that count is additionally bounded by addressable memory, so
+// `uint32(len(b))` cannot produce the enormous wrapped length this rule
+// exists to catch. Narrowing a length to 16 bits or fewer IS still reported:
+// a slice longer than 65535 is entirely ordinary.
+func nonNegative(e ast.Expr) bool {
+	switch v := unparen(e).(type) {
+	case *ast.BasicLit:
+		return v.Kind == token.INT
+	case *ast.CallExpr:
+		id, ok := v.Fun.(*ast.Ident)
+		return ok && (id.Name == "len" || id.Name == "cap")
+	case *ast.BinaryExpr:
+		switch v.Op {
+		case token.ADD, token.MUL, token.QUO, token.REM, token.SHL, token.SHR:
+			return nonNegative(v.X) && nonNegative(v.Y)
+		}
+	}
+	return false
+}
+
+// fitsIn reports whether every value with magnitude at most max is
+// representable in kind k.
+func fitsIn(max uint64, k intKind) bool {
+	bits := uint(k.bits)
+	if k.signed {
+		bits--
+	}
+	if bits >= 64 {
+		return true
+	}
+	return max < (uint64(1) << bits)
+}
+
+// parseUintLit parses a Go integer literal (decimal, hex, octal, binary, with
+// underscores) as an unsigned value.
+func parseUintLit(s string) (uint64, bool) {
+	s = strings.ReplaceAll(s, "_", "")
+	base := 10
+	switch {
+	case strings.HasPrefix(s, "0x"), strings.HasPrefix(s, "0X"):
+		s, base = s[2:], 16
+	case strings.HasPrefix(s, "0b"), strings.HasPrefix(s, "0B"):
+		s, base = s[2:], 2
+	case strings.HasPrefix(s, "0o"), strings.HasPrefix(s, "0O"):
+		s, base = s[2:], 8
+	case len(s) > 1 && s[0] == '0':
+		s, base = s[1:], 8
+	}
+	var v uint64
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		var d uint64
+		switch {
+		case c >= '0' && c <= '9':
+			d = uint64(c - '0')
+		case c >= 'a' && c <= 'f':
+			d = uint64(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			d = uint64(c-'A') + 10
+		default:
+			return 0, false
+		}
+		if d >= uint64(base) {
+			return 0, false
+		}
+		v = v*uint64(base) + d
+	}
+	return v, true
+}
+
+// ---------------------------------------------------------------------------
+// Sink detection
+// ---------------------------------------------------------------------------
+
+// collectSinks records every name used as an allocation size or a slice bound
+// anywhere in the function, and every conversion expression used directly in
+// such a position.
+func (s *funcScan) collectSinks() {
+	ast.Inspect(s.fn.Body, func(n ast.Node) bool {
+		for _, e := range sizeOperands(n) {
+			if id, ok := e.(*ast.Ident); ok {
+				s.sinks[id.Name] = true
+			}
+		}
+		return true
+	})
+}
+
+// sizeOperands returns the sub-expressions of n that determine an allocation
+// size or a slice bound.
+//
+// The set is deliberately small and each member is unambiguous:
+//   - `make(T, n)` / `make(T, n, m)` — the allocation length and capacity.
+//   - `s[lo:hi]`, `s[lo:hi:max]` — every slice bound.
+//
+// A bare INDEX expression `s[i]` is deliberately NOT a sink, for two reasons.
+// Syntactically it is indistinguishable from a map lookup, where an index is
+// not a bounds context at all and no value of it is wrong — telling the two
+// apart needs go/types. And semantically Go bounds-checks every slice index,
+// so a wrapped index panics rather than reading out of bounds; the harm is
+// capped at the denial of service the slice-bound case already covers.
+// Measured against the Go standard library, treating indexes as sinks
+// produced 46 findings, every one of them correct code: AES S-box lookups
+// (`te0[uint8(s0>>24)]`), Latin-1 property tables, and a `map[uint64]string`
+// in the linker.
+//
+// `copy` and `append` are likewise not sinks: they are bounded by the slices
+// they operate on, so a wrapped value there cannot index out of range.
+func sizeOperands(n ast.Node) []ast.Expr {
+	switch v := n.(type) {
+	case *ast.CallExpr:
+		id, ok := v.Fun.(*ast.Ident)
+		if !ok || id.Name != "make" || len(v.Args) < 2 {
+			return nil
+		}
+		return v.Args[1:]
+	case *ast.SliceExpr:
+		var out []ast.Expr
+		for _, e := range []ast.Expr{v.Low, v.High, v.Max} {
+			if e != nil {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+// report walks the function for conversions that are lossy, unguarded, and
+// reach a size sink either directly or through one local assignment.
+func (s *funcScan) report() []findings.Finding {
+	var out []findings.Finding
+	seen := map[token.Pos]bool{}
+
+	// Conversions sitting directly in a size position.
+	ast.Inspect(s.fn.Body, func(n ast.Node) bool {
+		for _, e := range sizeOperands(n) {
+			if f, ok := s.check(e, "directly"); ok && !seen[e.Pos()] {
+				seen[e.Pos()] = true
+				out = append(out, f)
+			}
+		}
+		return true
+	})
+
+	// Conversions assigned to a name that is later used as a size.
+	ast.Inspect(s.fn.Body, func(n ast.Node) bool {
+		lhs, rhs := assignPairs(n)
+		for i := range lhs {
+			id, ok := lhs[i].(*ast.Ident)
+			if !ok || !s.sinks[id.Name] || s.guarded[id.Name] {
+				continue
+			}
+			if f, ok := s.check(rhs[i], "through "+id.Name); ok && !seen[rhs[i].Pos()] {
+				seen[rhs[i].Pos()] = true
+				out = append(out, f)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// assignPairs returns the 1:1 left- and right-hand sides of an assignment or
+// short var declaration, or nil for anything else.
+func assignPairs(n ast.Node) ([]ast.Expr, []ast.Expr) {
+	switch v := n.(type) {
+	case *ast.AssignStmt:
+		if len(v.Lhs) == len(v.Rhs) {
+			return v.Lhs, v.Rhs
+		}
+	case *ast.ValueSpec:
+		if len(v.Names) == len(v.Values) {
+			lhs := make([]ast.Expr, len(v.Names))
+			for i, n := range v.Names {
+				lhs[i] = n
+			}
+			return lhs, v.Values
+		}
+	}
+	return nil, nil
+}
+
+// check decides whether expression e is a reportable conversion and builds the
+// finding. Every early return is a reason NOT to report, and they are ordered
+// cheapest first.
+func (s *funcScan) check(e ast.Expr, how string) (findings.Finding, bool) {
+	call, ok := unparen(e).(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return findings.Finding{}, false
+	}
+	to, ok := identKind(call.Fun)
+	if !ok {
+		return findings.Finding{}, false
+	}
+	arg := unparen(call.Args[0])
+
+	// A constant expression cannot overflow at runtime — the compiler rejects
+	// one that does not fit.
+	if isConstantish(arg) {
+		return findings.Finding{}, false
+	}
+	// The operand bounds itself: `x & 0xFF`, `x % 10`, `x >> 24`.
+	if s.selfBounded(arg, to) {
+		return findings.Finding{}, false
+	}
+	// The operand's own type must be locally provable. Unknown means silent.
+	from, ok := s.exprKind(arg)
+	if !ok {
+		return findings.Finding{}, false
+	}
+	reason, bad := lossy(from, to)
+	if !bad {
+		return findings.Finding{}, false
+	}
+	// A length is non-negative and, in a live process, bounded by addressable
+	// memory. Narrowing one to 32 bits or more cannot produce the wrapped
+	// value this rule exists to catch, whatever the lattice says about signs.
+	if to.bits >= 32 && nonNegative(arg) {
+		return findings.Finding{}, false
+	}
+	// The function already bounds this name somewhere — either by comparison,
+	// or by a mask/modulo tight enough for the destination.
+	for _, n := range plainNames(arg) {
+		if s.guarded[n] {
+			return findings.Finding{}, false
+		}
+		if max, ok := s.bounds[n]; ok && fitsIn(max, to) {
+			return findings.Finding{}, false
+		}
+	}
+
+	pos := s.fset.Position(call.Pos())
+	return findings.Finding{
+		RuleID:     ruleID,
+		Severity:   findings.SeverityMedium,
+		Confidence: findings.ConfidenceMedium,
+		Message: "Integer conversion " + typeName(from) + " to " + typeName(to) +
+			" (" + reason + ") sizes an allocation or slice bound " + how + " without a range check",
+		Location: findings.Location{
+			FilePath:    s.path,
+			StartLine:   pos.Line,
+			EndLine:     pos.Line,
+			StartColumn: pos.Column,
+		},
+		Metadata: map[string]string{
+			"cwe":  "CWE-190",
+			"from": typeName(from),
+			"to":   typeName(to),
+		},
+	}, true
+}
+
+// plainNames returns the bare identifiers an expression is built from, so a
+// guard on any of them suppresses the conversion.
+func plainNames(e ast.Expr) []string {
+	var out []string
+	ast.Inspect(e, func(n ast.Node) bool {
+		// Only identifiers in value position: a selector's field name is not a
+		// name this analyzer tracks.
+		switch v := n.(type) {
+		case *ast.SelectorExpr:
+			return false
+		case *ast.Ident:
+			out = append(out, v.Name)
+		}
+		return true
+	})
+	return out
+}
+
+// typeName renders a kind back to the canonical Go type name, for messages.
+func typeName(k intKind) string {
+	if k.signed {
+		switch k.bits {
+		case 8:
+			return "int8"
+		case 16:
+			return "int16"
+		case 32:
+			return "int32"
+		}
+		return "int64"
+	}
+	switch k.bits {
+	case 8:
+		return "uint8"
+	case 16:
+		return "uint16"
+	case 32:
+		return "uint32"
+	}
+	return "uint64"
+}
+
+func unparen(e ast.Expr) ast.Expr {
+	for {
+		p, ok := e.(*ast.ParenExpr)
+		if !ok {
+			return e
+		}
+		e = p.X
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File filters
+// ---------------------------------------------------------------------------
+
+// generatedMarker is the convention from https://go.dev/s/generatedcode. Only
+// the first few lines of a file are inspected, per that convention.
+const generatedMarker = "// Code generated"
+
+func isGenerated(content []byte) bool {
+	head := content
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	for _, line := range strings.Split(string(head), "\n") {
+		if strings.HasPrefix(line, generatedMarker) && strings.Contains(line, "DO NOT EDIT") {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestPath reports whether a path is Go test code or a test fixture tree.
+func isTestPath(p string) bool {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(p)), "_test.go") {
+		return true
+	}
+	lower := strings.ToLower(p)
+	return strings.Contains(lower, "/testdata/") || strings.HasPrefix(lower, "testdata/")
+}

--- a/core/analyzers/memsafe/memsafe.go
+++ b/core/analyzers/memsafe/memsafe.go
@@ -550,12 +550,12 @@ func (s *funcScan) markBound(name, lit ast.Expr, op token.Token) {
 	if !ok {
 		return
 	}
-	max, ok := literalBound(lit, op)
+	limit, ok := literalBound(lit, op)
 	if !ok {
 		return
 	}
-	if prev, seen := s.bounds[id.Name]; !seen || max < prev {
-		s.bounds[id.Name] = max
+	if prev, seen := s.bounds[id.Name]; !seen || limit < prev {
+		s.bounds[id.Name] = limit
 	}
 }
 
@@ -614,11 +614,11 @@ func (s *funcScan) selfBounded(e ast.Expr, to intKind) bool {
 	}
 	switch v.Op {
 	case token.AND, token.REM:
-		max, ok := literalBound(v.Y, v.Op)
+		limit, ok := literalBound(v.Y, v.Op)
 		if !ok {
 			return false
 		}
-		return fitsIn(max, to)
+		return fitsIn(limit, to)
 	case token.SHR:
 		from, ok := s.exprKind(v.X)
 		if !ok || from.signed {
@@ -664,9 +664,9 @@ func nonNegative(e ast.Expr) bool {
 	return false
 }
 
-// fitsIn reports whether every value with magnitude at most max is
+// fitsIn reports whether every value with magnitude at most limit is
 // representable in kind k.
-func fitsIn(max uint64, k intKind) bool {
+func fitsIn(limit uint64, k intKind) bool {
 	bits := uint(k.bits)
 	if k.signed {
 		bits--
@@ -674,7 +674,7 @@ func fitsIn(max uint64, k intKind) bool {
 	if bits >= 64 {
 		return true
 	}
-	return max < (uint64(1) << bits)
+	return limit < (uint64(1) << bits)
 }
 
 // parseUintLit parses a Go integer literal (decimal, hex, octal, binary, with
@@ -815,7 +815,7 @@ func (s *funcScan) report() []findings.Finding {
 
 // assignPairs returns the 1:1 left- and right-hand sides of an assignment or
 // short var declaration, or nil for anything else.
-func assignPairs(n ast.Node) ([]ast.Expr, []ast.Expr) {
+func assignPairs(n ast.Node) (lhs, rhs []ast.Expr) {
 	switch v := n.(type) {
 	case *ast.AssignStmt:
 		if len(v.Lhs) == len(v.Rhs) {
@@ -823,11 +823,11 @@ func assignPairs(n ast.Node) ([]ast.Expr, []ast.Expr) {
 		}
 	case *ast.ValueSpec:
 		if len(v.Names) == len(v.Values) {
-			lhs := make([]ast.Expr, len(v.Names))
+			names := make([]ast.Expr, len(v.Names))
 			for i, n := range v.Names {
-				lhs[i] = n
+				names[i] = n
 			}
-			return lhs, v.Values
+			return names, v.Values
 		}
 	}
 	return nil, nil
@@ -877,7 +877,7 @@ func (s *funcScan) check(e ast.Expr, how string) (findings.Finding, bool) {
 		if s.guarded[n] {
 			return findings.Finding{}, false
 		}
-		if max, ok := s.bounds[n]; ok && fitsIn(max, to) {
+		if limit, ok := s.bounds[n]; ok && fitsIn(limit, to) {
 			return findings.Finding{}, false
 		}
 	}

--- a/core/analyzers/memsafe/memsafe_test.go
+++ b/core/analyzers/memsafe/memsafe_test.go
@@ -1,0 +1,587 @@
+package memsafe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanSource writes src to a temp file and returns the findings for it.
+func scanSource(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := (&Analyzer{}).ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs.Findings()
+}
+
+func count(t *testing.T, src string) int {
+	t.Helper()
+	return len(scanSource(t, "a.go", src))
+}
+
+// ---------------------------------------------------------------------------
+// Positives: truncation that reaches a size sink
+// ---------------------------------------------------------------------------
+
+func TestFiresOnTruncationReachingASizeSink(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			// The canonical CWE-190: a wire-decoded 64-bit length narrowed to
+			// int32 and handed straight to make. A length above 2^31 wraps
+			// negative and panics; one crafted to wrap positive allocates a
+			// buffer smaller than the caller believes.
+			name: "wire length into make, inline",
+			src: `package m
+func f(buf []byte) []byte {
+	return make([]byte, int32(binary.BigEndian.Uint64(buf)))
+}`,
+		},
+		{
+			name: "parsed length into make, through a local",
+			src: `package m
+func f(s string) []byte {
+	n, _ := strconv.ParseInt(s, 10, 64)
+	sz := int32(n)
+	return make([]byte, sz)
+}`,
+		},
+		{
+			// Signed to unsigned: a negative length becomes enormous.
+			name: "signed to unsigned length",
+			src: `package m
+func f(n int64) []byte {
+	sz := uint32(n)
+	return make([]byte, sz)
+}`,
+		},
+		{
+			name: "declared int64 narrowed into a slice bound",
+			src: `package m
+func f(buf []byte) []byte {
+	var off int64 = readOffset()
+	return buf[:int32(off)]
+}`,
+		},
+		{
+			name: "uint64 parameter truncated to a slice bound",
+			src: `package m
+func f(buf []byte, pos uint64) []byte {
+	i := uint8(pos)
+	return buf[i:]
+}`,
+		},
+		{
+			name: "make capacity argument counts as a size",
+			src: `package m
+func f(n int64) []byte {
+	return make([]byte, 0, int32(n))
+}`,
+		},
+		{
+			name: "three-index slice max bound counts as a size",
+			src: `package m
+func f(buf []byte, n int64) []byte {
+	return buf[0:1:int32(n)]
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if n := count(t, c.src); n != 1 {
+				t.Errorf("got %d findings, want 1", n)
+			}
+		})
+	}
+}
+
+// The message and metadata must name the actual types, because that is what
+// makes the finding actionable without opening the file.
+func TestFindingNamesTheConversion(t *testing.T) {
+	f := scanSource(t, "a.go", `package m
+func f(n int64) []byte { return make([]byte, int32(n)) }`)
+	if len(f) != 1 {
+		t.Fatalf("got %d findings, want 1", len(f))
+	}
+	if f[0].RuleID != ruleID {
+		t.Errorf("rule ID = %q, want %q", f[0].RuleID, ruleID)
+	}
+	if got := f[0].Metadata["from"]; got != "int64" {
+		t.Errorf("from = %q, want int64", got)
+	}
+	if got := f[0].Metadata["to"]; got != "int32" {
+		t.Errorf("to = %q, want int32", got)
+	}
+	if !strings.Contains(f[0].Message, "int64 to int32") {
+		t.Errorf("message %q does not name the conversion", f[0].Message)
+	}
+	if f[0].Location.StartLine != 2 {
+		t.Errorf("line = %d, want 2", f[0].Location.StartLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: conversions that cannot lose information
+// ---------------------------------------------------------------------------
+
+func TestSilentOnConversionsThatCannotOverflow(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			name: "widening keeps the value",
+			src: `package m
+func f(n int32) []byte { return make([]byte, int64(n)) }`,
+		},
+		{
+			name: "byte to int is exact",
+			src: `package m
+func f(b byte) []byte { return make([]byte, int(b)) }`,
+		},
+		{
+			name: "uint8 to int16 is exact",
+			src: `package m
+func f(b uint8) []byte { return make([]byte, int16(b)) }`,
+		},
+		{
+			name: "uint32 to int64 is exact",
+			src: `package m
+func f(u uint32) []byte { return make([]byte, int64(u)) }`,
+		},
+		{
+			name: "identity conversion",
+			src: `package m
+func f(n int32) []byte { return make([]byte, int32(n)) }`,
+		},
+		{
+			name: "constant that fits",
+			src: `package m
+func f() []byte { return make([]byte, int32(1024)) }`,
+		},
+		{
+			name: "constant arithmetic that fits",
+			src: `package m
+func f() []byte { return make([]byte, int32(4*1024+7)) }`,
+		},
+		{
+			name: "masked to the destination width",
+			src: `package m
+func f(n int64, buf []byte) []byte { return buf[:uint8(n&0xFF)] }`,
+		},
+		{
+			name: "reduced modulo a fitting constant",
+			src: `package m
+func f(n int64, buf []byte) []byte { return buf[:uint8(n%16)] }`,
+		},
+		{
+			name: "reduced modulo a named constant",
+			src: `package m
+func f(h uint64, tab []entry) []entry { return tab[:int32(h%tableSize)] }`,
+		},
+		{
+			name: "logical shift leaves a fitting number of bits",
+			src: `package m
+func f(s0 uint32, tab []byte) []byte { return tab[:uint8(s0>>24)] }`,
+		},
+		{
+			name: "length narrowed to 32 bits is bounded by memory",
+			src: `package m
+func f(buf []byte) []uint16 { return make([]uint16, uint32(2*len(buf))) }`,
+		},
+		{
+			name: "guard written through a conversion",
+			src: `package m
+func f(r rune, props []byte) []byte {
+	if uint32(r) <= MaxLatin1 {
+		return props[:uint8(r)]
+	}
+	return nil
+}`,
+		},
+		{
+			name: "range checked before the conversion",
+			src: `package m
+func f(n int64) ([]byte, error) {
+	if n < 0 || n > 4096 {
+		return nil, errTooBig
+	}
+	return make([]byte, int32(n)), nil
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if n := count(t, c.src); n != 0 {
+				t.Errorf("got %d findings, want 0", n)
+			}
+		})
+	}
+}
+
+// A mask that is WIDER than the destination does not bound the conversion, so
+// the suppression must not be a blanket "any mask is fine".
+func TestMaskWiderThanDestinationStillFires(t *testing.T) {
+	src := `package m
+func f(n int64, buf []byte) []byte { return buf[:uint8(n&0xFFFF)] }`
+	if got := count(t, src); got != 1 {
+		t.Errorf("got %d findings, want 1: a 16-bit mask does not fit uint8", got)
+	}
+}
+
+// A mask applied to something that is not a bare name — a call result, a field
+// — is bounded by the expression itself rather than by any tracked variable.
+// This is the case only the inline check covers, so assert it separately from
+// the `x & 0xFF` form above, which the whole-function bound map also catches.
+func TestInlineMaskOnANonIdentifierOperandSuppresses(t *testing.T) {
+	src := `package m
+func f(s string) []byte { return make([]byte, uint8(len(s)&0xFF)) }`
+	if got := count(t, src); got != 0 {
+		t.Errorf("got %d findings, want 0: len(s)&0xFF fits uint8 exactly", got)
+	}
+	// Control: the same shape with a mask too wide for the destination must
+	// still fire, so this is not passing because the operand is unresolvable.
+	wide := `package m
+func f(s string) []byte { return make([]byte, uint8(len(s)&0xFFFF)) }`
+	if got := count(t, wide); got != 1 {
+		t.Fatalf("control: got %d findings, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: truncation that does NOT reach a size sink
+// ---------------------------------------------------------------------------
+
+// This is the class that made gosec's G115 unusable on this fleet. Every case
+// below is a verbatim shape taken from a real gosec G115 finding measured
+// across sixteen fleet repositories, and every one of them is correct code.
+func TestSilentOnRealWorldGosecG115FalsePositives(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			// mnemos/internal/server/grpc/server.go and 40 siblings.
+			name: "protobuf count field",
+			src: `package m
+func f(out []Row, total, limit, offset int) *pb.ListResponse {
+	return &pb.ListResponse{Rows: out, Count: int32(len(out)), Total: int32(total), Limit: int32(limit), Offset: int32(offset)}
+}`,
+		},
+		{
+			// auth-go/domain/totp.go — HOTP counter, positive until year 292e9.
+			name: "unix time into an HOTP counter",
+			src: `package m
+func f(t time.Time, period uint64) uint64 { return uint64(t.Unix()) / period }`,
+		},
+		{
+			// scout/urlvalidator.go — IPv4 octet extraction; truncation is the point.
+			name: "ipv4 octet extraction",
+			src: `package m
+func f(addr uint64) net.IP {
+	return net.IPv4(byte(addr>>24), byte(addr>>16), byte(addr>>8), byte(addr))
+}`,
+		},
+		{
+			// bolt/encode.go — digit formatting behind a modulo.
+			name: "digit formatting",
+			src: `package m
+func f(nano int, digitBuf []byte) {
+	for i := 8; i >= 0; i-- {
+		digitBuf[i] = byte(nano%10) + '0'
+		nano /= 10
+	}
+}`,
+		},
+		{
+			// nox sdk/response.go — line/column numbers into a protobuf Location.
+			name: "line numbers into a protobuf location",
+			src: `package m
+func f(filePath string, startLine, endLine int) *pb.Location {
+	return &pb.Location{FilePath: filePath, StartLine: int32(startLine), EndLine: int32(endLine)}
+}`,
+		},
+		{
+			// nox registry/oci/extract.go — masked to 0o777 after the conversion.
+			name: "file mode masked to nine bits",
+			src: `package m
+func f(mode int64, target string) error {
+	return os.MkdirAll(target, os.FileMode(mode)&0o777|0o755)
+}`,
+		},
+		{
+			// warden internal/infrastructure/watch/watch.go — hashing a size.
+			name: "size folded into a hash",
+			src: `package m
+func f(size int64, buf []byte) {
+	binary.LittleEndian.PutUint64(buf, uint64(size))
+}`,
+		},
+		{
+			// statekit/eventstore.go — digit rendering.
+			name: "int to rune for a digit",
+			src: `package m
+func f(v int) string { return string(rune(v + '0')) }`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if n := count(t, c.src); n != 0 {
+				t.Errorf("got %d findings, want 0 — this shape is correct code", n)
+			}
+		})
+	}
+}
+
+// A bare index expression is not a sink: it may be a map lookup, which needs
+// go/types to rule out, and Go bounds-checks slice indexes anyway. Measured on
+// the Go standard library this single decision removed 46 findings, all of
+// them correct code. The matching slice-bound form must still fire, so the
+// pair is asserted together.
+func TestIndexExpressionsAreNotSizeSinksButSliceBoundsAre(t *testing.T) {
+	index := `package m
+func f(buf []byte, pos int64) byte { return buf[int16(pos)] }`
+	if got := count(t, index); got != 0 {
+		t.Errorf("index: got %d findings, want 0", got)
+	}
+	// The AES S-box shape, which is what made this decision necessary.
+	sbox := `package m
+func f(s0 uint32, te0 []uint32) uint32 { return te0[uint8(s0)] }`
+	if got := count(t, sbox); got != 0 {
+		t.Errorf("table index: got %d findings, want 0", got)
+	}
+	bound := `package m
+func f(buf []byte, pos int64) []byte { return buf[:int16(pos)] }`
+	if got := count(t, bound); got != 1 {
+		t.Fatalf("slice bound: got %d findings, want 1", got)
+	}
+}
+
+// copy and append are bounded by the slices they operate on, so a wrapped
+// length there cannot index out of range. They are not sinks.
+func TestCopyAndAppendAreNotSizeSinks(t *testing.T) {
+	for _, src := range []string{
+		`package m
+func f(dst, src []byte, n int64) int { return copy(dst[:], src[:]) + int(int32(n)) }`,
+		`package m
+func f(xs []int32, n int64) []int32 { return append(xs, int32(n)) }`,
+	} {
+		if got := count(t, src); got != 0 {
+			t.Errorf("got %d findings, want 0 for %q", got, src)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: the operand's type is not locally provable
+// ---------------------------------------------------------------------------
+
+// Without go/types the type of a struct field, a named type, or a multi-value
+// call result cannot be established. The rule stays silent rather than
+// guessing — a deliberate false negative documented in the package comment.
+func TestSilentWhenTheOperandTypeIsNotLocallyProvable(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			name: "struct field from another package",
+			src: `package m
+func f(h *tar.Header) []byte { return make([]byte, int32(h.Size)) }`,
+		},
+		{
+			name: "named type with an integer underlying type",
+			src: `package m
+func f(d time.Duration) []byte { return make([]byte, int32(d)) }`,
+		},
+		{
+			name: "multi-value call result",
+			src: `package m
+func f(r io.Reader, p []byte) []byte {
+	n, _ := r.Read(p)
+	return make([]byte, int32(n))
+}`,
+		},
+		{
+			name: "package-level variable",
+			src: `package m
+var limit int64
+func f() []byte { return make([]byte, int32(limit)) }`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if n := count(t, c.src); n != 0 {
+				t.Errorf("got %d findings, want 0 (documented false negative)", n)
+			}
+		})
+	}
+}
+
+// len() returns int, so int32(len(x)) IS a narrowing the analyzer can prove —
+// but only reports it where it sizes memory, never where it fills a count
+// field. Both halves are asserted together so a change to either is caught.
+func TestLenIsProvableButOnlyReportedAtASizeSink(t *testing.T) {
+	sink := `package m
+func f(s string) []byte { return make([]byte, int16(len(s))) }`
+	if got := count(t, sink); got != 1 {
+		t.Errorf("size sink: got %d findings, want 1", got)
+	}
+	notSink := `package m
+func f(s string) *pb.R { return &pb.R{Count: int32(len(s))} }`
+	if got := count(t, notSink); got != 0 {
+		t.Errorf("count field: got %d findings, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File-level filters
+// ---------------------------------------------------------------------------
+
+func TestSkipsTestAndGeneratedAndNonGoFiles(t *testing.T) {
+	body := `package m
+func f(n int64) []byte { return make([]byte, int32(n)) }`
+
+	if got := len(scanSource(t, "a_test.go", body)); got != 0 {
+		t.Errorf("test file: got %d findings, want 0", got)
+	}
+	if got := len(scanSource(t, "a.py", body)); got != 0 {
+		t.Errorf("non-Go file: got %d findings, want 0", got)
+	}
+	gen := "// Code generated by protoc-gen-go. DO NOT EDIT.\n" + body
+	if got := len(scanSource(t, "a.pb.go", gen)); got != 0 {
+		t.Errorf("generated file: got %d findings, want 0", got)
+	}
+	// Control: the same body in an ordinary file must fire, so the three
+	// assertions above are testing the filters and not a broken detector.
+	if got := len(scanSource(t, "a.go", body)); got != 1 {
+		t.Fatalf("control: got %d findings, want 1", got)
+	}
+}
+
+// A file that does not parse must degrade to whatever the recovered AST
+// supports, never panic and never fail the scan.
+func TestUnparseableFileDegradesQuietly(t *testing.T) {
+	if got := count(t, "package m\nfunc f( { this is not go"); got != 0 {
+		t.Errorf("got %d findings, want 0", got)
+	}
+}
+
+// Non-Go artifacts must not even be read, and the analyzer must honour
+// cancellation like every other one.
+func TestRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(p, []byte("package m\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&Analyzer{}).ScanArtifacts(ctx,
+		[]discovery.Artifact{{Path: "a.go", AbsPath: p}}); err == nil {
+		t.Error("want a context error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule catalogue
+// ---------------------------------------------------------------------------
+
+func TestRuleIsCataloguedAtMediumSeverity(t *testing.T) {
+	rs := (&Analyzer{}).Rules().Rules()
+	if len(rs) != 1 {
+		t.Fatalf("got %d rules, want 1", len(rs))
+	}
+	r := rs[0]
+	if r.ID != ruleID {
+		t.Errorf("ID = %q, want %q", r.ID, ruleID)
+	}
+	// Medium is a deliberate choice, not an oversight: the fleet gate fails on
+	// net-new critical/high, and no true positive for this shape has been
+	// observed in the wild yet. Promoting it is a decision with evidence
+	// attached, so pin it here.
+	if r.Severity != findings.SeverityMedium {
+		t.Errorf("severity = %q, want medium", r.Severity)
+	}
+	if r.Metadata["cwe"] != "CWE-190" {
+		t.Errorf("cwe = %q, want CWE-190", r.Metadata["cwe"])
+	}
+	if r.Remediation == "" || r.Description == "" {
+		t.Error("rule must carry a description and remediation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit-level checks on the lattice, which the rest of the analyzer rests on
+// ---------------------------------------------------------------------------
+
+func TestLossyLattice(t *testing.T) {
+	k := func(n string) intKind { return intTypes[n] }
+	cases := []struct {
+		from, to string
+		want     bool
+	}{
+		{"int64", "int32", true},
+		{"int", "int32", true},
+		{"int64", "uint64", true},  // negative becomes enormous
+		{"int32", "uint64", true},  // ditto, even though it widens
+		{"uint64", "int64", true},  // top half becomes negative
+		{"uint32", "int32", true},  // ditto
+		{"uint8", "int16", false},  // exact
+		{"uint32", "int64", false}, // exact
+		{"int32", "int64", false},
+		{"byte", "int", false},
+		{"int32", "int32", false},
+		{"int32", "rune", false}, // rune IS int32
+		{"uint64", "uint8", true},
+	}
+	for _, c := range cases {
+		if _, got := lossy(k(c.from), k(c.to)); got != c.want {
+			t.Errorf("lossy(%s, %s) = %v, want %v", c.from, c.to, got, c.want)
+		}
+	}
+}
+
+func TestParseUintLit(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want uint64
+		ok   bool
+	}{
+		{"255", 255, true},
+		{"0xFF", 255, true},
+		{"0o777", 511, true},
+		{"0777", 511, true},
+		{"0b1010", 10, true},
+		{"1_000", 1000, true},
+		{"0x", 0, false},
+		{"0b2", 0, false},
+	} {
+		got, ok := parseUintLit(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("parseUintLit(%q) = %d,%v; want %d,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestFitsIn(t *testing.T) {
+	for _, c := range []struct {
+		max  uint64
+		kind string
+		want bool
+	}{
+		{255, "uint8", true},
+		{256, "uint8", false},
+		{127, "int8", true},
+		{128, "int8", false},
+		{65535, "uint16", true},
+		{65536, "uint16", false},
+	} {
+		if got := fitsIn(c.max, intTypes[c.kind]); got != c.want {
+			t.Errorf("fitsIn(%d, %s) = %v, want %v", c.max, c.kind, got, c.want)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/fileperms"
 	"github.com/nox-hq/nox/core/analyzers/hardening"
 	"github.com/nox-hq/nox/core/analyzers/iac"
+	"github.com/nox-hq/nox/core/analyzers/memsafe"
 	"github.com/nox-hq/nox/core/analyzers/provenance"
 	"github.com/nox-hq/nox/core/analyzers/secrets"
 	"github.com/nox-hq/nox/core/analyzers/slop"
@@ -272,6 +273,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
 	filepermsAnalyzer := fileperms.NewAnalyzer()
 	hardeningAnalyzer := hardening.NewAnalyzer()
+	memsafeAnalyzer := memsafe.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
 	// A signature database that fails to parse leaves every VARIANT-* rule
 	// unable to match. The scan would otherwise report zero variant findings
@@ -378,6 +380,14 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			return nil
 		},
 		func(c context.Context) error {
+			fs, err := memsafeAnalyzer.ScanArtifacts(c, artifacts)
+			if err != nil {
+				return err
+			}
+			addFindings(fs)
+			return nil
+		},
+		func(c context.Context) error {
 			fs, err := slopAnalyzer.ScanArtifacts(c, artifacts)
 			if err != nil {
 				return err
@@ -471,6 +481,9 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		allRules.Add(r)
 	}
 	for _, r := range hardeningAnalyzer.Rules().Rules() {
+		allRules.Add(r)
+	}
+	for _, r := range memsafeAnalyzer.Rules().Rules() {
 		allRules.Add(r)
 	}
 	for _, r := range slopAnalyzer.Rules().Rules() {

--- a/docs/design/go-integer-overflow.md
+++ b/docs/design/go-integer-overflow.md
@@ -1,0 +1,218 @@
+# Integer overflow in Go — why `MEMSAFE-001` is not gosec's `G115`
+
+Status: implemented. Companion to [`go-taint.md`](./go-taint.md), which explains
+why nox parses Go with `go/ast`. This document explains what that choice costs
+for a rule that wants types, and why the rule that shipped is deliberately a
+different — and much narrower — rule than the one it replaces.
+
+## The gap
+
+gosec was removed from the fleet's shared golangci config. `G115` (integer
+overflow in a type conversion) was its largest uncovered class by a wide
+margin. The obvious task was to reimplement it.
+
+Measuring gosec first made that the wrong task.
+
+## `go/types` is not available to nox, and the reason is structural
+
+nox parses Go with `go/parser` + `go/ast` + `go/token`. It has never used
+`go/types`. That is not an oversight, and it is not cheap to change.
+
+`G115` as gosec defines it needs full type resolution: to know that
+`int32(l.StartLine)` narrows, you must resolve `l`'s type, find `StartLine` on
+it, and learn that the field is an `int`. `go/ast` gives you the identifier and
+nothing else.
+
+Resolving that needs `go/types` with a working `Importer`, and every available
+importer has the same prerequisite — a resolvable module graph:
+
+| Importer | Needs |
+|---|---|
+| `importer.Default()` | compiled export data in `GOROOT`/build cache |
+| `importer.ForCompiler(fset, "source", nil)` | every dependency's **source**, on disk |
+| `golang.org/x/tools/go/packages` | shells out to `go list`; a Go toolchain **and** a resolvable module graph |
+
+Measured directly — a `types.Config{Importer: importer.Default()}` run over a
+six-line file that imports a module not present in the cache fails outright:
+
+```
+typecheck err: could not import github.com/some/external/pkg
+  (cannot find package … in any of: $GOROOT/src, $GOPATH/src)
+Check returned err: could not import …
+```
+
+Stdlib-only files type-check fine. Anything else does not.
+
+This collides with three properties nox is built on:
+
+1. **Offline by construction.** `nox scan --offline` guarantees zero network.
+   Type-checking a repo whose module cache is cold requires `go mod download`.
+2. **No toolchain assumption.** nox ships as a single static CGo-free binary and
+   scans checked-out trees — in CI containers, in pre-commit hooks, in images
+   with no Go installed. `go list` is not available there.
+3. **Determinism.** A scan is a pure function of the bytes on disk. Type
+   checking makes the result depend on what happens to be in the module cache,
+   so the same commit can scan differently on two machines.
+
+gosec does not have this problem because gosec runs **inside the project's own
+build**, where the module graph is already resolved. nox is not in that
+position and adopting it would be a change of product category, not a feature.
+
+**Cost of closing the gap properly**: a `go/types` mode would need a new
+dependency (`x/tools`), a network/toolchain precondition, per-package caching,
+and a documented degradation path for every repo that cannot be type-checked —
+for a rule class whose measured value is described below. It was not worth it.
+
+### What that costs in recall, measured
+
+Of gosec's 11 `G115` findings on nox's own source, 7 (64%) name a type that
+only `go/types` could resolve — struct fields from another package
+(`findings.Location.StartLine`), and named types with integer underlying types
+(`findings.FingerprintVersion`, `os.FileMode`). Those are permanent false
+negatives for an AST-only analyzer, and the package doc says so.
+
+## Why reimplementing `G115` would have been actively harmful
+
+Before writing anything, gosec was run across sixteen fleet Go repositories plus
+nox itself.
+
+| Rule | Findings | True positives |
+|---|---|---|
+| `G115` integer overflow | 96 | **0** |
+| `G103` use of `unsafe` | 20 | **0** |
+| `G602` slice out of bounds | 13 | **0** |
+
+Every one of the 96 `G115` findings is correct code:
+
+- `int32(len(out))`, `int32(total)`, `int32(limit)` — filling protobuf count
+  fields. 70 of the 96.
+- `uint64(t.Unix())` — an HOTP counter, positive until the year 292 billion.
+- `byte(addr>>24)`, `byte(addr>>16)`, `byte(addr)` — IPv4 octet extraction,
+  where truncation is the entire point.
+- `byte(nano%10)` — digit formatting behind a modulo that provably fits.
+- `os.FileMode(hdr.Mode)&0o777|0o755` — masked to nine bits on the same line.
+
+That is the shape of a rule people suppress rather than fix, and they already
+have: 63 `#nosec G115` suppressions exist across that fleet.
+
+All 20 `G103` findings sit in generated `*.pb.go` files, from protoc-gen-go's
+own `unsafe.Slice(unsafe.StringData(...))` idiom. There is no hand-written
+`unsafe` in the fleet at all. All 13 `G602` findings are three lines in one file
+reported four times each, plus one already carrying a `//nolint` with a comment
+explaining the guard.
+
+## The rule that shipped
+
+`MEMSAFE-001` reports the shape where truncation is a memory-safety bug rather
+than a style question: **a value that is narrowed, or flipped signed→unsigned,
+and then used to size an allocation or bound a slice.**
+
+Everything is function-local. Source types come from parameters, results, `var`
+declarations, explicit conversions, and a small table of stdlib functions with
+fixed integer return types. A conversion whose operand type cannot be
+established locally is not reported.
+
+### Sinks
+
+- `make(T, n)` / `make(T, n, m)` — allocation length and capacity.
+- `s[lo:hi]`, `s[lo:hi:max]` — slice bounds.
+
+A bare **index** `s[i]` is deliberately not a sink. Syntactically it is
+indistinguishable from a map lookup, where an index is not a bounds context at
+all — telling them apart needs `go/types`. And Go bounds-checks every slice
+index, so a wrapped index panics rather than reading out of bounds; the harm is
+capped at the denial of service the slice-bound case already covers. Measured
+on the Go standard library, treating indexes as sinks produced 46 findings,
+every one correct code: AES S-box lookups, Latin-1 property tables, and a
+`map[uint64]string` in the linker.
+
+`copy` and `append` are not sinks either: they are bounded by the slices they
+operate on.
+
+### Suppressions
+
+Each one removes a class that was observed firing on correct code:
+
+| Suppression | Removes |
+|---|---|
+| mask fitting the destination (`x & 0xFF`) | byte extraction |
+| modulo, any divisor | table confinement (`h % buckHashSize`) |
+| logical shift on an unsigned value (`x >> 24`) | AES S-box, binary-search midpoints |
+| comparison guard, seen through a conversion (`if uint32(r) <= MaxLatin1`) | the stdlib's own range-check idiom |
+| `len`/`cap`-derived, destination ≥ 32 bits | `uint32(2*len(buf))` |
+| constant expressions | `int32(4*1024)` |
+
+`len`-derived values narrowed to **16 bits or fewer** are still reported: a
+slice longer than 65535 is entirely ordinary.
+
+## Measured behaviour
+
+| Corpus | Go files | gosec `G115` | `MEMSAFE-001` |
+|---|---|---|---|
+| nox itself | 638 | 11 (0 real) | **0** |
+| 16 fleet repos + warden | 2,803 | 85 (0 real) | **0** |
+| Go standard library | 6,822 | not run | **0** |
+| Go module cache (third-party) | 116,032 | — | **18** |
+
+On `segmentio/kafka-go` specifically, where a real bug lives: gosec reports
+**156** `G115` findings, two of which are the bug. `MEMSAFE-001` reports
+**one**, and it is the bug.
+
+Of the 18 module-cache findings (≈15 distinct sites, several repeated across
+module versions), auditing every one:
+
+**Genuine, remotely triggerable (3):**
+
+- `IBM/sarama` `broker.go:1593` —
+  `make([]byte, int32(binary.BigEndian.Uint32(header)))`. A four-byte length
+  from the network, sign-flipped; a peer sending ≥ 2³¹ makes `make` panic.
+- `segmentio/kafka-go` `saslauthenticate.go:44` — the identical shape.
+- `rabbitmq/amqp091-go` `write.go:246` — `uint8(len(b))` declared as the frame
+  length, then `w.Write(b[:length])`. A string longer than 255 bytes is
+  silently mis-framed.
+
+**Defensive / weak (3 sites):** `hashicorp/go-msgpack` and `ugorji/go/codec`
+convert an `io.Reader.Read` result to `uint` before a slice bound — safe by the
+`io.Reader` contract, unsafe against a misbehaving implementation.
+
+**False positives (9 findings across ~7 sites):** `gonum/mat/pool.go`
+(`uint(r*c)` on documented-precondition dimensions), `ristretto` and
+`bytedance/sonic` (`uintptr` alignment and code-size arithmetic that is provably
+small), `k8s.io/apimachinery` (a marshal-path size the code checks immediately
+after).
+
+So: roughly one finding per 6,400 files of third-party Go, about 40% precision
+by distinct site, and it finds real remote-DoS bugs in widely deployed
+networking libraries. That is a rule worth keeping. A 1.3%-precision rule is
+not.
+
+## Severity, and whether it gates
+
+**Medium / Medium confidence — it does NOT gate the fleet**, whose CI fails only
+on net-new critical/high.
+
+That is deliberate. The rule produced zero findings across nox and every fleet
+repository, so nothing about the gate changes today either way. Promoting it to
+high would make a rule with no observed true positive *in this fleet* able to
+turn builds red, on the strength of third-party evidence and synthetic fixtures
+alone. Medium reports it, people can see it, and the severity can be raised once
+there is field evidence from these repositories rather than from the module
+cache.
+
+## The other three gosec rules
+
+- **`G103` (`unsafe`)** — not implemented. All 20 fleet findings are in
+  generated protobuf code, which this analyzer skips on principle. There is no
+  hand-written `unsafe` in the fleet to find. Worth revisiting only if that
+  changes; a bare "you used `unsafe`" report is an inventory, not a finding.
+- **`G602` (slice bounds)** — not implemented as a separate rule. The valuable
+  half of it is exactly what `MEMSAFE-001`'s slice-bound sink already covers,
+  with the overflow requirement making it precise. gosec's own 13 findings were
+  three lines reported four times each.
+- **`G104` (unhandled errors)** — **should be left to `errcheck`**, which is
+  still enabled in the fleet's golangci config and covers this class properly,
+  with per-package configuration people have already tuned. Reimplementing it in
+  nox would mean two tools reporting the same thing under two rule IDs — the
+  precise duplication that retired `nox-plugin-sast` (see the `weakcrypto`
+  package comment) and the ten IaC rule IDs in 1.23.0. Recommended: do not
+  implement.


### PR DESCRIPTION
Closes part of #405.

## TL;DR

I did not implement G115. I measured it first, found it has **zero true positives across 96 findings** on this fleet, and shipped a much narrower rule instead. G103, G602 and G104 are **not** implemented, with reasons.

## `go/ast` vs `go/types` — the finding you asked for

**nox uses `go/ast` only.** The Go taint extractor (`core/taint/engine/extract_go.go`) parses with `go/parser` + `go/ast` + `go/token` and `parser.SkipObjectResolution`. `docs/design/go-taint.md` already documents the "AST-only (no `go/types`)" scope. `golang.org/x/tools` is not in `go.mod`.

**`go/types` cannot be adopted here, and the reason is structural, not effort.** Every Go importer needs a resolvable module graph:

| Importer | Needs |
|---|---|
| `importer.Default()` | compiled export data in `GOROOT` / build cache |
| `importer.ForCompiler(…, "source", …)` | every dependency's source, on disk |
| `x/tools/go/packages` | shells out to `go list` — a toolchain **and** a resolvable module graph |

I probed this directly. Type-checking a six-line file importing a module absent from the cache:

```
typecheck err: could not import github.com/some/external/pkg
  (cannot find package … in any of: $GOROOT/src, $GOPATH/src)
```

Stdlib-only files check fine; anything else does not. That collides with three things nox is built on: `--offline` guarantees zero network (type checking needs `go mod download`); nox ships as a static CGo-free binary into containers with no Go toolchain; and a scan is meant to be a pure function of the bytes on disk, not of whatever is in the module cache.

gosec does not have this problem because it runs *inside the project's build*. nox does not.

**Cost of the false negatives**: 7 of gosec's 11 G115 findings on nox's own source (64%) name a type only `go/types` could resolve — cross-package struct fields (`findings.Location.StartLine`) and named types (`findings.FingerprintVersion`, `os.FileMode`). Permanent FNs, documented in the package doc. All 7 were false positives anyway.

## Why G115 itself is not worth porting

Ran gosec across 16 fleet Go repos + nox itself before writing a line:

| Rule | Findings | True positives |
|---|---|---|
| G115 | 96 | **0** |
| G103 | 20 | **0** |
| G602 | 13 | **0** |

All 96 G115 are correct code. 70 of them are `int32(len(out))` / `int32(total)` / `int32(limit)` filling protobuf count fields. The rest: `uint64(t.Unix())` in an HOTP counter; `byte(addr>>24)`/`byte(addr)` extracting IPv4 octets, where truncation *is* the intent; `byte(nano%10)` behind a provably-fitting modulo; `os.FileMode(hdr.Mode)&0o777|0o755`, masked to nine bits on the same line. That is what earns 63 blanket `#nosec G115` suppressions.

## What shipped: `MEMSAFE-001`

**Fires on**: a value narrowed (or flipped signed→unsigned) whose *operand type is provable from the enclosing function*, reaching a memory-sizing sink — `make(T, n)` / `make(T, n, m)`, or a slice bound `s[lo:hi]` / `s[lo:hi:max]` — directly or through one local assignment.

**Deliberately does not fire on**:

- **Bare index `s[i]`.** Indistinguishable from a map lookup without types, and Go bounds-checks slice indexes so a wrapped one panics rather than reading OOB. Treating indexes as sinks produced **46 findings on the Go stdlib, all correct code** (AES S-boxes, Latin-1 tables, a `map[uint64]string` in the linker).
- Masks fitting the destination, modulo (any divisor), **logical shifts on unsigned values**, comparison guards seen **through a conversion** (`if uint32(r) <= MaxLatin1` — the stdlib's own idiom), `len`/`cap`-derived values at ≥32-bit destinations, constant expressions.
- `copy` / `append` — bounded by their slices.
- Test files and generated code.
- **Anything whose operand type isn't locally provable.** Silence beats a guess.

`len`-derived values narrowed to **≤16 bits** still fire — a slice longer than 65535 is ordinary.

## Measured behaviour

| Corpus | Go files | gosec G115 | MEMSAFE-001 |
|---|---|---|---|
| **nox itself** | 638 | 11 (0 real) | **0** |
| 16 fleet repos + warden | 2,803 | 85 (0 real) | **0** |
| Go standard library | 6,822 | — | **0** |
| Go module cache | 116,032 | — | **18** |

**On nox's own repository: 0 findings.** No self-suppressions needed.

On `segmentio/kafka-go`, where a real bug lives: **gosec reports 156 G115, two of which are the bug. This rule reports 1, and it is the bug.**

I audited all 18 module-cache findings (~15 distinct sites; several repeat across module versions):

**Genuine, remotely triggerable (3):**
- `IBM/sarama` `broker.go:1593` — `make([]byte, int32(binary.BigEndian.Uint32(header)))`. Four-byte network length, sign-flipped; a peer sending ≥2³¹ panics the allocation.
- `segmentio/kafka-go` `saslauthenticate.go:44` — identical shape.
- `rabbitmq/amqp091-go` `write.go:246` — `uint8(len(b))` declared as the frame length, then `w.Write(b[:length])`. Strings >255 bytes are silently mis-framed.

**Defensive/weak (3 sites):** msgpack + ugorji convert an `io.Reader.Read` result to `uint` before a slice bound — safe by contract, unsafe against a misbehaving reader.

**False positives (9 findings / ~7 sites):** gonum `mat/pool.go` (`uint(r*c)` on documented preconditions), ristretto + sonic (`uintptr` alignment and code-size arithmetic, provably small), k8s apimachinery (a marshal-path size checked immediately after).

So: ~1 finding per 6,400 files of third-party Go, ~40% precision by distinct site, and it catches real remote-DoS bugs. A 1.3%-precision rule is not worth keeping; this is.

**False-negative rate**: high by construction and by choice. It reports 0 of gosec's 96 fleet findings (all FPs, so 0 real FNs there) and skips any conversion whose operand type isn't locally provable — 64% of sites on nox's own source.

## Severity and gating

**Medium / Medium confidence — this does NOT gate the fleet**, which fails only on net-new critical/high. Stated plainly because you asked.

The rule produces zero findings across nox and every fleet repo, so gating changes nothing today either way. Promoting to high would let a rule with no observed true positive *in this fleet* turn builds red on the strength of third-party evidence plus synthetic fixtures. Medium reports it visibly; raise it once there's field evidence from these repos.

## The other three

- **G103 (`unsafe`)** — not implemented. All 20 fleet findings are in generated `*.pb.go` (protoc-gen-go's `unsafe.Slice(unsafe.StringData(...))`). There is no hand-written `unsafe` in the fleet. A bare "you used unsafe" report is an inventory, not a finding.
- **G602 (slice bounds)** — not implemented separately. Its useful half *is* this rule's slice-bound sink, with the overflow requirement making it precise. gosec's 13 were three lines reported four times each, one already `//nolint`'d with an explanation.
- **G104 (unhandled errors)** — **leave it to `errcheck`**, which is still enabled in the fleet's golangci config, covers the class properly, and has per-package config people have tuned. Duplicating it would reintroduce exactly the double-reporting under two rule IDs that retired `nox-plugin-sast` and the ten IaC IDs in 1.23.0. My clear recommendation: do not implement.

## Verification

- `go test ./...`, `gofmt -l`, `go vet ./...` — all clean.
- **Mutation-tested.** Broke detection six ways and confirmed the suite catches each: `lossy()` always-safe, every call arg a sink, guard suppression removed, inline mask suppression removed, generated/test filters removed, unknown operand types guessed as `int64`. The first pass caught 5 of 6 — the inline-mask mutation **survived**, exposing an untested path, so I added `TestInlineMaskOnANonIdentifierOperandSuppresses` and re-verified all six now fail. Positive-control assertions are paired with negatives throughout so a silent detector cannot pass.
- Negative fixtures include the real fleet shapes verbatim (protobuf count fields, HOTP counter, IPv4 octets, digit formatting, nox's own `int32(startLine)` and `os.FileMode(mode)&0o777`).

https://claude.ai/code/session_01LMVPJFeTCEtUk2CSNBBBdK
