### PR TITLE
feat(taint): model Clojure threading macros, closing the last Lisp recall gap

### DIFF
--- a/core/taint/engine/extract_clojure.go
+++ b/core/taint/engine/extract_clojure.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/nox-hq/nox/core/lexctx"
@@ -186,6 +187,8 @@ func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitD
 		walkClojureChildren(code, f, 1, cur, units)
 	case "let", "let*", "binding", "loop", "when-let", "if-let", "when-some", "if-some", "with-open", "with-local-vars", "for", "doseq":
 		clojureLetForm(code, f, cur, units)
+	case "->", "->>", "some->", "some->>", "cond->", "cond->>":
+		clojureThreadingForm(code, f, cur, units)
 	default:
 		// An ordinary call `(callee args…)`.
 		if st, ok := clojureCallStatement(code, f); ok {
@@ -734,4 +737,104 @@ var clojureHOFDispatchers = map[string]bool{
 	"keep": true, "filter": true, "remove": true,
 	"run!": true, "doseq": false, // doseq binds, it does not dispatch
 	"some": true, "every?": true,
+}
+
+// clojureThreadHeads are the threading macros whose stages each receive the
+// value threaded from the previous stage.
+var clojureThreadHeads = map[string]bool{
+	"->": true, "->>": true,
+	"some->": true, "some->>": true,
+	"cond->": true, "cond->>": true,
+}
+
+// clojureThreadingForm models `(-> x (f a) (g b))` — and its `->>` / `some->` /
+// `cond->` variants — by flowing the threaded value's evidence through every
+// stage. A threading macro REWRITES argument position at read time, so a value
+// threaded into a sink never appears as a literal argument of that sink and the
+// flow was invisible to the positional form recognizer.
+//
+// Each stage is emitted as its own call statement carrying the accumulated
+// evidence (reads, source chains) of everything threaded into it, and the
+// carried set then grows by that stage's own reads so the value keeps flowing.
+//
+// A nested threading form appearing AS a stage — `(-> x (->> (sh "sh" "-c")))`,
+// which is how `->` and `->>` are mixed — re-threads the SAME carried value, so
+// its children are all stages with no initial expression of their own.
+//
+// Deliberate simplification: this tracks WHAT flows, not into WHICH argument
+// slot. `->` prepends and `->>` appends, but for taint the question is whether
+// the tainted value reaches the sink at all, and both do. A position-sensitive
+// argument note (the parameterized-jdbc vector check) therefore does not apply
+// to a threaded stage; that costs precision nowhere in the corpus but is the
+// honest limit of the approximation.
+func clojureThreadingForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitDraft) {
+	// The threaded value is modeled as a synthetic BINDING that each stage reads
+	// and rebinds. The engine taints a variable at its binding and reports a sink
+	// that READS a tainted variable, so carrying evidence alone was not enough —
+	// the value has to have a name. The name is per-form so two threading
+	// expressions in one unit cannot alias each other.
+	tmp := "__nox_threaded_" + strconv.Itoa(clojureLine(code, f.start))
+	bind := stmtDraft{line: clojureLine(code, f.start), assigns: tmp, sinkArgs: map[string]sinkArgDraft{}}
+	if len(f.children) > 1 {
+		clojureCollectExpr(code, f.children[1], &bind)
+	}
+	cur.stmts = append(cur.stmts, bind)
+	clojureThreadStages(code, f, 2, tmp, cur, units)
+	// The initial expression may itself contain calls worth reporting on their
+	// own (`(-> (sh cmd) ...)`), so walk it normally too.
+	if len(f.children) > 1 {
+		walkClojureForm(code, f.children[1], cur, units)
+	}
+}
+
+// clojureThreadStages emits a statement per stage in f.children[from:]. Each
+// stage READS the synthetic threaded variable and REBINDS it to its own result,
+// so the value keeps flowing and a sanitizing stage correctly clears the taint.
+func clojureThreadStages(code []byte, f clojureForm, from int, tmp string, cur *unitDraft, units *[]*unitDraft) {
+	for i := from; i < len(f.children); i++ {
+		stage := f.children[i]
+		if stage.delim == '(' && len(stage.children) > 0 &&
+			clojureThreadHeads[clojureAtomText(code, stage.children[0])] {
+			// A nested threading macro re-threads the same value; all of its
+			// children after the head are stages.
+			clojureThreadStages(code, stage, 1, tmp, cur, units)
+			continue
+		}
+		st, ok := clojureStageStatement(code, stage)
+		if !ok {
+			continue
+		}
+		st.reads = appendUnique(st.reads, tmp)
+		// The threaded value arrives as an argument of this stage's callee, so it
+		// counts as a tainted argument for the per-sink danger check.
+		for _, callee := range st.calls {
+			info := st.sinkArgs[callee]
+			info.taintedArgVars = appendUnique(info.taintedArgVars, tmp)
+			info.argCount++
+			st.sinkArgs[callee] = info
+		}
+		// The stage's result becomes the new threaded value.
+		st.assigns = tmp
+		cur.stmts = append(cur.stmts, st)
+	}
+}
+
+// clojureStageStatement builds the statement for one threading stage: a call
+// form `(f a b)`, or a bare symbol `f` which threads as `(f value)`.
+func clojureStageStatement(code []byte, stage clojureForm) (stmtDraft, bool) {
+	if stage.delim == '(' {
+		return clojureCallStatement(code, stage)
+	}
+	if stage.delim != 0 {
+		return stmtDraft{}, false
+	}
+	callee := clojureNormalizeCallee(clojureAtomText(code, stage))
+	if callee == "" || !isClojureCalleeStart(callee[0]) {
+		return stmtDraft{}, false
+	}
+	return stmtDraft{
+		line:     clojureLine(code, stage.start),
+		calls:    []string{callee},
+		sinkArgs: map[string]sinkArgDraft{callee: {}},
+	}, true
 }

