### PR TITLE
feat(taint): close 6 of the 13 documented recall gaps across 5 languages

### DIFF
--- a/core/taint/engine/extract_clojure.go
+++ b/core/taint/engine/extract_clojure.go
@@ -330,6 +330,21 @@ func clojureCallStatement(code []byte, f clojureForm) (stmtDraft, bool) {
 	}
 	st := stmtDraft{line: clojureLine(code, f.children[0].start), sinkArgs: map[string]sinkArgDraft{}}
 
+	// A higher-order dispatcher passes the real callee as DATA: `(apply shell/sh
+	// "sh" "-c" args)` and `(map client/get urls)` both invoke a sink that never
+	// appears as a literal call head, so the flow was invisible. Re-attribute the
+	// statement to the dispatched function and drop it from the argument list, so
+	// the remaining arguments are scored against the sink they actually reach.
+	// Only a bare SYMBOL is re-attributed — an inline `#(...)`/`fn` literal is
+	// left alone, and the symbol still has to BE a catalog sink to report.
+	argStart := 1
+	if clojureHOFDispatchers[callee] && len(f.children) > 2 {
+		if sym := clojureNormalizeCallee(clojureAtomText(code, f.children[1])); sym != "" && isClojureCalleeStart(sym[0]) {
+			callee = sym
+			argStart = 2
+		}
+	}
+
 	// A jdbc query/execute passes its SQL as a `["… ?" v]` parameterized VECTOR
 	// (the value is a bind arg, SAFE) or as a `(str "…" v)` concat (the value is
 	// interpolated into the SQL string, UNSAFE). A variable inside a bind vector is
@@ -341,7 +356,7 @@ func clojureCallStatement(code []byte, f clojureForm) (stmtDraft, bool) {
 	info := sinkArgDraft{}
 	var allReads []string
 	seen := map[string]struct{}{}
-	for i := 1; i < len(f.children); i++ {
+	for i := argStart; i < len(f.children); i++ {
 		arg := f.children[i]
 		var vars []string
 		if jdbcParam && arg.delim == '[' && clojureVectorIsParamBind(code, arg) {
@@ -707,4 +722,16 @@ func isClojureSpecial(s string) bool {
 		return true
 	}
 	return false
+}
+
+// clojureHOFDispatchers are the core higher-order functions that take the
+// function to invoke as their FIRST argument. For taint purposes the flow runs
+// through them into that function, so a sink reached this way is a real flow
+// even though the sink is never a literal call head.
+var clojureHOFDispatchers = map[string]bool{
+	"apply": true,
+	"map":   true, "mapv": true, "pmap": true, "mapcat": true,
+	"keep": true, "filter": true, "remove": true,
+	"run!": true, "doseq": false, // doseq binds, it does not dispatch
+	"some": true, "every?": true,
 }

--- a/core/taint/engine/extract_clojure_test.go
+++ b/core/taint/engine/extract_clojure_test.go
@@ -118,3 +118,50 @@ func TestExtractClojureJdbcConcatFirstArg(t *testing.T) {
 		t.Errorf("jdbc/query concat should carry id as a tainted arg; got %+v", info)
 	}
 }
+
+// TestExtractClojureHOFDispatch: `apply` and `map` pass the real callee as DATA,
+// so a sink reached through them never appears as a literal call head and the
+// flow was invisible. The statement is re-attributed to the dispatched symbol.
+func TestExtractClojureHOFDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name, src, wantCallee, wantRead string
+	}{
+		{"apply", "(defn f [req]\n  (let [args (:params req)]\n    (apply shell/sh \"sh\" \"-c\" args)))\n", "shell/sh", "args"},
+		{"map", "(defn f [req]\n  (let [urls (:params req)]\n    (map client/get urls)))\n", "client/get", "urls"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			units := extractUnits(lexctx.LangClojure, []byte(tc.src))
+			u := findUnit(t, units, "f")
+			var found *stmtDraft
+			for i := range u.stmts {
+				for _, c := range u.stmts[i].calls {
+					if c == tc.wantCallee {
+						found = &u.stmts[i]
+					}
+				}
+			}
+			if found == nil {
+				t.Fatalf("dispatched callee %q not attributed: %+v", tc.wantCallee, u.stmts)
+			}
+			if !containsStr(found.reads, tc.wantRead) {
+				t.Errorf("reads = %v, want to include %q", found.reads, tc.wantRead)
+			}
+		})
+	}
+}
+
+// TestExtractClojureHOFDispatchKeepsInlineFn is the precision guard: only a bare
+// SYMBOL is re-attributed. An inline `#(...)` or `fn` literal has no name to
+// attribute the flow to and must leave the dispatcher as the callee.
+func TestExtractClojureHOFDispatchKeepsInlineFn(t *testing.T) {
+	src := []byte("(defn f [req]\n  (let [urls (:params req)]\n    (map #(str % \"x\") urls)))\n")
+	units := extractUnits(lexctx.LangClojure, src)
+	u := findUnit(t, units, "f")
+	for _, st := range u.stmts {
+		for _, c := range st.calls {
+			if c == "#" || c == "%" {
+				t.Errorf("inline fn literal re-attributed as callee %q: %+v", c, st)
+			}
+		}
+	}
+}

