### PR TITLE
fix(crypto): report the one-shot digest call, and cover all 15 SAST languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on, and the absence of a finding is not evidence that a file generates its
   secrets safely.
 
+### Fixed
+
+- **`CRYPTO-001` missed the one-shot digest call, which is the commoner one.**
+  The rule matched the CONSTRUCTOR form and nothing else, so `md5.New()` was
+  reported and `md5.Sum(b)` — in the same file, same package — was not.
+  `sha1` behaved identically. `Sum()` is the more idiomatic of the two calls, so
+  the shape being missed was the one people actually write: a scan of
+  `klarlabs-studio/agent-go` reported 10 findings before and 18 after, every new
+  one a `Sum()` call the rule had been silent about, and none removed.
+
+  The constructor-only pattern existed for a good reason — matching the bare
+  word `md5` would flag a variable named `md5sum` and the word in a comment. The
+  fix keeps that property by matching the package-qualified call
+  (`md5.Sum(`/`md5.New(`) rather than the algorithm name, so an identifier and
+  prose still do not match. Both call shapes are now asserted together in one
+  test so they cannot drift apart again. (#402)
+
+### Changed
+
+- **`CRYPTO-001` now covers all 15 languages core's SAST supports, up from 5.**
+  The rule was Go, Python, JavaScript, TypeScript and Java only; C, C++, C#,
+  Kotlin, Objective-C, PHP, Ruby, Rust, Shell and Swift were silent, as were the
+  JS/TS variant extensions (`.jsx`, `.mjs`, `.cjs`, `.tsx`, `.mts`, `.cts`).
+  Coverage now also includes 3DES and ECB mode alongside MD5, SHA-1, DES and
+  RC4, and — as in Go — both the streaming and one-shot call shapes wherever a
+  language offers both (`MD5_Init` *and* `MD5()`; `MD5.Create()` *and*
+  `MD5.HashData()`).
+
+  **Two languages are deliberately narrower than they could be.** PHP does not
+  match bare `md5()`/`sha1()`: they are global functions, among the most-called
+  in the language, and overwhelmingly used for cache keys, ETags and Gravatar
+  hashes (which the Gravatar protocol *requires* to be MD5). Flagging them would
+  put a finding in nearly every PHP file in existence, and a rule like that gets
+  globally disabled — taking the genuinely broken `mcrypt_*` and
+  `openssl_encrypt(…, 'des-ecb', …)` detections down with it. Shell does not
+  match `md5sum`/`sha1sum`/`shasum`, which verify downloads against accidental
+  corruption rather than an attacker; only `openssl enc` with a broken cipher is
+  matched there.
+
+  Patterns stay bound per extension. `Digest::MD5` is a Ruby constant path,
+  `md5::compute` is a Rust path and `MD5(` is an OpenSSL C function; a test
+  feeds every language's positive corpus through every other language's
+  extension and requires zero matches, so one language's vocabulary cannot
+  manufacture findings in another's files. Two known-noisy shapes are excluded
+  by name: `Cipher.getInstance("RSA/ECB/OAEP…")`, where JCA's "ECB" is a
+  historical misnomer for correct RSA padding, and `printf("MD5 (%s)…")`, which
+  is OpenSSL's own output format rather than a call.
+
+  The rule reports **zero findings on nox's own repository**, before and after.
+  (#405)
+
 ## [1.23.0] - 2026-07-26
 
 ### Changed

--- a/core/analyzers/weakcrypto/crypto.go
+++ b/core/analyzers/weakcrypto/crypto.go
@@ -21,6 +21,22 @@
 // pretending every occurrence is a vulnerability. Over-flagging a ubiquitous
 // stdlib call is how a rule gets globally suppressed, which costs more than the
 // rule is worth.
+//
+// TWO CALL SHAPES, NOT ONE. Every language here exposes a digest both as a
+// streaming constructor (md5.New(), MD5_Init(), MD5.Create()) and as a one-shot
+// convenience call (md5.Sum(b), MD5(b, n, out), MD5.HashData(b)). The one-shot
+// form is usually the *more* idiomatic of the two, so a pattern that knows only
+// the constructor misses the commoner usage. The patterns below cover both
+// shapes wherever a language offers both.
+//
+// LANGUAGE ISOLATION. Patterns are keyed by extension and are never shared
+// across languages that do not share syntax. This matters: `Digest::MD5` is a
+// Ruby constant path, `md5::compute` is a Rust path, and `MD5(` is an OpenSSL C
+// function — applying any one of them to the other two languages would
+// manufacture matches out of unrelated syntax. The `languages` table below is
+// the single source of truth binding a pattern, its extensions, and its comment
+// markers together, so an extension cannot silently acquire another language's
+// pattern.
 package weakcrypto
 
 import (
@@ -44,26 +60,305 @@ func NewAnalyzer() *Analyzer { return &Analyzer{} }
 // ruleID is the single rule this analyzer emits.
 const ruleID = "CRYPTO-001"
 
-// weakByExt matches construction of a broken primitive, per language.
-//
-// Each pattern targets the CONSTRUCTOR rather than the bare algorithm name, so
-// a comment, a variable called `md5sum`, or a string in documentation does not
-// match. That precision is the difference between a rule people keep and one
-// they suppress.
-var weakByExt = map[string]*regexp.Regexp{
-	// crypto/md5, crypto/sha1, crypto/des, golang.org/x/crypto/rc4
-	".go": regexp.MustCompile(`\b(md5|sha1|des|rc4)\.New(?:Cipher)?\(`),
-	// hashlib.md5(...) / hashlib.sha1(...); also the Crypto.Cipher DES/ARC4 forms
-	".py": regexp.MustCompile(`\bhashlib\.(md5|sha1)\(|\b(DES|ARC4)\.new\(`),
-	// node: crypto.createHash('md5'), createCipheriv('des-...'/'rc4')
-	".js": regexp.MustCompile(`createHash\(\s*['"](md5|sha1)['"]|createCipheriv\(\s*['"](des|rc4)`),
-	".ts": regexp.MustCompile(`createHash\(\s*['"](md5|sha1)['"]|createCipheriv\(\s*['"](des|rc4)`),
-	// MessageDigest.getInstance("MD5"), Cipher.getInstance("DES/...")
-	".java": regexp.MustCompile(`(?:MessageDigest|Cipher)\.getInstance\(\s*"(MD5|SHA-?1|DES|RC4)`),
+// language binds one language's detection pattern to the file extensions it may
+// be applied to and the line-comment markers used to suppress commented-out
+// code. Keeping the three together is deliberate: a pattern written for one
+// language's syntax must never become reachable from another language's files.
+type language struct {
+	// name is the canonical language name, matching core's SAST language set.
+	name string
+	// exts are the lowercased file extensions this pattern applies to.
+	exts []string
+	// pattern matches construction *or* one-shot invocation of a primitive that
+	// is broken for security purposes.
+	pattern *regexp.Regexp
+	// comments are the line-comment markers for the language. A match sitting
+	// to the right of one is ignored.
+	comments []string
 }
 
-// algoNames extracts a human-readable algorithm from a match, for the message.
-var algoNames = regexp.MustCompile(`(?i)\b(md5|sha-?1|des|rc4|arc4)\b`)
+// jsPattern is shared by JavaScript and TypeScript, which reach the same
+// node:crypto and CryptoJS APIs with identical syntax.
+var jsPattern = regexp.MustCompile(
+	`\bcreateHash\s*\(\s*['"](?i:md5|sha-?1)['"]` +
+		`|\bcreate(?:De)?[Cc]ipheriv\s*\(\s*['"](?i:des|rc4|rc2|[a-z0-9-]*-ecb)` +
+		`|\bCryptoJS\.(?:MD5|SHA1|DES|TripleDES|RC4)\b`)
+
+// jvmPattern is shared by Java and Kotlin, which call the same JCA factories.
+// JCA is entirely string-named, so the algorithm is a literal argument to
+// getInstance; ECB is named inside the transformation string
+// ("AES/ECB/PKCS5Padding"), which is why it needs its own alternative.
+//
+// The ECB alternative is restricted to symmetric ciphers by name. JCA calls RSA
+// padding modes "ECB" as a historical misnomer, so the extremely common and
+// entirely correct `Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding")`
+// must not match — a rule that flags correct OAEP would be turned off within a
+// day.
+var jvmPattern = regexp.MustCompile(
+	// "DES" is left to prefix-match "DESede" rather than being listed
+	// separately: the matched text is what the reported algorithm name is
+	// scraped from, and lengthening the match would rename an existing finding,
+	// which changes its fingerprint and silently invalidates baselines.
+	`\b(?:MessageDigest|Cipher|Signature)\.getInstance\s*\(\s*"(?i:MD5|SHA-?1|DES|RC4|RC2|ARCFOUR)` +
+		`|\bCipher\.getInstance\s*\(\s*"(?i:AES|DES|3DES|Blowfish|RC2|RC4)[^"]*/ECB/`)
+
+// cPattern is shared by C, C++ and Objective-C, which reach the same OpenSSL
+// and CommonCrypto entry points. It covers both call shapes: the streaming
+// _Init/_Update/_Final trio and the one-shot MD5(d, n, out) form.
+//
+// The bare one-shot form is bounded twice over. The parenthesis must touch the
+// name — `MD5 (` with a space is far more likely to be prose in a string
+// literal, since OpenSSL's own dgst output is `MD5 (file) = …` and a printf of
+// that format string is not a finding. And the name must not be preceded by a
+// dot, so a member call such as `obj.MD5(x)` (or another language's
+// `CryptoJS.MD5(x)`, should such a line ever reach a C file) stays out.
+var cPattern = regexp.MustCompile(
+	`\b(?:MD5|SHA1|MD4)_(?:Init|Update|Final)\s*\(` +
+		`|(?:^|[^A-Za-z0-9_.])(?:MD5|SHA1|MD4)\(` +
+		`|\bCC_(?:MD5|SHA1)(?:_Init|_Update|_Final)?\s*\(` +
+		`|\bEVP_(?:md5|md4|sha1)\s*\(` +
+		`|\bEVP_(?:des|rc4|rc2)[a-z0-9_]*\s*\(` +
+		`|\bEVP_[a-z0-9_]*_ecb\s*\(` +
+		`|\bDES_(?:set_key[a-z_]*|key_sched|ecb[0-9]?_encrypt|ncbc_encrypt|cbc_encrypt|ede3_cbc_encrypt)\s*\(` +
+		`|\bRC4_set_key\s*\(|(?:^|[^A-Za-z0-9_.])RC4\(` +
+		`|\bkCCAlgorithm(?:DES|3DES|RC4|RC2)\b` +
+		`|\bkCCOptionECBMode\b`)
+
+// languages holds one entry per language core's SAST supports, or none at all
+// where the deliberate decision was to stay silent (see the shell entry).
+//
+// Each pattern targets a CALL or a package-qualified symbol rather than the
+// bare algorithm name, so a comment, a variable called `md5sum`, or a string in
+// documentation does not match. That precision is the difference between a rule
+// people keep and one they suppress.
+var languages = []language{
+	{
+		name: "go",
+		exts: []string{".go"},
+		// crypto/md5 and crypto/sha1 expose both New() (streaming) and Sum()
+		// (one-shot); crypto/des and golang.org/x/crypto/rc4 expose cipher
+		// constructors. Go's stdlib has no ECB mode, so there is nothing to
+		// match for it here.
+		pattern: regexp.MustCompile(
+			`\b(?:md5|sha1)\.(?:New|Sum)\s*\(` +
+				`|\b(?:des|rc4)\.New(?:Cipher|TripleDESCipher)\s*\(`),
+		comments: []string{"//"},
+	},
+	{
+		name: "python",
+		exts: []string{".py"},
+		// hashlib's direct constructors and its string-named new() form;
+		// PyCryptodome's DES/DES3/ARC4 ciphers; and the `cryptography`
+		// package's explicit ECB mode and legacy algorithm classes.
+		pattern: regexp.MustCompile(
+			`\bhashlib\.(?:md5|sha1)\s*\(` +
+				`|\bhashlib\.new\s*\(\s*['"](?i:md5|sha-?1)['"]` +
+				`|\b(?:DES|DES3|ARC2|ARC4)\.new\s*\(` +
+				`|\bmodes\.ECB\s*\(` +
+				`|\balgorithms\.(?:TripleDES|ARC4)\s*\(`),
+		comments: []string{"#"},
+	},
+	{
+		name: "javascript",
+		exts: []string{".js", ".jsx", ".mjs", ".cjs"},
+		// A URL inside a string ("http://…") is indexed as a comment start by
+		// the marker scan below. That can only ever suppress a match, never
+		// create one, so it is an accepted false negative rather than noise.
+		pattern:  jsPattern,
+		comments: []string{"//"},
+	},
+	{
+		name:     "typescript",
+		exts:     []string{".ts", ".tsx", ".mts", ".cts"},
+		pattern:  jsPattern,
+		comments: []string{"//"},
+	},
+	{
+		name:     "java",
+		exts:     []string{".java"},
+		pattern:  jvmPattern,
+		comments: []string{"//"},
+	},
+	{
+		name: "kotlin",
+		exts: []string{".kt"},
+		// Kotlin calls the same JCA API with the same string literals.
+		pattern:  jvmPattern,
+		comments: []string{"//"},
+	},
+	{
+		name: "php",
+		exts: []string{".php"},
+		// DELIBERATELY EXCLUDES BARE md5() AND sha1(). They are global
+		// functions, they are among the most-called functions in the language,
+		// and the overwhelming majority of calls are cache keys, ETags,
+		// Gravatar hashes (which the Gravatar protocol *requires* to be MD5),
+		// asset fingerprints and array keys. Flagging them would put findings
+		// in essentially every PHP file in existence — precisely the
+		// "ubiquitous stdlib call" the scope note above forbids. The rule would
+		// be globally disabled, and the genuinely broken cipher usage below
+		// would be disabled with it. What is kept is the subset that is
+		// unambiguously security-bearing: the encryption and digest APIs, where
+		// there is no benign "checksum" reading of DES, RC4 or ECB.
+		pattern: regexp.MustCompile(
+			`\bmcrypt_[a-z_]+\s*\(` +
+				`|\bMCRYPT_(?:DES|3DES|TRIPLEDES|RC4|RC2|ARCFOUR)\b` +
+				`|\bopenssl_(?:encrypt|decrypt)\s*\([^,]*,\s*['"](?i:des|rc4|rc2|[a-z0-9-]*-ecb)` +
+				`|\bopenssl_digest\s*\([^,]*,\s*['"](?i:md5|sha-?1)['"]`),
+		comments: []string{"//", "#"},
+	},
+	{
+		name: "ruby",
+		exts: []string{".rb"},
+		// Digest::MD5 is a constant path, not a bare word, so it cannot be
+		// confused with a local variable named md5. OpenSSL::Cipher takes its
+		// cipher either as a constant or as an OpenSSL cipher string.
+		pattern: regexp.MustCompile(
+			`\b(?:OpenSSL::)?Digest::(?:MD5|SHA1)\b` +
+				`|\bOpenSSL::Digest\.new\s*\(\s*['"](?i:md5|sha-?1)['"]` +
+				`|\bOpenSSL::Cipher::(?:DES|RC4|RC2)\b` +
+				`|\bOpenSSL::Cipher(?:::[A-Za-z0-9]+)?\.new\s*\(\s*['"](?i:des|rc4|rc2|[a-z0-9-]*-ecb)` +
+				`|\bOpenSSL::Cipher::[A-Za-z0-9]+\.new\s*\([^)]*:ECB\b`),
+		comments: []string{"#"},
+	},
+	{
+		name: "csharp",
+		exts: []string{".cs"},
+		// System.Security.Cryptography exposes each algorithm as a class with a
+		// static Create()/HashData() factory, plus the legacy
+		// *CryptoServiceProvider / *Managed / *Cng implementation types.
+		pattern: regexp.MustCompile(
+			`\b(?:MD5|SHA1|DES|TripleDES|RC2)\.(?:Create|HashData)\s*\(` +
+				`|\b(?:MD5|SHA1|DES|TripleDES|RC2)(?:CryptoServiceProvider|Managed|Cng)\b` +
+				`|\b(?:HashAlgorithm|CryptoConfig|SymmetricAlgorithm)\.Create\s*\(\s*"(?i:md5|sha-?1|des|tripledes|rc2)` +
+				`|\bCipherMode\.ECB\b`),
+		comments: []string{"//"},
+	},
+	{
+		name: "rust",
+		exts: []string{".rs"},
+		// The `md5` crate's one-shot compute(), the RustCrypto Digest types,
+		// the legacy block ciphers, and the `ecb` mode wrapper. `Md5::new()` is
+		// a path-qualified associated function, so a local named md5 does not
+		// match.
+		pattern: regexp.MustCompile(
+			`\bmd5::compute\s*\(` +
+				`|\b(?:Md5|Sha1|Md4)::(?:new|new_with_prefix|default|digest)\s*\(` +
+				`|\b(?:Des|TdesEde3|TdesEde2|Rc4|Rc2)::new\s*\(` +
+				`|\becb::(?:Encryptor|Decryptor)\b`),
+		comments: []string{"//"},
+	},
+	{
+		name: "c",
+		exts: []string{".c", ".h"},
+		// Headers stay on the C pattern even in Objective-C and C++ projects:
+		// it is the superset (OpenSSL plus CommonCrypto) and the dialects share
+		// the same dangerous API surface.
+		pattern:  cPattern,
+		comments: []string{"//"},
+	},
+	{
+		name:     "cpp",
+		exts:     []string{".cpp", ".cc", ".cxx", ".c++", ".hpp", ".hh", ".hxx", ".ipp", ".inl"},
+		pattern:  cPattern,
+		comments: []string{"//"},
+	},
+	{
+		name: "objc",
+		exts: []string{".m", ".mm"},
+		// `.m` is also MATLAB's extension. That is safe here only because every
+		// alternative in cPattern is an Apple CommonCrypto or OpenSSL
+		// identifier that does not occur in MATLAB — which is exactly why
+		// patterns are bound per extension rather than pooled.
+		pattern:  cPattern,
+		comments: []string{"//"},
+	},
+	{
+		name: "swift",
+		exts: []string{".swift"},
+		// CryptoKit puts the broken digests behind an `Insecure` namespace, so
+		// `Insecure.MD5` is both unambiguous and self-documenting. Bridged
+		// CommonCrypto is still widely used and is matched too.
+		pattern: regexp.MustCompile(
+			`\bInsecure\.(?:MD5|SHA1)\b` +
+				`|\bCC_(?:MD5|SHA1)(?:_Init|_Update|_Final)?\s*\(` +
+				`|\bkCCAlgorithm(?:DES|3DES|RC4|RC2)\b` +
+				`|\bkCCOptionECBMode\b`),
+		comments: []string{"//"},
+	},
+	{
+		name: "shell",
+		exts: []string{".sh"},
+		// DELIBERATELY EXCLUDES md5sum, sha1sum AND shasum. In shell those
+		// commands are almost never a security control: they verify a download
+		// against accidental corruption, fingerprint a build artifact, or key a
+		// cache. Flagging them would bury every Makefile-adjacent script in
+		// findings for a checksum that was never claimed to be
+		// collision-resistant. The security-bearing case in shell is `openssl
+		// enc` (or the legacy `openssl des3`/`openssl rc4` subcommands) with a
+		// broken cipher, which is unambiguous, so that is all this matches.
+		pattern: regexp.MustCompile(
+			`\bopenssl\s+enc\b[^\n]*\s-(?:des|des3|desx|rc4|rc2|[a-z0-9-]*-ecb)\b` +
+				`|\bopenssl\s+(?:des3|des-ede3|rc4)\b`),
+		comments: []string{"#"},
+	},
+}
+
+// weakByExt indexes the language table by extension. It is built once from
+// `languages` so an extension can never be bound to a pattern written for a
+// language it does not belong to.
+var weakByExt = func() map[string]*regexp.Regexp {
+	m := make(map[string]*regexp.Regexp, len(languages)*3)
+	for _, l := range languages {
+		for _, e := range l.exts {
+			m[e] = l.pattern
+		}
+	}
+	return m
+}()
+
+// commentsByExt indexes the line-comment markers by extension, from the same
+// table.
+var commentsByExt = func() map[string][]string {
+	m := make(map[string][]string, len(languages)*3)
+	for _, l := range languages {
+		for _, e := range l.exts {
+			m[e] = l.comments
+		}
+	}
+	return m
+}()
+
+// algoAlternatives lists the algorithm names reported in a finding's message
+// and `algorithm` metadata. Longer names precede their own prefixes so
+// `TripleDES` does not report as `DES`.
+const algoAlternatives = `3des|des3|desede|tdesede[23]|tripledes|des|md5|md4|sha-?1|rc4|rc2|arc4|arcfour|ecb`
+
+// algoSeparated finds an algorithm delimited by non-alphanumerics or by a
+// CamelCase boundary on the right. Plain `\b` is not enough here: `_` is a word
+// character, so `\bmd5\b` never matches `MD5_Init` or `CC_MD5`, and the
+// analyzer used to fall back to the placeholder name for most C findings.
+var algoSeparated = regexp.MustCompile(
+	`(?:^|[^A-Za-z0-9])((?i:` + algoAlternatives + `))(?:[^A-Za-z0-9]|[A-Z]|$)`)
+
+// algoCamel is the fallback for identifiers with no separator at all, where the
+// only boundary is the case transition: `kCCAlgorithmDES`, `kCCOptionECBMode`.
+// It is case-sensitive by design — requiring the algorithm in upper case is
+// what keeps it from reading `des` out of the middle of an ordinary lowercase
+// word such as `modes`.
+var algoCamel = regexp.MustCompile(
+	`[a-z](3DES|DES3|DESede|TripleDES|DES|MD5|MD4|SHA-?1|RC4|RC2|ARC4|ARCFOUR|ECB)(?:[^a-z0-9]|[A-Z]|$)`)
+
+// algorithmIn names the primitive a matched call uses, or "" when the match
+// carries no recognisable algorithm name.
+func algorithmIn(match string) string {
+	for _, re := range []*regexp.Regexp{algoSeparated, algoCamel} {
+		if m := re.FindStringSubmatch(match); m != nil {
+			return strings.ToUpper(m[1])
+		}
+	}
+	return ""
+}
 
 // Rules returns the rule this analyzer can emit, for the rule catalogue.
 func (a *Analyzer) Rules() *rules.RuleSet {
@@ -71,13 +366,13 @@ func (a *Analyzer) Rules() *rules.RuleSet {
 	rs.Add(&rules.Rule{
 		ID:          ruleID,
 		Version:     "1.0",
-		Description: "Broken or deprecated cryptographic primitive (MD5, SHA-1, DES, RC4)",
+		Description: "Broken or deprecated cryptographic primitive (MD5, SHA-1, DES, 3DES, RC4, ECB mode)",
 		Severity:    findings.SeverityMedium,
 		// Low: the call site is unambiguous, but whether it is a VULNERABILITY
 		// depends on what the digest is used for, which this cannot see.
 		Confidence: findings.ConfidenceLow,
 		Tags:       []string{"crypto", "weak-algorithm", "owasp-a02"},
-		Remediation: "This constructs a primitive that is broken for security purposes: MD5 and SHA-1 are not collision-resistant, and DES and RC4 are not safe ciphers. " +
+		Remediation: "This constructs or invokes a primitive that is broken for security purposes: MD5 and SHA-1 are not collision-resistant, DES, 3DES and RC4 are not safe ciphers, and ECB mode leaks plaintext structure. " +
 			"If this value is used for authentication, signatures, password storage, integrity against a motivated attacker, or anything else security-bearing, replace it — SHA-256 or better for digests, AES-GCM or ChaCha20-Poly1305 for encryption, and a dedicated KDF (Argon2id, scrypt, bcrypt) for passwords. " +
 			"If it is used for a non-security purpose such as a cache key, an ETag, content addressing, or a checksum against accidental corruption, MD5 and SHA-1 are acceptable and this finding can be suppressed with a nox:ignore comment recording that reason.",
 		References: []string{
@@ -126,7 +421,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			continue
 		}
 
-		lineComment := lineCommentFor(ext)
+		markers := commentsByExt[ext]
 
 		for i, line := range strings.Split(string(content), "\n") {
 			loc := re.FindStringIndex(line)
@@ -141,12 +436,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			// Line comments only: block comments and string literals are not
 			// tracked, since doing so properly needs a parser per language and
 			// the residual false-positive rate is low enough to accept.
-			if c := strings.Index(line, lineComment); lineComment != "" && c >= 0 && c < loc[0] {
+			if inLineComment(line, markers, loc[0]) {
 				continue
 			}
 			algo := "a broken primitive"
-			if m := algoNames.FindString(line[loc[0]:loc[1]]); m != "" {
-				algo = strings.ToUpper(m)
+			if m := algorithmIn(line[loc[0]:loc[1]]); m != "" {
+				algo = m
 			}
 			fs.Add(findings.Finding{
 				RuleID:   ruleID,
@@ -166,30 +461,59 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	return fs, nil
 }
 
-// lineCommentFor returns the line-comment marker for an extension, or "" when
-// the language is not one this analyzer handles.
-func lineCommentFor(ext string) string {
-	switch ext {
-	case ".go", ".js", ".ts", ".java":
-		return "//"
-	case ".py":
-		return "#"
-	default:
-		return ""
+// inLineComment reports whether a match starting at `at` sits to the right of a
+// line-comment marker. Languages with more than one marker (PHP accepts both
+// `//` and `#`) are checked against all of theirs.
+func inLineComment(line string, markers []string, at int) bool {
+	for _, m := range markers {
+		if m == "" {
+			continue
+		}
+		if c := strings.Index(line, m); c >= 0 && c < at {
+			return true
+		}
 	}
+	return false
 }
+
+// testSuffixes are filename endings that identify test code across the
+// languages this analyzer handles.
+var testSuffixes = []string{
+	"_test.go",
+	".test.js", ".test.jsx", ".test.mjs", ".test.cjs",
+	".test.ts", ".test.tsx",
+	".spec.js", ".spec.jsx", ".spec.ts", ".spec.tsx",
+	"_test.py",
+	"_test.rb", "_spec.rb",
+	"_test.rs",
+	"test.java", "tests.java",
+	"test.kt", "tests.kt",
+	"test.cs", "tests.cs",
+	"test.php", "tests.php",
+	"test.swift", "tests.swift",
+}
+
+// testDirs are path fragments that identify a test tree. Only unambiguous ones:
+// a bare `test/` is a real source directory in plenty of projects, and skipping
+// it would silently drop findings rather than merely quieten fixtures.
+var testDirs = []string{"testdata/", "__tests__/", "src/test/", "src/tests/"}
 
 // isTestPath reports whether a path is test code, across the languages above.
 func isTestPath(p string) bool {
 	base := strings.ToLower(filepath.Base(p))
-	if strings.HasSuffix(base, "_test.go") || strings.HasSuffix(base, ".test.js") ||
-		strings.HasSuffix(base, ".test.ts") || strings.HasSuffix(base, ".spec.js") ||
-		strings.HasSuffix(base, ".spec.ts") {
+	for _, s := range testSuffixes {
+		if strings.HasSuffix(base, s) {
+			return true
+		}
+	}
+	if strings.HasPrefix(base, "test_") {
 		return true
 	}
-	if strings.HasPrefix(base, "test_") && strings.HasSuffix(base, ".py") {
-		return true
+	lower := strings.ToLower(filepath.ToSlash(p))
+	for _, d := range testDirs {
+		if strings.HasPrefix(lower, d) || strings.Contains(lower, "/"+d) {
+			return true
+		}
 	}
-	lower := strings.ToLower(p)
-	return strings.Contains(lower, "/testdata/") || strings.Contains(lower, "/__tests__/")
+	return false
 }

--- a/core/analyzers/weakcrypto/crypto.go
+++ b/core/analyzers/weakcrypto/crypto.go
@@ -124,8 +124,9 @@ var cPattern = regexp.MustCompile(
 		`|\bkCCAlgorithm(?:DES|3DES|RC4|RC2)\b` +
 		`|\bkCCOptionECBMode\b`)
 
-// languages holds one entry per language core's SAST supports, or none at all
-// where the deliberate decision was to stay silent (see the shell entry).
+// languages holds one entry per language core's SAST supports. Two entries —
+// PHP and shell — are deliberately narrower than the language's full weak-crypto
+// surface; each says why in place.
 //
 // Each pattern targets a CALL or a package-qualified symbol rather than the
 // bare algorithm name, so a comment, a variable called `md5sum`, or a string in

--- a/core/analyzers/weakcrypto/crypto_test.go
+++ b/core/analyzers/weakcrypto/crypto_test.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/discovery"
 )
 
 func scanSource(t *testing.T, name, content string) int {
+	t.Helper()
+	return len(scanLines(t, name, content))
+}
+
+// scanLines returns the 1-based line numbers that reported a finding, so a test
+// can assert *which* call shapes fired rather than only how many did.
+func scanLines(t *testing.T, name, content string) []int {
 	t.Helper()
 	dir := t.TempDir()
 	p := filepath.Join(dir, name)
@@ -21,64 +30,536 @@ func scanSource(t *testing.T, name, content string) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return len(fs.Findings())
+	var lines []int
+	for _, f := range fs.Findings() {
+		lines = append(lines, f.Location.StartLine)
+	}
+	sort.Ints(lines)
+	return lines
+}
+
+// algorithmsFor returns the algorithm names reported for a source, so the
+// message and the `algorithm` metadata can be asserted rather than assumed.
+func algorithmsFor(t *testing.T, name, content string) []string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := (&Analyzer{}).ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, f := range fs.Findings() {
+		got = append(got, f.Metadata["algorithm"])
+	}
+	sort.Strings(got)
+	return got
+}
+
+// A digest has two call shapes and both must fire. CRYPTO-001 originally
+// matched only the CONSTRUCTOR (md5.New()) and missed the one-shot
+// (md5.Sum(b)) — which is the *more* idiomatic of the two, so the commoner
+// usage was the unreported one. Both shapes are asserted in one file so they
+// cannot drift apart again. (#402)
+func TestFlagsBothConstructorAndOneShot(t *testing.T) {
+	src := strings.Join([]string{
+		"package m", // 1
+		"func a(b []byte) [16]byte { return md5.Sum(b) }",  // 2 one-shot
+		"func b() { _ = md5.New() }",                       // 3 constructor
+		"func c(b []byte) [20]byte { return sha1.Sum(b) }", // 4 one-shot
+		"func d() { _ = sha1.New() }",                      // 5 constructor
+	}, "\n")
+	want := []int{2, 3, 4, 5}
+	got := scanLines(t, "a.go", src)
+	if len(got) != len(want) {
+		t.Fatalf("lines = %v, want %v — a call shape is unreported", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("lines = %v, want %v", got, want)
+		}
+	}
+}
+
+// The same split exists outside Go: OpenSSL in C has both MD5_Init/Update/Final
+// and the one-shot MD5(), and .NET has both MD5.Create() and MD5.HashData().
+func TestFlagsBothCallShapesInCAndCSharp(t *testing.T) {
+	cSrc := "void a(void) {\n  MD5_Init(&ctx);\n  MD5(data, len, out);\n}"
+	if got := scanLines(t, "a.c", cSrc); len(got) != 2 {
+		t.Errorf("c: lines = %v, want both MD5_Init and MD5()", got)
+	}
+	csSrc := "class A {\n  void B() {\n    var a = MD5.Create();\n    var b = MD5.HashData(x);\n  }\n}"
+	if got := scanLines(t, "A.cs", csSrc); len(got) != 2 {
+		t.Errorf("csharp: lines = %v, want both MD5.Create and MD5.HashData", got)
+	}
+}
+
+// positives is one entry per language, covering the primitive families that
+// language actually exposes. Every line here was run through the scanner before
+// being asserted.
+var positives = map[string][]string{
+	"a.go": {
+		"h := md5.New()",
+		"d := md5.Sum(b)",
+		"h := sha1.New()",
+		"d := sha1.Sum(b)",
+		"c, _ := des.NewCipher(k)",
+		"c, _ := des.NewTripleDESCipher(k)",
+		"c, _ := rc4.NewCipher(k)",
+	},
+	"a.py": {
+		"d = hashlib.md5(b'x')",
+		"d = hashlib.sha1(b'x')",
+		`d = hashlib.new("md5", b'x')`,
+		"d = hashlib.new('sha-1')",
+		"c = DES.new(key, DES.MODE_ECB)",
+		"c = DES3.new(key, DES3.MODE_CBC, iv)",
+		"c = ARC4.new(key)",
+		"c = Cipher(algorithms.AES(key), modes.ECB())",
+		"a = algorithms.TripleDES(key)",
+	},
+	"a.js": {
+		"const h = crypto.createHash('md5')",
+		`const h = crypto.createHash("sha1")`,
+		"const c = crypto.createCipheriv('des-ede3-cbc', k, iv)",
+		`const c = crypto.createDecipheriv("aes-128-ecb", k, iv)`,
+		"const c = crypto.createCipheriv('rc4', k, '')",
+		"const d = CryptoJS.MD5(x)",
+		"const d = CryptoJS.TripleDES.encrypt(x, k)",
+	},
+	"a.ts": {
+		"const h = crypto.createHash('md5')",
+		"const c = crypto.createCipheriv('des-ede3-cbc', k, iv)",
+	},
+	"A.java": {
+		`MessageDigest md = MessageDigest.getInstance("MD5");`,
+		`MessageDigest md = MessageDigest.getInstance("SHA-1");`,
+		`MessageDigest md = MessageDigest.getInstance("SHA1");`,
+		`Cipher c = Cipher.getInstance("DES/ECB/PKCS5Padding");`,
+		`Cipher c = Cipher.getInstance("AES/ECB/PKCS5Padding");`,
+		`Cipher c = Cipher.getInstance("DESede/CBC/PKCS5Padding");`,
+		`Signature s = Signature.getInstance("SHA1withRSA");`,
+	},
+	"A.kt": {
+		`val md = MessageDigest.getInstance("MD5")`,
+		`val c = Cipher.getInstance("AES/ECB/NoPadding")`,
+	},
+	"a.php": {
+		"$a = mcrypt_encrypt(MCRYPT_DES, $key, $data, MCRYPT_MODE_ECB);",
+		"$b = MCRYPT_3DES;",
+		"$c = openssl_encrypt($data, 'des-ecb', $key);",
+		`$d = openssl_decrypt($data, "aes-128-ecb", $key);`,
+		"$e = openssl_encrypt($data, 'rc4', $key);",
+		"$f = openssl_digest($data, 'md5');",
+	},
+	"a.rb": {
+		"a = Digest::MD5.hexdigest(x)",
+		"a = Digest::SHA1.hexdigest(x)",
+		"a = OpenSSL::Digest::MD5.new",
+		"a = OpenSSL::Digest.new('md5')",
+		"a = OpenSSL::Cipher::DES.new",
+		"a = OpenSSL::Cipher.new('DES-EDE3-CBC')",
+		`a = OpenSSL::Cipher.new("aes-128-ecb")`,
+		"a = OpenSSL::Cipher::AES.new(256, :ECB)",
+	},
+	"A.cs": {
+		"var a = MD5.Create();",
+		"var a = SHA1.Create();",
+		"var a = MD5.HashData(bytes);",
+		"var a = new DESCryptoServiceProvider();",
+		"var a = new TripleDESCryptoServiceProvider();",
+		"var a = new SHA1Managed();",
+		"aes.Mode = CipherMode.ECB;",
+		`var a = HashAlgorithm.Create("MD5");`,
+	},
+	"a.rs": {
+		`let d = md5::compute(b"x");`,
+		"let mut h = Md5::new();",
+		"let mut h = Sha1::new();",
+		"let c = Des::new(&key);",
+		"let c = TdesEde3::new(&key);",
+		"let c = Rc4::new(&key);",
+		"let e: ecb::Encryptor<Aes128> = enc;",
+	},
+	"a.c": {
+		"MD5_Init(&ctx);",
+		"MD5_Update(&ctx, d, n);",
+		"MD5_Final(out, &ctx);",
+		"MD5(data, len, out);",
+		"SHA1(data, len, out);",
+		"SHA1_Init(&s);",
+		"const EVP_MD *m = EVP_md5();",
+		"const EVP_MD *m = EVP_sha1();",
+		"const EVP_CIPHER *c = EVP_des_ede3_cbc();",
+		"const EVP_CIPHER *c = EVP_aes_128_ecb();",
+		"const EVP_CIPHER *c = EVP_rc4();",
+		"DES_set_key(&k, &s);",
+		"DES_ecb_encrypt(in, out, &s, DES_ENCRYPT);",
+		"RC4_set_key(&rk, 16, key);",
+	},
+	"a.cpp": {
+		"MD5_Init(&ctx);",
+		"SHA1(data, len, out);",
+	},
+	"a.m": {
+		"CC_MD5(data, len, out);",
+		"CC_SHA1(data, len, out);",
+		"CCCrypt(kCCEncrypt, kCCAlgorithmDES, kCCOptionECBMode, key, 8, NULL, in, n, out, n, &moved);",
+	},
+	"a.swift": {
+		"let d = Insecure.MD5.hash(data: data)",
+		"let d = Insecure.SHA1.hash(data: data)",
+		"CC_MD5(bytes, len, &digest)",
+		"let alg = kCCAlgorithm3DES",
+		"let opt = kCCOptionECBMode",
+	},
+	"a.sh": {
+		"openssl enc -des-ecb -in a -out b",
+		"openssl enc -rc4 -in a -out b",
+		"openssl enc -aes-128-ecb -in a -out b",
+		"openssl des3 -in a -out b",
+	},
 }
 
 func TestFlagsBrokenPrimitives(t *testing.T) {
-	for _, c := range []struct{ name, src string }{
-		{"a.go", "package m\nfunc f(){ h := md5.New() ; _ = h }"},
-		{"a.go", "package m\nfunc f(){ h := sha1.New() ; _ = h }"},
-		{"a.py", "import hashlib\nd = hashlib.md5(b'x')"},
-		{"a.js", "const h = crypto.createHash('md5')"},
-		{"a.java", "MessageDigest md = MessageDigest.getInstance(\"MD5\");"},
-	} {
-		if n := scanSource(t, c.name, c.src); n != 1 {
-			t.Errorf("%s: got %d findings, want 1 for %q", c.name, n, c.src)
+	for name, srcs := range positives {
+		for _, src := range srcs {
+			if n := scanSource(t, name, src); n != 1 {
+				t.Errorf("%s: got %d findings, want 1 for %q", name, n, src)
+			}
 		}
 	}
 }
 
-func TestIgnoresStrongPrimitives(t *testing.T) {
-	for _, c := range []struct{ name, src string }{
-		{"a.go", "package m\nfunc f(){ h := sha256.New() ; _ = h }"},
-		{"a.py", "import hashlib\nd = hashlib.sha256(b'x')"},
-		{"a.js", "const h = crypto.createHash('sha256')"},
-	} {
-		if n := scanSource(t, c.name, c.src); n != 0 {
-			t.Errorf("%s: got %d findings, want 0 for %q", c.name, n, c.src)
+// negatives is the counterpart corpus: strong primitives, the algorithm named
+// in a comment, an identifier named after the algorithm, and a legitimate
+// non-crypto checksum. None of these may fire — a rule that flags them is a
+// rule that gets globally suppressed.
+var negatives = map[string][]string{
+	"a.go": {
+		"// we used to use md5 here, now sha256",
+		"var md5sum string",
+		`var sha1Digest = "sha1"`,
+		"return sha256.Sum256(b)",
+		"h := sha256.New()",
+		"// md5.Sum(b) was removed",
+	},
+	"a.py": {
+		"# hashlib.md5 was removed in favour of sha256",
+		"NOTE = 'md5'",
+		"md5sum = compute()",
+		"d = hashlib.sha256(b'x')",
+		`d = hashlib.new("sha256")`,
+		"c = Cipher(algorithms.AES(key), modes.GCM(iv))",
+		"def md5_of(path): return read(path)",
+	},
+	"a.js": {
+		"// createHash('md5') is no longer used",
+		"const algo = 'md5';",
+		"const md5sum = fileHash(x);",
+		"const h = crypto.createHash('sha256')",
+		"const c = crypto.createCipheriv('aes-256-gcm', k, iv)",
+		"const d = CryptoJS.SHA256(x)",
+	},
+	"a.ts": {
+		"// createHash('md5') is no longer used",
+		"const md5sum: string = fileHash(x);",
+		"const h = crypto.createHash('sha512')",
+	},
+	"A.java": {
+		`// MessageDigest.getInstance("MD5") was replaced`,
+		`String md5 = "md5";`,
+		`MessageDigest md = MessageDigest.getInstance("SHA-256");`,
+		`Cipher c = Cipher.getInstance("AES/GCM/NoPadding");`,
+		`Mac mac = Mac.getInstance("HmacSHA1");`,
+		"String md5sum = compute();",
+		// RSA "ECB" is a JCA misnomer, not a mode; OAEP is the correct and
+		// recommended RSA padding. Flagging it would be a false positive on
+		// code that is doing the right thing.
+		`Cipher c = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding");`,
+		`Cipher c = Cipher.getInstance("RSA/ECB/PKCS1Padding");`,
+	},
+	"A.kt": {
+		`// Cipher.getInstance("DES/ECB/PKCS5Padding") was replaced`,
+		"val md5sum: String = compute()",
+		`val md = MessageDigest.getInstance("SHA-256")`,
+	},
+	"a.php": {
+		"// md5() is used for cache keys here",
+		"# openssl_encrypt($x, 'des-ecb', $k) was removed",
+		// Bare md5()/sha1() are deliberately not matched: they are
+		// overwhelmingly cache keys, ETags and Gravatar hashes, and flagging
+		// them would put a finding in nearly every PHP file in existence.
+		"$cacheKey = md5($url);",
+		"$etag = sha1_file($path);",
+		"$h = hash('sha256', $data);",
+		"$md5sum = md5($contents);",
+		"$gravatar = 'https://gravatar.com/avatar/' . md5(strtolower($email));",
+		"$g = openssl_encrypt($data, 'aes-256-gcm', $key, 0, $iv, $tag);",
+	},
+	"a.rb": {
+		"# Digest::MD5 was replaced by SHA256",
+		"md5sum = compute",
+		"a = Digest::SHA256.hexdigest(x)",
+		"a = OpenSSL::Cipher.new('aes-256-gcm')",
+		"a = OpenSSL::Digest.new('sha256')",
+		`algo = "md5"`,
+	},
+	"A.cs": {
+		"// MD5.Create() was removed",
+		`string md5 = "md5";`,
+		"var a = SHA256.Create();",
+		"var a = SHA512.Create();",
+		"aes.Mode = CipherMode.CBC;",
+		"var md5sum = Compute();",
+	},
+	"a.rs": {
+		"// md5::compute was replaced with sha2",
+		"let md5sum = String::new();",
+		"let mut h = Sha256::new();",
+		`let algo = "md5";`,
+		"fn md5_path(p: &str) -> String { p.to_string() }",
+	},
+	"a.c": {
+		"// MD5(data, len, out) is no longer called",
+		"static const int MD5_DIGEST_LENGTH_LOCAL = 16;",
+		"static char md5sum[33];",
+		"MD5_CTX ctx;",
+		"SHA256_Init(&ctx);",
+		"const EVP_MD *m = EVP_sha256();",
+		"const EVP_CIPHER *c = EVP_aes_256_gcm();",
+		"compute_md5_checksum(path);",
+		// OpenSSL's own dgst output format. A space before the parenthesis
+		// means prose in a string literal far more often than it means a call.
+		`printf("MD5 (%s) = %s\n", name, hex);`,
+		`fprintf(f, "SHA1 (%s)\n", name);`,
+	},
+	"a.swift": {
+		"// Insecure.MD5 was replaced by SHA256",
+		`let md5sum = ""`,
+		"let d = SHA256.hash(data: data)",
+		"let alg = kCCAlgorithmAES",
+	},
+	"a.sh": {
+		"# openssl enc -des-ecb was removed",
+		// md5sum/sha1sum/shasum in shell are checksums against accidental
+		// corruption, not security controls. Flagging them would bury every
+		// release script in findings.
+		"md5sum dist/app.tar.gz > dist/app.tar.gz.md5",
+		"sha1sum -c checksums.txt",
+		"shasum -a 1 file",
+		`echo "expected md5: $md5"`,
+		"openssl enc -aes-256-cbc -pbkdf2 -in a -out b",
+		"openssl dgst -sha256 file",
+	},
+}
+
+func TestIgnoresMentionsAndStrongPrimitives(t *testing.T) {
+	for name, srcs := range negatives {
+		for _, src := range srcs {
+			if n := scanSource(t, name, src); n != 0 {
+				t.Errorf("%s: got %d findings, want 0 for %q", name, n, src)
+			}
 		}
 	}
 }
 
-// The patterns target CONSTRUCTORS, not the algorithm name. Matching prose or
-// identifiers would make this rule noisy enough to be globally suppressed,
-// which costs more than the rule is worth.
-func TestIgnoresMentionsThatAreNotCalls(t *testing.T) {
-	for _, c := range []struct{ name, src string }{
-		{"a.go", "package m\n// we used to use md5 here, now sha256\nvar md5sum string"},
-		{"a.py", "# hashlib.md5 was removed in favour of sha256\nNOTE = 'md5'"},
-		{"a.js", "// createHash('md5') is no longer used\nconst algo = 'md5';"},
-	} {
-		if n := scanSource(t, c.name, c.src); n != 0 {
-			t.Errorf("%s: got %d findings, want 0 — matched a mention, not a call: %q", c.name, n, c.src)
+// languageFamilies groups extensions that legitimately share a pattern because
+// they share syntax and APIs. Anything outside a line's own family must not
+// match it: a keyword that means "broken cipher" in one language is ordinary
+// text in another, and letting a pattern leak across file types is how a rule
+// starts inventing findings.
+var languageFamilies = [][]string{
+	{".go"},
+	{".py"},
+	{".js", ".ts"},
+	{".java", ".kt"},
+	{".php"},
+	{".rb"},
+	{".cs"},
+	{".rs"},
+	// Swift bridges CommonCrypto, so `CC_MD5` and `kCCAlgorithmDES` are shared
+	// vocabulary with C, C++ and Objective-C rather than a leak.
+	{".c", ".cpp", ".m", ".swift"},
+	{".sh"},
+}
+
+func familyOf(ext string) []string {
+	for _, f := range languageFamilies {
+		for _, e := range f {
+			if e == ext {
+				return f
+			}
 		}
+	}
+	return nil
+}
+
+func TestPatternsDoNotLeakAcrossLanguages(t *testing.T) {
+	allExts := []string{".go", ".py", ".js", ".ts", ".java", ".kt", ".php", ".rb",
+		".cs", ".rs", ".c", ".cpp", ".m", ".swift", ".sh"}
+
+	for name, srcs := range positives {
+		own := strings.ToLower(filepath.Ext(name))
+		family := familyOf(own)
+		if family == nil {
+			t.Fatalf("positives key %q has no declared family", name)
+		}
+		for _, other := range allExts {
+			inFamily := false
+			for _, e := range family {
+				if e == other {
+					inFamily = true
+				}
+			}
+			if inFamily {
+				continue
+			}
+			for _, src := range srcs {
+				if n := scanSource(t, "x"+other, src); n != 0 {
+					t.Errorf("%s source %q matched under %s — a pattern leaked across languages",
+						own, src, other)
+				}
+			}
+		}
+	}
+}
+
+// Every language core's SAST supports must have a pattern, and no entry may
+// name a language core does not have.
+func TestCoversEverySASTLanguage(t *testing.T) {
+	// core.extensionLanguages, mirrored here: weakcrypto cannot import core
+	// (core imports weakcrypto), so this list is the contract between the two.
+	want := []string{
+		"c", "cpp", "csharp", "go", "java", "javascript", "kotlin", "objc",
+		"php", "python", "ruby", "rust", "shell", "swift", "typescript",
+	}
+	have := map[string]bool{}
+	for _, l := range languages {
+		if l.pattern == nil {
+			t.Errorf("language %q has a nil pattern", l.name)
+		}
+		if len(l.exts) == 0 {
+			t.Errorf("language %q declares no extensions", l.name)
+		}
+		if len(l.comments) == 0 {
+			t.Errorf("language %q declares no comment markers", l.name)
+		}
+		if have[l.name] {
+			t.Errorf("language %q declared twice", l.name)
+		}
+		have[l.name] = true
+	}
+	for _, w := range want {
+		if !have[w] {
+			t.Errorf("no CRYPTO-001 pattern for SAST language %q", w)
+		}
+	}
+	for h := range have {
+		found := false
+		for _, w := range want {
+			if w == h {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("language %q is not one of core's SAST languages", h)
+		}
+	}
+}
+
+// An extension may be bound to exactly one pattern. Two entries claiming the
+// same extension would silently hand one language's files to another's regex.
+func TestNoExtensionIsClaimedTwice(t *testing.T) {
+	seen := map[string]string{}
+	for _, l := range languages {
+		for _, e := range l.exts {
+			if prev, ok := seen[e]; ok {
+				t.Errorf("extension %s claimed by both %q and %q", e, prev, l.name)
+			}
+			seen[e] = l.name
+			if e != strings.ToLower(e) || !strings.HasPrefix(e, ".") {
+				t.Errorf("%s: extension %q must be lowercase and start with a dot", l.name, e)
+			}
+		}
+	}
+}
+
+// The reported algorithm drives the finding message, and the message drives the
+// fingerprint. `_` is a word character, so a naive \b-delimited scrape silently
+// falls back to a placeholder for most C and Objective-C matches.
+func TestReportsTheAlgorithmName(t *testing.T) {
+	for _, c := range []struct {
+		name, src, want string
+	}{
+		{"a.c", "MD5_Init(&ctx);", "MD5"},
+		{"a.c", "DES_set_key(&k, &s);", "DES"},
+		{"a.c", "const EVP_CIPHER *c = EVP_aes_128_ecb();", "ECB"},
+		{"a.m", "CC_SHA1(data, len, out);", "SHA1"},
+		{"a.m", "CCCrypt(kCCEncrypt, kCCAlgorithmDES, 0, k, 8, NULL, i, n, o, n, &m);", "DES"},
+		{"a.swift", "let opt = kCCOptionECBMode", "ECB"},
+		{"A.cs", "var a = new TripleDESCryptoServiceProvider();", "TRIPLEDES"},
+		{"A.cs", "var a = new SHA1Managed();", "SHA1"},
+		{"a.py", "c = Cipher(algorithms.AES(key), modes.ECB())", "ECB"},
+		{"a.go", "d := md5.Sum(b)", "MD5"},
+	} {
+		got := algorithmsFor(t, c.name, c.src)
+		if len(got) != 1 || got[0] != c.want {
+			t.Errorf("%s %q: algorithm = %v, want [%s]", c.name, c.src, got, c.want)
+		}
+	}
+}
+
+// `modes` contains the substring "des". The algorithm scrape must not read it.
+func TestAlgorithmScrapeDoesNotReadSubstrings(t *testing.T) {
+	if got := algorithmIn("modes.ECB("); got != "ECB" {
+		t.Errorf("algorithmIn(%q) = %q, want ECB", "modes.ECB(", got)
+	}
+	if got := algorithmIn("Digest::SHA1"); got != "SHA1" {
+		t.Errorf("algorithmIn(%q) = %q, want SHA1", "Digest::SHA1", got)
 	}
 }
 
 // Fixtures deliberately exercise weak primitives; flagging them trains people
 // to ignore the rule.
 func TestSkipsTestFiles(t *testing.T) {
-	for _, name := range []string{"a_test.go", "test_a.py", "a.test.js", "a.spec.ts"} {
-		src := "md5.New(); hashlib.md5(b''); crypto.createHash('md5')"
+	for _, name := range []string{
+		"a_test.go", "test_a.py", "a.test.js", "a.spec.ts", "a.test.tsx",
+		"a_spec.rb", "a_test.rb", "CryptoTest.java", "CryptoTests.cs",
+		"CryptoTest.kt", "a_test.rs",
+	} {
+		src := "md5.New(); md5.Sum(b); hashlib.md5(b''); crypto.createHash('md5'); Digest::MD5; MD5_Init(&c); MD5.Create();"
 		if n := scanSource(t, name, src); n != 0 {
 			t.Errorf("%s: got %d findings, want 0 (test file)", name, n)
+		}
+	}
+	for _, p := range []string{
+		"src/test/java/com/x/Crypto.java",
+		"pkg/testdata/sample.go",
+		"web/__tests__/hash.js",
+	} {
+		if !isTestPath(p) {
+			t.Errorf("isTestPath(%q) = false, want true", p)
+		}
+	}
+	// A bare `test/` directory is a real source tree in plenty of projects and
+	// must NOT be treated as fixtures — skipping it would drop findings.
+	for _, p := range []string{"internal/test/helper.go", "lib/tests.go"} {
+		if isTestPath(p) {
+			t.Errorf("isTestPath(%q) = true, want false — that silently drops findings", p)
 		}
 	}
 }
 
 func TestUnknownExtensionIsSkipped(t *testing.T) {
-	if n := scanSource(t, "notes.md", "hashlib.md5(b'x')"); n != 0 {
-		t.Errorf("got %d findings for a markdown file, want 0", n)
+	for _, name := range []string{"notes.md", "config.yaml", "data.json", "x.txt"} {
+		if n := scanSource(t, name, "hashlib.md5(b'x')\nmd5.Sum(b)\nMD5_Init(&c);"); n != 0 {
+			t.Errorf("%s: got %d findings, want 0", name, n)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #402 and extends #405. One PR, not two: Part 2 rewrites the same pattern table Part 1 fixes, so splitting would have meant writing the Go pattern twice and landing a guaranteed conflict — and the property Part 1 establishes (*a digest has two call shapes and both must fire*) is exactly the design rule Part 2 applies to nine more languages.

## Part 1 — the one-shot call was unreported (#402)

`CRYPTO-001` matched the CONSTRUCTOR form and nothing else. Reproduced on `main` before touching anything:

```go
// scratch/repro/hash.go
func hashSum(b []byte) [16]byte { return md5.Sum(b) }   // line 8
func hashNew()                  { _ = md5.New() }       // line 9
func sha1Sum(b []byte) [20]byte { return sha1.Sum(b) }  // line 10
func sha1New()                  { _ = sha1.New() }      // line 11
```

```
$ nox scan .            # main
hash.go:9   MD5
hash.go:11  SHA1
-- 2 CRYPTO findings    # lines 8 and 10 silent
```

`Sum()` is the *more* idiomatic of the two calls, so the shape being missed was the commoner one. On the live example from the issue, `klarlabs-studio/agent-go`:

| | before | after |
|---|---|---|
| `contrib/pack-string/string.go` | 0 | 2 |
| `contrib/pack-hash/hash.go` | 0 | 6 |
| everything else | 10 | 10 |
| **total** | **10** | **18** |

Every new finding is a `Sum()` call site; nothing was removed.

**The precision property is preserved.** The analyzer's comment explains that it targets constructors so a variable named `md5sum` or the word in a comment does not match. The fix keeps that by matching the *package-qualified call* — `md5.Sum(` / `md5.New(` — rather than the algorithm name. `md5sum` has no dot-call and prose does not contain `md5.Sum(`. The negative corpus asserts it, and `TestFlagsBothConstructorAndOneShot` pins both shapes in a single file so they cannot drift apart again.

## Part 2 — language coverage (#405)

### Audit: what `weakByExt` actually covered

Measured against `core.extensionLanguages` (core's 15 SAST languages), not assumed:

| Language | Before | After | What is matched now |
|---|---|---|---|
| go | ✅ `.go` | ✅ | `md5/sha1 .New/.Sum`, `des.NewCipher`, `des.NewTripleDESCipher`, `rc4.NewCipher` |
| python | ✅ `.py` | ✅ | `hashlib.md5/sha1`, `hashlib.new("md5")`, `DES/DES3/ARC2/ARC4.new`, `modes.ECB`, `algorithms.TripleDES/ARC4` |
| javascript | ⚠️ `.js` only | ✅ `+ .jsx .mjs .cjs` | `createHash('md5')`, `create(De)cipheriv('des‑…'/'rc4'/'…‑ecb')`, `CryptoJS.MD5/SHA1/DES/TripleDES/RC4` |
| typescript | ⚠️ `.ts` only | ✅ `+ .tsx .mts .cts` | as JavaScript |
| java | ✅ `.java` | ✅ | `MessageDigest/Cipher/Signature.getInstance("MD5"/"SHA‑1"/"DES"/"RC4"/…)`, `"<symmetric>/ECB/…"` |
| kotlin | ❌ | ✅ `.kt` | same JCA surface |
| csharp | ❌ | ✅ `.cs` | `MD5/SHA1.Create()`, `.HashData()`, `*CryptoServiceProvider/Managed/Cng`, `HashAlgorithm.Create("MD5")`, `CipherMode.ECB` |
| ruby | ❌ | ✅ `.rb` | `Digest::MD5/SHA1`, `OpenSSL::Digest.new('md5')`, `OpenSSL::Cipher::DES`, `OpenSSL::Cipher.new('des‑…'/'…‑ecb')`, `:ECB` |
| php | ❌ | ⚠️ `.php`, narrowed | `mcrypt_*`, `MCRYPT_DES/3DES/RC4`, `openssl_encrypt/decrypt(…, 'des'/'rc4'/'…‑ecb')`, `openssl_digest(…, 'md5')` — **not** bare `md5()` |
| rust | ❌ | ✅ `.rs` | `md5::compute`, `Md5/Sha1/Md4::new/default/digest`, `Des/TdesEde3/Rc4::new`, `ecb::Encryptor` |
| c | ❌ | ✅ `.c .h` | `MD5_Init/Update/Final`, `MD5()`, `EVP_md5/sha1/des_*/rc4/*_ecb`, `DES_set_key`, `DES_ecb_encrypt`, `RC4_set_key`, `CC_MD5`, `kCCAlgorithmDES` |
| cpp | ❌ | ✅ `.cpp .cc .cxx .c++ .hpp .hh .hxx .ipp .inl` | as C |
| objc | ❌ | ✅ `.m .mm` | as C (CommonCrypto + OpenSSL) |
| swift | ❌ | ✅ `.swift` | `Insecure.MD5/SHA1`, `CC_MD5/CC_SHA1`, `kCCAlgorithmDES/3DES/RC4`, `kCCOptionECBMode` |
| shell | ❌ | ⚠️ `.sh`, narrowed | `openssl enc -des/-rc4/-…-ecb`, `openssl des3` — **not** `md5sum`/`sha1sum` |

**5 of 15 → 15 of 15**, plus six previously-unreachable JS/TS extensions. Primitive coverage also grows from MD5/SHA‑1/DES/RC4 to include **3DES and ECB mode**.

### The two ambiguous calls

**PHP `md5()` — excluded, deliberately.** It is a global function, among the most-called in the language, and the overwhelming majority of call sites are cache keys, ETags, asset fingerprints and Gravatar hashes — and the Gravatar protocol *requires* MD5, so those can never be "fixed". Flagging it would put a finding in nearly every PHP file in existence, which is precisely the "ubiquitous stdlib call" the analyzer's header forbids: the rule would be globally suppressed and take the genuinely broken `mcrypt_*` and `openssl_encrypt(…, 'des-ecb', …)` detections down with it. Two measurements back this up — `laravel/framework` has 17 bare `md5()`/`sha1()` call sites and reports **0**, and PHPMailer's `md5()` uses turn out to be a hand-rolled HMAC-MD5 implementing **CRAM-MD5 SMTP auth**, where MD5 is mandated by the protocol and a finding would be unactionable. What is kept is the subset with no benign reading: there is no "it's just a checksum" story for DES, RC4 or ECB.

The accepted cost is a false negative on `md5($password)`. Catching that needs variable-name heuristics, which would reintroduce exactly the noise the exclusion buys away.

**Shell `md5sum` — excluded, deliberately.** In shell these are release-script checksums against accidental corruption, artifact fingerprints and cache keys, essentially never a security control. `openssl enc` with a broken cipher *is* unambiguously encryption, so that is what `.sh` matches instead. Negative fixtures pin `md5sum dist/app.tar.gz`, `sha1sum -c checksums.txt` and `shasum -a 1 file` as non-findings.

### Cross-language leakage

This repo has the hazard on record, so it is now a test rather than a convention. Pattern, extensions and comment markers are bound together in one `languages` table, and `TestPatternsDoNotLeakAcrossLanguages` feeds every language's positive corpus through every *other* language's extension and requires zero matches. It caught two things while being written: `CryptoJS.MD5(x)` matched under `.c` (fixed — the bare C one-shot now refuses a preceding dot, so `obj.MD5(x)` member calls are out), and Swift/C/C++/ObjC genuinely *do* share CommonCrypto vocabulary (`CC_MD5`, `kCCAlgorithmDES`), so they are declared one family rather than papered over.

Two known-noisy shapes are excluded by name, both found by running fixtures rather than by reasoning:

- **`Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding")`** — JCA calls RSA padding modes "ECB" as a historical misnomer. This is correct, recommended code. The ECB alternative is restricted to named symmetric ciphers so it cannot fire.
- **`printf("MD5 (%s) = %s\n", …)`** — OpenSSL's own `dgst` output format. The bare C one-shot now requires the parenthesis to touch the name.

### Evidence and test discipline

- **Every fixture was run through the built scanner before any assertion was written** — 25 fixture files, 91 expected positives, 0 from the negative files. Several patterns were wrong on the first attempt (`[a-z0-9-]*-ecb` needed the dash in the class to reach `aes-128-ecb`; `des.NewTripleDESCipher` was never matched by the old `New(?:Cipher)?\(`).
- **Negative fixtures per language**: the primitive named in a comment, an identifier named after it (`md5sum`, `md5_path`, `MD5_DIGEST_LENGTH`), a legitimate non-crypto checksum, and the strong replacement (`sha256`, `AES/GCM`, `aes-256-gcm`).
- **The tests were verified to fail.** Four patterns were broken one at a time and restored:

  | Break | Caught by |
  |---|---|
  | drop `Sum` from the Go pattern (i.e. revert #402) | `TestFlagsBothConstructorAndOneShot` (`lines = [3 5], want [2 3 4 5]`), `TestFlagsBrokenPrimitives`, `TestReportsTheAlgorithmName` |
  | widen the Java ECB alternative to `"[^"]*/ECB/` | `TestIgnoresMentionsAndStrongPrimitives` — both `RSA/ECB/OAEP…` and `RSA/ECB/PKCS1Padding` fired |
  | let the C one-shot accept `MD5 (` with a space | `TestIgnoresMentionsAndStrongPrimitives` (the two `printf` lines), `TestPatternsDoNotLeakAcrossLanguages` |
  | add bare `md5()`/`sha1()` to PHP (the rejected decision) | `TestIgnoresMentionsAndStrongPrimitives` (`$cacheKey = md5($url)`), `TestPatternsDoNotLeakAcrossLanguages` |

- `go test ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` on the package: all clean. (`core/analyzers/secrets/testdata/benign/config.go` is gofmt-dirty on `main` too — untouched here.)

### Blast radius on real repositories

| Repo | Language | before | after | Notes |
|---|---|---|---|---|
| **nox itself** | Go | 0 | **0** | no self-findings |
| laravel/framework | PHP | 0 | 0 | 17 bare `md5()`/`sha1()` sites, all correctly silent |
| PHPMailer | PHP | 0 | 0 | CRAM-MD5 SMTP auth, protocol-mandated |
| expressjs/express | JS | 0 | 0 | |
| google/gson | Java | 0 | 0 | |
| BurntSushi/ripgrep | Rust | 0 | 0 | |
| Alamofire | Swift | 0 | 0 | |
| AutoMapper | C# | 0 | 0 | |
| zlib, cJSON | C | 0 | 0 | |
| psf/requests | Python | 3 | 3 | unchanged (HTTP Digest auth) |
| sinatra | Ruby | 0 | **1** | `Digest::SHA1` as rack-protection's default token encryptor — security-bearing, true positive |
| libgit2 | C | 0 | **8** | 1 × `kCCAlgorithmDES`/`kCCOptionECBMode` in the NTLM client (real DES-ECB); 7 × SHA-1 in `src/util/hash/*` for git object IDs — content addressing, exactly what Medium/**Low confidence** and the remediation text exist for |
| agent-go | Go | 10 | **18** | the #402 fix |

Nine of thirteen repositories are unchanged at zero. The three that move all move onto real weak-primitive call sites; none is an invented match.

### Compatibility

Existing fingerprints are preserved. The finding message carries the algorithm name and the message feeds `ComputeFingerprint`, so `DESede` was deliberately *not* added to the JVM alternation — `DES` already prefix-matches it, and lengthening the match would have renamed an existing finding and silently invalidated baselines. Test-path skipping was extended for the new languages by filename convention plus `src/test/`, but *not* by a bare `test/` directory: that is a real source tree in plenty of projects, and skipping it would drop findings rather than quieten fixtures. A test asserts that too.

---

https://claude.ai/code/session_01LMVPJFeTCEtUk2CSNBBBdK
