### PR TITLE
fix(data): DATA-005 said "public IP" but matched every IPv4

### DIFF
--- a/core/analyzers/data/data_test.go
+++ b/core/analyzers/data/data_test.go
@@ -69,8 +69,10 @@ func TestDataRuleMatches(t *testing.T) {
 			name:     "DATA-001: Email address in config",
 			ruleID:   "DATA-001",
 			severity: findings.SeverityMedium,
-			positive: "admin_email = user@example.com\n",
-			negative: "// TODO: add email support later\n",
+			positive: "admin_email = jane.doe@acmecorp.io\n",
+			// example.com is reserved by RFC 2606 for documentation, so an
+			// address there is not PII. See TestDATA001_ReservedDomains.
+			negative: "admin_email = jane.doe@example.com\n",
 		},
 		{
 			name:     "DATA-002: US Social Security Number",
@@ -111,8 +113,11 @@ func TestDataRuleMatches(t *testing.T) {
 			name:     "DATA-005: Hardcoded IP address",
 			ruleID:   "DATA-005",
 			severity: findings.SeverityMedium,
-			positive: "server = '192.168.1.100'\n",
-			negative: "message = 'the server is running'\n",
+			positive: "server = '8.8.8.8'\n",
+			// 192.168/16 is RFC 1918 private space — not a public address,
+			// which is what this rule claims to find. See
+			// TestDATA005_NonPublicRanges.
+			negative: "server = '192.168.1.100'\n",
 		},
 		{
 			name:     "DATA-006: Date of birth",
@@ -207,11 +212,11 @@ func TestDataRuleMatches(t *testing.T) {
 
 func TestAllRules_PositiveMatch(t *testing.T) {
 	examples := map[string]string{
-		"DATA-001": "email = user@example.com\n",
+		"DATA-001": "email = jane.doe@acmecorp.io\n",
 		"DATA-002": "ssn = 123-45-6789\n",
 		"DATA-003": "card = 4111111111111111\n",
 		"DATA-004": "phone = '555-123-4567'\n",
-		"DATA-005": "server = '10.0.0.1'\n",
+		"DATA-005": "server = '8.8.8.8'\n",
 		"DATA-006": "dob = '1990-01-15'\n",
 		"DATA-007": "iban = DE89370400440532013000\n",
 		"DATA-008": "nino = AB123456C\n",
@@ -317,7 +322,7 @@ func TestScanArtifacts_MixedFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	// File with PII (email address).
-	piiFile := writeFile(t, dir, "config.env", "admin_email = user@example.com\n")
+	piiFile := writeFile(t, dir, "config.env", "admin_email = jane.doe@acmecorp.io\n")
 	// Clean file with no PII.
 	cleanFile := writeFile(t, dir, "clean.go", "package main\n\nfunc main() {}\n")
 	// File with SSN.
@@ -363,8 +368,8 @@ func TestScanArtifacts_Deduplicates(t *testing.T) {
 	// Two files with identical content should produce findings that are
 	// NOT deduplicated because they have different file paths (different
 	// fingerprints).
-	file1 := writeFile(t, dir, "a.env", "email = user@example.com\n")
-	file2 := writeFile(t, dir, "b.env", "email = user@example.com\n")
+	file1 := writeFile(t, dir, "a.env", "email = jane.doe@acmecorp.io\n")
+	file2 := writeFile(t, dir, "b.env", "email = jane.doe@acmecorp.io\n")
 
 	artifacts := []discovery.Artifact{
 		{Path: "a.env", AbsPath: file1, Type: discovery.Config, Size: 30},

--- a/core/analyzers/data/rules.go
+++ b/core/analyzers/data/rules.go
@@ -17,6 +17,11 @@ type dataRule struct {
 	keywords    []string
 	remediation string
 	references  []string
+	// validate is an optional post-match predicate (see
+	// rules.Rule.ValidateMatch). Rules whose pattern can only find a candidate
+	// — an IPv4-shaped or email-shaped token — use it to decide in Go whether
+	// that particular value is reportable. See validate.go.
+	validate func(matchText string) bool
 }
 
 // builtinDataRules returns all built-in data sensitivity detection rules.
@@ -30,6 +35,10 @@ func builtinDataRules() []*rules.Rule {
 			pattern:     `(?i)["'=:]\s*[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`,
 			description: "Email address in code or config",
 			cwe:         "CWE-359", keywords: []string{"@"},
+			// RFC 2606 / RFC 6761 reserved domains and TLDs exist so that
+			// documentation, examples and tests have an address to use. They
+			// are not PII. See isReportableEmailMatch.
+			validate:    isReportableEmailMatch,
 			remediation: "Remove or externalize PII data. Never hard-code sensitive personal information in source code or configuration files. Use environment variables, encrypted vaults, or database references.",
 			references:  []string{"https://cwe.mitre.org/data/definitions/359.html"},
 		},
@@ -62,6 +71,12 @@ func builtinDataRules() []*rules.Rule {
 			pattern:     `(?i)(?:ip|host|server|addr)\s*[=:]\s*['"]?(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`,
 			description: "Hardcoded public IP address in configuration",
 			cwe:         "CWE-200", keywords: []string{"ip", "host", "server", "addr"},
+			// The pattern matches any dotted quad; "public" is decided here.
+			// Without this the rule fired on `host: 127.0.0.1` and
+			// `addr: 10.0.0.5` — the common case in real configuration and the
+			// exact opposite of what the description promises. See
+			// isPublicIPv4Match.
+			validate:    isPublicIPv4Match,
 			remediation: "Remove or externalize PII data. Never hard-code sensitive personal information in source code or configuration files. Use environment variables, encrypted vaults, or database references.",
 			references:  []string{"https://cwe.mitre.org/data/definitions/200.html"},
 		},
@@ -126,18 +141,19 @@ func builtinDataRules() []*rules.Rule {
 	out := make([]*rules.Rule, len(defs))
 	for i := range defs {
 		out[i] = &rules.Rule{
-			ID:          defs[i].id,
-			Version:     "1.0",
-			Description: defs[i].description,
-			Severity:    defs[i].severity,
-			Confidence:  defs[i].confidence,
-			MatcherType: "regex",
-			Pattern:     defs[i].pattern,
-			Keywords:    defs[i].keywords,
-			Tags:        []string{"data-sensitivity", "pii"},
-			Metadata:    map[string]string{"cwe": defs[i].cwe},
-			Remediation: defs[i].remediation,
-			References:  defs[i].references,
+			ID:            defs[i].id,
+			Version:       "1.0",
+			Description:   defs[i].description,
+			Severity:      defs[i].severity,
+			Confidence:    defs[i].confidence,
+			MatcherType:   "regex",
+			Pattern:       defs[i].pattern,
+			Keywords:      defs[i].keywords,
+			Tags:          []string{"data-sensitivity", "pii"},
+			Metadata:      map[string]string{"cwe": defs[i].cwe},
+			Remediation:   defs[i].remediation,
+			References:    defs[i].references,
+			ValidateMatch: defs[i].validate,
 		}
 	}
 	return out

--- a/core/analyzers/data/validate.go
+++ b/core/analyzers/data/validate.go
@@ -1,0 +1,147 @@
+package data
+
+import (
+	"net/netip"
+	"regexp"
+	"strings"
+)
+
+// This file holds the post-match predicates for the data-sensitivity rules
+// whose regex can only find a *candidate*. The rule pattern says "something
+// IP-shaped / email-shaped is assigned here"; the predicate here decides
+// whether that particular value is worth reporting.
+//
+// The split exists because the decisions below are range and suffix
+// membership, and RE2 expresses those only as long alternations that nobody
+// can check against an RFC afterwards. A netip.Prefix table and a domain list
+// can be diffed against the RFC line by line — see rules.Rule.ValidateMatch.
+
+// ---------------------------------------------------------------------------
+// DATA-005 — public IPv4 addresses
+// ---------------------------------------------------------------------------
+
+// nonPublicIPv4 lists every IPv4 range DATA-005 must stay silent on. The rule
+// is titled "Hardcoded public IP address"; anything in this table is not a
+// public address, so reporting it contradicts the rule's own description.
+//
+// Two groups, both non-findings for the same reason — the value is not a
+// routable endpoint that leaks infrastructure:
+//
+//   - Non-routable / special-purpose space (RFC 1918, loopback, link-local,
+//     CGNAT, multicast, reserved). `host: 127.0.0.1` and `addr: 10.0.0.5` are
+//     the overwhelmingly common case in real configuration, and flagging them
+//     is what made this rule mostly noise.
+//   - Reserved documentation space (RFC 5737 TEST-NET-1/2/3). These exist
+//     precisely so examples, tests and docs have an address to use. Writing
+//     192.0.2.1 in a sample config is the correct thing for a developer to do.
+//
+// Ordered numerically so it reads against the IANA special-purpose registry.
+var nonPublicIPv4 = []struct {
+	prefix netip.Prefix
+	why    string
+}{
+	{netip.MustParsePrefix("0.0.0.0/8"), `RFC 1122 "this network"`},
+	{netip.MustParsePrefix("10.0.0.0/8"), "RFC 1918 private"},
+	{netip.MustParsePrefix("100.64.0.0/10"), "RFC 6598 carrier-grade NAT"},
+	{netip.MustParsePrefix("127.0.0.0/8"), "RFC 1122 loopback"},
+	{netip.MustParsePrefix("169.254.0.0/16"), "RFC 3927 link-local"},
+	{netip.MustParsePrefix("172.16.0.0/12"), "RFC 1918 private"},
+	{netip.MustParsePrefix("192.0.0.0/24"), "RFC 6890 IETF protocol assignments"},
+	{netip.MustParsePrefix("192.0.2.0/24"), "RFC 5737 TEST-NET-1 (documentation)"},
+	{netip.MustParsePrefix("192.88.99.0/24"), "RFC 7526 6to4 relay anycast (deprecated)"},
+	{netip.MustParsePrefix("192.168.0.0/16"), "RFC 1918 private"},
+	{netip.MustParsePrefix("198.18.0.0/15"), "RFC 2544 benchmarking"},
+	{netip.MustParsePrefix("198.51.100.0/24"), "RFC 5737 TEST-NET-2 (documentation)"},
+	{netip.MustParsePrefix("203.0.113.0/24"), "RFC 5737 TEST-NET-3 (documentation)"},
+	{netip.MustParsePrefix("224.0.0.0/4"), "RFC 5771 multicast"},
+	{netip.MustParsePrefix("240.0.0.0/4"), "RFC 1112 reserved (includes 255.255.255.255 broadcast)"},
+}
+
+// ipv4InMatch pulls the dotted-quad out of a DATA-005 match. The match text is
+// the whole `host: 203.0.113.9` assignment, so the address is the last
+// IPv4-shaped run in it — "last" because the key can itself contain digits
+// (`ip2 = ...`), while nothing follows the address in the pattern.
+var ipv4InMatch = regexp.MustCompile(`\d{1,3}(?:\.\d{1,3}){3}`)
+
+// isPublicIPv4Match reports whether a DATA-005 candidate carries a genuinely
+// public IPv4 address, and is the rule's ValidateMatch.
+//
+// A candidate whose address does not parse is dropped rather than reported:
+// netip rejects forms real configuration does not use (leading-zero octets,
+// out-of-range values), and a value nox cannot resolve to an address is a
+// value it cannot claim is public.
+//
+// IPv4 only, deliberately: DATA-005's pattern is a dotted quad and no rule in
+// this analyzer matches IPv6 today, so an IPv6 leg here (RFC 3849's
+// 2001:db8::/32 in particular) would be unreachable code guarding a rule that
+// does not exist. Add it with the rule.
+func isPublicIPv4Match(matchText string) bool {
+	candidates := ipv4InMatch.FindAllString(matchText, -1)
+	if len(candidates) == 0 {
+		return false
+	}
+	addr, err := netip.ParseAddr(candidates[len(candidates)-1])
+	if err != nil || !addr.Is4() {
+		return false
+	}
+	for i := range nonPublicIPv4 {
+		if nonPublicIPv4[i].prefix.Contains(addr) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// DATA-001 — email addresses
+// ---------------------------------------------------------------------------
+
+// reservedEmailDomains are the second-level domains RFC 2606 §3 reserves for
+// documentation and examples. They resolve to nothing and belong to nobody, so
+// an address at one of them is not PII and never was.
+var reservedEmailDomains = []string{
+	"example.com",
+	"example.net",
+	"example.org",
+}
+
+// reservedEmailTLDs are the top-level domains reserved by RFC 2606 §2 and
+// RFC 6761 for testing, examples and local use. Same reasoning: a developer
+// writing user@myapp.test is following the standard, not leaking an address.
+var reservedEmailTLDs = []string{
+	"example",
+	"invalid",
+	"localhost",
+	"test",
+}
+
+// isReportableEmailMatch reports whether a DATA-001 candidate names a real
+// mailbox rather than a reserved documentation address, and is the rule's
+// ValidateMatch.
+//
+// Subdomains count: RFC 2606 reserves example.com and everything under it, so
+// noreply@mail.example.com is excluded on the same grounds as
+// noreply@example.com.
+func isReportableEmailMatch(matchText string) bool {
+	at := strings.LastIndex(matchText, "@")
+	if at < 0 {
+		return false
+	}
+	domain := strings.ToLower(strings.Trim(matchText[at+1:], `"' `))
+	// A trailing dot is the fully-qualified spelling of the same domain.
+	domain = strings.TrimSuffix(domain, ".")
+	if domain == "" {
+		return false
+	}
+	for _, d := range reservedEmailDomains {
+		if domain == d || strings.HasSuffix(domain, "."+d) {
+			return false
+		}
+	}
+	for _, tld := range reservedEmailTLDs {
+		if domain == tld || strings.HasSuffix(domain, "."+tld) {
+			return false
+		}
+	}
+	return true
+}

--- a/core/analyzers/data/validate_test.go
+++ b/core/analyzers/data/validate_test.go
@@ -1,0 +1,258 @@
+package data
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests pin the precision fix for DATA-005 and DATA-001 from both sides.
+//
+// The recall side matters most and comes first in each pair: a precision fix
+// that quietly guts the rule is worse than the false positives it removed, so
+// every "must still fire" case is asserted before any "must not fire" case.
+//
+// They go through the analyzer, not the predicate function, so they fail if
+// the predicate is correct but never wired into the rule — which is the way
+// this fix is most likely to be lost in a future refactor.
+
+// scanFires reports whether scanning content produces a finding for ruleID.
+func scanFires(t *testing.T, a *Analyzer, ruleID, content string) bool {
+	t.Helper()
+	results, err := a.ScanFile("config.yaml", []byte(content))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	for i := range results {
+		if results[i].RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// DATA-005 — recall: genuinely public addresses must still be reported
+// ---------------------------------------------------------------------------
+
+// TestDATA005_PublicAddressesStillFire is the recall guard. Every address here
+// is publicly routable and hardcoding it in configuration is the disclosure
+// DATA-005 exists to catch (CWE-200). If this test goes quiet, the rule has
+// been suppressed rather than fixed.
+func TestDATA005_PublicAddressesStillFire(t *testing.T) {
+	a := NewAnalyzer()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"public DNS resolver", "server = '8.8.8.8'\n"},
+		{"cloudflare resolver", "ip: 1.1.1.1\n"},
+		{"quad9 resolver", "addr = \"9.9.9.9\"\n"},
+		{"arbitrary public host", "host: 93.184.216.34\n"},
+		{"just below the private block", "ip = 9.255.255.255\n"},
+		{"just above the private block", "ip = 11.0.0.0\n"},
+		{"just below 172.16/12", "server: 172.15.255.255\n"},
+		{"just above 172.16/12", "server: 172.32.0.0\n"},
+		{"just below 192.168/16", "addr: 192.167.255.255\n"},
+		{"just above 192.168/16", "addr: 192.169.0.0\n"},
+		{"just below CGNAT", "host = 100.63.255.255\n"},
+		{"just above CGNAT", "host = 100.128.0.0\n"},
+		{"just below TEST-NET-1", "ip = 192.0.1.255\n"},
+		{"just above TEST-NET-1", "ip = 192.0.3.0\n"},
+		{"just below TEST-NET-2", "ip = 198.51.99.255\n"},
+		{"just above TEST-NET-2", "ip = 198.51.101.0\n"},
+		{"just below TEST-NET-3", "ip = 203.0.112.255\n"},
+		{"just above TEST-NET-3", "ip = 203.0.114.0\n"},
+		{"just below multicast", "ip = 223.255.255.255\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !scanFires(t, a, "DATA-005", tt.content) {
+				t.Fatalf("DATA-005 must still fire on a public address: %q", strings.TrimSpace(tt.content))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DATA-005 — precision: non-public and reserved space must stay silent
+// ---------------------------------------------------------------------------
+
+// TestDATA005_NonPublicRanges covers every range the rule must exclude. Each
+// case is a value a developer writes on purpose: a loopback bind address, an
+// RFC 1918 service host, an RFC 5737 address in a sample config. Before the
+// fix the pattern matched every dotted quad, so all of these were reported as
+// a "public IP address".
+func TestDATA005_NonPublicRanges(t *testing.T) {
+	a := NewAnalyzer()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		// RFC 1122 "this network" / unspecified.
+		{"unspecified bind address", "host: 0.0.0.0\n"},
+		{"this-network", "ip = 0.1.2.3\n"},
+		// RFC 1122 loopback.
+		{"loopback", "host: 127.0.0.1\n"},
+		{"loopback elsewhere in /8", "server = '127.255.255.254'\n"},
+		// RFC 1918 private.
+		{"private 10/8", "server: 10.0.0.5\n"},
+		{"private 172.16/12 low", "addr = 172.16.0.1\n"},
+		{"private 172.16/12 high", "addr = 172.31.255.254\n"},
+		{"private 192.168/16", "addr: 192.168.1.1\n"},
+		// RFC 3927 link-local.
+		{"link-local", "ip = 169.254.169.254\n"},
+		// RFC 6598 carrier-grade NAT.
+		{"cgnat low", "host = 100.64.0.1\n"},
+		{"cgnat high", "host = 100.127.255.254\n"},
+		// RFC 6890 IETF protocol assignments.
+		{"protocol assignments", "ip: 192.0.0.8\n"},
+		// RFC 5737 documentation ranges — reserved so docs and tests can use them.
+		{"TEST-NET-1", "server = '192.0.2.1'\n"},
+		{"TEST-NET-2", "server = '198.51.100.42'\n"},
+		{"TEST-NET-3", "server = '203.0.113.9'\n"},
+		// RFC 7526 6to4 relay anycast (deprecated).
+		{"6to4 relay anycast", "ip = 192.88.99.1\n"},
+		// RFC 2544 benchmarking.
+		{"benchmarking", "host: 198.19.0.1\n"},
+		// RFC 5771 multicast.
+		{"multicast low", "addr = 224.0.0.1\n"},
+		{"multicast high", "addr = 239.255.255.255\n"},
+		// RFC 1112 reserved, including the broadcast address.
+		{"reserved 240/4", "ip = 240.0.0.1\n"},
+		{"limited broadcast", "ip = 255.255.255.255\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if scanFires(t, a, "DATA-005", tt.content) {
+				t.Fatalf("DATA-005 must not fire on a non-public address: %q", strings.TrimSpace(tt.content))
+			}
+		})
+	}
+}
+
+// TestDATA005_UnparseableCandidate pins the drop-on-parse-failure behaviour.
+// The pattern's octet alternation admits a leading-zero form that netip
+// rejects; nox cannot claim such a value is public, so it stays silent rather
+// than guessing.
+func TestDATA005_UnparseableCandidate(t *testing.T) {
+	a := NewAnalyzer()
+	if scanFires(t, a, "DATA-005", "ip = 008.008.008.008\n") {
+		t.Fatal("DATA-005 must not fire on an address netip cannot parse")
+	}
+}
+
+// TestIsPublicIPv4Match_Extraction pins how the predicate picks the address
+// out of the match text, independently of what today's pattern can produce.
+//
+// The address is the LAST dotted quad in the match, because the key can carry
+// digits while nothing follows the address. DATA-005's current pattern will
+// not match a key like `ip2`, so the multi-quad case is unreachable through it
+// — the predicate is asserted directly so a future pattern widening does not
+// silently start reading the wrong number.
+func TestIsPublicIPv4Match_Extraction(t *testing.T) {
+	tests := []struct {
+		name  string
+		match string
+		want  bool
+	}{
+		{"no address at all", "host = ", false},
+		{"trailing address wins — public", "10.0.0.5_ip = 8.8.8.8", true},
+		{"trailing address wins — private", "8.8.8.8_ip = 10.0.0.5", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPublicIPv4Match(tt.match); got != tt.want {
+				t.Fatalf("isPublicIPv4Match(%q) = %v, want %v", tt.match, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DATA-001 — recall: real addresses must still be reported
+// ---------------------------------------------------------------------------
+
+// TestDATA001_RealAddressesStillFire is the recall guard for the email rule.
+// Every address here is at an ordinary registrable domain and is exactly the
+// hardcoded PII DATA-001 exists to catch.
+func TestDATA001_RealAddressesStillFire(t *testing.T) {
+	a := NewAnalyzer()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"corporate address", "admin_email = jane.doe@acmecorp.io\n"},
+		{"quoted address", "owner: \"j.smith@northwind-logistics.co.uk\"\n"},
+		{"gmail address", "contact = 'someone.real@gmail.com'\n"},
+		{"plus addressing", "notify: alerts+prod@acmecorp.io\n"},
+		// The reserved names are reserved as domains, not as substrings: a
+		// domain that merely contains "example" or ends in "testing" is a real
+		// registrable domain and must still be reported.
+		{"example as a label prefix", "email = ops@example-corp.com\n"},
+		{"reserved TLD as a suffix fragment", "email = ops@acmecorp.contest\n"},
+		{"reserved domain as a suffix fragment", "email = ops@notexample.com\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !scanFires(t, a, "DATA-001", tt.content) {
+				t.Fatalf("DATA-001 must still fire on a real address: %q", strings.TrimSpace(tt.content))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DATA-001 — precision: RFC-reserved documentation addresses stay silent
+// ---------------------------------------------------------------------------
+
+// TestDATA001_ReservedDomains covers the domains and TLDs that RFC 2606 and
+// RFC 6761 reserve so documentation, examples and tests have an address to
+// use. Writing one of these is the correct thing for a developer to do, so
+// reporting it as leaked PII is always a false positive.
+func TestDATA001_ReservedDomains(t *testing.T) {
+	a := NewAnalyzer()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		// RFC 2606 §3 reserved second-level domains.
+		{"example.com", "email = user@example.com\n"},
+		{"example.net", "email = user@example.net\n"},
+		{"example.org", "email = user@example.org\n"},
+		{"subdomain of example.com", "email = noreply@mail.example.com\n"},
+		{"uppercase example.com", "email = User@Example.COM\n"},
+		{"fully qualified example.com", "email = user@example.com.\n"},
+		// RFC 2606 §2 / RFC 6761 reserved TLDs.
+		{".example TLD", "email = user@myapp.example\n"},
+		{".test TLD", "email = user@myapp.test\n"},
+		{".invalid TLD", "email = user@myapp.invalid\n"},
+		{".localhost TLD", "email = user@myapp.localhost\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if scanFires(t, a, "DATA-001", tt.content) {
+				t.Fatalf("DATA-001 must not fire on an RFC-reserved address: %q", strings.TrimSpace(tt.content))
+			}
+		})
+	}
+}
+
+// TestIsReportableEmailMatch_Degenerate covers the predicate's guards for
+// match text that carries no usable domain. Unreachable through the current
+// pattern, which requires an "@" and a dotted domain, but the predicate must
+// not depend on that.
+func TestIsReportableEmailMatch_Degenerate(t *testing.T) {
+	for _, match := range []string{"= nobody", `= user@""`} {
+		if isReportableEmailMatch(match) {
+			t.Fatalf("a match with no domain must not be reported: %q", match)
+		}
+	}
+}

--- a/core/rules/engine.go
+++ b/core/rules/engine.go
@@ -66,6 +66,13 @@ func (e *Engine) ScanFile(path string, content []byte) ([]findings.Finding, erro
 
 		results := matcher.Match(content, rule)
 		for _, mr := range results {
+			// Post-match predicate: the rule inspects its own match text and
+			// vetoes it. Runs before the line-windowed filters because it is
+			// the cheapest of the three and needs no line splitting.
+			if rule.ValidateMatch != nil && !rule.ValidateMatch(mr.MatchText) {
+				continue
+			}
+
 			// Precision filters: drop matches in comments or defensive
 			// contexts when the rule opts in. Lines are computed lazily.
 			if rule.IgnoreInComments || len(rule.ExcludeContextKeywords) > 0 ||

--- a/core/rules/rules.go
+++ b/core/rules/rules.go
@@ -64,6 +64,26 @@ type Rule struct {
 	// identifier also rejects the key.
 	RequireContextKeywords []string `yaml:"require_context_keywords"`
 
+	// ValidateMatch is an optional post-match predicate: the engine keeps a
+	// match only when it returns true for the matched text. It is set
+	// programmatically by built-in rules (there is no YAML spelling — a
+	// predicate is code, not data) and is nil for every rule that does not
+	// need one.
+	//
+	// It exists for the class of rule whose *candidate* is cheap to express as
+	// a regex but whose *decision* is not. DATA-005 is the motivating case: RE2
+	// can find an IPv4-shaped token in one line of pattern, but deciding
+	// whether that address is publicly routable means excluding a dozen
+	// numeric ranges (RFC 1918, loopback, CGNAT, multicast, the RFC 5737
+	// documentation nets). Written as a regex that is an unreviewable wall of
+	// alternations; written as a netip.Prefix table it is a list anyone can
+	// check against the RFCs. Match broadly, then decide in Go.
+	//
+	// The predicate receives only the matched text, so it stays a pure
+	// function of the match and cannot smuggle in file or line state — the
+	// line-windowed context filters above remain the tool for that.
+	ValidateMatch func(matchText string) bool `yaml:"-"`
+
 	// Absence* fields drive the block-scoped absence matcher (MatcherType
 	// "absence"). They restore IaC "resource present but hardening property
 	// missing" detections that Go's RE2 regexp cannot express: those were

--- a/core/rules/validate_match_test.go
+++ b/core/rules/validate_match_test.go
@@ -1,0 +1,82 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// validateMatchRule builds a rule that matches any dotted quad and vetoes
+// matches through the supplied predicate.
+func validateMatchRule(validate func(string) bool) *Rule {
+	return &Rule{
+		ID:            "TEST-VALIDATE",
+		Version:       "1.0",
+		Description:   "test rule with a post-match predicate",
+		Severity:      findings.SeverityMedium,
+		Confidence:    findings.ConfidenceMedium,
+		MatcherType:   "regex",
+		Pattern:       `\b[0-9]{1,3}(?:\.[0-9]{1,3}){3}\b`,
+		ValidateMatch: validate,
+	}
+}
+
+// TestValidateMatch_NilKeepsEveryMatch is the control: a rule without a
+// predicate behaves exactly as before the hook existed.
+func TestValidateMatch_NilKeepsEveryMatch(t *testing.T) {
+	rs := NewRuleSet()
+	rs.Add(validateMatchRule(nil))
+
+	got, err := NewEngine(rs).ScanFile("config.yaml", []byte("a = 1.2.3.4\nb = 10.0.0.1\n"))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("nil ValidateMatch must keep every match: got %d findings, want 2", len(got))
+	}
+}
+
+// TestValidateMatch_VetoesRejectedMatches asserts the engine drops exactly the
+// matches the predicate rejects and keeps the rest — a rule can raise its
+// precision without losing recall on the matches it still accepts.
+func TestValidateMatch_VetoesRejectedMatches(t *testing.T) {
+	rs := NewRuleSet()
+	rs.Add(validateMatchRule(func(m string) bool { return !strings.HasPrefix(m, "10.") }))
+
+	got, err := NewEngine(rs).ScanFile("config.yaml", []byte("a = 1.2.3.4\nb = 10.0.0.1\n"))
+	if err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+	if got[0].Location.StartLine != 1 {
+		t.Fatalf("the surviving finding must be the accepted match on line 1, got line %d", got[0].Location.StartLine)
+	}
+}
+
+// TestValidateMatch_ReceivesMatchTextOnly pins the predicate's contract: it
+// sees the matched text and nothing else, so it stays a pure function of the
+// match and cannot come to depend on file or line state.
+func TestValidateMatch_ReceivesMatchTextOnly(t *testing.T) {
+	var seen []string
+	rs := NewRuleSet()
+	rs.Add(validateMatchRule(func(m string) bool {
+		seen = append(seen, m)
+		return true
+	}))
+
+	if _, err := NewEngine(rs).ScanFile("config.yaml", []byte("a = 1.2.3.4\nb = 10.0.0.1\n")); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	want := []string{"1.2.3.4", "10.0.0.1"}
+	if len(seen) != len(want) {
+		t.Fatalf("predicate saw %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("predicate saw %v, want %v", seen, want)
+		}
+	}
+}

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -44,7 +44,7 @@ nox bench --precision testdata/precision-suite --baseline testdata/precision-sui
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite` scores
-**precision 1.00 / recall 1.00 / F1 1.00** (35 TP, 0 FP, 0 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (37 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits is a true positive, and both Go clean
 stressors (`clean_html_autoescape.go`, `clean_field_safe.go`) fire nothing — and
 recall is back to 1.00 now that the Go tier-2 gaps are closed. The second Go tier
@@ -54,6 +54,17 @@ engine missed — three XSS-to-response sinks and one map-value container taint 
 dropping recall to 0.89. Those were closed by building the engine (an
 XSS-to-response sink family + container-level index/field taint), not by curating
 the corpus. See "Go coverage" below for what each fix added.
+
+A configuration tier (`tp_data_pii.yaml`, `clean_data_placeholders.yaml`) was
+added alongside the DATA-005 / DATA-001 precision fix, and named **nine honest
+false positives** on landing: DATA-005's pattern matched every dotted quad
+despite the rule being titled "public IP address", so it reported all six
+loopback / RFC 1918 / link-local / RFC 5737 addresses in the clean sample, and
+DATA-001 reported all three RFC 2606 / RFC 6761 reserved documentation
+addresses. Measured on this corpus, DATA-005 scored **precision 0.14** and
+DATA-001 **precision 0.25**, dropping corpus precision to 0.80 / F1 0.89. Both
+are now 1.00 with recall unchanged at 1.00 — closed by deciding publicness in
+Go against a `netip.Prefix` table rather than by widening the regex.
 
 For the historical record, recall dipped to 0.79 when the *first* realistic **Go**
 samples landed (six FNs: injection / traversal / SSRF / deserialization / SSTI),
@@ -183,6 +194,12 @@ language for the first time):
 | `tp_field_taint.go` | cmd injection laundered through a struct field | TAINT-002 | TP (container-level field taint) |
 | `tp_container_taint.go` | cmd injection through a map value **and** a slice element | TAINT-002 (×2) | TP ×2 (container-level index/element taint) |
 
+True positives — configuration (annotated ground truth):
+
+| File | What it exercises | Correct rule | nox today |
+| --- | --- | --- | --- |
+| `tp_data_pii.yaml` | publicly routable IPv4 + mailbox at a registrable domain in config | DATA-005 / DATA-001 | TP |
+
 Clean stressors (zero annotations — any finding is a false positive):
 
 | File | Noise class | nox today |
@@ -204,6 +221,7 @@ Clean stressors (zero annotations — any finding is a false positive):
 | `clean_identifiers.go` | UUID, git SHA, hex colors, **SRI integrity hash** | clean (SRI fix) |
 | `clean_html_autoescape.go` | `html/template` context-aware auto-escaping of user data | clean (correct escaping → not a sink) |
 | `clean_field_safe.go` | struct field sanitized (`strconv.Atoi`, `filepath.Base`) before the sink | clean (sanitizer recognized) |
+| `clean_data_placeholders.yaml` | loopback / RFC 1918 / link-local IPs and RFC 2606 + RFC 6761 reserved email domains | clean (DATA-005/001 range + reserved-domain predicates) |
 
 Grow this corpus over time; the honest way to raise the number is to fix the
 rules the corpus indicts, not to curate the corpus to pass. When a rule fix

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,12 +3,22 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 35,
+  "tp": 37,
   "fn": 0,
-  "findings_per_issue": 1.0606060606060606,
+  "findings_per_issue": 1.0571428571428572,
   "rules": [
     {
       "rule_id": "AI-002",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "DATA-001",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "DATA-005",
       "precision": 1,
       "recall": 1
     },

--- a/testdata/precision-suite/clean_data_placeholders.yaml
+++ b/testdata/precision-suite/clean_data_placeholders.yaml
@@ -1,0 +1,19 @@
+# Clean sample: every value here is a placeholder that exists to be safe.
+#
+# The IPs are loopback, RFC 1918 private, link-local and the RFC 5737
+# documentation nets; the addresses are at the RFC 2606 / RFC 6761 reserved
+# domains and TLDs. All are the correct thing for a developer to write in a
+# config, and none discloses infrastructure or PII. Any finding here is a FALSE
+# POSITIVE — DATA-005 used to report all six IPs as a "public IP address"
+# because its pattern matched every dotted quad.
+server:
+  bind_host: 127.0.0.1
+  advertise_addr: 0.0.0.0
+  database_host: 10.0.0.5
+  cache_host: 192.168.1.10
+  link_local_ip: 169.254.10.20
+  docs_example_host: 203.0.113.9
+contacts:
+  support_email: support@example.com
+  staging_email: noreply@staging.example
+  fixture_email: qa@myapp.test

--- a/testdata/precision-suite/tp_data_pii.yaml
+++ b/testdata/precision-suite/tp_data_pii.yaml
@@ -1,0 +1,9 @@
+# True positives for the data-sensitivity rules. Both values below are the real
+# thing: a publicly routable IPv4 address and a mailbox at an ordinary
+# registrable domain, hardcoded into configuration. These are the recall side of
+# the DATA-005 precision fix — if a future exclusion silences them, the rule has
+# been gutted rather than sharpened.
+service:
+  name: reporting-api
+  dns_server: 8.8.8.8  # nox-expect: DATA-005
+  oncall_contact: jane.doe@acmecorp.io  # nox-expect: DATA-001


### PR DESCRIPTION
## The headline: the rule's description and its behaviour disagreed

`DATA-005` is titled **"Hardcoded public IP address in configuration"**. Its pattern matched any dotted quad, so it reported:

```yaml
host: 127.0.0.1      # loopback
server: 10.0.0.5     # RFC 1918
addr: 192.168.1.1    # RFC 1918
```

Private and loopback addresses are the *common* case in real configuration, so the rule was mostly noise. Not a cosmetic complaint: in one downstream repo it helped block four PRs, because branch protection there requires conversation resolution and every advisory finding opens a review thread.

## Second, smaller: reserved documentation values

RFC 2606 / RFC 6761 reserve `example.com/.net/.org` and the `.example`, `.test`, `.invalid`, `.localhost` TLDs; RFC 5737 reserves `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`. They exist **precisely so** documentation, examples and tests have an address to use. Writing one is correct practice, not a leak. `DATA-001` and `DATA-005` flagged them anyway.

## Approach

Range exclusion is the wrong job for a regex — as alternations it becomes something nobody can later verify. The candidate is matched by pattern, then parsed and classified in code (`core/analyzers/data/validate.go`).

## Verification — the part that matters

A precision fix that quietly guts a rule looks identical to a successful one in a "0 findings" run, so the **positive** cases are the real evidence. End-to-end against the patched binary on a mixed fixture:

| Value | Class | Result |
|---|---|---|
| `8.8.8.8`, `1.1.1.1` | genuinely public | **fires** |
| `felix@klarlabs.de` | real domain | **fires** |
| `203.0.113.9`, `198.51.100.4`, `192.0.2.10` | RFC 5737 | silent |
| `127.0.0.1`, `10.0.0.5`, `192.168.1.1` | loopback / RFC 1918 | silent |
| `ops@example.com` | RFC 2606 | silent |
| `admin@corp.invalid` | RFC 6761 TLD | silent |

Plus:

- **Precision suite** (`nox bench --precision testdata/precision-suite`): **P/R/F1 = 1.000 / 1.000 / 1.000**, 37 TP, **0 FP, 0 FN**, noise ratio 0.00. No recall loss.
- Table-driven positive **and** negative cases for every DATA-001..012 rule — all pass.
- `go build ./...`, `go vet`, `go test ./core/analyzers/data/... ./core/rules/...` all clean.
- New fixtures: `clean_data_placeholders.yaml` (must not fire) and an addition to `tp_data_pii.yaml` (must fire).

https://claude.ai/code/session_012qFD1UhQT9tiKkMsPAskK7