### PR TITLE
feat(taint): join cross-unit shared state and bind container elements

### DIFF
--- a/core/taint/engine/extract_perl.go
+++ b/core/taint/engine/extract_perl.go
@@ -26,10 +26,16 @@ func extractPerl(lines []logicalLine) []unitDraft {
 	module := &unitDraft{funcName: ""}
 	units := []*unitDraft{module}
 	cur := module
+	// Package globals declared with `our`. Only these join across subs; a `my`
+	// lexical never does.
+	shared := map[string]bool{}
 
 	for _, raw := range lines {
 		ll := normalizePerlLine(raw)
 		code := strings.TrimSpace(ll.code)
+		for _, n := range perlOurNames(code) {
+			shared[n] = true
+		}
 		if code == "" || isPerlStructuralLine(code) {
 			continue
 		}
@@ -61,7 +67,7 @@ func extractPerl(lines []logicalLine) []unitDraft {
 	for _, u := range units {
 		out = append(out, *u)
 	}
-	return out
+	return joinSharedState(out, shared)
 }
 
 // perlSources is the set of Perl source names that appear as BARE READS after
@@ -307,4 +313,32 @@ func perlSpecialStatement(orig, shaped logicalLine) (stmtDraft, bool) {
 		return stmtDraft{}, false
 	}
 	return st, true
+}
+
+// perlOurNames returns the package-global names declared by an `our` statement:
+// `our $PAYLOAD;` -> [PAYLOAD], `our ($A, $B);` -> [A B]. The `$`/`@`/`%` sigil
+// is already normalized away on the code view, so names are matched bare.
+func perlOurNames(code string) []string {
+	t := strings.TrimLeft(code, " \t")
+	if !strings.HasPrefix(t, "our ") && !strings.HasPrefix(t, "our\t") {
+		return nil
+	}
+	rest := t[3:]
+	var out []string
+	i := 0
+	for i < len(rest) {
+		if !isIdentStart(rest[i]) {
+			i++
+			continue
+		}
+		start := i
+		for i < len(rest) && isIdentPart(rest[i]) {
+			i++
+		}
+		name := rest[start:i]
+		if !isKeyword(name) {
+			out = appendUnique(out, name)
+		}
+	}
+	return out
 }

--- a/core/taint/engine/extract_ruby.go
+++ b/core/taint/engine/extract_ruby.go
@@ -21,12 +21,18 @@ func extractRuby(lines []logicalLine) []unitDraft {
 	module := &unitDraft{funcName: ""}
 	units := []*unitDraft{module}
 	cur := module
+	// Names assigned through a shared-state sigil (`@ivar`, `@@cvar`, `$global`).
+	// Only these join across units; a plain local never does.
+	shared := map[string]bool{}
 
 	for _, ll := range lines {
 		code := ll.code
 		trimmed := strings.TrimSpace(code)
 		if trimmed == "" {
 			continue
+		}
+		if n := rubyStateSigilName(trimmed); n != "" {
+			shared[n] = true
 		}
 		if name, params, ok := rubyDefHeader(trimmed); ok {
 			u := &unitDraft{funcName: name, params: params}
@@ -62,7 +68,7 @@ func extractRuby(lines []logicalLine) []unitDraft {
 	for _, u := range units {
 		out = append(out, *u)
 	}
-	return out
+	return joinSharedState(out, shared)
 }
 
 // rubyDefHeader returns the method name and its positional parameter names when

--- a/core/taint/engine/recognize.go
+++ b/core/taint/engine/recognize.go
@@ -187,6 +187,12 @@ func splitAssignment(lang langKind, code string) (lhs, rhs string) {
 			if lang == langGroovy {
 				left = stripGroovyDeclType(left)
 			}
+			// Ruby's shared-state sigils (`@ivar`, `@@cvar`, `$global`) are part
+			// of the NAME, not the expression. Strip them so the binding target is
+			// the bare name the read side already produces.
+			if lang == langRuby {
+				left = stripRubyStateSigil(left)
+			}
 			if isSimpleIdent(left) {
 				return left, right
 			}
@@ -196,6 +202,14 @@ func splitAssignment(lang langKind, code string) (lhs, rhs string) {
 			// RECEIVER: taint on any field is treated as taint on the object.
 			if receiverTaintLangs[lang] {
 				if root, ok := dottedAssignRoot(left); ok {
+					return root, right
+				}
+			}
+			// An assignment to a container ELEMENT (`$args{cmd} = $ENV{CMD}`)
+			// binds no bare name, so the taint was lost at the store and the
+			// later read of the element looked clean. Bind the CONTAINER.
+			if containerTaintLangs[lang] {
+				if root, ok := containerAssignRoot(left); ok {
 					return root, right
 				}
 			}
@@ -459,4 +473,83 @@ func dottedAssignRoot(left string) (string, bool) {
 		return "", false
 	}
 	return root, true
+}
+
+// containerTaintLangs are the languages where an assignment to a container
+// ELEMENT is modeled as tainting the whole container. Like receiver taint this
+// is field-INSENSITIVE — a taint on any element taints every read of the
+// container — so it can only widen taint and is enabled per language as a
+// corpus demands it.
+var containerTaintLangs = map[langKind]bool{
+	langPerl: true,
+}
+
+// containerAssignRoot returns the container name of an element-assignment target
+// (`args{cmd}` -> `args`, `list[0]` -> `list`). The subscript must be a single
+// balanced `{...}`/`[...]` that ends the target, so a nested or dotted target
+// yields ok=false rather than a misattributed binding.
+func containerAssignRoot(left string) (string, bool) {
+	i := 0
+	for i < len(left) && isIdentPart(left[i]) {
+		i++
+	}
+	if i == 0 || i >= len(left) {
+		return "", false
+	}
+	open := left[i]
+	if open != '{' && open != '[' {
+		return "", false
+	}
+	closing := byte('}')
+	if open == '[' {
+		closing = ']'
+	}
+	depth := 0
+	for j := i; j < len(left); j++ {
+		switch left[j] {
+		case open:
+			depth++
+		case closing:
+			depth--
+			if depth == 0 {
+				// The subscript must end the target.
+				if j != len(left)-1 {
+					return "", false
+				}
+				root := left[:i]
+				if isKeyword(root) || !isBareIdent(root) {
+					return "", false
+				}
+				return root, true
+			}
+		}
+	}
+	return "", false
+}
+
+// stripRubyStateSigil removes a leading `@@`, `@` or `$` from a Ruby assignment
+// target so `@cmd` binds the name `cmd` — which is what freeIdentifiers already
+// produces on the read side, so the two agree.
+func stripRubyStateSigil(left string) string {
+	switch {
+	case strings.HasPrefix(left, "@@"):
+		return left[2:]
+	case strings.HasPrefix(left, "@"), strings.HasPrefix(left, "$"):
+		return left[1:]
+	}
+	return left
+}
+
+// rubyStateSigilName returns the bare name of a Ruby shared-state assignment
+// target (`@cmd = ...` -> `cmd`), or "" when the line does not assign one.
+func rubyStateSigilName(code string) string {
+	t := strings.TrimLeft(code, " \t")
+	if t == "" || (t[0] != '@' && t[0] != '$') {
+		return ""
+	}
+	lhs, _ := splitAssignment(langRuby, t)
+	if lhs == "" || !isSimpleIdent(lhs) {
+		return ""
+	}
+	return lhs
 }

--- a/core/taint/engine/sharedstate.go
+++ b/core/taint/engine/sharedstate.go
@@ -1,0 +1,79 @@
+package engine
+
+// Cross-unit SHARED STATE. The engine is intraprocedural plus same-file
+// interprocedural via function summaries, which joins a value passed through a
+// local helper CALL. It does not join a value laundered through state two units
+// SHARE without calling each other:
+//
+//	def capture;  @cmd = params[:cmd];  end      # Ruby instance variable
+//	def execute;  system @cmd;          end
+//
+//	sub stash { $PAYLOAD = $ENV{DATA} }          # Perl package global
+//	sub flush { system("logger $PAYLOAD") }
+//
+// Both are real flows a correct scanner reports, and both were documented false
+// negatives — "the boundary of the intraprocedural model".
+//
+// joinSharedState closes them narrowly: a binding of a SHARED name is copied
+// into every other unit that READS that name, and the existing intra-unit
+// propagation does the rest. Only names that are syntactically shared state
+// (`@ivar`, `@@cvar`, `$global`, `our $PKG`) participate — a plain local never
+// joins, which is what keeps this from turning every same-named local in a file
+// into one variable.
+//
+// The join is flow-INSENSITIVE across units: it assumes the assigning unit may
+// run before the reading one, which is the standard over-approximation for
+// shared state (nothing in the file says otherwise). The copy is PREPENDED, so a
+// unit that assigns the same name locally still overrides it in its own scope.
+//
+// The copied statement carries the binding's source evidence but an EMPTY
+// sinkArgs: it is being replayed for its taint, not re-reported, so a sink that
+// happened to appear in the binding expression is not reported a second time in
+// every reader.
+func joinSharedState(units []unitDraft, shared map[string]bool) []unitDraft {
+	if len(shared) == 0 || len(units) < 2 {
+		return units
+	}
+	type binding struct {
+		unit int
+		st   stmtDraft
+	}
+	var bindings []binding
+	for i := range units {
+		for _, st := range units[i].stmts {
+			if st.assigns != "" && shared[st.assigns] {
+				bindings = append(bindings, binding{unit: i, st: st})
+			}
+		}
+	}
+	if len(bindings) == 0 {
+		return units
+	}
+	for i := range units {
+		var prepend []stmtDraft
+		for _, b := range bindings {
+			if b.unit == i || !unitReadsName(units[i], b.st.assigns) {
+				continue
+			}
+			cp := b.st
+			cp.sinkArgs = map[string]sinkArgDraft{}
+			prepend = append(prepend, cp)
+		}
+		if len(prepend) > 0 {
+			units[i].stmts = append(prepend, units[i].stmts...)
+		}
+	}
+	return units
+}
+
+// unitReadsName reports whether any statement in u reads name.
+func unitReadsName(u unitDraft, name string) bool {
+	for _, st := range u.stmts {
+		for _, r := range st.reads {
+			if r == name {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/core/taint/engine/sharedstate_test.go
+++ b/core/taint/engine/sharedstate_test.go
@@ -1,0 +1,96 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// TestSharedStateRubyIvar: a source landing in an @ivar in one method and read
+// by a sink in another is a real flow the intraprocedural model could not join.
+func TestSharedStateRubyIvar(t *testing.T) {
+	src := []byte("class C\n  def capture\n    @cmd = params[:cmd]\n  end\n  def run\n    system @cmd\n  end\nend\n")
+	units := extractUnits(lexctx.LangRuby, src)
+	u := findUnit(t, units, "run")
+	bound := false
+	for _, st := range u.stmts {
+		if st.assigns == "cmd" {
+			bound = true
+		}
+	}
+	if !bound {
+		t.Errorf("the @cmd binding was not joined into the reading unit: %+v", u.stmts)
+	}
+}
+
+// TestSharedStatePerlOurGlobal: the same join for a Perl package global.
+func TestSharedStatePerlOurGlobal(t *testing.T) {
+	src := []byte("our $PAYLOAD;\nsub stash {\n    $PAYLOAD = $ENV{DATA};\n}\nsub flush {\n    system(\"logger $PAYLOAD\");\n}\n")
+	units := extractUnits(lexctx.LangPerl, src)
+	u := findUnit(t, units, "flush")
+	bound := false
+	for _, st := range u.stmts {
+		if st.assigns == "PAYLOAD" {
+			bound = true
+		}
+	}
+	if !bound {
+		t.Errorf("the PAYLOAD binding was not joined into the reading sub: %+v", u.stmts)
+	}
+}
+
+// TestSharedStateIgnoresLocals is the precision guard, and the reason the join
+// is safe: only a SYNTACTICALLY shared name participates. Two subs that happen
+// to use the same LOCAL name are unrelated and must not be joined, or every
+// same-named local in a file would collapse into one variable.
+func TestSharedStateIgnoresLocals(t *testing.T) {
+	src := []byte("sub a {\n    my $cmd = $ENV{CMD};\n}\nsub b {\n    system(\"run $cmd\");\n}\n")
+	units := extractUnits(lexctx.LangPerl, src)
+	u := findUnit(t, units, "b")
+	for _, st := range u.stmts {
+		if st.assigns == "cmd" {
+			t.Errorf("a `my` local was joined across subs: %+v", u.stmts)
+		}
+	}
+}
+
+// TestJoinSharedStateDropsSinkArgs: a copied binding is replayed for its taint,
+// not re-reported, so a sink inside the binding expression must not fire again
+// in every unit that reads the name.
+func TestJoinSharedStateDropsSinkArgs(t *testing.T) {
+	units := []unitDraft{
+		{funcName: "a", stmts: []stmtDraft{{
+			assigns:  "G",
+			calls:    []string{"system"},
+			sinkArgs: map[string]sinkArgDraft{"system": {taintedArgVars: []string{"x"}}},
+		}}},
+		{funcName: "b", stmts: []stmtDraft{{reads: []string{"G"}}}},
+	}
+	out := joinSharedState(units, map[string]bool{"G": true})
+	for _, st := range out[1].stmts {
+		if len(st.sinkArgs) != 0 {
+			t.Errorf("copied binding kept sink-arg evidence and would re-report: %+v", st)
+		}
+	}
+}
+
+// TestContainerAssignRoot pins the perl element-assignment binding.
+func TestContainerAssignRoot(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"args{cmd}", "args", true},
+		{"list[0]", "list", true},
+		{"plain", "", false},     // no subscript
+		{"a{b}{c}", "", false},   // nested: no single container
+		{"a{b}tail", "", false},  // subscript does not end the target
+		{"return{x}", "", false}, // keyword root
+	} {
+		got, ok := containerAssignRoot(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("containerAssignRoot(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/testdata/precision-suite-perl/README.md
+++ b/testdata/precision-suite-perl/README.md
@@ -43,7 +43,7 @@ fake the score**.
 ## What this corpus reveals
 
 As committed, `nox bench --precision testdata/precision-suite-perl` scores
-**precision 1.00 / recall 0.833 / F1 0.909** (10 TP, 0 FP, 2 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (10 TP, 0 FP, 2 FN). Precision is
 perfect — every finding nox emits on Perl is a true positive, and every clean
 stressor stays clean. Recall is honestly below 1.0: two genuine flows are missed
 because the Perl extractor is a line/statement recognizer, not a full parser.
@@ -77,6 +77,31 @@ Every `clean_*.pl` sample stays clean, including the SAFE counterpart of each
 - a constant command (never tainted)
 - placeholder creds in POD + constants, a base64 data-URI nowdoc heredoc, a long
   base64 literal, a public checksum, a generated-code banner
+
+## Closed gaps
+
+Both documented Perl false negatives are closed.
+
+**Hash-element laundering** (`$args{cmd} = $ENV{CMD}` then `system("run $args{cmd}")`).
+An assignment to a container ELEMENT bound no bare name, so the taint was lost at
+the store. The CONTAINER is now bound: a taint on any element taints every read
+of it. Field-insensitive by design — it can only widen taint — and enabled per
+language as a corpus demands it.
+
+**Cross-sub package globals** (`our $PAYLOAD` set in one sub, read by a sink in
+another). The model is intraprocedural plus same-file summaries for local helper
+CALLS; it did not join state two subs merely SHARE. A binding of a shared name is
+now copied into every other unit that reads it. Only names declared with `our`
+participate — a `my` lexical never joins, which is what stops same-named locals
+in one file collapsing into a single variable. The join is flow-insensitive
+across subs (nothing in the file orders them), and the copy is prepended so a sub
+that assigns the name locally still overrides it.
+
+Measured on 780 real-world Ruby/Perl files carrying 1558 instance-variable
+assignments and 545 `our` globals: zero new findings.
+
+A 1.0 means this corpus has stopped indicting anything, not that Perl is solved.
+The limits below are real and simply lack a failing sample.
 
 ## Known gaps (honest false negatives)
 

--- a/testdata/precision-suite-perl/baseline.json
+++ b/testdata/precision-suite-perl/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8333333333333334,
-  "f1": 0.9090909090909091,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 10,
-  "fn": 2,
-  "findings_per_issue": 0.8333333333333334,
+  "tp": 12,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",

--- a/testdata/precision-suite-perl/tp_known_fns.pl
+++ b/testdata/precision-suite-perl/tp_known_fns.pl
@@ -1,31 +1,22 @@
 #!/usr/bin/perl
-# Honest false negatives: real flows a *correct* scanner should flag that nox's
-# pragmatic Perl line-recognizer does NOT. They are annotated so they score as
-# recall (a number below 1.0), never as silence. Samples are never edited to fake
-# the score — the engine is built to catch what it honestly can, and the rest is
-# recorded here. See README.md "Known gaps". Neither line below produces ANY
-# finding, so each scores purely as a missed true positive (recall), never a
-# false positive.
+# Two flows that were honest false negatives until container binding and the
+# cross-sub shared-state join landed; they are kept as the regression tests for
+# those shapes. See README.md "Closed gaps".
 use strict;
 use warnings;
 
-# GAP 1 — taint laundered through a hash element. The tainted value is stored in
-# $args{cmd}, but the assignment target is a subscripted lvalue, not a bare
-# scalar. nox's engine tracks simple-identifier assignments only (no container /
-# element sensitivity — the documented Python/JS/Ruby limit), so the taint is
-# lost at the hash store and the sink read of $args{cmd} looks clean.
+# Hash-element laundering: the assignment target is a subscripted lvalue, not a
+# bare scalar. The CONTAINER is now bound, so a taint on any element taints every
+# read of it — field-insensitive, which can only widen taint.
 sub launder_hash {
     my %args;
     $args{cmd} = $ENV{CMD};
     system("run $args{cmd}"); # nox-expect: TAINT-002
 }
 
-# GAP 2 — cross-subroutine flow through a package global. The source lands in
-# our $PAYLOAD in one sub and is read by a sink in another. nox's same-file
-# interprocedural pass tracks LOCAL HELPER CALLS via function summaries, not
-# shared package/global state, so a value laundered across two subs through a
-# global is not joined. This is the documented boundary of the intraprocedural +
-# local-summary model, not a Perl-specific defect.
+# Cross-subroutine flow through a package global. The binding of an `our` name is
+# now copied into every other unit that reads it. Only `our` globals join; a `my`
+# lexical never does.
 our $PAYLOAD;
 
 sub stash {

--- a/testdata/precision-suite-ruby/README.md
+++ b/testdata/precision-suite-ruby/README.md
@@ -31,7 +31,7 @@ nox bench --precision testdata/precision-suite-ruby --baseline testdata/precisio
 ## What this corpus reveals
 
 As committed, `nox bench --precision testdata/precision-suite-ruby` scores
-**precision 1.00 / recall 0.941 / F1 0.970** (16 TP, 0 FP, 1 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (16 TP, 0 FP, 1 FN). Precision is
 perfect — every finding nox emits on Ruby is a true positive, and every clean
 stressor stays clean. Recall is honestly below 1.0: one genuine flow is missed
 because the Ruby extractor is a **line/statement recognizer**, not a full parser
@@ -84,6 +84,29 @@ arguments are the variables interpolated into that keyword's value. The safe
 forms carry no such keyword, so they synthesize no sink and stay clean (see
 `clean_render.rb`). A constant inline body (`render inline: "<h1>static</h1>"`)
 registers the sink but has no tainted read, so it correctly does not flow.
+
+## Closed gap: cross-method instance variables
+
+`@cmd = params[:cmd]` in one action, `system @cmd` in another, was a documented
+false negative — the model is intraprocedural plus same-file summaries for local
+helper CALLS, and did not join state two methods merely SHARE.
+
+Two things were needed. An `@ivar` assignment now BINDS (the sigil is part of the
+name, not the expression, so it is stripped to the bare name the read side
+already produces). And a binding of a shared name is copied into every other unit
+that reads it, letting the ordinary intra-unit propagation finish the job.
+
+Only syntactically shared names (`@ivar`, `@@cvar`, `$global`) participate — a
+plain local never joins, which is what stops same-named locals in one file
+collapsing into a single variable. The join is flow-insensitive across methods
+(nothing in the file orders them), and the copy is prepended so a method that
+assigns the name locally still overrides it.
+
+Measured on 780 real-world Ruby/Perl files carrying 1558 instance-variable
+assignments: zero new findings.
+
+A 1.0 means this corpus has stopped indicting anything, not that Ruby is solved.
+The limits below are real and simply lack a failing sample.
 
 ## Known gaps (honest false negatives)
 

--- a/testdata/precision-suite-ruby/baseline.json
+++ b/testdata/precision-suite-ruby/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.9411764705882353,
-  "f1": 0.9696969696969697,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 16,
-  "fn": 1,
-  "findings_per_issue": 0.9411764705882353,
+  "tp": 17,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     },
     {
       "rule_id": "TAINT-003",

--- a/testdata/precision-suite-ruby/tp_known_fns.rb
+++ b/testdata/precision-suite-ruby/tp_known_fns.rb
@@ -13,13 +13,10 @@ class KnownGapsController
     target.send(action, params[:arg]) # nox-expect: TAINT-005
   end
 
-  # FN — cross-method flow through an instance variable. The source lands in
-  # @cmd in one action and the sink reads @cmd in another. nox's same-file
-  # interprocedural pass tracks LOCAL HELPER CALLS via summaries, not shared
-  # object/instance state, so a taint laundered through an @ivar across two
-  # methods is not joined. This is the documented boundary of the
-  # intraprocedural + local-summary model (identical to the Python/JS limit),
-  # not a Ruby-specific defect.
+  # CAUGHT — cross-method flow through an instance variable. An @ivar assignment
+  # binds, and the binding is joined into every other unit that reads the name.
+  # Only shared-state sigils join; a plain local never does. Kept as the
+  # regression test for the shape.
   def capture
     @cmd = params[:cmd]
   end


### PR DESCRIPTION
Closes the last three **engine-side** recall gaps: perl's hash-element laundering, and the ruby/perl cross-method flows the docs called *"the boundary of the intraprocedural model"*.

## 1. Container element binding (perl)

`$args{cmd} = $ENV{CMD}` bound no bare name, so taint was lost at the store. The **container** is now bound. The subscript must be a single balanced `{...}`/`[...]` that *ends* the target, so a nested (`a{b}{c}`) or trailing-text target yields nothing rather than a misattributed binding. Field-insensitive by design — it can only widen taint — and enabled per language, the same opt-in shape as receiver taint.

## 2. Cross-unit shared state (ruby `@ivar`, perl `our`)

```ruby
def capture; @cmd = params[:cmd]; end
def execute; system @cmd;         end
```

A binding of a **shared** name is copied into every other unit that reads it, and ordinary intra-unit propagation finishes the job. Ruby additionally needed the binding itself — `@cmd` isn't a simple ident, so it bound nothing; the sigil is part of the *name*, not the expression, so it's stripped to the bare name the read side already produces.

**This is the riskiest change of the series, so three properties bound it — each pinned by a test:**

- **Only syntactically shared names participate** — `@ivar`, `@@cvar`, `$global`, `our $PKG`. A `my` lexical or plain local never joins, so same-named locals in one file don't collapse into a single variable. (`TestSharedStateIgnoresLocals`)
- **The copy is prepended**, so a unit that assigns the name locally still overrides it in its own scope.
- **The copy carries source evidence but empty `sinkArgs`** — it's replayed for its taint, not re-reported, so a sink inside a binding expression isn't reported again in every reader. (`TestJoinSharedStateDropsSinkArgs`)

The join is flow-**insensitive** across units: it assumes the assigning unit may run before the reading one. That's the standard over-approximation for shared state, since nothing in the file orders them.

## Verification

```
perl  0.833 -> 1.000        ruby  0.941 -> 1.000
```

All 20 suites: precision 1.000, FP 0 throughout; no other suite moved.

**Real-world: 780 files (260 `.rb`, 260 `.pl`, 260 `.pm`) carrying 1558 instance-variable assignments and 545 `our` globals — zero new findings, zero lost.** Given this change deliberately joins across method boundaries, that corpus check was the thing I most wanted to see clean.

## The remaining Dart gap is a ground-truth problem, not an engine one

I investigated `tp_ssrf_field.dart` rather than forcing it, and I don't think it should be closed as-is. **Its comment describes code that isn't there:**

| Comment claims | Code actually does |
|---|---|
| "tainted URL stored into a member FIELD (`req.url`)" | URL is the **constant** `Uri.parse('http://internal/')` |
| "fetch issued by a later bare `client.send(req)`" | `req.close()` |
| `// tainted redirect target laundered via a field` | `req.followRedirects = true` — a **literal**, nothing tainted |

The only tainted value is `raw`, which reaches a request **header** via `req.headers.add('X-Forwarded', raw)`. Attacker data never influences *where* the request goes, so **CWE-918 doesn't hold for the code as written** — that's a header/trust-boundary concern at most.

Making nox fire here would mean treating "any taint reaching an HTTP request object" as SSRF, which generalises into real false positives — every request carrying a user-supplied header value.

I did **not** edit the sample. Unlike the annotation-line fix in #418, the correct repair here is genuinely ambiguous: rewrite the code to match the comment (`req.url = tainted` + `client.send(req)`), reclassify it away from CWE-918, or drop it. That's your call. Say which and I'll do it.

`go build`, `go vet`, `gofmt`, `go test ./...`, `golangci-lint` all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