--- a/core/taint/engine/extract_cpp.go
+++ b/core/taint/engine/extract_cpp.go
@@ -70,6 +70,7 @@ func extractCPP(lines []logicalLine) []unitDraft {
 		}
 
 		if !isCPPStructuralLine(trimmed) {
+			ll = shapeCPPConstructorDecl(ll)
 			if st, ok := recognizeStatement(langCPP, ll); ok {
 				applyCPPBufferBuilder(&st)
 				cur.stmts = append(cur.stmts, st)
@@ -538,4 +539,107 @@ func matchParenBackward(s string, closeIdx int) int {
 		}
 	}
 	return -1
+}
+
+// shapeCPPConstructorDecl rewrites a C++ variable declaration whose initializer
+// is a CONSTRUCTOR call — `std::ifstream in(path);` — into the assignment form
+// `in = std::ifstream(path)` the shared recognizer already understands.
+//
+// Without it the recognizer reads `in(path)` as a call to a function named `in`
+// (the VARIABLE), so the constructed type never appears as the callee and a sink
+// keyed on the type (`ifstream`, opening an attacker-controlled path) never
+// fires. The declared variable is also left unbound.
+//
+// It fires only on the unambiguous shape: exactly two tokens before a balanced
+// argument list that ends the statement, no top-level `=`, the second token a
+// plain identifier, and the FIRST token recognizably a type — namespace- or
+// class-qualified (`std::ifstream`, containing `::` or `.`) or upper-case
+// initial (`Foo bar(x)`). Requiring that keeps built-in-typed function
+// PROTOTYPES (`int helper(int a);`), which reach this same path, from being
+// rewritten into a call to `int`.
+func shapeCPPConstructorDecl(ll logicalLine) logicalLine {
+	code := strings.TrimSpace(ll.code)
+	if code == "" || !strings.HasSuffix(code, ")") {
+		return ll
+	}
+	if splitAssignmentIndexCPP(code) >= 0 {
+		return ll
+	}
+	open := strings.IndexByte(code, '(')
+	if open < 0 {
+		return ll
+	}
+	if _, end := balancedArgs(code, open); end != len(code) {
+		return ll
+	}
+	head := strings.Fields(code[:open])
+	if len(head) != 2 {
+		return ll
+	}
+	typeTok, name := head[0], head[1]
+	// A DECLARED name may legitimately collide with the shared keyword set
+	// (`std::ifstream in(path)` — `in` is Python's membership operator), so the
+	// name is only required to be a bare identifier. The keyword guard belongs on
+	// the TYPE token below, which is what keeps `return foo(bar)` out.
+	if !isBareIdent(name) {
+		return ll
+	}
+	qualified := strings.Contains(typeTok, "::") || strings.Contains(typeTok, ".")
+	upper := typeTok != "" && typeTok[0] >= 'A' && typeTok[0] <= 'Z'
+	if !qualified && !upper {
+		return ll
+	}
+	if isKeyword(strings.SplitN(typeTok, "::", 2)[0]) {
+		return ll
+	}
+	args := code[open:]
+	indent := ll.code[:len(ll.code)-len(strings.TrimLeft(ll.code, " \t"))]
+	rewritten := indent + name + " = " + typeTok + args
+	return logicalLine{line: ll.line, code: rewritten, raw: rewritten}
+}
+
+// splitAssignmentIndexCPP returns the index of a top-level `=` assignment in
+// code, or -1. Mirrors splitAssignment's operator filtering without building the
+// two halves.
+func splitAssignmentIndexCPP(code string) int {
+	depth := 0
+	for i := 0; i < len(code); i++ {
+		switch code[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '=':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < len(code) && code[i+1] == '=' {
+				i++
+				continue
+			}
+			if i > 0 {
+				switch code[i-1] {
+				case '=', '!', '<', '>', '+', '-', '*', '/', '%', '&', '|', '^':
+					continue
+				}
+			}
+			return i
+		}
+	}
+	return -1
+}
+
+// isBareIdent reports whether s is a single identifier — like isSimpleIdent but
+// WITHOUT the keyword exclusion, for positions where a declared name may shadow
+// a keyword from another language in the shared set.
+func isBareIdent(s string) bool {
+	if s == "" || !isIdentStart(s[0]) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if !isIdentPart(s[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/core/taint/engine/extract_cpp_test.go
+++ b/core/taint/engine/extract_cpp_test.go
@@ -154,3 +154,26 @@ func TestExtractCPPConstMethodHeader(t *testing.T) {
 	// The name is the final dotted segment after `::`->`.` normalization.
 	findUnit(t, units, "describe")
 }
+
+// TestShapeCPPConstructorDecl: `std::ifstream in(path)` is a declaration whose
+// initializer is a constructor call. Read literally it looks like a call to a
+// function named `in` (the VARIABLE), so the constructed type never appeared as
+// the callee and a sink keyed on it could not fire.
+func TestShapeCPPConstructorDecl(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"    std.ifstream in(path)", "    in = std.ifstream(path)"},
+		{"    std::ofstream out(p)", "    out = std::ofstream(p)"},
+		{"    Foo bar(baz)", "    bar = Foo(baz)"},
+		// Not the shape: leave untouched.
+		{"    foo(bar)", "    foo(bar)"},                   // ordinary call
+		{"    int helper(int a)", "    int helper(int a)"}, // builtin-typed prototype
+		{"    return foo(bar)", "    return foo(bar)"},     // keyword head
+		{"    auto x = mk(y)", "    auto x = mk(y)"},       // already an assignment
+		{"    Foo bar(baz) extra", "    Foo bar(baz) extra"},
+	} {
+		got := shapeCPPConstructorDecl(logicalLine{line: 1, code: tc.in, raw: tc.in})
+		if got.code != tc.want {
+			t.Errorf("shape(%q) = %q, want %q", tc.in, got.code, tc.want)
+		}
+	}
+}

--- a/core/taint/engine/extract_elixir.go
+++ b/core/taint/engine/extract_elixir.go
@@ -65,6 +65,21 @@ func extractElixir(lines []logicalLine) []unitDraft {
 		shaped := shapeElixirLine(ll)
 		if st, ok := recognizeStatement(langElixir, shaped); ok {
 			cur.stmts = append(cur.stmts, st)
+			// A DESTRUCTURING pattern-match (`%{"q" => q} = conn.params`) binds
+			// names the single-assignee model cannot express, so recognizeStatement
+			// reports no assignee and the extracted variable never carries the
+			// RHS's taint. Emit one additional binding statement per extracted
+			// name, carrying the same RHS source evidence.
+			for _, name := range elixirDestructuredNames(shaped.code) {
+				cur.stmts = append(cur.stmts, stmtDraft{
+					line:     st.line,
+					assigns:  name,
+					calls:    st.calls,
+					reads:    st.reads,
+					chains:   st.chains,
+					sinkArgs: map[string]sinkArgDraft{},
+				})
+			}
 		}
 	}
 
@@ -505,4 +520,97 @@ func addElixirParenlessCallParens(code, raw string) (newCode, newRaw string) {
 // variable name (letters, digits, underscore).
 func isElixirNameByte(b byte) bool {
 	return isIdentPart(b)
+}
+
+// elixirDestructuredNames returns the variable names bound by a destructuring
+// pattern-match on the LHS of `pattern = expr` — the map, tuple and list
+// patterns Elixir uses everywhere:
+//
+//	%{"file" => path} = conn.params      -> [path]
+//	%{query: q} = conn                   -> [q]
+//	{:ok, body} = fetch()                -> [body]
+//	[head | tail] = list                 -> [head tail]
+//
+// Only a PATTERN LHS yields names; a simple `x = expr` is already handled by the
+// ordinary assignment path and returns nothing here, so no binding is doubled.
+//
+// A name is in binding position when it is neither an atom (`:ok`, preceded by
+// `:`) nor a keyword key (`query:`, followed by `:`). Module aliases (an
+// upper-case first letter) and the `_` wildcard are skipped: neither is a
+// taint-carrying binding. String keys are already blanked in the code view.
+func elixirDestructuredNames(code string) []string {
+	eq := elixirTopLevelPatternAssign(code)
+	if eq < 0 {
+		return nil
+	}
+	lhs := strings.TrimSpace(code[:eq])
+	if lhs == "" || isSimpleIdent(lhs) {
+		return nil
+	}
+	switch lhs[0] {
+	case '%', '{', '[':
+	default:
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	for i := 0; i < len(lhs); {
+		if !isIdentStart(lhs[i]) {
+			i++
+			continue
+		}
+		start := i
+		for i < len(lhs) && isIdentPart(lhs[i]) {
+			i++
+		}
+		name := lhs[start:i]
+		// A keyword key (`query:`) names a field, not a binding.
+		if i < len(lhs) && lhs[i] == ':' {
+			continue
+		}
+		// An atom (`:ok`) is a literal, not a binding.
+		if start > 0 && lhs[start-1] == ':' {
+			continue
+		}
+		if name == "_" || isKeyword(name) || (name[0] >= 'A' && name[0] <= 'Z') {
+			continue
+		}
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// elixirTopLevelPatternAssign returns the index of the top-level `=` match
+// operator in code, or -1. It skips `==`/`<=`/`>=`/`!=` comparisons and any `=`
+// nested inside brackets (a `%{a => b}` arrow is not a match, and its `>` is
+// already excluded by requiring the previous byte not be `=`).
+func elixirTopLevelPatternAssign(code string) int {
+	depth := 0
+	for i := 0; i < len(code); i++ {
+		switch code[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '=':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < len(code) && (code[i+1] == '=' || code[i+1] == '>') {
+				i++
+				continue
+			}
+			if i > 0 {
+				switch code[i-1] {
+				case '=', '!', '<', '>', ':', '+', '-', '*', '/':
+					continue
+				}
+			}
+			return i
+		}
+	}
+	return -1
 }

--- a/core/taint/engine/extract_elixir_test.go
+++ b/core/taint/engine/extract_elixir_test.go
@@ -190,3 +190,35 @@ Code.eval_string(x)
 		t.Fatalf("Code.eval_string not recognized in module unit: %+v", u.stmts)
 	}
 }
+
+// TestElixirDestructuredNames: a destructuring pattern-match binds names the
+// single-assignee model cannot express, so the extracted variable never carried
+// the RHS's taint.
+func TestElixirDestructuredNames(t *testing.T) {
+	for _, tc := range []struct {
+		code string
+		want []string
+	}{
+		{`%{      => path} = conn.params`, []string{"path"}},
+		{`%{query: q} = conn`, []string{"q"}},
+		{`{:ok, body} = fetch()`, []string{"body"}},
+		{`[head | tail] = list`, []string{"head", "tail"}},
+		// Not a destructuring bind: the ordinary assignment path handles it, so
+		// nothing must be doubled here.
+		{`x = conn.params`, nil},
+		{`conn.params`, nil},
+		{`a == b`, nil},
+	} {
+		got := elixirDestructuredNames(tc.code)
+		if len(got) != len(tc.want) {
+			t.Errorf("names(%q) = %v, want %v", tc.code, got, tc.want)
+			continue
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Errorf("names(%q) = %v, want %v", tc.code, got, tc.want)
+				break
+			}
+		}
+	}
+}

--- a/core/taint/engine/extract_groovy.go
+++ b/core/taint/engine/extract_groovy.go
@@ -77,6 +77,14 @@ func extractGroovy(lines []logicalLine) []unitDraft {
 			cur.stmts = append(cur.stmts, st)
 		}
 
+		// A scope function's lambda parameter aliases its receiver, so bind it
+		// before the lambda body's statements (which arrive on later lines).
+		if b, ok := scopeFunctionBinding(ll); ok {
+			if st, ok := recognizeStatement(langGroovy, b); ok {
+				cur.stmts = append(cur.stmts, st)
+			}
+		}
+
 		if closesMethod {
 			cur = module
 			methodDepth = -1

--- a/core/taint/engine/extract_kotlin.go
+++ b/core/taint/engine/extract_kotlin.go
@@ -79,6 +79,14 @@ func extractKotlin(lines []logicalLine) []unitDraft {
 			cur.stmts = append(cur.stmts, st)
 		}
 
+		// A scope function's lambda parameter aliases its receiver, so bind it
+		// before the lambda body's statements (which arrive on later lines).
+		if b, ok := scopeFunctionBinding(ll); ok {
+			if st, ok := recognizeStatement(langKotlin, b); ok {
+				cur.stmts = append(cur.stmts, st)
+			}
+		}
+
 		if closesFun {
 			cur = module
 			funDepth = -1

--- a/core/taint/engine/scopefn.go
+++ b/core/taint/engine/scopefn.go
@@ -1,0 +1,73 @@
+package engine
+
+import "strings"
+
+// scopeFunctions are the receiver-scoping higher-order functions whose lambda
+// parameter IS the value the function was applied to:
+//
+//	request.getParameter("cmd").let { cmd -> exec(cmd) }   // Kotlin
+//	request.getParameter("cmd").with { c -> c.execute() }  // Groovy
+//
+// In both, `cmd`/`c` is an ALIAS of the receiver, so taint on the receiver is
+// taint on the parameter. Without modeling that, a source piped straight into
+// the lambda is never bound to a name and the sink inside sees a clean value.
+//
+// Deliberately limited to the pure receiver-scoping functions. The COLLECTION
+// ones (`each`, `collect`, `find`, `map`) bind an ELEMENT rather than the
+// receiver; propagating container taint to elements is a broader decision than
+// this aliasing, so they are left out rather than guessed at.
+//
+// `run`/`apply` bind the receiver to `this` instead of a named parameter and are
+// likewise out of scope here.
+var scopeFunctions = map[string]bool{
+	// Kotlin
+	"let": true, "also": true, "takeIf": true, "takeUnless": true,
+	// Groovy
+	"with": true, "tap": true, "identity": true,
+}
+
+// scopeFunctionBinding recognizes `RECEIVER.scopefn { PARAM ->` (or an implicit
+// `it` when the lambda declares no parameter) and returns a synthetic
+// `PARAM = RECEIVER` logical line. Feeding that to recognizeStatement binds the
+// parameter to the receiver's taint using the ordinary assignment machinery, so
+// statements inside the lambda body — which arrive on later lines — resolve the
+// parameter as tainted.
+//
+// Returns ok=false for anything that is not this exact shape, including a typed
+// or destructuring parameter list, which is not a simple alias.
+func scopeFunctionBinding(ll logicalLine) (logicalLine, bool) {
+	code := ll.code
+	brace := strings.IndexByte(code, '{')
+	if brace < 0 {
+		return logicalLine{}, false
+	}
+	head := strings.TrimRight(code[:brace], " \t")
+	dot := strings.LastIndexByte(head, '.')
+	if dot < 0 || !scopeFunctions[head[dot+1:]] {
+		return logicalLine{}, false
+	}
+	recv := strings.TrimSpace(head[:dot])
+	if recv == "" {
+		return logicalLine{}, false
+	}
+	// The lambda parameter: `{ cmd ->` names it, a bare `{` implies `it`. A
+	// non-identifier before the arrow (a typed or destructuring parameter) is not
+	// a plain alias, so it is skipped rather than guessed at.
+	param := "it"
+	if arrow := strings.Index(code[brace+1:], "->"); arrow >= 0 {
+		cand := strings.TrimSpace(code[brace+1 : brace+1+arrow])
+		if !isBareIdent(cand) {
+			return logicalLine{}, false
+		}
+		param = cand
+	}
+	rawRecv := recv
+	if len(ll.raw) == len(code) && dot <= len(ll.raw) {
+		rawRecv = strings.TrimSpace(ll.raw[:dot])
+	}
+	return logicalLine{
+		line: ll.line,
+		code: param + " = " + recv,
+		raw:  param + " = " + rawRecv,
+	}, true
+}

--- a/core/taint/engine/scopefn_test.go
+++ b/core/taint/engine/scopefn_test.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// TestScopeFunctionBindingKotlin: `source().let { cmd -> sink(cmd) }` pipes the
+// source straight into the lambda with no intermediate `val`, so the parameter
+// was never bound and the sink saw a clean value. The parameter aliases the
+// receiver and is now bound to it.
+func TestScopeFunctionBindingKotlin(t *testing.T) {
+	src := []byte("class R {\n  fun run(request: HttpServletRequest) {\n    request.getParameter(\"cmd\").let { cmd ->\n      Runtime.getRuntime().exec(cmd)\n    }\n  }\n}\n")
+	units := extractUnits(lexctx.LangKotlin, src)
+	u := findUnit(t, units, "run")
+	var bound stmtDraft
+	for i := range u.stmts {
+		if u.stmts[i].assigns == "cmd" {
+			bound = u.stmts[i]
+		}
+	}
+	if bound.assigns != "cmd" {
+		t.Fatalf("lambda parameter not bound to its receiver: %+v", u.stmts)
+	}
+	if !containsStr(bound.calls, "request.getParameter") {
+		t.Errorf("binding should carry the receiver's source call; calls=%v", bound.calls)
+	}
+}
+
+// TestScopeFunctionBindingGroovy: the Groovy `with { c -> }` form is the same
+// aliasing as Kotlin's `let`.
+func TestScopeFunctionBindingGroovy(t *testing.T) {
+	src := []byte("class R {\n  def go(request) {\n    request.getParameter(\"cmd\").with { c ->\n      c.execute()\n    }\n  }\n}\n")
+	units := extractUnits(lexctx.LangGroovy, src)
+	u := findUnit(t, units, "go")
+	found := false
+	for i := range u.stmts {
+		if u.stmts[i].assigns == "c" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("with{} parameter not bound to its receiver: %+v", u.stmts)
+	}
+}
+
+// TestScopeFunctionBindingImplicitIt: a lambda with no declared parameter binds
+// the implicit `it`.
+func TestScopeFunctionBindingImplicitIt(t *testing.T) {
+	ll := logicalLine{line: 1, code: `request.getParameter(     ).let {`, raw: `request.getParameter("cmd").let {`}
+	b, ok := scopeFunctionBinding(ll)
+	if !ok {
+		t.Fatal("implicit-it lambda not recognized")
+	}
+	if b.code != "it = request.getParameter(     )" {
+		t.Errorf("binding = %q, want the receiver bound to it", b.code)
+	}
+}
+
+// TestScopeFunctionBindingRejectsNonAlias is the precision guard: only the pure
+// receiver-scoping functions alias their receiver. A collection function binds
+// an ELEMENT, and a typed/destructuring parameter is not a plain alias — neither
+// may be turned into a binding.
+func TestScopeFunctionBindingRejectsNonAlias(t *testing.T) {
+	for _, code := range []string{
+		`items.each { item ->`, // collection element, not the receiver
+		`items.collect { x ->`, // ditto
+		`items.map { x ->`,     // ditto
+		`foo.let { (a, b) ->`,  // destructuring parameter
+		`foo.bar { x ->`,       // not a scope function
+		`someExpr {`,           // no receiver dot
+	} {
+		if b, ok := scopeFunctionBinding(logicalLine{line: 1, code: code, raw: code}); ok {
+			t.Errorf("%q must not bind, got %q", code, b.code)
+		}
+	}
+}

--- a/testdata/precision-suite-clojure/README.md
+++ b/testdata/precision-suite-clojure/README.md
@@ -44,12 +44,12 @@ where the honest false negatives live (see below).
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-clojure` scores
-**precision 1.00 / recall 0.77 / F1 0.87** (10 TP, 0 FP, 3 FN). Precision is
+**precision 1.00 / recall 0.92 / F1 0.96** (12 TP, 0 FP, 1 FN). Precision is
 perfect — every finding nox emits is a true positive, and every clean stressor
 (parameterized jdbc vector, `Integer/parseInt` coercion, placeholder creds,
 data-URI blob, generated banner) fires nothing — while recall is the lowest of any
-language, held down by three honest false negatives in threading-macro and
-higher-order forms the recognizer cannot follow.
+language, held down by ONE honest false negative: the threading-macro form. The
+two higher-order-dispatch gaps (`apply`, `map`) are closed — see below.
 
 That gap is **honest, not curated**: the FN samples are annotated as the true
 positives a correct scanner should fire, so the number tells the truth. The way to
@@ -74,8 +74,8 @@ expected to MISS — the Lisp recall gap):
 | File (line) | What flows | Rule | nox today | Why it is missed |
 | --- | --- | --- | --- | --- |
 | `tp_threading.clj` — `run-threaded` | `(:params req)` threaded via `->`/`->>` into `shell/sh` | TAINT-002 | **FN** | threading macros reorder the value's argument position; the positional recognizer sees `sh` called with only literal args |
-| `tp_threading.clj` — `run-apply` | tainted seq spread into `sh` via `apply` | TAINT-002 | **FN** | the call head is `apply`, not `shell/sh`; the sink is reached indirectly |
-| `tp_threading.clj` — `fetch-all` | `map client/get` over tainted URLs | TAINT-006 | **FN** | the sink is a HOF argument, never a literal call head |
+| `tp_threading.clj` — `run-apply` | tainted seq spread into `sh` via `apply` | TAINT-002 | **caught** | the statement is re-attributed to the dispatched symbol |
+| `tp_threading.clj` — `fetch-all` | `map client/get` over tainted URLs | TAINT-006 | **caught** | same re-attribution |
 
 Clean stressors (zero annotations — any finding is a false positive):
 
@@ -92,9 +92,14 @@ Clean stressors (zero annotations — any finding is a false positive):
 - **Threading macros** (`->`, `->>`, `as->`, `some->`, `cond->`) rewrite argument
   position at read time; the recognizer does not desugar them, so a value threaded
   into a sink is missed. This is the dominant recall gap.
-- **Higher-order dispatch** — `apply`, `map`, `partial`, `comp`, `reduce` — passes
-  the sink or the tainted value as data, so the sink never appears as a literal
-  call head.
+- **Higher-order dispatch — CLOSED for the dispatcher family.** `apply`, `map`,
+  `mapv`, `pmap`, `mapcat`, `keep`, `filter`, `remove`, `some`, `every?` and
+  `run!` take the function to invoke as their FIRST argument, so a sink reached
+  through them was never a literal call head. The statement is now re-attributed
+  to the dispatched SYMBOL and the remaining arguments scored against it. Only a
+  bare symbol is re-attributed — an inline `#(...)`/`fn` literal has no name to
+  attribute the flow to and leaves the dispatcher as callee. `partial` and `comp`
+  build a function rather than invoking one and are still not modeled.
 - **Destructuring binds** — `{:keys [a b]}`, `[x & xs]` — are not tracked; only a
   bare-symbol binding target taints. A value bound through destructuring is lost.
 - **`slurp` of a URL** is SSRF, not path traversal, but the recognizer cannot tell

--- a/testdata/precision-suite-clojure/baseline.json
+++ b/testdata/precision-suite-clojure/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.7692307692307693,
-  "f1": 0.8695652173913044,
+  "recall": 0.9230769230769231,
+  "f1": 0.9600000000000001,
   "fp": 0,
-  "tp": 10,
-  "fn": 3,
-  "findings_per_issue": 0.7692307692307693,
+  "tp": 12,
+  "fn": 1,
+  "findings_per_issue": 0.9230769230769231,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 0.75
     },
     {
       "rule_id": "TAINT-004",
@@ -30,7 +30,7 @@
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     }
   ]
 }

--- a/testdata/precision-suite-clojure/tp_threading.clj
+++ b/testdata/precision-suite-clojure/tp_threading.clj
@@ -8,21 +8,25 @@
   (:require [clojure.java.shell :as shell]
             [clj-http.client :as client]))
 