--- a/core/taint/engine/extract_clojure_test.go
+++ b/core/taint/engine/extract_clojure_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/lexctx"
@@ -163,5 +164,61 @@ func TestExtractClojureHOFDispatchKeepsInlineFn(t *testing.T) {
 				t.Errorf("inline fn literal re-attributed as callee %q: %+v", c, st)
 			}
 		}
+	}
+}
+
+// TestExtractClojureThreading: a threading macro rewrites argument position at
+// read time, so a value threaded into a sink never appears as a literal argument
+// of it. The threaded value is modeled as a synthetic binding each stage reads
+// and rebinds — carrying evidence alone was not enough, because the engine
+// taints a variable at its BINDING and reports a sink that READS one.
+func TestExtractClojureThreading(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"thread-first", "(defn f [req]\n  (-> (:params req)\n      (shell/sh)))\n"},
+		{"mixed-first-last", "(defn f [req]\n  (-> (:params req)\n      (->> (shell/sh \"sh\" \"-c\"))))\n"},
+		{"some-arrow", "(defn f [req]\n  (some-> (:params req)\n          (shell/sh)))\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			units := extractUnits(lexctx.LangClojure, []byte(tc.src))
+			u := findUnit(t, units, "f")
+			var sink *stmtDraft
+			for i := range u.stmts {
+				if containsStr(u.stmts[i].calls, "shell/sh") {
+					sink = &u.stmts[i]
+				}
+			}
+			if sink == nil {
+				t.Fatalf("threaded sink not recognized: %+v", u.stmts)
+			}
+			// The stage must READ the synthetic threaded variable, which is what
+			// carries the taint from the initial expression.
+			threaded := false
+			for _, r := range sink.reads {
+				if strings.HasPrefix(r, "__nox_threaded_") {
+					threaded = true
+				}
+			}
+			if !threaded {
+				t.Errorf("sink does not read the threaded value; reads=%v", sink.reads)
+			}
+		})
+	}
+}
+
+// TestExtractClojureThreadingRebinds: each stage rebinds the threaded variable,
+// so the value keeps flowing down the chain AND a sanitizing stage can clear it.
+func TestExtractClojureThreadingRebinds(t *testing.T) {
+	src := "(defn f [req]\n  (-> (:params req)\n      (clojure.string/trim)\n      (shell/sh)))\n"
+	units := extractUnits(lexctx.LangClojure, []byte(src))
+	u := findUnit(t, units, "f")
+	rebinds := 0
+	for _, st := range u.stmts {
+		if strings.HasPrefix(st.assigns, "__nox_threaded_") {
+			rebinds++
+		}
+	}
+	// One initial binding plus one per stage.
+	if rebinds < 3 {
+		t.Errorf("expected the threaded variable to be bound then rebound per stage, got %d: %+v", rebinds, u.stmts)
 	}
 }

