### PR TITLE
fix(taint): follow Elixir pipe chains to the sink, not just the first stage

### DIFF
--- a/cli/bench_precision_elixir_test.go
+++ b/cli/bench_precision_elixir_test.go
@@ -18,11 +18,12 @@ func elixirSuitePath() string {
 // if any gated metric regressed (precision/recall/F1 dropped, or FP /
 // findings-per-issue rose).
 //
-// Elixir recall is intentionally below 1.0 — its two dominant dataflow idioms,
-// the pipe operator `|>` and pattern matching, are more than a flat per-line
-// recognizer can follow, so the suite carries two documented honest false
-// negatives (a multi-stage pipe and a destructuring pattern match; see
-// testdata/precision-suite-elixir/README.md). Pinning the number here means
+// Elixir recall is intentionally below 1.0 — of its two dominant dataflow
+// idioms, the pipe operator `|>` is now followed to the end of the chain, but
+// pattern matching is still more than a flat per-line recognizer can follow, so
+// the suite carries one documented honest false negative (a destructuring
+// pattern match; see testdata/precision-suite-elixir/README.md). Pinning the
+// number here means
 // Elixir PRECISION can no longer silently regress: a change that makes the suite
 // noisier fails CI. When the suite legitimately improves, this test reports the
 // improvement and tells you to refresh baseline.json.

--- a/core/bench/baseline.go
+++ b/core/bench/baseline.go
@@ -133,7 +133,17 @@ func CompareBaseline(base, current Baseline) []Regression {
 	if current.FP > base.FP+fpTolerance {
 		out = append(out, Regression{"fp", float64(base.FP), float64(current.FP)})
 	}
-	if current.FindingsPerIssue > base.FindingsPerIssue+baselineEpsilon {
+	// findings-per-issue is a distance-from-ideal metric, not a lower-is-better
+	// one: 1.00 means every annotated issue produced exactly one finding. Below
+	// 1.00 the scanner is MISSING findings; above it, duplicating them. A suite
+	// that carries honest false negatives therefore sits under 1.00, and closing
+	// one of those FNs necessarily raises the number toward the ideal. Gating on
+	// a bare rise flagged those recall wins as regressions and would have forced
+	// every real improvement through a baseline regeneration. Only a rise past
+	// the ideal — genuine over-firing — regresses, so the ceiling is
+	// max(baseline, 1.0): a suite already over-firing may not get worse, and a
+	// suite under-firing may climb to 1.00 freely.
+	if ceiling := max(base.FindingsPerIssue, 1.0); current.FindingsPerIssue > ceiling+baselineEpsilon {
 		out = append(out, Regression{"findings_per_issue", base.FindingsPerIssue, current.FindingsPerIssue})
 	}
 	// Per-rule floors: any individual rule whose precision OR recall dropped
@@ -189,5 +199,20 @@ func Improved(base, current Baseline) bool {
 		current.Recall > base.Recall+baselineEpsilon ||
 		current.F1 > base.F1+baselineEpsilon ||
 		current.FP < base.FP ||
-		current.FindingsPerIssue < base.FindingsPerIssue-baselineEpsilon
+		// Closer to the 1.00 ideal in EITHER direction, mirroring the gate in
+		// CompareBaseline. A bare drop is not an improvement: for a suite that
+		// already under-fires, falling further below 1.00 means it started
+		// missing even more findings.
+		densityDistance(current.FindingsPerIssue) < densityDistance(base.FindingsPerIssue)-baselineEpsilon
+}
+
+// densityDistance is how far a findings-per-issue value sits from the 1.00
+// ideal — one finding per annotated issue. Under 1.00 the scanner misses
+// findings, over it duplicates them; the distance makes both directions
+// comparable.
+func densityDistance(v float64) float64 {
+	if v < 1.0 {
+		return 1.0 - v
+	}
+	return v - 1.0
 }

--- a/core/bench/baseline_test.go
+++ b/core/bench/baseline_test.go
@@ -73,6 +73,83 @@ func TestCompareBaseline(t *testing.T) {
 // regressing even when the overall numbers are untouched — the exact blind spot
 // an overall-only floor has. It also proves the schema is backward compatible: a
 // baseline with no `rules` section skips per-rule enforcement.
+// TestImprovedUnderFiringDensity is the mirror of the gate: for a suite already
+// below the 1.00 ideal, sliding FURTHER below means it started missing even more
+// findings, so it must not be advertised as an improvement worth snapshotting.
+func TestImprovedUnderFiringDensity(t *testing.T) {
+	t.Parallel()
+
+	base := Baseline{Precision: 1.0, Recall: 0.857, F1: 0.923, FP: 0, TP: 12, FN: 2, FindingsPerIssue: 0.857}
+
+	// Density alone falls further below the ideal, with every other metric flat.
+	worse := Baseline{Precision: 1.0, Recall: 0.857, F1: 0.923, FP: 0, TP: 12, FN: 2, FindingsPerIssue: 0.6}
+	if Improved(base, worse) {
+		t.Error("a density drop further below the 1.00 ideal must not count as an improvement")
+	}
+
+	// Climbing toward the ideal is the real improvement.
+	better := Baseline{Precision: 1.0, Recall: 0.857, F1: 0.923, FP: 0, TP: 12, FN: 2, FindingsPerIssue: 0.95}
+	if !Improved(base, better) {
+		t.Error("a density rise toward the 1.00 ideal must count as an improvement")
+	}
+}
+
+// TestCompareBaselineUnderFiringDensity pins the direction of the
+// findings-per-issue gate. The metric's ideal is 1.00: below it the scanner is
+// MISSING findings, above it the scanner is duplicating them. A suite carrying
+// honest false negatives sits below 1.0, so closing one of those FNs necessarily
+// raises the number — toward the ideal. Gating it as strictly lower-is-better
+// reported every such recall win as a regression, which would have forced each
+// genuine improvement to be laundered through a baseline regeneration. Only
+// movement past the 1.00 ideal (real over-firing) is a regression.
+func TestCompareBaselineUnderFiringDensity(t *testing.T) {
+	t.Parallel()
+
+	// An under-firing suite: 12 findings across 14 annotated issues.
+	base := Baseline{Precision: 1.0, Recall: 0.857, F1: 0.923, FP: 0, TP: 12, FN: 2, FindingsPerIssue: 0.857}
+
+	tests := []struct {
+		name    string
+		current Baseline
+		want    []string
+	}{
+		{
+			name:    "closing a false negative raises density toward 1.0 and is not a regression",
+			current: Baseline{Precision: 1.0, Recall: 0.929, F1: 0.963, FP: 0, TP: 13, FN: 1, FindingsPerIssue: 0.929},
+			want:    nil,
+		},
+		{
+			name:    "reaching the 1.00 ideal is not a regression",
+			current: Baseline{Precision: 1.0, Recall: 1.0, F1: 1.0, FP: 0, TP: 14, FN: 0, FindingsPerIssue: 1.0},
+			want:    nil,
+		},
+		{
+			name:    "over-firing past the ideal is a regression",
+			current: Baseline{Precision: 1.0, Recall: 1.0, F1: 1.0, FP: 0, TP: 14, FN: 0, FindingsPerIssue: 1.6},
+			want:    []string{"findings_per_issue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CompareBaseline(base, tt.current)
+			names := make([]string, len(got))
+			for i := range got {
+				names[i] = got[i].Metric
+			}
+			if len(names) != len(tt.want) {
+				t.Fatalf("regressions = %v, want %v", names, tt.want)
+			}
+			for i := range tt.want {
+				if names[i] != tt.want[i] {
+					t.Errorf("regression[%d] = %s, want %s", i, names[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestCompareBaselinePerRule(t *testing.T) {
 	t.Parallel()
 
@@ -206,6 +283,11 @@ func TestImproved(t *testing.T) {
 		{"fewer FPs is an improvement", Baseline{Precision: 0.30, Recall: 0.80, F1: 0.44, FP: 10, FindingsPerIssue: 3.0}, true},
 		{"lower density is an improvement", Baseline{Precision: 0.30, Recall: 0.80, F1: 0.44, FP: 18, FindingsPerIssue: 1.5}, true},
 		{"a regression is not an improvement", Baseline{Precision: 0.20, Recall: 0.80, F1: 0.44, FP: 18, FindingsPerIssue: 3.0}, false},
+		// Density is distance-from-1.00, so overshooting the ideal is not a win:
+		// 3.0 -> 0.2 swaps heavy duplication for heavy under-firing (distance
+		// 2.0 -> 0.8 is closer, so this one IS an improvement), but a suite that
+		// starts under 1.00 and falls further is strictly worse. Covered below.
+		{"overshooting from over-firing to closer-but-under is an improvement", Baseline{Precision: 0.30, Recall: 0.80, F1: 0.44, FP: 18, FindingsPerIssue: 0.9}, true},
 	}
 
 	for _, tt := range tests {

--- a/core/taint/engine/extract_elixir.go
+++ b/core/taint/engine/extract_elixir.go
@@ -15,17 +15,15 @@ import "strings"
 //   - a leading `:` on an Erlang-module chain (`:os.cmd`, `:erlang.binary_to_term`)
 //     is stripped so the chain reads as `os.cmd` / `erlang.binary_to_term` and
 //     resolves against the catalog by suffix.
-//   - the pipe operator `x |> f(args)` is rewritten to `f(x, args)` (best-effort)
-//     so the shared recognizer sees the piped value as the FIRST argument of f —
-//     this is how a tainted value flowing through a pipe into a sink is caught.
+//   - the pipe operator `x |> f(args)` is rewritten to `f(x, args)`, applied to
+//     fixpoint so a MULTI-stage chain (`a |> f() |> g()`) nests all the way down
+//     to `g(f(a))` — this is how a tainted value flowing through a pipe into a
+//     sink is caught, however many hops downstream the sink sits.
 //   - paren-less calls (`IO.puts x`, `System.halt 1`) are rewritten to a
 //     parenthesized form so the shared call recognizer sees `IO.puts(...)`.
 //
 // HONEST LIMITS (recall is lower than the function-call-shaped languages, by
 // design and documented in testdata/precision-suite-elixir/README.md):
-//   - The pipe rewrite is per-line and best-effort: a MULTI-stage pipe chain
-//     (`a |> f() |> g()`) only binds the value into the FIRST stage; a value that
-//     reaches a sink two-or-more pipe hops downstream is missed.
 //   - Pattern-matching binds only a SIMPLE-ident LHS (`x = expr`). A destructuring
 //     match (`%{"q" => q} = conn.params`, `[h | t] = list`, `{:ok, v} = ...`) does
 //     not surface `q`/`v` as a tainted binding — a documented false negative.
@@ -355,41 +353,50 @@ func stripElixirErlangColon(s string) string {
 	return string(b)
 }
 
-// desugarElixirPipe rewrites the FIRST top-level pipe `lhs |> callee(args)` on the
-// line into `callee(lhs, args)` so the shared recognizer sees the piped value as
-// the callee's first positional argument. It is best-effort and per-line: only
-// the first pipe stage is rewritten (a multi-stage chain binds the value into the
-// first stage only, a documented recall limit). Both views are transformed
-// identically so they stay aligned; if the rewrite would break alignment it is
-// skipped (returning the inputs unchanged) so the recognizer never sees a
-// mismatched pair.
+// desugarElixirPipe rewrites a top-level pipe chain `a |> f(args) |> g()` on the
+// line into the equivalent nesting `g(f(a, args))`, so the shared recognizer sees
+// the piped value as the first positional argument of EVERY stage — including the
+// final one, which is where the sink usually is.
+//
+// One rewrite consumes exactly the leftmost pipe (`a |> f() |> g()` becomes
+// `f(a) |> g()`), so the transform is applied to fixpoint: each pass strictly
+// removes one `|>`, which both walks the whole chain and guarantees termination.
+// Rewriting only the first stage — as this did before — bound the value into the
+// head of the chain and lost any sink two or more hops downstream.
+//
+// Both views are transformed identically so they stay aligned; if a stage cannot
+// be rewritten the chain stops there (keeping what was already desugared) so the
+// recognizer never sees a mismatched pair.
 func desugarElixirPipe(code, raw string) (newCode, newRaw string) {
-	pipe := elixirTopLevelPipe(code)
-	if pipe < 0 {
-		return code, raw
-	}
-	lhs := strings.TrimSpace(code[:pipe])
-	rhsStart := pipe + 2 // past `|>`
-	rhs := code[rhsStart:]
-	// The RHS must be a call `callee(args)` or a paren-less callee. Locate the
-	// callee head and its argument list.
-	rewritten, ok := rewritePipeStage(lhs, rhs)
-	if !ok {
-		return code, raw
-	}
-	newCode = rewritten
-	// Apply the SAME structural rewrite to the raw view by reconstructing it from
-	// the raw halves, so both views carry the piped value identically. When raw is
-	// not aligned to code we fall back to the code rewrite for both (argument
-	// counting then uses the code view, which is safe).
-	if len(raw) == len(code) {
-		rawLHS := strings.TrimSpace(raw[:pipe])
-		rawRHS := raw[rhsStart:]
-		if newRaw, ok := rewritePipeStage(rawLHS, rawRHS); ok {
-			return newCode, newRaw
+	// Guard against a pathological line; the loop already terminates on its own
+	// because every pass removes one pipe.
+	const maxPipeStages = 64
+	for range maxPipeStages {
+		pipe := elixirTopLevelPipe(code)
+		if pipe < 0 {
+			break
 		}
+		lhs := strings.TrimSpace(code[:pipe])
+		rhsStart := pipe + 2 // past `|>`
+		// The RHS must be a call `callee(args)` or a paren-less callee. Locate the
+		// callee head and its argument list.
+		rewritten, ok := rewritePipeStage(lhs, code[rhsStart:])
+		if !ok {
+			break
+		}
+		// Apply the SAME structural rewrite to the raw view by reconstructing it
+		// from the raw halves, so both views carry the piped value identically.
+		// Once raw is no longer aligned to code it follows the code rewrite
+		// (argument counting then uses the code view, which is safe).
+		nextRaw := rewritten
+		if len(raw) == len(code) {
+			if rr, ok := rewritePipeStage(strings.TrimSpace(raw[:pipe]), raw[rhsStart:]); ok {
+				nextRaw = rr
+			}
+		}
+		code, raw = rewritten, nextRaw
 	}
-	return newCode, newCode
+	return code, raw
 }
 
 // rewritePipeStage rewrites `lhs` piped into the call expression `rhs` as

--- a/core/taint/engine/extract_elixir_test.go
+++ b/core/taint/engine/extract_elixir_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/lexctx"
@@ -99,6 +100,61 @@ end
 	}
 	if !found {
 		t.Errorf("piped System.cmd reads = %v, want to include cmd", sink.reads)
+	}
+}
+
+// TestExtractElixirMultiStagePipe: a value piped through TWO-plus stages
+// (`x |> f() |> g()`) must reach the final sink, not just the first stage.
+// Desugaring peels one pipe per rewrite (`a |> f() |> g()` → `f(a) |> g()`), so
+// the rewrite has to run to fixpoint; stopping after one stage leaves the sink
+// holding no argument and loses the flow. This is the elixir suite's documented
+// `run_piped/1` false negative.
+func TestExtractElixirMultiStagePipe(t *testing.T) {
+	// The source expression is piped INLINE, with no intermediate binding — the
+	// exact shape of the suite's run_piped/1 sample. A bound variable would leak a
+	// line-level read and mask the gap.
+	src := []byte(`def handle(conn) do
+  conn.params["cmd"] |> String.trim() |> :os.cmd()
+end
+`)
+	units := extractUnits(lexctx.LangElixir, src)
+	u := findUnit(t, units, "handle")
+	sink := stmtWithCall(t, u, "os.cmd")
+	if sink.line == 0 {
+		t.Fatalf("final pipe stage os.cmd not recognized: %+v", u.stmts)
+	}
+	found := false
+	for _, c := range sink.chains {
+		if strings.Contains(c, "conn.params") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("multi-stage piped os.cmd chains = %v, want to include conn.params", sink.chains)
+	}
+}
+
+// TestExtractElixirThreeStagePipe: the fixpoint rewrite must not stop at two —
+// an arbitrary-length chain lands the value in the final sink.
+func TestExtractElixirThreeStagePipe(t *testing.T) {
+	src := []byte(`def handle(conn) do
+  conn.params["cmd"] |> String.trim() |> String.downcase() |> :os.cmd()
+end
+`)
+	units := extractUnits(lexctx.LangElixir, src)
+	u := findUnit(t, units, "handle")
+	sink := stmtWithCall(t, u, "os.cmd")
+	if sink.line == 0 {
+		t.Fatalf("final pipe stage os.cmd not recognized: %+v", u.stmts)
+	}
+	found := false
+	for _, c := range sink.chains {
+		if strings.Contains(c, "conn.params") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("three-stage piped os.cmd chains = %v, want to include conn.params", sink.chains)
 	}
 }
 

--- a/core/taint/engine/extract_ruby.go
+++ b/core/taint/engine/extract_ruby.go
@@ -309,12 +309,16 @@ func leadingCallHead(code string) (head string, end int) {
 	if head == "" || strings.HasPrefix(head, ".") {
 		return "", 0
 	}
-	// Reject keywords used as statement heads.
-	firstSeg := head
-	if dot := strings.IndexByte(head, '.'); dot >= 0 {
-		firstSeg = head[:dot]
-	}
-	if isKeyword(firstSeg) {
+	// Reject keywords used as statement heads (`return x` is not a call to
+	// `return`). Only a BARE head can be a keyword statement: no language writes
+	// `return.foo(...)`, so a DOTTED chain whose first segment happens to be in the
+	// shared keyword set is a call on a module or type that merely shares the name
+	// — Elixir's `String.trim` / `Map.get` / `List.first` / `Stream.map`, Java's
+	// `String.format`, C#'s `Uri.EscapeDataString`. Those are real, frequently
+	// tainted call heads; rejecting them dropped the sink entirely. The shared set
+	// carries Dart's built-in type names, so this distinction is what keeps them
+	// from suppressing calls across every other language.
+	if !strings.Contains(head, ".") && isKeyword(head) {
 		return "", 0
 	}
 	return head, i

--- a/testdata/precision-suite-elixir/README.md
+++ b/testdata/precision-suite-elixir/README.md
@@ -20,12 +20,12 @@ As committed, `nox bench --precision testdata/precision-suite-elixir` scores:
 | Metric | Value |
 | --- | --- |
 | **Precision** | **1.00** (0 false positives) |
-| **Recall** | **0.86** |
-| **F1** | **0.92** |
-| TP / FP / FN | 12 / 0 / 2 |
-| findings-per-issue | 0.86 |
+| **Recall** | **0.93** |
+| **F1** | **0.96** |
+| TP / FP / FN | 13 / 0 / 1 |
+| findings-per-issue | 0.93 |
 
-Per rule: TAINT-001 (SQLi) 1/1, TAINT-002 (cmd injection) 3/4, TAINT-004 (path
+Per rule: TAINT-001 (SQLi) 1/1, TAINT-002 (cmd injection) 4/4, TAINT-004 (path
 traversal) 3/4, TAINT-005 (code injection / deserialization) 2/2, TAINT-006
 (SSRF) 3/3. **Precision is 1.00** — every finding nox emits is a true positive,
 and all four clean stressors fire nothing.
@@ -66,33 +66,54 @@ is a false positive:
 - **clean_generated.exs** — a machine-generated banner, constant lookup tables,
   and a constant fixture `File.read` — no untrusted input anywhere.
 
-## Why Elixir recall is below 1.0 (the honest false negatives)
+## Why Elixir recall is below 1.0 (the honest false negative)
 
-Elixir's two dominant dataflow idioms — the **pipe operator** `|>` and
-**pattern matching** — are exactly the constructs a flat, per-line recognizer
-cannot follow without becoming an Elixir interpreter (which nox deliberately is
-not: pure-Go, no CGo, no dependency). The two annotated false negatives make
-this measurable rather than hand-waved:
+Elixir's two dominant dataflow idioms are the **pipe operator** `|>` and
+**pattern matching**. The pipe is now followed to the end of the chain; pattern
+matching still is not, and that is the one remaining annotated false negative —
+measurable rather than hand-waved:
 
-1. **Multi-stage pipe** (`tp_cmdinjection.exs` `run_piped/1`):
-   `conn.params["cmd"] |> String.trim() |> :os.cmd()`. nox's pipe desugaring is
-   per-line and best-effort — it rewrites `x |> f(args)` to `f(x, args)`, binding
-   the value into the **first** pipe stage only. A value sunk two-or-more hops
-   downstream is missed. A correct scanner fires TAINT-002 here; nox does not.
-
-2. **Destructuring pattern match** (`tp_pathtraversal.exs`
+1. **Destructuring pattern match** (`tp_pathtraversal.exs`
    `read_destructured/1`): `%{"file" => path} = conn.params`. nox binds only a
    **simple-ident** LHS (`x = expr`), so a map / tuple / list destructuring match
    never marks the extracted variable tainted. A correct scanner fires TAINT-004;
    nox does not.
 
-These are **not** bugs to be "fixed by editing the samples" — they are the honest
-boundary of a deterministic line/statement recognizer, and precisely the territory
-where the cross-file taint-analysis plugin (with a real dataflow graph) takes over.
-Both false negatives are held in the committed `baseline.json`, so they cannot be
-silently hidden, and if the recognizer later learns to follow multi-stage pipes or
-destructuring binds, the ratchet test reports the improvement and asks for a
-baseline refresh.
+### Closed: multi-stage pipe (`tp_cmdinjection.exs` `run_piped/1`)
+
+`conn.params["cmd"] |> String.trim() |> :os.cmd()` used to be a documented FN:
+desugaring rewrote `x |> f(args)` into `f(x, args)` **once**, binding the value
+into the first stage only, so a sink two-or-more hops downstream was missed.
+
+Two defects were behind it, and both are fixed:
+
+- the rewrite is now applied **to fixpoint**. Each pass peels the leftmost `|>`
+  (`a |> f() |> g()` → `f(a) |> g()`), so iterating nests the whole chain into
+  `g(f(a))` and the value reaches the final stage. Each pass strictly removes one
+  pipe, so it terminates.
+- `leadingCallHead` rejected any head whose first segment was in the SHARED
+  keyword set, which carries Dart's built-in type names — including `String`,
+  `Map`, `List`, `Set`, `Stream`, `Object`. Those are Elixir's core modules, so
+  `String.trim()` was not recognized as a call head at all and the chain could
+  not be walked. The keyword check now applies only to a **bare** head: no
+  language writes `return.foo()`, so a dotted chain is a call on a module that
+  merely shares a keyword's name.
+
+That second defect was not Elixir-specific. `leadingCallHead` is shared by the
+Elixir and Ruby extractors, so Ruby lost the same heads (`String.new`,
+`Set.new`, `Hash.new`) — Ruby's suite happens not to exercise one, so its
+numbers are unchanged, but the recognizer is correct for it now too. The
+lesson is the one the keyword set's own comment already warns about: putting a
+language's built-in TYPE names into a set shared across languages silently
+suppresses real call heads elsewhere.
+
+The remaining false negative is **not** a bug to be "fixed by editing the
+samples" — it is the honest boundary of a deterministic line/statement
+recognizer, and precisely the territory where the cross-file taint-analysis
+plugin (with a real dataflow graph) takes over. It is held in the committed
+`baseline.json`, so it cannot be silently hidden, and if the recognizer later
+learns destructuring binds, the ratchet test reports the improvement and asks
+for a baseline refresh.
 
 ## The ratchet
 

--- a/testdata/precision-suite-elixir/baseline.json
+++ b/testdata/precision-suite-elixir/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 0.9285714285714286,
+  "f1": 0.962962962962963,
   "fp": 0,
-  "tp": 12,
-  "fn": 2,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 13,
+  "fn": 1,
+  "findings_per_issue": 0.9285714285714286,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-elixir/tp_cmdinjection.exs
+++ b/testdata/precision-suite-elixir/tp_cmdinjection.exs
@@ -21,11 +21,11 @@ defmodule TpCmdInjection do
     Port.open(prog) # nox-expect: TAINT-002
   end
 
-  # HONEST FALSE NEGATIVE (multi-stage pipe): the tainted value flows through a
-  # TWO-hop pipe chain (`|> String.trim() |> :os.cmd()`) before reaching the
-  # sink. nox's per-line pipe desugaring only binds the value into the FIRST
-  # stage, so a value sunk two-plus hops downstream is missed. A correct scanner
-  # fires TAINT-002; nox does not — documented in README.md.
+  # Multi-stage pipe: the tainted value flows through a TWO-hop pipe chain
+  # (`|> String.trim() |> :os.cmd()`) before reaching the sink. Pipe desugaring
+  # runs to fixpoint — each rewrite peels the leftmost `|>`, so the chain nests
+  # into `:os.cmd(String.trim(conn.params["cmd"]))` and the value lands in the
+  # FINAL stage, where the sink is. Caught since the fixpoint rewrite landed.
   def run_piped(conn) do
     conn.params["cmd"] |> String.trim() |> :os.cmd() # nox-expect: TAINT-002
   end


### PR DESCRIPTION
## The finding

`conn.params["cmd"] |> String.trim() |> :os.cmd()` was carried as a documented false negative in the Elixir precision suite. Investigating it turned up **two** defects, and the second is not Elixir-specific.

### 1. Pipe desugaring stopped after one stage

`rewritePipeStage` already peels exactly the leftmost pipe — `a |> f() |> g()` → `f(a) |> g()` — so the transform was always re-appliable. It was simply never repeated. It now runs to **fixpoint**, nesting the chain into `g(f(a))` so the value reaches the final stage, which is where the sink is.

Each pass strictly removes one `|>`, so it terminates on its own; the iteration bound is a guard, not the mechanism.

### 2. `leadingCallHead` rejected `String.trim` as a call head at all

This is the part worth reviewing. The head was rejected whenever its first segment appeared in the **shared** keyword set — which carries Dart's built-in *type* names:

```go
"String", "List", "Map", "Set", "Future", "Stream", "Object", "Function", "Never", "Uri",
```

Those are Elixir's core modules. `String.trim()` was therefore not recognized as a call head at all, so the chain could not be walked even once — the fixpoint loop alone fixes nothing without this.

The keyword check now applies only to a **bare** head. No language writes `return.foo()`, so a dotted chain whose first segment collides with a keyword is a call on a module that merely shares the name.

`leadingCallHead` is shared with the Ruby extractor, which lost `String.new` / `Set.new` / `Hash.new` the same way. Ruby's suite happens not to exercise one, so its numbers do not move — but the recognizer is correct for it now too.

This is precisely the hazard the keyword set's own comment warns about for Dart's *contextual* keywords (`on`, `show`, `num` — deliberately excluded). The type names were added anyway.

## Verification

A recall fix that quietly costs precision looks identical to a real one if you only measure the suite you touched, so **all 20 precision suites were re-measured**:

| | before | after |
|---|---|---|
| Elixir recall | 0.857 | **0.929** |
| Elixir F1 | 0.923 | **0.963** |
| Elixir TP / FP / FN | 12 / 0 / 2 | **13 / 0 / 1** |
| TAINT-002 recall | 0.750 | **1.000** |

**Precision stayed 1.000 with 0 FP on every one of the 20 suites, and no suite other than Elixir moved at all.** `baseline.json` refreshed to lock in the gain.

New tests: multi-stage and three-stage pipe cases at the extractor level, both using the *inline* source shape (a bound variable leaks a line-level read and masks the gap — the first draft of these tests passed against the broken code for exactly that reason).

## Also: the ratchet that hid this class of win

`findings-per-issue` is a **distance-from-1.00** metric — below it the scanner is missing findings, above it duplicating them — but `CompareBaseline` gated it as strictly lower-is-better. A suite carrying honest FNs sits below 1.00, so closing one *necessarily* raises it, and the ratchet reported the improvement as a regression:

```
elixir suite regressed: findings_per_issue: 0.8571 -> 0.9286 (regressed)
```

Left alone, every genuine recall fix in the 13 suites that carry FNs would have to be laundered through a baseline regeneration — which is exactly how a real regression would slip in unnoticed. The ceiling is now `max(baseline, 1.0)`, so only movement past the ideal (real over-firing) fails. `Improved()` is made symmetric, so a drop *further below* 1.00 no longer counts as a win — a case the old logic actively got backwards.

## Scope

The remaining Elixir FN (destructuring pattern match, `%{"file" => path} = conn.params`) is unchanged and still annotated as ground truth. Docs updated in all four places that described the pipe gap as a known limitation.

`go build`, `go vet`, `go test ./...`, and `golangci-lint` are clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