-;; Thread-first `->`: the tainted value is threaded as the FIRST argument of each
-;; stage, so it arrives at `sh` in a position the flat recognizer does not track.
+;; Thread-first `->` — still an honest FALSE NEGATIVE. The tainted value is
+;; threaded as the FIRST argument of each stage, and the nested `->>` reverses
+;; that position again, so it arrives at `sh` somewhere the positional FORM
+;; recognizer does not track. Closing it needs a real threading-macro desugarer
+;; over the s-expression tree; the HOF re-attribution below does not reach it.
 (defn run-threaded [req]
   (-> (:params req)
       (clojure.string/trim)
       (->> (shell/sh "sh" "-c")))) ; nox-expect: TAINT-002
 
-;; Higher-order dispatch: the sink is applied via `apply` over a tainted seq, so
-;; the value never appears as a literal argument of the sink call.
+;; Higher-order dispatch via `apply` — CAUGHT. A dispatcher passes the real
+;; callee as DATA, so the sink is never a literal call head; the statement is now
+;; re-attributed to the dispatched symbol and the remaining args scored against
+;; it. Kept as the regression test.
 (defn run-apply [req]
   (let [args (:params req)]
     (apply shell/sh "sh" "-c" args))) ; nox-expect: TAINT-002
 
-;; `map` over tainted URLs: each fetch is an SSRF, but the taint flows through a
-;; HOF the recognizer does not model.
+;; `map` over tainted URLs — CAUGHT by the same re-attribution as `apply`.
 (defn fetch-all [req]
   (let [urls (:params req)]
     (map client/get urls))) ; nox-expect: TAINT-006

