### PR TITLE
feat(taint): receiver taint closes the swift/objc property idiom

### DIFF
--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -3950,6 +3950,13 @@
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
           "note": "receiver-varies webView.loadHTMLString(tainted, baseURL:)"
+        },
+        {
+          "call": "launch",
+          "vuln_class": "command_injection",
+          "cwe": "CWE-78",
+          "rule_id": "TAINT-002",
+          "note": "receiver-varies task.launch() over a Process whose arguments/launchPath are tainted (mirrors the objc `launch` entry)"
         }
       ],
       "sanitizers": [

--- a/core/taint/engine/receivertaint_test.go
+++ b/core/taint/engine/receivertaint_test.go
@@ -1,0 +1,55 @@
+package engine
+
+import "testing"
+
+// TestDottedAssignRoot pins which assignment targets bind their receiver. Only a
+// pure dotted chain of bare identifiers does: a subscripted or call-bearing
+// target has no single object to attribute the taint to, and misattributing one
+// would taint an unrelated name.
+func TestDottedAssignRoot(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"task.arguments", "task", true},
+		{"req.followRedirects", "req", true},
+		{"a.b.c", "a", true},
+		// Not a receiver binding.
+		{"task", "", false},     // bare name: the ordinary path handles it
+		{"", "", false},         //
+		{`m["k"].x`, "", false}, // subscripted
+		{"f().y", "", false},    // call-bearing
+		{"return.x", "", false}, // keyword root
+		{".leading", "", false}, // empty first segment
+	} {
+		got, ok := dottedAssignRoot(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("dottedAssignRoot(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestReceiverTaintIsScoped: receiver taint is an over-approximation, so it is
+// enabled per language rather than everywhere. A language not in the set must
+// still ignore a field-assignment target.
+func TestReceiverTaintIsScoped(t *testing.T) {
+	// Java is deliberately absent: stripJavaDeclType already reads `obj.field`
+	// as a `Type name` declaration and binds `field`, which predates receiver
+	// taint and is a separate question from it.
+	for _, lang := range []langKind{langPython, langJavaScript, langRuby} {
+		if receiverTaintLangs[lang] {
+			t.Errorf("receiver taint unexpectedly enabled for lang %v", lang)
+		}
+		lhs, _ := splitAssignment(lang, "obj.field = tainted")
+		if lhs != "" {
+			t.Errorf("lang %v bound %q from a field assignment without opting in", lang, lhs)
+		}
+	}
+	for _, lang := range []langKind{langSwift, langCPP, langDart} {
+		lhs, _ := splitAssignment(lang, "obj.field = tainted")
+		if lhs != "obj" {
+			t.Errorf("lang %v field assignment bound %q, want obj", lang, lhs)
+		}
+	}
+}

--- a/core/taint/engine/recognize.go
+++ b/core/taint/engine/recognize.go
@@ -190,6 +190,15 @@ func splitAssignment(lang langKind, code string) (lhs, rhs string) {
 			if isSimpleIdent(left) {
 				return left, right
 			}
+			// An assignment to a member FIELD (`task.arguments = [...]`) binds no
+			// bare name, so the tainted value never associated with the object and
+			// a later bare `task.launch()` carried nothing to match. Bind the
+			// RECEIVER: taint on any field is treated as taint on the object.
+			if receiverTaintLangs[lang] {
+				if root, ok := dottedAssignRoot(left); ok {
+					return root, right
+				}
+			}
 			return "", ""
 		}
 	}
@@ -427,4 +436,27 @@ func suffixKeys(chain string) []string {
 		out = append(out, strings.Join(parts[i:], "."))
 	}
 	return out
+}
+
+var receiverTaintLangs = map[langKind]bool{
+	langSwift: true,
+	langCPP:   true,
+	langDart:  true,
+}
+
+func dottedAssignRoot(left string) (string, bool) {
+	if left == "" || !strings.Contains(left, ".") {
+		return "", false
+	}
+	segs := strings.Split(left, ".")
+	for _, seg := range segs {
+		if !isBareIdent(strings.TrimSpace(seg)) {
+			return "", false
+		}
+	}
+	root := strings.TrimSpace(segs[0])
+	if isKeyword(root) {
+		return "", false
+	}
+	return root, true
 }

--- a/testdata/precision-suite-objc/README.md
+++ b/testdata/precision-suite-objc/README.md
@@ -25,13 +25,25 @@ TAINT-003  1   0   0   1.000      1.000   1.000
 TAINT-004  1   0   0   1.000      1.000   1.000
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    6   0   1   1.000      0.857   0.923
+OVERALL    7   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.857**, held below 1.0 by one
-honestly-labeled false negative (see the gap below).
+`clean_*` sample false-positives.
+
+The last gap — the NSTask PROPERTY idiom, where the tainted value is stored
+into `task.arguments = @[...]` and the shell is started by a later bare `[task launch]` —
+is closed. An assignment to a member field binds no bare name, so the tainted
+value never associated with the object; a field assignment now binds the
+RECEIVER, treating taint on any field as taint on the object. It is
+deliberately field-INSENSITIVE, an over-approximation that can only widen
+taint, so it is enabled per language as a corpus demands it. Measured on 1018
+real-world files carrying 2185 field assignments: zero new findings.
+
+A 1.0 means this corpus has stopped indicting anything, not that the model is
+complete — the structural limits below are real and simply lack a failing
+sample.
 
 ## Ground-truth philosophy
 
@@ -134,3 +146,21 @@ refresh it:
 rm testdata/precision-suite-objc/baseline.json
 nox bench --precision testdata/precision-suite-objc --baseline testdata/precision-suite-objc/baseline.json
 ```
+
+## Where an annotation goes
+
+`nox-expect` marks the line a correct scanner **reports**, which is the SINK —
+the line where the dangerous operation happens — not the line where the tainted
+value was constructed or stored. That is what SARIF consumers and human triagers
+expect, and it is the convention every sample here follows:
+
+```
+task.arguments = @[@"-c", arg];   // configuration: NOT annotated
+[task launch];                    // nox-expect: TAINT-002   <- the sink
+```
+
+Annotating a configuration line instead makes a correct finding score as a false
+positive at the sink plus a false negative at the annotation, which reads as a
+precision regression when nothing is wrong. Two samples in this corpus had that
+defect and were corrected; the rule is written down here so it cannot drift back
+in silently.

--- a/testdata/precision-suite-objc/baseline.json
+++ b/testdata/precision-suite-objc/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",

--- a/testdata/precision-suite-objc/tp_cmdinjection_nstask.m
+++ b/testdata/precision-suite-objc/tp_cmdinjection_nstask.m
@@ -19,6 +19,6 @@ void runTask(void) {
     NSString *arg = [[[NSProcessInfo processInfo] environment] objectForKey:@"ARG"];
     NSTask *task = [[NSTask alloc] init];
     task.launchPath = @"/bin/sh";
-    task.arguments = @[@"-c", arg]; // nox-expect: TAINT-002
-    [task launch];
+    task.arguments = @[@"-c", arg];
+    [task launch]; // nox-expect: TAINT-002
 }

--- a/testdata/precision-suite-swift/README.md
+++ b/testdata/precision-suite-swift/README.md
@@ -25,13 +25,25 @@ TAINT-003  1   0   0   1.000      1.000   1.000
 TAINT-004  1   0   0   1.000      1.000   1.000
 TAINT-005  1   0   0   1.000      1.000   1.000
 TAINT-006  1   0   0   1.000      1.000   1.000
-OVERALL    6   0   1   1.000      0.857   0.923
+OVERALL    7   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.857 / F1 0.923** (6 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (7 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.857**, held below 1.0 by one
-honestly-labeled false negative (see the gap below).
+`clean_*` sample false-positives.
+
+The last gap — the Foundation Process PROPERTY idiom, where the tainted value is stored
+into `task.arguments = [...]` and the shell is started by a later bare `task.launch()` —
+is closed. An assignment to a member field binds no bare name, so the tainted
+value never associated with the object; a field assignment now binds the
+RECEIVER, treating taint on any field as taint on the object. It is
+deliberately field-INSENSITIVE, an over-approximation that can only widen
+taint, so it is enabled per language as a corpus demands it. Measured on 1018
+real-world files carrying 2185 field assignments: zero new findings.
+
+A 1.0 means this corpus has stopped indicting anything, not that the model is
+complete — the structural limits below are real and simply lack a failing
+sample.
 
 ## Ground-truth philosophy
 
@@ -129,3 +141,21 @@ refresh it:
 rm testdata/precision-suite-swift/baseline.json
 nox bench --precision testdata/precision-suite-swift --baseline testdata/precision-suite-swift/baseline.json
 ```
+
+## Where an annotation goes
+
+`nox-expect` marks the line a correct scanner **reports**, which is the SINK —
+the line where the dangerous operation happens — not the line where the tainted
+value was constructed or stored. That is what SARIF consumers and human triagers
+expect, and it is the convention every sample here follows:
+
+```
+task.arguments = @[@"-c", arg];   // configuration: NOT annotated
+[task launch];                    // nox-expect: TAINT-002   <- the sink
+```
+
+Annotating a configuration line instead makes a correct finding score as a false
+positive at the sink plus a false negative at the annotation, which reads as a
+precision regression when nothing is wrong. Two samples in this corpus had that
+defect and were corrected; the rule is written down here so it cannot drift back
+in silently.

--- a/testdata/precision-suite-swift/baseline.json
+++ b/testdata/precision-suite-swift/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8571428571428571,
-  "f1": 0.923076923076923,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 6,
-  "fn": 1,
-  "findings_per_issue": 0.8571428571428571,
+  "tp": 7,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.5
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",

--- a/testdata/precision-suite-swift/tp_cmdinjection_property.swift
+++ b/testdata/precision-suite-swift/tp_cmdinjection_property.swift
@@ -18,6 +18,6 @@ func runReport() {
     let name = ProcessInfo.processInfo.environment["REPORT"] ?? ""
     let task = Process()
     task.launchPath = "/bin/sh"
-    task.arguments = ["-c", "generate-report \(name)"] // nox-expect: TAINT-002
-    task.launch()
+    task.arguments = ["-c", "generate-report \(name)"]
+    task.launch() // nox-expect: TAINT-002
 }


### PR DESCRIPTION
Two commits, deliberately separate: an engine change, and a ground-truth correction that is auditable on its own.

## 1. Receiver taint on a field assignment

`task.arguments = [...]` followed by a bare `task.launch()` is how Foundation's Process/NSTask are idiomatically driven, and it was invisible: an assignment to a member **field** binds no bare name, so the tainted value never associated with the object and the later launch carried nothing to match.

A field assignment now binds the **receiver** — taint on any field is taint on the object. The target must be a pure dotted chain of bare identifiers; a subscripted or call-bearing target (`m["k"].x`, `f().y`) has no single object to attribute taint to and still binds nothing.

This is deliberately **field-insensitive**. It can only widen taint, so it's enabled per language as a corpus demands it (swift, cpp — which the engine also uses for Objective-C — and dart) rather than switched on globally. A test pins that scoping so it can't spread silently.

Also adds a receiver-varies `launch` sink for Swift, mirroring the one Objective-C already had: the catalog listed only `Process.launch`, but the call site is `task.launch()` where the receiver is a variable.

**A consequence I'm recording rather than hiding:** because a binding overwrites, a later field assignment with a *clean* RHS kills the object's taint — `o.a = tainted; o.b = "x"; sink(o)` is missed. That's an under-approximation (a false negative, never a false positive), which is the safe direction, but it is a real limit.

## 2. The ground-truth correction — please review this one closely

`nox-expect` marks the line a correct scanner **reports**: the sink. Every other `tp_*` sample in both suites follows that convention:

```
system([cmd UTF8String]);                              // nox-expect: TAINT-002
sqlite3_exec(db, [sql UTF8String], NULL, NULL, NULL);  // nox-expect: TAINT-001
[session dataTaskWithURL:url];                         // nox-expect: TAINT-006
```

Two samples did not. They annotated the **configuration** line while the sink is the next line:

```
task.arguments = @[@"-c", arg];   // nox-expect: TAINT-002   <- was here
[task launch];                                              <- the actual sink
```

Both READMEs already described the correct behaviour as firing *"on the launch"*, so the annotations contradicted both the corpus convention and their own documentation. The effect: a correct finding scored as an FP at the sink **plus** an FN at the annotation — reading as a precision regression when nothing was wrong.

I treated this as a fixture correction rather than curation on one test: **would I make this edit if it made the numbers worse?** Yes — the inconsistency is a defect either way. To keep that honest rather than self-serving, it's in its own commit, and the convention is now written into both READMEs so it can't drift back in silently.

If you'd rather keep the annotations as they were, drop commit 2 and I'll reopen the gaps instead — the engine commit stands on its own.

## Verification

```
objc    0.857 -> 1.000        swift   0.857 -> 1.000
```

All 20 suites: **precision 1.000, FP 0 throughout.** On **1018 real-world files** (150 each `.cpp`/`.cc`/`.hpp`/`.h`, 132 `.m`, 140 `.swift`, 146 `.dart`) carrying **2185 field-assignment lines**: **zero new findings, zero lost.**

## Correcting the record on #417

I reverted this same idea in #417, reporting it "regressed objc precision and closed none of the FNs". The revert was right on the evidence I had, but the diagnosis was wrong twice over: the FP was this location mismatch, not a spurious finding, and my claim that string-interpolation reads were being blanked was simply incorrect — `reads=[name task]` is present. Swift additionally needed the missing `launch` catalog entry, which is what made it look like a total non-starter.

## Standing

**8 of 13 gaps now closed.** Remaining: clojure threading macros (1), dart `req.close()` (1 — needs taint through a method call's arguments plus a `close` sink, which is broad enough to be risky), ruby/perl cross-method shared state (2), perl hash element (1).

`go build`, `go vet`, `gofmt`, `go test ./...`, `golangci-lint` all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb

---

**Correction (post-merge):** the "N of 13" count in this description was overstated. The 13-FN inventory was taken AFTER the shell work in #416, so shell's 2 closures were never part of it. Accurate tally: #417 closed 6, #418 closed 2 (running total 8), #419 closed 1 (running total 9). 4 FNs remain — dart 1, perl 2, ruby 1 — which matches the measured suite state.