--- a/testdata/precision-suite-clojure/README.md
+++ b/testdata/precision-suite-clojure/README.md
@@ -44,12 +44,20 @@ where the honest false negatives live (see below).
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-clojure` scores
-**precision 1.00 / recall 0.92 / F1 0.96** (12 TP, 0 FP, 1 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (13 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits is a true positive, and every clean stressor
 (parameterized jdbc vector, `Integer/parseInt` coercion, placeholder creds,
 data-URI blob, generated banner) fires nothing — while recall is the lowest of any
-language, held down by ONE honest false negative: the threading-macro form. The
-two higher-order-dispatch gaps (`apply`, `map`) are closed — see below.
+language. The last gap — the threading-macro form — is now closed, alongside the
+two higher-order-dispatch gaps (`apply`, `map`).
+
+A 1.0 means this corpus has stopped indicting anything, not that a Lisp is
+solved without a reader. `clean_threading.clj` was added as the guard: threading
+is THE idiomatic Clojure shape, so modeling it is exactly where an engine risks
+inventing noise, and that sample asserts silence across `->`, `->>`, `some->`
+and `cond->` chains over constants, coerced numbers and pure data transforms.
+It matters more than usual here because no large real-world Clojure corpus was
+available to validate against — the guard is a corpus one.
 
 That gap is **honest, not curated**: the FN samples are annotated as the true
 positives a correct scanner should fire, so the number tells the truth. The way to
@@ -73,7 +81,7 @@ expected to MISS — the Lisp recall gap):
 
 | File (line) | What flows | Rule | nox today | Why it is missed |
 | --- | --- | --- | --- | --- |
-| `tp_threading.clj` — `run-threaded` | `(:params req)` threaded via `->`/`->>` into `shell/sh` | TAINT-002 | **FN** | threading macros reorder the value's argument position; the positional recognizer sees `sh` called with only literal args |
+| `tp_threading.clj` — `run-threaded` | `(:params req)` threaded via `->`/`->>` into `shell/sh` | TAINT-002 | **caught** | the threaded value is modeled as a synthetic binding each stage reads and rebinds |
 | `tp_threading.clj` — `run-apply` | tainted seq spread into `sh` via `apply` | TAINT-002 | **caught** | the statement is re-attributed to the dispatched symbol |
 | `tp_threading.clj` — `fetch-all` | `map client/get` over tainted URLs | TAINT-006 | **caught** | same re-attribution |
 
@@ -89,9 +97,21 @@ Clean stressors (zero annotations — any finding is a false positive):
 
 ## Honest limits — the next indictment when a sample lands
 
-- **Threading macros** (`->`, `->>`, `as->`, `some->`, `cond->`) rewrite argument
-  position at read time; the recognizer does not desugar them, so a value threaded
-  into a sink is missed. This is the dominant recall gap.
+- **Threading macros — CLOSED.** `->`, `->>`, `some->`, `some->>`, `cond->` and
+  `cond->>` rewrite argument position at read time, so a threaded value never
+  appears as a literal argument of the sink. The value is now modeled as a
+  synthetic BINDING that each stage reads and rebinds: the engine taints a
+  variable at its binding and reports a sink that reads one, so carrying the
+  evidence alone was not enough — the value had to have a name. Rebinding per
+  stage means the value keeps flowing AND a sanitizing stage correctly clears it.
+  A nested threading form used as a stage (`(-> x (->> (sh …)))`, how `->` and
+  `->>` are mixed) re-threads the same value.
+
+  Deliberate simplification: this tracks WHAT flows, not into WHICH argument
+  slot. `->` prepends and `->>` appends, but for taint the question is whether
+  the value reaches the sink at all, and both do. A position-sensitive argument
+  note (the parameterized-jdbc vector check) therefore does not apply to a
+  threaded stage. `as->` is not handled: it names its own binding.
 - **Higher-order dispatch — CLOSED for the dispatcher family.** `apply`, `map`,
   `mapv`, `pmap`, `mapcat`, `keep`, `filter`, `remove`, `some`, `every?` and
   `run!` take the function to invoke as their FIRST argument, so a sink reached

--- a/testdata/precision-suite-clojure/baseline.json
+++ b/testdata/precision-suite-clojure/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.9230769230769231,
-  "f1": 0.9600000000000001,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 12,
-  "fn": 1,
-  "findings_per_issue": 0.9230769230769231,
+  "tp": 13,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-clojure/clean_threading.clj
+++ b/testdata/precision-suite-clojure/clean_threading.clj
@@ -1,0 +1,57 @@
+(ns app.clean-threading
+  "Clean stressor for the threading-macro model. Threading is THE idiomatic
+   Clojure control shape — `->`, `->>`, `some->`, `cond->` appear in almost every
+   namespace — so modeling it is precisely where a taint engine risks inventing
+   noise. Every form below is benign: any finding here is a false positive.
+
+   This sample exists because the threading model could not be validated against
+   a large real-world Clojure corpus, so the guard is a corpus one."
+  (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
+            [clj-http.client :as client]))
+
+;; Threading over CONSTANTS: no untrusted value anywhere in the chain.
+(defn build-banner []
+  (-> "  Report  "
+      (str/trim)
+      (str/upper-case)))
+
+;; Threading a request value into pure data transforms that never reach a sink.
+(defn summarize [req]
+  (->> (:params req)
+       (map str/trim)
+       (remove str/blank?)
+       (sort)
+       (take 10)))
+
+;; The tainted value is COERCED to a number before anything else; a parsed long
+;; carries no injection metacharacters.
+(defn fetch-page [req]
+  (-> (:page req)
+      (Long/parseLong)
+      (max 1)
+      (min 100)))
+
+;; A constant command threaded into the shell sink — the sink fires only on a
+;; TAINTED word, and nothing untrusted enters this chain.
+(defn disk-usage []
+  (-> ["df" "-h"]
+      (->> (apply shell/sh))))
+
+;; some-> short-circuits on nil; the threaded value is a literal config URL.
+(defn ping-health []
+  (some-> "https://status.internal.example/health"
+          (client/get)))
+
+;; cond-> threads a map through conditional assoc calls — data shaping only.
+(defn describe [req verbose?]
+  (cond-> {:ok true}
+    verbose? (assoc :agent "nox")
+    (:trace req) (assoc :traced true)))
+
+;; A threading chain whose stages are all local pure helpers.
+(defn normalize [s]
+  (-> s
+      (str/replace "\\" "/")
+      (str/lower-case)
+      (str/trim)))

--- a/testdata/precision-suite-clojure/tp_threading.clj
+++ b/testdata/precision-suite-clojure/tp_threading.clj
@@ -1,18 +1,17 @@
 (ns app.threading
-  "Honest false-negative corner: Clojure's threading macros and higher-order
-   functions reorder or indirect the argument position in ways a positional,
-   straight-line FORM recognizer cannot follow. These are REAL vulnerabilities a
-   correct scanner should fire, and they are annotated as such — nox is expected
-   to MISS them (recall gap), which is the honest cost of recognizing a Lisp
-   without a full reader/evaluator. See README.md."
+  "Threading macros and higher-order dispatch reorder or indirect the argument
+   position, so the sink never appears with the tainted value as a literal
+   argument. All three flows here were honest false negatives until the
+   threading and HOF-dispatch models landed; they are kept as the regression
+   tests for those shapes. See README.md, and clean_threading.clj for the
+   companion no-false-positive guard."
   (:require [clojure.java.shell :as shell]
             [clj-http.client :as client]))
 
-;; Thread-first `->` — still an honest FALSE NEGATIVE. The tainted value is
-;; threaded as the FIRST argument of each stage, and the nested `->>` reverses
-;; that position again, so it arrives at `sh` somewhere the positional FORM
-;; recognizer does not track. Closing it needs a real threading-macro desugarer
-;; over the s-expression tree; the HOF re-attribution below does not reach it.
+;; Thread-first `->` with a nested `->>` — CAUGHT. The threaded value is modeled
+;; as a synthetic binding that each stage reads and rebinds, and a nested
+;; threading form used as a stage re-threads that same value. Kept as the
+;; regression test for the mixed `->` / `->>` shape.
 (defn run-threaded [req]
   (-> (:params req)
       (clojure.string/trim)


### PR DESCRIPTION
`(-> (:params req) (clojure.string/trim) (->> (shell/sh "sh" "-c")))` was the clojure suite's last false negative. A threading macro rewrites argument position at read time, so a threaded value never appears as a literal argument of the sink — the positional FORM recognizer saw `sh` called with only literal args.

## The detail that actually mattered

My first implementation carried the source evidence (reads, chains, keyword markers) onto each stage. The extraction looked *exactly right* — `calls=[shell/sh] reads=[req] chains=[params]`, tainted-arg set populated — and **still fired nothing**.

The reason: the engine taints a variable **at its binding** and reports a sink that **reads** a tainted variable. Evidence alone isn't a binding. Confirming this, an inlined source doesn't fire for Clojure either:

```clojure
(shell/sh "sh" "-c" (:params req))          ; no finding
(let [cmd (:params req)] (shell/sh "sh" "-c" cmd))  ; fires
```

which is why every working sample in the corpus binds through a `let` first.

So the threaded value is now modeled as a synthetic **binding** that each stage reads and rebinds. Rebinding per stage means the value keeps flowing *and* a sanitizing stage correctly clears it. A nested threading form used **as** a stage — `(-> x (->> (sh …)))`, which is how `->` and `->>` get mixed — re-threads the same value, so its children are all stages with no initial expression of their own.

Covers `->`, `->>`, `some->`, `some->>`, `cond->`, `cond->>`. `as->` is deliberately not handled: it names its own binding.

**Deliberate simplification:** this tracks *what* flows, not into *which* argument slot. `->` prepends and `->>` appends, but for taint the question is whether the value reaches the sink at all, and both do. A position-sensitive argument note (the parameterized-jdbc vector check) therefore doesn't apply to a threaded stage.

## Verification, and its limit

```
clojure  0.923 -> 1.000  (1 FN -> 0)
```

All 20 suites: precision 1.000, FP 0 throughout; no other suite moved.

**I could not validate this against a real-world Clojure corpus.** Only 3 external `.clj` files exist on this machine (nvim treesitter samples); both binaries agree on them, which is close to no evidence. Threading is *the* idiomatic Clojure shape — it appears in nearly every namespace — so this is precisely where an engine risks inventing noise at scale, and I don't want that gap papered over.

The substitute is a corpus guard: `clean_threading.clj`, asserting silence across benign `->`/`->>`/`some->`/`cond->` chains over constants, coerced numbers, pure data transforms, and a constant command threaded into the shell sink. It currently produces zero findings. If you have a real Clojure codebase to point this at before relying on it, that would be worth doing.

Adding that sample also partly answers a complaint I've repeated in these PRs — that suites hitting 1.0 stop indicting anything. A clean stressor is the one addition that *raises* the bar rather than lowering it.

## Standing

**9 of 13 gaps closed.** Remaining 4 FNs across 3 suites, each needing a design decision rather than a recognizer fix:

- **dart** `req.close()` (1) — needs taint through a *method call's* arguments plus a `close` sink; `close` is broad enough that I'd expect real-world FPs
- **ruby/perl** cross-method shared state, `@ivar` / `our $G` (2) — the documented intraprocedural boundary
- **perl** hash element `$args{cmd}` (1) — container sensitivity

`go build`, `go vet`, `gofmt`, `go test ./...`, `golangci-lint` all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb

---

**Correction (post-merge):** the "N of 13" count in this description was overstated. The 13-FN inventory was taken AFTER the shell work in #416, so shell's 2 closures were never part of it. Accurate tally: #417 closed 6, #418 closed 2 (running total 8), #419 closed 1 (running total 9). 4 FNs remain — dart 1, perl 2, ruby 1 — which matches the measured suite state.