--- a/testdata/precision-suite-cpp/README.md
+++ b/testdata/precision-suite-cpp/README.md
@@ -52,12 +52,12 @@ TAINT-002  2   0   0   1.000      1.000   1.000
 TAINT-004  1   0   1   1.000      0.500   0.667
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    6   0   1   1.000      0.857   0.923
+OVERALL    7   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.857 by design and honestly** —
+`clean_*` sample false-positives. Recall reached 1.00 by closing the std::ifstream in(path)` constructor-declaration gap the corpus indicted, not by deleting the sample. A 1.0 means this corpus has stopped indicting anything; the structural limits below are real and simply lack a failing sample. Previously **0.857** —
 see the documented FN below.
 
 ## Ground-truth philosophy

--- a/testdata/precision-suite-cpp/baseline.json
+++ b/testdata/precision-suite-cpp/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -20,7 +20,7 @@
     {
       "rule_id": "TAINT-004",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-005",

--- a/testdata/precision-suite-elixir/README.md
+++ b/testdata/precision-suite-elixir/README.md
@@ -20,13 +20,13 @@ As committed, `nox bench --precision testdata/precision-suite-elixir` scores:
 | Metric | Value |
 | --- | --- |
 | **Precision** | **1.00** (0 false positives) |
-| **Recall** | **0.93** |
-| **F1** | **0.96** |
-| TP / FP / FN | 13 / 0 / 1 |
-| findings-per-issue | 0.93 |
+| **Recall** | **1.00** |
+| **F1** | **1.00** |
+| TP / FP / FN | 14 / 0 / 0 |
+| findings-per-issue | 1.00 |
 
 Per rule: TAINT-001 (SQLi) 1/1, TAINT-002 (cmd injection) 4/4, TAINT-004 (path
-traversal) 3/4, TAINT-005 (code injection / deserialization) 2/2, TAINT-006
+traversal) 4/4, TAINT-005 (code injection / deserialization) 2/2, TAINT-006
 (SSRF) 3/3. **Precision is 1.00** — every finding nox emits is a true positive,
 and all four clean stressors fire nothing.
 
@@ -66,18 +66,23 @@ is a false positive:
 - **clean_generated.exs** — a machine-generated banner, constant lookup tables,
   and a constant fixture `File.read` — no untrusted input anywhere.
 
-## Why Elixir recall is below 1.0 (the honest false negative)
+## Elixir's two dominant idioms are both modeled now
 
-Elixir's two dominant dataflow idioms are the **pipe operator** `|>` and
-**pattern matching**. The pipe is now followed to the end of the chain; pattern
-matching still is not, and that is the one remaining annotated false negative —
-measurable rather than hand-waved:
+The **pipe operator** `|>` is followed to the end of the chain, and **pattern
+matching** now binds destructured names.
 
-1. **Destructuring pattern match** (`tp_pathtraversal.exs`
-   `read_destructured/1`): `%{"file" => path} = conn.params`. nox binds only a
-   **simple-ident** LHS (`x = expr`), so a map / tuple / list destructuring match
-   never marks the extracted variable tainted. A correct scanner fires TAINT-004;
-   nox does not.
+### Closed: destructuring pattern match (`tp_pathtraversal.exs` `read_destructured/1`)
+
+`%{"file" => path} = conn.params` bound nothing: only a **simple-ident** LHS
+(`x = expr`) was tracked, so a map / tuple / list match never marked the
+extracted variable tainted. A destructuring LHS now emits one binding statement
+per extracted name, carrying the RHS's source evidence — `%{"file" => path}`,
+`%{query: q}`, `{:ok, body}` and `[head | tail]` all bind. A name is in binding
+position when it is neither an atom (`:ok`) nor a keyword key (`query:`); module
+aliases and `_` are skipped.
+
+A 1.0 means this corpus has stopped indicting anything, not that Elixir dataflow
+is solved. The limits below are real and simply lack a failing sample.
 
 ### Closed: multi-stage pipe (`tp_cmdinjection.exs` `run_piped/1`)
 

--- a/testdata/precision-suite-elixir/baseline.json
+++ b/testdata/precision-suite-elixir/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.9285714285714286,
-  "f1": 0.962962962962963,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 13,
-  "fn": 1,
-  "findings_per_issue": 0.9285714285714286,
+  "tp": 14,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -20,7 +20,7 @@
     {
       "rule_id": "TAINT-004",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     },
     {
       "rule_id": "TAINT-005",

--- a/testdata/precision-suite-groovy/README.md
+++ b/testdata/precision-suite-groovy/README.md
@@ -25,12 +25,12 @@ TAINT-002  2   0   1   1.000      0.667   0.800
 TAINT-004  1   0   0   1.000      1.000   1.000
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    6   0   1   1.000      0.857   0.923
+OVERALL    7   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.857 by design and honestly** —
+`clean_*` sample false-positives. Recall reached 1.00 by closing the `with { }` closure receiver aliasing gap the corpus indicted, not by deleting the sample. A 1.0 means this corpus has stopped indicting anything; the structural limits below are real and simply lack a failing sample. Previously **0.857** —
 see the gap below.
 
 ## Ground-truth philosophy

--- a/testdata/precision-suite-groovy/baseline.json
+++ b/testdata/precision-suite-groovy/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-groovy/tp_cmdinjection_closure.groovy
+++ b/testdata/precision-suite-groovy/tp_cmdinjection_closure.groovy
@@ -1,16 +1,11 @@
-// Command injection laundered through a Groovy CLOSURE — a labeled FALSE NEGATIVE.
-// This is a genuine CWE-78 bug (the untrusted `cmd` reaches .execute()), but nox's
-// Groovy model does NOT catch it, and it is kept in the corpus rather than deleted:
-// inflating recall by removing a hard true positive would defeat an honest suite.
+// Command injection laundered through a Groovy CLOSURE. `with { c -> }` is the
+// same receiver-aliasing shape as Kotlin's `.let { }`: the closure parameter IS
+// the value the closure was applied to, so the untrusted `cmd` reaches
+// .execute(). CWE-78.
 //
-// The idiom is idiomatic Groovy: the untrusted value is piped straight into a
-// closure via `with { ... }` and the closure's implicit `it` / captured binding is
-// executed, with no intermediate top-level `def` binding the sink reads. nox
-// introduces taint from source calls assigned to a variable and propagates it
-// through variable reads; it does not model a closure parameter (`c` here, or the
-// implicit `it`) as an alias of the value the closure is applied to, so `c` inside
-// the closure is never marked tainted and the .execute sink does not fire. Closing
-// it needs closure/receiver modeling — future work, not a curation trick.
+// The recognizer now emits that binding when it sees the closure header, so `c`
+// is tainted inside the body and the sink fires. This was a documented false
+// negative until the aliasing landed; it is kept as the regression test for it.
 package com.example
 
 class Runner {

--- a/testdata/precision-suite-kotlin/README.md
+++ b/testdata/precision-suite-kotlin/README.md
@@ -25,12 +25,12 @@ TAINT-003  1   0   0   1.000      1.000   1.000
 TAINT-004  1   0   0   1.000      1.000   1.000
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    6   0   1   1.000      0.857   0.923
+OVERALL    7   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.857 by design and honestly** —
+`clean_*` sample false-positives. Recall reached 1.00 by closing the `.let { }` scope-function receiver aliasing gap the corpus indicted, not by deleting the sample. A 1.0 means this corpus has stopped indicting anything; the structural limits below are real and simply lack a failing sample. Previously **0.857** —
 see the gap below.
 
 ## Ground-truth philosophy

--- a/testdata/precision-suite-kotlin/baseline.json
+++ b/testdata/precision-suite-kotlin/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",

--- a/testdata/precision-suite-kotlin/tp_cmdinjection_scopefn.kt
+++ b/testdata/precision-suite-kotlin/tp_cmdinjection_scopefn.kt
@@ -1,18 +1,13 @@
-// Command injection through a Kotlin SCOPE-FUNCTION chain — a labeled FALSE
-// NEGATIVE nox's flat line-recognizer does not catch. The untrusted value is read
-// and immediately piped into a `.let { }` lambda whose receiver (`cmd`) is passed
-// to Runtime.getRuntime().exec, with no intermediate `val` binding. This is a real
-// CWE-78 bug a correct scanner would fire TAINT-002 on — it is kept in the corpus,
-// not deleted, because removing a hard true positive to inflate recall would defeat
-// the point of an honest measurement suite.
+// Command injection through a Kotlin SCOPE-FUNCTION chain. The untrusted value
+// is read and piped straight into a `.let { }` lambda whose parameter is passed
+// to Runtime.getRuntime().exec, with no intermediate `val` binding. CWE-78.
 //
-// Why nox misses it: taint is introduced from source CALLS assigned to a variable,
-// and propagated through variable reads. Here the source result is never bound to a
-// name — it flows straight into the `.let { cmd -> ... }` lambda, and the recognizer
-// does not model a scope-function lambda's parameter as an alias of its receiver.
-// The `cmd` inside the lambda is therefore never marked tainted, so the .exec sink
-// does not fire. Closing this needs scope-function/lambda-receiver modeling — future
-// work, not a curation trick. See testdata/precision-suite-kotlin/README.md.
+// A scope function's lambda parameter ALIASES its receiver: `cmd` here IS the
+// value `.let` was applied to. On seeing the lambda header the recognizer now
+// emits that binding (`cmd = request.getParameter(...)`), so statements in the
+// body — which arrive on later lines — resolve `cmd` as tainted and the sink
+// fires. This was a documented false negative until the aliasing landed; it is
+// kept as the regression test for it.
 package com.example
 
 import javax.servlet.http.HttpServletRequest


### PR DESCRIPTION
Four independent causes, each with ground truth already sitting in the corpora. Every one was measured against **all 20 precision suites** and a real-world corpus before landing.

## What closed

| # | Cause | Suites | FNs |
|---|---|---|---|
| 1 | Destructuring binds | elixir | 1 |
| 2 | Constructor declarations | cpp | 1 |
| 3 | Scope-function receiver aliasing | kotlin, groovy | 2 |
| 4 | Higher-order dispatch | clojure | 2 |

**1. Elixir destructuring.** `%{"file" => path} = conn.params` bound nothing — only a simple-ident LHS was tracked. A destructuring LHS now emits one binding statement per extracted name. A name is in binding position when it is neither an atom (`:ok`) nor a keyword key (`query:`).

**2. C++ constructor declarations.** `std::ifstream in(path)` read literally is a call to a function named `in` — the *variable* — so the constructed type never appeared as the callee. Rewritten to `in = std::ifstream(path)`.

Two guards worth reviewing: it fires only on the unambiguous shape (exactly two tokens before a balanced argument list ending the statement, no top-level `=`, type token qualified or upper-case initial), which keeps built-in-typed function **prototypes** — which reach the same code path — from becoming a call to `int`. And the declared *name* is checked as a bare identifier rather than `isSimpleIdent`, because `in` is in the shared keyword set — the same collision class as the Dart type names fixed in #414.

**3. Scope-function aliasing.** Kotlin `.let { cmd -> }` and Groovy `.with { c -> }` are one concept: the lambda parameter *is* the value the function was applied to. A `param = receiver` binding is emitted at the lambda header so body statements on later lines resolve it as tainted.

Deliberately limited to the pure receiver-scoping functions. The **collection** ones (`each`/`collect`/`map`) bind an *element*, not the receiver — propagating container taint to elements is a broader decision than this aliasing, so I left it alone rather than guessing. Typed and destructuring parameters are skipped. There's a precision-guard test pinning all of that.

**4. Clojure HOF dispatch.** `(apply shell/sh "sh" "-c" args)` and `(map client/get urls)` pass the real callee as *data*, so the sink is never a literal call head. The statement is re-attributed to the dispatched symbol. Only a bare **symbol** is re-attributed — an inline `#(...)` literal has no name to attribute the flow to.

