### PR TITLE
feat(taint): model PowerShell pipeline dataflow, closing the last suite FN

### DIFF
--- a/cli/bench_precision_powershell_test.go
+++ b/cli/bench_precision_powershell_test.go
@@ -20,13 +20,15 @@ func powershellSuitePath() string {
 // committed baseline snapshot, and fails if any gated metric regressed
 // (precision/recall/F1 dropped, or FP / findings-per-issue rose).
 //
-// PowerShell recall is intentionally moderate — the flat line/statement
-// recognizer does not model pipeline dataflow, so the suite carries one honest,
-// documented false negative (`tp_pipeline_fn.ps1`; see
-// testdata/precision-suite-powershell/README.md), scoring recall below 1.0.
-// Pinning that number here means PowerShell precision can no longer silently
-// regress and the known FN cannot be quietly hidden; the precision floor (0.90)
-// is asserted directly so no new PowerShell false positive can creep in.
+// The suite now scores 1.0 across the board: its last honest false negative,
+// pipeline dataflow (`$x | Invoke-Expression`, `tp_pipeline_fn.ps1`), was closed
+// by folding pipeline stages into nested positional calls. Pinning that here
+// means the flow cannot silently stop being detected, and the precision floor
+// (0.90) is asserted directly so no new PowerShell false positive can creep in.
+//
+// A suite at 1.0 has stopped indicting anything, so it no longer measures the
+// recognizer's real limits — see the README's still-open list (splatting,
+// receiver typing). Adding a sample that FAILS is what keeps this honest.
 func TestPrecisionSuiteBaselinePowerShell(t *testing.T) {
 	dir := powershellSuitePath()
 

--- a/core/taint/engine/extract_powershell.go
+++ b/core/taint/engine/extract_powershell.go
@@ -17,27 +17,36 @@ import "strings"
 //   - the `$` variable sigil is deleted (like PHP), so `$cmd`/`$env:X`/`$args`
 //     become the plain identifiers the engine's variable tracking and the
 //     catalog's source keys expect;
+//
 //   - the static-member separator `::` becomes `.` and a leading type accelerator
 //     `[Namespace.Type]` is unwrapped, so `[IO.File]::ReadAllText($p)` reads as
 //     the dotted chain `IO.File.ReadAllText($p)` matched by the `.ReadAllText`
 //     suffix;
+//
 //   - a `[int]` / `[long]` cast is rewritten to a call `int(...)` / `long(...)`
 //     so numeric coercion is recognized as a sanitizer;
+//
 //   - a cmdlet's `Verb-Noun` hyphen is normalized to an underscore (`Verb_Noun`)
 //     because the shared token scanner treats `-` as an operator; the catalog is
 //     keyed on the same underscore form (see the `powershell` block comment);
+//
 //   - a paren-less command call (`Invoke-Expression $u`, `Get-Content $p`,
 //     `Invoke-WebRequest -Uri $url`) is wrapped in parentheses so the shared call
 //     recognizer sees a call, with the (possibly `-Param`-prefixed) argument text
 //     preserved as the call's arguments;
+//
 //   - the call operator `& $cmd args` is rewritten to a synthetic call
 //     `InvokeOperator($cmd args)` (a command-injection sink) so an indirect
-//     invocation of a tainted command is caught.
+//     invocation of a tainted command is caught;
+//
+//   - a pipeline `a | Cmd1 args | Cmd2` is split at every top-level `|` and
+//     folded left into nested positional calls `Cmd2(Cmd1(a, args))`, because
+//     binding to a cmdlet's pipeline input is a real argument position.
 //
 // Its honest limits (documented in testdata/precision-suite-powershell/README.md):
-// pipelines (`$x | Invoke-Expression`), splatting (`@params`), and paren-less
-// arguments that span the pipeline are only partially modeled, so PowerShell
-// recall is moderate.
+// splatting (`@params`) hides arguments inside an untracked hashtable, and
+// method-suffix sinks are matched by name rather than by proving the receiver's
+// .NET type.
 func extractPowerShell(lines []logicalLine) []unitDraft {
 	module := &unitDraft{funcName: ""}
 	units := []*unitDraft{module}

--- a/core/taint/engine/extract_powershell_shape.go
+++ b/core/taint/engine/extract_powershell_shape.go
@@ -11,11 +11,133 @@ import "strings"
 // `[int]$x`), the `& ` call operator before paren-less wrapping, and the cmdlet
 // hyphen normalization before the call recognizer scans identifiers.
 func shapePowerShellLine(ll logicalLine) logicalLine {
-	return logicalLine{
-		line: ll.line,
-		code: shapePowerShellExpr(ll.code),
-		raw:  shapePowerShellExpr(ll.raw),
+	code := shapePowerShellExpr(ll.code)
+	raw := shapePowerShellExpr(ll.raw)
+	// The pipeline rewrite runs last and needs BOTH views at once: a `|` is only
+	// an operator when it is not inside a string, and string bodies are blanked
+	// in the code view alone. Deciding from raw would read a regex alternation
+	// (`'^start|stop$'`) as a pipeline.
+	code, raw = desugarPowerShellPipeline(code, raw)
+	return logicalLine{line: ll.line, code: code, raw: raw}
+}
+
+// desugarPowerShellPipeline rewrites a pipeline `a | Cmd1 args | Cmd2` into the
+// nested positional form `Cmd2(Cmd1(a, args))`. Binding to a cmdlet's PIPELINE
+// input is a real argument position — `$x | Invoke-Expression` executes `$x`
+// exactly as `Invoke-Expression $x` does — so the value has to land in the
+// callee's argument list for the shared recognizer to see the flow.
+//
+// Stages are split at every top-level `|` and folded left, rather than peeled
+// one at a time: PowerShell cmdlets are paren-LESS, so a leftmost-peel would
+// swallow the remaining `| Cmd2` text into Cmd1's argument list.
+//
+// Pipe positions come from the CODE view (string bodies blanked) and the same
+// structural rewrite is applied to raw while the two stay aligned; once
+// alignment is lost raw follows code, matching how the Elixir pipe desugars.
+func desugarPowerShellPipeline(code, raw string) (newCode, newRaw string) {
+	pipes := powerShellTopLevelPipes(code)
+	if len(pipes) == 0 {
+		return code, raw
 	}
+	// An assignment left of the first pipe keeps its LHS: `$out = $x | Cmd`.
+	prefixEnd := 0
+	if eq := topLevelAssignIndex(code); eq >= 0 && eq < pipes[0] {
+		prefixEnd = eq + 1
+	}
+	rewritten, ok := foldPowerShellPipeline(code, prefixEnd, pipes)
+	if !ok {
+		return code, raw
+	}
+	if len(raw) == len(code) {
+		if rr, ok := foldPowerShellPipeline(raw, prefixEnd, pipes); ok {
+			return rewritten, rr
+		}
+	}
+	return rewritten, rewritten
+}
+
+// foldPowerShellPipeline folds the pipeline in s (whose top-level pipes sit at
+// the byte offsets in pipes, all at or past prefixEnd) into nested calls,
+// preserving everything before prefixEnd verbatim. Returns ok=false when a stage
+// past the first has no recognizable command head, leaving the line unshaped
+// rather than half-rewritten.
+func foldPowerShellPipeline(s string, prefixEnd int, pipes []int) (string, bool) {
+	prefix := s[:prefixEnd]
+	acc := strings.TrimSpace(s[prefixEnd:pipes[0]])
+	if acc == "" {
+		return "", false
+	}
+	for i, p := range pipes {
+		end := len(s)
+		if i+1 < len(pipes) {
+			end = pipes[i+1]
+		}
+		stage := strings.TrimSpace(s[p+1 : end])
+		bound, ok := bindPowerShellStage(acc, stage)
+		if !ok {
+			return "", false
+		}
+		acc = bound
+	}
+	return prefix + acc, true
+}
+
+// bindPowerShellStage binds acc as the leading argument of one pipeline stage:
+// `Cmd -Flag v` with acc becomes `Cmd(acc, -Flag v)`, and a bare `Cmd` becomes
+// `Cmd(acc)`. Returns ok=false when the stage does not start with a command head
+// (a scriptblock or a variable stage, which carries no callee to attribute the
+// flow to).
+func bindPowerShellStage(acc, stage string) (string, bool) {
+	i := 0
+	for i < len(stage) && (isIdentPart(stage[i]) || stage[i] == '.') {
+		i++
+	}
+	head := stage[:i]
+	if head == "" || strings.HasPrefix(head, ".") || isKeyword(head) {
+		return "", false
+	}
+	rest := strings.TrimSpace(stage[i:])
+	if rest == "" {
+		return head + "(" + acc + ")", true
+	}
+	// An already-parenthesized stage `Cmd(a)` takes acc as its first argument.
+	if strings.HasPrefix(rest, "(") && strings.HasSuffix(rest, ")") {
+		inner := strings.TrimSpace(rest[1 : len(rest)-1])
+		if inner == "" {
+			return head + "(" + acc + ")", true
+		}
+		return head + "(" + acc + ", " + inner + ")", true
+	}
+	return head + "(" + acc + ", " + rest + ")", true
+}
+
+// powerShellTopLevelPipes returns the byte offsets of every pipeline `|` in code
+// that is not nested inside brackets or braces. A `||` (the PowerShell 7
+// pipeline-CHAIN operator, which passes no value) is skipped: it is control
+// flow, not dataflow. A `|` inside a string is already blanked in the code view.
+func powerShellTopLevelPipes(code string) []int {
+	var out []int
+	depth := 0
+	for i := 0; i < len(code); i++ {
+		switch code[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '|':
+			if i+1 < len(code) && code[i+1] == '|' {
+				i++ // `||` chain operator: passes no value
+				continue
+			}
+			if i > 0 && code[i-1] == '|' {
+				continue
+			}
+			if depth == 0 {
+				out = append(out, i)
+			}
+		}
+	}
+	return out
 }
 
 // shapePowerShellExpr applies the PowerShell → shared-recognizer rewrites to one

--- a/core/taint/engine/extract_powershell_test.go
+++ b/core/taint/engine/extract_powershell_test.go
@@ -124,3 +124,54 @@ func stmtWithAssignPS(t *testing.T, u unitDraft, name string) stmtDraft {
 	t.Fatalf("no assignment to %q in unit %q; stmts=%+v", name, u.funcName, u.stmts)
 	return stmtDraft{}
 }
+
+// TestExtractPowerShellPipelineSink: `$x | Invoke-Expression` binds $x to the
+// cmdlet's PIPELINE input, which is a real argument position — the value is as
+// executed as it would be in `Invoke-Expression $x`. The recognizer models the
+// pipeline by rewriting it into that positional form. This is the suite's
+// documented tp_pipeline_fn.ps1 false negative.
+func TestExtractPowerShellPipelineSink(t *testing.T) {
+	src := []byte("$payload = $args[0]\n$payload | Invoke-Expression\n")
+	units := extractUnits(lexctx.LangPowerShell, src)
+	u := findUnit(t, units, "")
+	sink := stmtWithCall(t, u, "Invoke_Expression")
+	if sink.line == 0 {
+		t.Fatalf("piped Invoke-Expression not recognized: %+v", u.stmts)
+	}
+	if !containsStr(sink.reads, "payload") {
+		t.Errorf("piped Invoke_Expression reads = %v, want to include payload", sink.reads)
+	}
+}
+
+// TestExtractPowerShellMultiStagePipeline: a value carried through several
+// pipeline stages still reaches the final cmdlet, where the sink is.
+func TestExtractPowerShellMultiStagePipeline(t *testing.T) {
+	src := []byte("$payload = $args[0]\n$payload | Out-String | Invoke-Expression\n")
+	units := extractUnits(lexctx.LangPowerShell, src)
+	u := findUnit(t, units, "")
+	sink := stmtWithCall(t, u, "Invoke_Expression")
+	if sink.line == 0 {
+		t.Fatalf("final pipeline stage Invoke-Expression not recognized: %+v", u.stmts)
+	}
+	if !containsStr(sink.reads, "payload") {
+		t.Errorf("multi-stage piped Invoke_Expression reads = %v, want to include payload", sink.reads)
+	}
+}
+
+// TestExtractPowerShellPipeInStringIsNotAPipeline is the precision guard for the
+// rewrite above. A `|` inside a STRING — an alternation in a regex literal, the
+// shape clean_validated.ps1 uses — is not a pipeline operator. Pipe positions are
+// therefore taken from the code view, where string bodies are blanked, never from
+// the raw text. Misreading one would splice a sink out of a comparison.
+func TestExtractPowerShellPipeInStringIsNotAPipeline(t *testing.T) {
+	src := []byte("$action = $args[0]\nif ($action -match '^start|stop$') { Write-Output 'ok' }\n")
+	units := extractUnits(lexctx.LangPowerShell, src)
+	u := findUnit(t, units, "")
+	for _, st := range u.stmts {
+		for _, c := range st.calls {
+			if c == "stop$'" || c == "stop" {
+				t.Errorf("a | inside a string literal was treated as a pipeline: calls = %v", st.calls)
+			}
+		}
+	}
+}

--- a/testdata/precision-suite-powershell/README.md
+++ b/testdata/precision-suite-powershell/README.md
@@ -33,18 +33,18 @@ nox bench --precision testdata/precision-suite-powershell --baseline testdata/pr
 ## What this corpus reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-powershell` scores
-**precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN).
+**precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN).
 
 Precision is perfect — every finding nox emits on this corpus is a true positive,
-and every clean stressor fires nothing. Recall is **intentionally below 1.0**:
-PowerShell recall is moderate by design, and the corpus carries one honest,
-documented false negative so the number tells the truth rather than being curated
-to a misleading 1.0.
+and every clean stressor fires nothing. Recall reached 1.0 the way the corpus
+always demanded: by fixing the recognizer the corpus indicted (pipeline
+dataflow), not by deleting the failing sample. `tp_pipeline_fn.ps1` is retained
+as a regression test for exactly that flow.
 
-The honest way to raise the number is to fix the recognizer the corpus indicts
-(model pipeline dataflow), never to delete the failing sample. When a legitimate
-engine improvement flips the FN, `TestPrecisionSuiteBaselinePowerShell` reports
-the gain and tells you to refresh `baseline.json`.
+A 1.0 here means this corpus has stopped measuring — it no longer indicts
+anything. The open limits below (splatting, `-match` semantics, receiver typing)
+are real and simply lack a sample; adding one that fails is the way to keep the
+number honest.
 
 ### Sample inventory
 
@@ -58,7 +58,7 @@ True positives (annotated ground truth):
 | `tp_sqlinjection.ps1` | SQL injection | `Invoke-Sqlcmd -Query "…$id"` | TAINT-001 (CWE-89) | TP |
 | `tp_pathtraversal.ps1` | path traversal | `Get-Content -Path $path` | TAINT-004 (CWE-22) | TP |
 | `tp_ssrf.ps1` | SSRF | `Invoke-WebRequest -Uri $url` | TAINT-006 (CWE-918) | TP |
-| `tp_pipeline_fn.ps1` | code injection | `$payload \| Invoke-Expression` | TAINT-005 | **FN (honest)** |
+| `tp_pipeline_fn.ps1` | code injection | `$payload \| Invoke-Expression` | TAINT-005 | caught |
 
 Clean stressors (zero annotations — any finding is a false positive):
 
@@ -106,12 +106,19 @@ What nox catches in PowerShell today:
 | Path traversal | `Get-Content $p` / `Import-Csv` / `[IO.File]::ReadAllText` | TAINT-004 | CWE-22 |
 | SSRF | `Invoke-WebRequest $url` / `iwr` / `curl` / `Invoke-RestMethod` | TAINT-006 | CWE-918 |
 
-### Still-open limits (the honest FNs)
+### Still-open limits
 
-- **Pipeline dataflow — the documented FN.** `$x | Invoke-Expression` binds `$x`
-  to the cmdlet's pipeline input; the flat recognizer does not track this, so
-  `tp_pipeline_fn.ps1` is a genuine recall gap (TAINT-005 not fired). Modeling
-  `|` pipeline binding is the next indictment.
+- **Pipeline dataflow — CLOSED.** `$x | Invoke-Expression` binds `$x` to the
+  cmdlet's pipeline input, which is a real argument position. The line is now
+  split at every top-level `|` and folded left into nested positional calls
+  (`a | Cmd1 args | Cmd2` becomes `Cmd2(Cmd1(a, args))`), so the value reaches
+  the final stage where the sink is. Stages are split-and-folded rather than
+  peeled one at a time because PowerShell cmdlets are paren-LESS: peeling the
+  leftmost pipe would swallow the remaining `| Cmd2` text into Cmd1's argument
+  list. Pipe positions are read from the CODE view, where string bodies are
+  blanked, so a regex alternation (`'^start|stop$'`) is never mistaken for a
+  pipeline; `||`, the PowerShell 7 pipeline-CHAIN operator, is skipped because
+  it passes no value.
 - **Splatting.** `Invoke-WebRequest @params` where `$params` is a hashtable of
   arguments hides the tainted URL inside an untracked structure.
 - **`-match` is not a laundering sanitizer.** Regex validation with `-match` does

--- a/testdata/precision-suite-powershell/baseline.json
+++ b/testdata/precision-suite-powershell/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -25,7 +25,7 @@
     {
       "rule_id": "TAINT-005",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-006",

--- a/testdata/precision-suite-powershell/tp_pipeline_fn.ps1
+++ b/testdata/precision-suite-powershell/tp_pipeline_fn.ps1
@@ -1,10 +1,9 @@
-# Honest FALSE NEGATIVE (documented): the tainted value is piped into
-# Invoke-Expression rather than passed as a positional argument. This is a real
-# CWE-95 code injection — a correct scanner SHOULD fire TAINT-005 — but nox's
-# flat line/statement recognizer does not model PowerShell pipeline dataflow
-# (`$x | Cmdlet` binds $x to the cmdlet's pipeline input, which the recognizer
-# does not track). The annotation below therefore scores as a recall gap, which
-# is exactly the point of the honest suite: PowerShell recall is moderate and the
-# number must show it. See README.md "What this corpus reveals".
+# Pipeline dataflow (CWE-95 code injection): the tainted value is piped into
+# Invoke-Expression rather than passed as a positional argument. `$x | Cmdlet`
+# binds $x to the cmdlet's pipeline input, which is a real argument position —
+# this executes $x exactly as `Invoke-Expression $x` would. The recognizer splits
+# the line at every top-level `|` and folds the stages left into nested calls, so
+# the value reaches the final stage. Was a documented false negative until that
+# landed; kept as the regression test for it.
 $payload = $args[0]
 $payload | Invoke-Expression  # nox-expect: TAINT-005


### PR DESCRIPTION
## What

`$payload | Invoke-Expression` was the PowerShell suite's one documented false negative. Binding to a cmdlet's **pipeline input is a real argument position** — it executes the value exactly as `Invoke-Expression $payload` would — so the value has to land in the callee's argument list for the recognizer to see the flow.

A line is now split at every top-level `|` and folded left into nested positional calls:

```
a | Cmd1 args | Cmd2   →   Cmd2(Cmd1(a, args))
```

so the value reaches the final stage, where the sink is.

### Why split-and-fold, not peel-the-leftmost

The Elixir pipe fix (#414) peels one pipe per pass and iterates to fixpoint. That does **not** work here: PowerShell cmdlets are paren-*less*, so peeling `a | Cmd1 | Cmd2` would produce `Cmd1(a, | Cmd2)` — the remaining pipeline text swallowed into `Cmd1`'s argument list. Splitting at all top-level pipes first and folding left avoids that.

## Two correctness details worth review

**Pipe positions come from the code view, never raw.** String bodies are blanked in the code view only. A regex alternation — `'^(start|stop|status)$'`, a shape `clean_validated.ps1` already carries — is not a pipeline, and deciding from raw would splice a sink out of a comparison. There's a dedicated precision-guard test using the *unparenthesized* `'^start|stop$'`, which has a genuinely top-level `|` in the raw text (the parenthesized form would be protected by depth tracking and wouldn't actually test this).

**`||` is skipped.** The PowerShell 7 pipeline-*chain* operator is control flow and passes no value.

The rewrite runs at the `logicalLine` level so both views are available at once, applying the same structural transform to raw while the two stay aligned and falling back to the code view when they diverge — matching `desugarElixirPipe`.

## Verification

| | before | after |
|---|---|---|
| PowerShell recall | 0.857 | **1.000** |
| PowerShell F1 | 0.923 | **1.000** |
| TP / FP / FN | 6 / 0 / 1 | **7 / 0 / 0** |

**All 20 precision suites re-measured: precision 1.000 and FP 0 everywhere, and no suite other than PowerShell moved.** `baseline.json` refreshed.

## A caveat I want to flag

The suite now scores a flat 1.0 — which means **it has stopped measuring anything**. That is a real cost, not just a win: the corpus exists to indict the recognizer, and one at 1.0 no longer does.

`tp_pipeline_fn.ps1` is retained as the regression test for the flow, and I've updated both the README and the ratchet-test comment to say plainly that the remaining known limits (splatting via `@params`, receiver typing on method-suffix sinks) are real but currently lack a sample — and that adding one which *fails* is what keeps the number honest. Happy to add such a sample in a follow-up if you'd like the suite to keep earning its place.

`go build`, `go vet`, `gofmt`, `go test ./...`, and `golangci-lint` are all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
