### PR TITLE
docs(changelog): 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-07-27
+
 ### Added
 
 - **World-writable file and directory modes are now reported (`PERM-001`,


### PR DESCRIPTION
Release notes for **1.24.0** — six commits since v1.23.0, five of them new code-security rules.

| rule | replaces | severity |
|---|---|---|
| `HARDEN-001/002` TLS misconfiguration | gosec G402 | high / medium |
| `CRYPTO-002` predictable randomness | gosec G404 | high |
| `PERM-001/002` world-writable modes | gosec G301/302/306 | medium |
| `MEMSAFE-001` truncation sizing memory | gosec G115 (narrowed) | medium |
| `CRYPTO-001` one-shot digest + 15 languages | gosec G401/G501/G505 | medium |

**These are unusable to consumers until released.** Downstream pins a released version, so a rule on `main` does not exist for any repo — which is currently blocking klarlabs-studio/agent-go#87.