## Results

```
cpp      0.857 -> 1.000     kotlin   0.857 -> 1.000
elixir   0.929 -> 1.000     groovy   0.857 -> 1.000
clojure  0.769 -> 0.923  (3 FN -> 1)
```

**All 20 suites re-measured: precision 1.000 and FP 0 everywhere; no suite other than these five moved.** On 440 real-world files (120 `.cpp`, 120 `.cc`, 120 `.hpp`, 68 `.kt`, 7 `.groovy`, 4 `.exs`): **zero new findings, zero lost**.

Caveat on that corpus: I found no real-world `.clj` on this machine, so the Clojure change is covered by suite + unit tests only. The first corpus I built was also contaminated with nox's own `testdata/` — the "new findings" were my own fixtures. Excluding them is what produced the numbers above.

## A fifth cause I tried and reverted

Field/property assignment as **receiver taint**, aimed at the swift/objc/dart property idiom (`task.arguments = [...]` then `task.launch()`). It **regressed objc precision to 0.857 with a false positive and closed none of the three FNs it targeted.**

The diagnosis is worth keeping: those samples also need string-interpolation reads, which are blanked in the code view, so the tainted value never reaches the field assignment in the first place. Receiver taint alone is both insufficient *and* costly here. Reverted rather than layered on — recorded in the commit so the next attempt starts from it.

## What remains

Seven gaps, unchanged, each needing engine work beyond a recognizer shape:

- clojure threading macros `->`/`->>` (1) — needs a real desugarer over the s-expression tree
- swift/objc/dart property idiom (3) — needs interpolation reads *and* receiver taint
- ruby/perl cross-method shared state, `@ivar` / `our $G` (2) — the documented intraprocedural boundary
- perl hash element `$args{cmd}` (1) — container sensitivity

Also worth flagging: this takes eight suites to a flat 1.0, which means they have **stopped indicting anything**. I noted that in each README rather than treating it as unambiguous success — the honest way to keep them useful is to add samples that fail.

`go build`, `go vet`, `gofmt`, `go test ./...`, and `golangci-lint` are clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
