### PR TITLE
fix(taint): recognize shell declaration-assignments, and the sink bugs that exposed

### DIFF
--- a/cli/bench_precision_shell_test.go
+++ b/cli/bench_precision_shell_test.go
@@ -19,13 +19,17 @@ func shellSuitePath() string {
 // if any gated metric regressed (precision/recall/F1 dropped, or FP /
 // findings-per-issue rose).
 //
-// Shell deliberately scores the LOWEST recall of any supported language — its
-// paren-less, word-splitting, dynamically-constructed command grammar is more
-// than a flat per-line recognizer can follow, so the suite carries honest false
-// negatives (see testdata/precision-suite-shell/README.md). Pinning the number
-// here means shell PRECISION can no longer silently regress: a change that makes
-// the suite noisier fails CI. When the suite legitimately improves, this test
-// reports the improvement and tells you to refresh baseline.json.
+// Shell's paren-less, word-splitting, dynamically-constructed command grammar is
+// the hardest of any supported language for a flat per-line recognizer. The
+// suite's last two false negatives — taint laundered through a `local`-declared
+// variable — are now closed, so it scores 1.0 (see
+// testdata/precision-suite-shell/README.md).
+//
+// That 1.0 means the corpus has stopped INDICTING anything, not that shell
+// dataflow is solved; the README's open limits (word-splitting, arrays,
+// pipeline-fed commands) are real and simply lack a failing sample. Pinning the
+// number here means shell precision can no longer silently regress: a change
+// that makes the suite noisier fails CI.
 func TestPrecisionSuiteBaselineShell(t *testing.T) {
 	dir := shellSuitePath()
 

--- a/core/taint/engine/extract_shell.go
+++ b/core/taint/engine/extract_shell.go
@@ -18,10 +18,12 @@ import "strings"
 // Function bodies (`f() {` or `function f {`) open their own unit keyed by name;
 // everything else accumulates into the module-level unit (funcName "").
 //
-// HONEST LIMITS (recall is the lowest of any supported language, by design):
-// word-splitting, globbing, arrays, `${var//a/b}` transforms, arithmetic
-// re-entry, and `xargs`/pipeline-fed commands are constructs a flat, per-line
-// recognizer cannot follow. A miss only weakens recall (a false negative), never
+// A declaration builtin that INITIALIZES (`local x="$1"`, `export u="$2"`) is an
+// assignment and is recognized as one; a bare declaration (`local a b`) is not.
+//
+// HONEST LIMITS (by design): word-splitting, globbing, arrays, `${var//a/b}`
+// transforms, arithmetic re-entry, and `xargs`/pipeline-fed commands are
+// constructs a flat, per-line recognizer cannot follow. A miss only weakens recall (a false negative), never
 // correctness — an unrecognized line simply yields no statement. Precision is
 // defended: a properly QUOTED expansion `"$var"` passed to a NON-sink command is
 // naturally clean because that command is not in the catalog, and the actual
@@ -47,6 +49,14 @@ func extractShell(lines []logicalLine) []unitDraft {
 			units = append(units, u)
 			cur = u
 			continue
+		}
+		// A declaration builtin that introduces an ASSIGNMENT (`local x="$1"`)
+		// carries real dataflow and must not be skipped with the bare
+		// declarations. Blanking the keyword lets the assignment underneath be
+		// recognized normally.
+		if decl, ok := stripShellDeclPrefix(ll); ok {
+			ll = decl
+			trimmed = strings.TrimSpace(ll.code)
 		}
 		if isShellStructuralLine(trimmed) {
 			continue
@@ -198,6 +208,75 @@ func isShellStructuralLine(trimmed string) bool {
 	return false
 }
 
+// shellDeclKeywords are the declaration builtins that may prefix an assignment.
+// Each declares a variable and may also initialize it in the same word.
+var shellDeclKeywords = map[string]bool{
+	"local":    true,
+	"declare":  true,
+	"export":   true,
+	"readonly": true,
+	"typeset":  true,
+}
+
+// stripShellDeclPrefix blanks a leading declaration builtin, and any option
+// flags it carries, to SPACES when what follows is a real `NAME=value`
+// assignment — so `local arg="$1"` is recognized as the assignment it is and the
+// declared variable can carry taint.
+//
+// Blanking rather than slicing keeps every byte offset intact, so the code and
+// raw views stay mutually aligned (the recognizer slices raw by offsets found in
+// code) and the assignment recognizer, which already skips leading whitespace,
+// needs no change.
+//
+// A BARE declaration (`local a b c`, `declare -A map`, `local count`) declares
+// without initializing: it carries no dataflow, so ok=false leaves it to be
+// skipped as scaffolding. Reading one as a command would invent a call to
+// `local`/`declare`.
+func stripShellDeclPrefix(ll logicalLine) (logicalLine, bool) {
+	code := ll.code
+	i := 0
+	for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+		i++
+	}
+	kwStart := i
+	for i < len(code) && isShellIdentByte(code[i]) {
+		i++
+	}
+	if !shellDeclKeywords[code[kwStart:i]] {
+		return ll, false
+	}
+	// The keyword must be a standalone word (`localx=1` is an ordinary
+	// assignment to a variable that merely starts with the keyword's letters).
+	if i >= len(code) || (code[i] != ' ' && code[i] != '\t') {
+		return ll, false
+	}
+	// Skip any option flags between the keyword and the name (`local -r`,
+	// `declare -i`, `declare -A`).
+	end := i
+	for {
+		j := end
+		for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+			j++
+		}
+		if j >= len(code) || code[j] != '-' {
+			break
+		}
+		for j < len(code) && code[j] != ' ' && code[j] != '\t' {
+			j++
+		}
+		end = j
+	}
+	// Only a real assignment underneath earns the rewrite.
+	if _, _, ok := splitShellAssignment(code[end:]); !ok {
+		return ll, false
+	}
+	out := logicalLine{line: ll.line, code: blankRange(code, kwStart, end), raw: ll.raw}
+	if len(ll.raw) == len(code) {
+		out.raw = blankRange(ll.raw, kwStart, end)
+	}
+	return out, true
+}
+
 // shellAssignment recognizes a `NAME=value` assignment (no whitespace around the
 // `=`, LHS a bare shell identifier). It surfaces the RHS reads (variable
 // expansions and source markers) so a `x=$1` taints x from the `$1` source and a
@@ -282,7 +361,15 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 		for i < len(code) && isShellCommandByte(code[i]) {
 			i++
 		}
-		callee = code[calleeStart:i]
+		token := code[calleeStart:i]
+		// A command word may be path-qualified (`/usr/bin/curl`, `./tool.sh`), so
+		// a leading `/` or `.` is a valid start; shellCalleeName then reduces the
+		// token to the bare final segment the catalog is keyed on. A lone `.`
+		// (the source builtin) was already handled above.
+		if token == "" || (!isShellIdentStart(token[0]) && token[0] != '/' && token[0] != '.') {
+			return stmtDraft{}, false
+		}
+		callee = shellCalleeName(token)
 		if callee == "" || !isShellIdentStart(callee[0]) {
 			return stmtDraft{}, false
 		}
@@ -290,6 +377,13 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 	// Normalize a leading `command`/`builtin`/`exec` wrapper to its target so
 	// `command eval x` still resolves eval.
 	// (Kept simple: only the bare callee is used.)
+
+	// `exec` with a REDIRECTION and no command word (`exec 200>"$f"`, `exec >log`)
+	// rebinds the shell's own file descriptors — it executes nothing, so a tainted
+	// path there is not command injection. Only `exec CMD ...` is the sink.
+	if callee == "exec" && shellStartsWithRedirection(code[i:]) {
+		return stmtDraft{}, false
+	}
 
 	st := stmtDraft{line: ll.line, assigns: "", sinkArgs: map[string]sinkArgDraft{}}
 
@@ -315,8 +409,23 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 	// For `sh`/`bash`-style callees, the tainted string may be the argument to
 	// `-c`; we still surface it as a read + tainted arg below via the generic
 	// expansion collection.
+	// On a fetch command, the argument after an output-file flag names a LOCAL
+	// FILE, not a remote URL — `curl --output "$path" "$url"` fetches $url and
+	// writes $path. Treating a tainted $path as the SSRF-controlling value
+	// reported the wrong thing entirely, so those slots carry no tainted arg.
+	fetch := shellFetchCommands[callee]
+	skipNext := false
 	for idx, a := range args {
 		vars := shellArgVars(a)
+		if skipNext {
+			skipNext = false
+			info.positionalVars = append(info.positionalVars, nil)
+			allReads = append(allReads, vars...)
+			continue
+		}
+		if fetch && shellFileArgFlags[strings.TrimSpace(a.raw)] {
+			skipNext = true
+		}
 		info.positionalVars = append(info.positionalVars, append([]string(nil), vars...))
 		if len(vars) > 0 {
 			info.argCount++
@@ -351,6 +460,40 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 	return st, true
 }
 
+// shellFetchCommands are the URL-fetching commands whose SSRF sink is controlled
+// by the URL argument specifically, so their local-file flags must be excluded.
+var shellFetchCommands = map[string]bool{"curl": true, "wget": true}
+
+// shellFileArgFlags are the fetch-command flags whose FOLLOWING argument names a
+// local file (an output path, a log, a cookie jar) rather than a remote URL.
+// Only consulted for shellFetchCommands, so `-c` here is curl's cookie-jar and
+// never `sh -c`.
+var shellFileArgFlags = map[string]bool{
+	"-o": true, "--output": true,
+	"-O": true, "--output-document": true,
+	"-D": true, "--dump-header": true,
+	"-c": true, "--cookie-jar": true,
+	"--output-file": true, "-a": true, "--append-output": true,
+	"--trace": true, "--trace-ascii": true,
+	"-K": true, "--config": true,
+}
+
+// shellStartsWithRedirection reports whether the text after a command word
+// begins with an I/O redirection (`>`, `>>`, `<`, `2>`, `200>&-`) rather than an
+// argument. Used to tell `exec 200>"$f"` (FD rebinding) from `exec cmd` (which
+// replaces the shell with a command).
+func shellStartsWithRedirection(rest string) bool {
+	i := 0
+	for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t') {
+		i++
+	}
+	// An optional leading file-descriptor number.
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		i++
+	}
+	return i < len(rest) && (rest[i] == '>' || rest[i] == '<')
+}
+
 // shellHasDashCFlag reports whether a `-c` flag word appears in the raw args of
 // a command, marking the `sh -c` / `bash -c` execute-a-string shape.
 func shellHasDashCFlag(rawArgs string) bool {
@@ -366,6 +509,7 @@ func shellHasDashCFlag(rawArgs string) bool {
 // single-quoted (fully literal — its `$` expansions are inert).
 type shellArg struct {
 	code        string // code-view text of the word (literals blanked, expansions kept)
+	raw         string // raw-view text of the word, needed to read literal FLAG words
 	singleQuote bool   // true when the word is wholly single-quoted (no expansion)
 }
 
@@ -380,7 +524,7 @@ func splitShellArgs(code, raw string) []shellArg {
 		// Fall back to a plain whitespace split of the code view.
 		var out []shellArg
 		for _, f := range strings.Fields(code) {
-			out = append(out, shellArg{code: f})
+			out = append(out, shellArg{code: f, raw: f})
 		}
 		return out
 	}
@@ -416,7 +560,10 @@ func splitShellArgs(code, raw string) []shellArg {
 			if c == '"' {
 				i++
 				for i < n && raw[i] != '"' {
-					if raw[i] == '\\' {
+					// A backslash escapes the next byte — but only when there IS a
+					// next byte. Without the bound check a word ending in a lone
+					// backslash advanced i past the end of the string.
+					if raw[i] == '\\' && i+1 < n {
 						i++
 					}
 					i++
@@ -428,12 +575,18 @@ func splitShellArgs(code, raw string) []shellArg {
 			}
 			i++
 		}
-		wordEnd := i
+		// Defensive clamp: every scanner branch above is bounded by n, but the
+		// slices below must never be able to run off the end of either view.
+		wordEnd := min(i, n)
 		codeWord := ""
 		if wordEnd <= len(code) {
 			codeWord = code[wordStart:wordEnd]
 		}
-		out = append(out, shellArg{code: codeWord, singleQuote: singleQuoted && !strings.ContainsAny(codeWord, "$")})
+		out = append(out, shellArg{
+			code:        codeWord,
+			raw:         raw[wordStart:wordEnd],
+			singleQuote: singleQuoted && !strings.ContainsAny(codeWord, "$"),
+		})
 	}
 	return out
 }
@@ -596,9 +749,11 @@ func shellCommandSubCallees(code string) []string {
 			inner++
 		}
 		if inner > start {
-			callee := code[start:inner]
-			if isShellIdentStart(callee[0]) {
-				addUniqueName(&out, seen, callee)
+			token := code[start:inner]
+			if isShellIdentStart(token[0]) {
+				if callee := shellCalleeName(token); callee != "" {
+					addUniqueName(&out, seen, callee)
+				}
 			}
 		}
 		i = inner
@@ -660,9 +815,24 @@ func isShellIdentByte(b byte) bool {
 }
 
 // isShellCommandByte reports whether b can appear inside a command name token.
-// Command names may include `/`, `.`, and `-` (paths and hyphenated commands),
-// but the callee we key on is normalized to the bare final segment elsewhere; a
-// leading `.` (the source/dot builtin) is handled specially.
+// Command names may include `/`, `.`, and `-` (paths and hyphenated commands);
+// shellCalleeName normalizes the scanned token to its bare final segment. A
+// leading `.` (the source/dot builtin) is handled specially by the caller.
+//
+// Accepting `-` is what keeps a hyphenated command NAME whole. Stopping at the
+// hyphen truncated `exec-add-path` — an ordinary user-defined function — to
+// `exec`, which is an exact-match command-injection sink, so any tainted
+// argument to it was reported as CWE-78.
 func isShellCommandByte(b byte) bool {
-	return isShellIdentByte(b)
+	return isShellIdentByte(b) || b == '-' || b == '.' || b == '/'
+}
+
+// shellCalleeName normalizes a scanned command token to the name the catalog is
+// keyed on: its final path segment, so `/usr/bin/curl` and `./curl` both resolve
+// as `curl`. A token that is all separators yields "".
+func shellCalleeName(token string) string {
+	if idx := strings.LastIndexByte(token, '/'); idx >= 0 {
+		return token[idx+1:]
+	}
+	return token
 }

--- a/core/taint/engine/extract_shell_test.go
+++ b/core/taint/engine/extract_shell_test.go
@@ -106,3 +106,166 @@ func TestExtractShellSpecialParamSources(t *testing.T) {
 		t.Errorf("$@ should surface as a source; calls=%v chains=%v", st.calls, st.chains)
 	}
 }
+
+// TestExtractShellLocalAssignmentIsTainted: `local x="$1"` is a declaration AND
+// an assignment. Skipping the whole line as scaffolding meant the declared
+// variable was never tainted, so a downstream `eval "$x"` was missed — the
+// suite's tp_known_fns.sh false negative. The declaration keyword is blanked and
+// the assignment underneath is recognized normally.
+func TestExtractShellLocalAssignmentIsTainted(t *testing.T) {
+	src := []byte("launder() {\n  local arg=\"$1\"\n  eval \"$arg\"\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "launder")
+	var assign stmtDraft
+	for i := range u.stmts {
+		if u.stmts[i].assigns == "arg" {
+			assign = u.stmts[i]
+		}
+	}
+	if assign.assigns != "arg" {
+		t.Fatalf("`local arg=\"$1\"` did not yield an assignment to arg: %+v", u.stmts)
+	}
+	if !containsStr(assign.calls, "$1") && !containsStr(assign.chains, "$1") {
+		t.Errorf("local assignment should surface the $1 source; calls=%v chains=%v",
+			assign.calls, assign.chains)
+	}
+	sink := stmtWithCall(t, u, "eval")
+	if !containsStr(sink.reads, "arg") {
+		t.Errorf("eval reads = %v, want to include arg", sink.reads)
+	}
+}
+
+// TestExtractShellDeclWithFlagsIsAssignment: the declaration builtins take
+// option flags (`local -r`, `declare -i`), which sit between the keyword and the
+// assignment and must not stop it being recognized.
+func TestExtractShellDeclWithFlagsIsAssignment(t *testing.T) {
+	for _, src := range []string{
+		"f() {\n  local -r arg=\"$1\"\n  eval \"$arg\"\n}\n",
+		"f() {\n  declare -i arg=\"$1\"\n  eval \"$arg\"\n}\n",
+		"f() {\n  readonly arg=\"$1\"\n  eval \"$arg\"\n}\n",
+		"f() {\n  export arg=\"$1\"\n  eval \"$arg\"\n}\n",
+	} {
+		units := extractUnits(lexctx.LangShell, []byte(src))
+		u := findUnit(t, units, "f")
+		found := false
+		for i := range u.stmts {
+			if u.stmts[i].assigns == "arg" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no assignment to arg for %q: %+v", src, u.stmts)
+		}
+	}
+}
+
+// TestExtractShellBareDeclarationStaysStructural is the precision guard. A
+// declaration with NO assignment (`local a b c`, `declare -A map`) carries no
+// dataflow and must stay scaffolding — reading it as a command would invent a
+// call to `local`/`declare` and could attribute a sink to it.
+func TestExtractShellBareDeclarationStaysStructural(t *testing.T) {
+	src := []byte("f() {\n  local a b c\n  declare -A map\n  local count\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "f")
+	for _, st := range u.stmts {
+		if st.assigns != "" {
+			t.Errorf("bare declaration produced an assignment to %q: %+v", st.assigns, st)
+		}
+		for _, c := range st.calls {
+			if c == "local" || c == "declare" {
+				t.Errorf("bare declaration read as a call to %q: %+v", c, st)
+			}
+		}
+	}
+}
+
+// TestExtractShellTrailingBackslashInQuotedWord is a crash regression. The
+// double-quote scanner treated a backslash as escaping the NEXT byte without
+// checking one existed, so a word ending in a lone backslash advanced the index
+// past the end of the line — panicking the scanner as soon as anything sliced
+// the raw view by that index. A security scanner must never crash on input it is
+// pointed at.
+func TestExtractShellTrailingBackslashInQuotedWord(t *testing.T) {
+	for _, src := range []string{
+		"f \"a\\\\\n",
+		"cmd \"x\\\\\n",
+		"eval \"$v\\\\\n",
+		"a=\"b\\\\\n",
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic on %q: %v", src, r)
+				}
+			}()
+			extractUnits(lexctx.LangShell, []byte(src))
+		}()
+	}
+}
+
+// TestExtractShellExecRedirectionIsNotACommand: `exec 200>"$f"` rebinds the
+// shell's own file descriptors and executes nothing, so a tainted path there is
+// not command injection. Only `exec CMD ...` is the sink.
+func TestExtractShellExecRedirectionIsNotACommand(t *testing.T) {
+	src := []byte("f() {\n  local lock=\"$1\"\n  exec 200>\"$lock\"\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "f")
+	for _, st := range u.stmts {
+		if containsStr(st.calls, "exec") {
+			t.Errorf("exec redirection recognized as a command call: %+v", st)
+		}
+	}
+}
+
+// TestExtractShellHyphenatedCommandIsNotExec: a user-defined `exec-add-path` is
+// its own command. Scanning the name only up to the hyphen truncated it to
+// `exec`, an exact-match command-injection sink, so every tainted argument to
+// any `exec-*` helper was reported as CWE-78.
+func TestExtractShellHyphenatedCommandIsNotExec(t *testing.T) {
+	src := []byte("f() {\n  local formula=\"$1\"\n  exec-add-path \"/opt/${formula}/bin\"\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "f")
+	for _, st := range u.stmts {
+		if containsStr(st.calls, "exec") {
+			t.Errorf("exec-add-path truncated to the exec sink: %+v", st)
+		}
+	}
+}
+
+// TestExtractShellPathQualifiedCommandResolves: the catalog is keyed on bare
+// command names, so a path-qualified invocation must normalize to its final
+// segment or the sink is lost.
+func TestExtractShellPathQualifiedCommandResolves(t *testing.T) {
+	src := []byte("f() {\n  local u=\"$1\"\n  /usr/bin/curl \"$u\"\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "f")
+	if sink := stmtWithCall(t, u, "curl"); sink.line == 0 {
+		t.Errorf("/usr/bin/curl did not resolve to the curl sink: %+v", u.stmts)
+	}
+}
+
+// TestExtractShellFetchOutputFlagIsNotTheURL: `curl --output "$path" "$url"`
+// writes $path and fetches $url. A tainted $path controls where the file lands,
+// not which host is contacted, so it must not be reported as the SSRF-carrying
+// argument. The URL argument still is.
+func TestExtractShellFetchOutputFlagIsNotTheURL(t *testing.T) {
+	src := []byte("f() {\n  local out=\"$1\"\n  curl --output \"$out\" \"https://example.com/x\"\n}\n")
+	units := extractUnits(lexctx.LangShell, src)
+	u := findUnit(t, units, "f")
+	sink := stmtWithCall(t, u, "curl")
+	if sink.line == 0 {
+		t.Fatalf("curl call not recognized: %+v", u.stmts)
+	}
+	if containsStr(sink.sinkArgs["curl"].taintedArgVars, "out") {
+		t.Errorf("--output argument treated as the SSRF URL: %+v", sink.sinkArgs["curl"])
+	}
+
+	// The URL argument must still count.
+	src2 := []byte("f() {\n  local u=\"$1\"\n  curl --output /tmp/x \"$u\"\n}\n")
+	units2 := extractUnits(lexctx.LangShell, src2)
+	u2 := findUnit(t, units2, "f")
+	sink2 := stmtWithCall(t, u2, "curl")
+	if !containsStr(sink2.sinkArgs["curl"].taintedArgVars, "u") {
+		t.Errorf("tainted URL argument lost: %+v", sink2.sinkArgs["curl"])
+	}
+}

--- a/testdata/precision-suite-shell/README.md
+++ b/testdata/precision-suite-shell/README.md
@@ -20,16 +20,20 @@ As committed, `nox bench --precision testdata/precision-suite-shell` scores:
 | Metric | Value |
 | --- | --- |
 | **Precision** | **1.00** (0 false positives) |
-| **Recall** | **0.82** |
-| **F1** | **0.90** |
-| TP / FP / FN | 9 / 0 / 2 |
-| findings-per-issue | 0.82 |
+| **Recall** | **1.00** |
+| **F1** | **1.00** |
+| TP / FP / FN | 11 / 0 / 0 |
+| findings-per-issue | 1.00 |
 
-Per rule: TAINT-002 (cmd injection) 3/4, TAINT-004 (traversal) 2/2, TAINT-005
-(code injection) 2/3, TAINT-006 (SSRF) 2/2. **Precision is 1.00** — every finding
+Per rule: TAINT-002 (cmd injection) 4/4, TAINT-004 (traversal) 2/2, TAINT-005
+(code injection) 3/3, TAINT-006 (SSRF) 2/2. **Precision is 1.00** — every finding
 nox emits is a true positive, and all four clean stressors fire nothing.
 
-## Why shell recall is the lowest of any supported language
+A 1.0 does NOT mean shell dataflow is solved — it means this corpus has stopped
+indicting anything. The limits below are real and simply lack a failing sample;
+adding one is how the number stays honest.
+
+## Why shell recall is the hardest of any supported language
 
 This is expected and honest. Unlike Python/Ruby/JS (function-call-shaped, so an
 `f(x)` call site and its arguments are unambiguous), **shell is command-oriented
@@ -42,24 +46,47 @@ straight-line eval/command patterns that carry the bulk of real shell injection
 and honestly misses the dynamic ones. The recall gap is the truth, not a defect
 to paper over.
 
-### The two honest false negatives (`tp_known_fns.sh`)
+### CLOSED: the two `local`-laundering false negatives (`tp_known_fns.sh`)
 
-Both FNs share one root cause: **taint laundered through a `local`-declared
-variable inside a function**. The recognizer skips `local` / `declare` / `export`
-/ `readonly` lines (they are treated as structural scaffolding), so the declared
-variable is never marked tainted and a downstream `eval "$arg"` / `bash -c
-"$target"` is missed:
+Both shared one root cause: **taint laundered through a `local`-declared
+variable inside a function**. `local` / `declare` / `export` / `readonly` lines
+were skipped wholesale as structural scaffolding, so the declared variable was
+never marked tainted and a downstream `eval "$arg"` / `bash -c "$target"` was
+missed.
 
-```bash
-launder_eval() {
-  local arg="$1"      # <- `local` line skipped: arg never tainted
-  eval "$arg"         # nox-expect: TAINT-005  (MISSED — false negative)
-}
-```
+A declaration that INITIALIZES (`local arg="$1"`) is an assignment and is now
+recognized as one: the keyword and any option flags are blanked to spaces
+(width-preserving, so the code and raw views stay aligned) and the assignment
+underneath is read normally. A BARE declaration (`local a b c`, `declare -A
+map`) still skips — it carries no dataflow, and reading it as a command would
+invent a call to `local`.
 
-Closing this means modeling `local x="$1"` as a tainted assignment without
-over-tainting the many benign `local` uses — the open work, deferred honestly
-rather than hacked in.
+The feared cost — "over-tainting the many benign `local` uses" — did not
+materialize, because `local x=RHS` only taints when RHS is actually a source:
+`local count=0` stays clean. What it DID do was expose four latent
+sink-modelling bugs, which had been invisible only because no tainted value ever
+reached them. Measured on 87 real-world shell scripts (452 declaration
+assignments), the recall fix alone added **five** false positives; all four
+causes are now fixed:
+
+| Bug | Effect |
+| --- | --- |
+| `isShellCommandByte` stopped at `-`, though its own doc comment said command names may contain `-`, `.` and `/` | `exec-add-path` truncated to `exec`, an exact-match command-injection sink — any tainted argument to any `exec-*` helper was CWE-78 |
+| `exec` matched on an I/O redirection | `exec 200>"$lock"` rebinds a file descriptor and executes nothing, but was reported as command injection |
+| fetch commands ignored argument position | `curl --output "$path" "$url"` writes `$path`; a tainted output path was reported as the SSRF-controlling value |
+| path-qualified commands were unrecognized | `/usr/bin/curl "$u"` resolved to no callee at all, losing the sink (a recall bug found while fixing the above) |
+
+After all four, the same 87-script corpus yields **one** new finding, and it is a
+genuine `argv → url → curl` dataflow (`curl -fSL -o "$tarball" "$url"` where
+`url` interpolates `$1`). Its exploitability is arguable — the scheme and host
+are literal, so only a path segment is attacker-controlled — but that is a
+question about how the SSRF rule should treat a partially-tainted URL, not an
+extractor defect. It is recorded here rather than suppressed.
+
+A crash was also fixed on the way: the double-quote scanner treated `\` as
+escaping the next byte without checking one existed, so a word ending in a lone
+backslash ran the index past the end of the line. It was latent only because
+nothing sliced the raw view by that index.
 
 ## Precision: the hard part for shell
 

--- a/testdata/precision-suite-shell/baseline.json
+++ b/testdata/precision-suite-shell/baseline.json
@@ -1,16 +1,16 @@
 {
   "precision": 1,
-  "recall": 0.8181818181818182,
-  "f1": 0.9,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 9,
-  "fn": 2,
-  "findings_per_issue": 0.8181818181818182,
+  "tp": 11,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",
@@ -20,7 +20,7 @@
     {
       "rule_id": "TAINT-005",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     },
     {
       "rule_id": "TAINT-006",

--- a/testdata/precision-suite-shell/tp_known_fns.sh
+++ b/testdata/precision-suite-shell/tp_known_fns.sh
@@ -1,23 +1,19 @@
 #!/bin/bash
-# Honest false negatives: real vulnerabilities a correct scanner SHOULD flag but
-# nox's flat, per-line shell recognizer cannot follow. These are annotated as
-# ground truth so the corpus reports them as recall gaps (FN), never hidden.
-# Shell has the lowest recall of any supported language precisely because of
-# constructs like these — this file is the honest evidence of that.
+# Taint laundered through a `local`-declared variable inside a function. These
+# were honest false negatives until declaration-with-initializer lines were
+# recognized as the assignments they are; they are kept as the regression test
+# for that flow.
 set -euo pipefail
 
-# FN: taint laundered through a `local`-declared variable inside a function. The
-# recognizer skips `local` / `declare` / `export` / `readonly` lines (they are
-# treated as structural), so the declared variable is never tainted and the sink
-# below is missed. Modeling `local x="$1"` as a tainted assignment would close
-# this, but distinguishing it from the many benign `local` uses without
-# over-tainting is the open work.
+# `local arg="$1"` initializes as well as declares, so the keyword is blanked and
+# the assignment underneath is read normally — arg carries the argv taint into
+# eval. A BARE `local a b c` still skips: it carries no dataflow.
 launder_eval() {
   local arg="$1"
   eval "$arg" # nox-expect: TAINT-005
 }
 
-# FN: same laundering shape into a command-injection sink.
+# The same laundering shape into a command-injection sink.
 launder_exec() {
   local target="$2"
   bash -c "$target" # nox-expect: TAINT-002


### PR DESCRIPTION
## The recall fix

`local arg="$1"` is a declaration **and** an assignment. `local`/`declare`/`export`/`readonly`/`typeset` lines were skipped wholesale as structural scaffolding, so the declared variable never carried taint and a downstream `eval "$arg"` was missed — the shell suite's two documented false negatives.

A declaration that *initializes* is now recognized as the assignment it is: the keyword and any option flags are blanked to spaces (width-preserving, so the code and raw views stay byte-aligned) and the assignment underneath is read normally. A **bare** declaration (`local a b c`, `declare -A map`) still skips — it carries no dataflow, and reading it as a command would invent a call to `local`.

The README warned this would mean "over-tainting the many benign `local` uses". That did not happen: `local x=RHS` only taints when RHS is actually a source, so `local count=0` stays clean.

## What it actually exposed — and why this PR is bigger than the FN

I measured the recall fix alone against **87 real-world shell scripts carrying 452 declaration assignments**. It added **five false positives**. None were caused by the new taint — the taint was correct every time. All five came from latent sink-modelling bugs that had been invisible only because no tainted value had ever reached them.

Shipping the recall win without these would have been a precision regression in the field, so all four causes are fixed here:

| Bug | Effect |
|---|---|
| `isShellCommandByte` stopped at `-`, contradicting **its own doc comment** ("command names may include `/`, `.`, and `-`") | `exec-add-path`, an ordinary user-defined function, was truncated to `exec` — an exact-match command-injection sink. Any tainted argument to any `exec-*` helper was reported as CWE-78. |
| `exec` matched on an I/O redirection | `exec 200>"$lock"` rebinds a file descriptor and executes nothing |
| Fetch commands ignored argument position | `curl --output "$path" "$url"` writes `$path` and fetches `$url`; a tainted **output path** was reported as the SSRF-controlling value |
| Path-qualified commands were unrecognized | `/usr/bin/curl "$u"` resolved to no callee at all, losing the sink (a *recall* bug found while fixing the above) |

The file-flag exclusion applies to `curl`/`wget` only, so `-c` there is the cookie jar and never `sh -c`.

## Plus a crash

`splitShellArgs`'s double-quote scanner treated `\` as escaping the next byte without checking one existed, so a word ending in a lone backslash advanced the index past the end of the line. It was latent only because nothing sliced the raw view by that index — my change did, and it panicked mid-scan. A security scanner must not crash on input it is pointed at. Fixed with a bound check, a defensive clamp, and a regression test.

## Verification

| | before | after |
|---|---|---|
| shell recall | 0.818 | **1.000** |
| shell F1 | 0.900 | **1.000** |
| TP / FP / FN | 9 / 0 / 2 | **11 / 0 / 0** |

**All 20 precision suites re-measured: precision 1.000 and FP 0 everywhere, and no suite other than shell moved.**

On the 87-script real-world corpus, base 6 findings → final 7. The net is **one** new finding, down from five:

```
+ TAINT-006  sh_37.sh:161   curl -fSL -o "$tarball" "$url"
```

This one is a genuine `argv → url → curl` dataflow — `url` interpolates `$1`. Its exploitability is arguable: the scheme and host are literal (`https://go.dev/dl/go${version}.src.tar.gz`), so only a path segment is attacker-controlled and the request cannot be redirected to another host. That is a question about how the SSRF rule should treat a *partially* tainted URL — a rule-semantics decision, not an extractor defect — so I documented it rather than suppressing it. Happy to follow up if you want partial-URL taint modelled.

## Note on the suite

Shell now scores 1.0, which means the corpus has stopped *indicting* anything — not that shell dataflow is solved. The README's open limits (word-splitting, arrays, pipeline-fed commands) are real and simply lack a failing sample. Both the README and the ratchet-test comment now say so explicitly.

`go build`, `go vet`, `gofmt`, `go test ./...`, and `golangci-lint` are clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
