### PR TITLE
fix(taint): a Clojure keyword is a source in function position, not as a map key

### DIFF
--- a/core/taint/engine/extract_clojure.go
+++ b/core/taint/engine/extract_clojure.go
@@ -475,6 +475,21 @@ func clojureCollectExpr(code []byte, f clojureForm, st *stmtDraft) {
 	// A vector/map RHS: collect each element's reads/calls (a data literal may hold
 	// a tainted value, e.g. a jdbc param vector).
 	for _, ch := range f.children {
+		if ch.delim == 0 {
+			// A bare atom INSIDE a data literal is a key or a literal value, not a
+			// keyword ACCESS. `{:headers {...} :body "..."}` CONSTRUCTS a request
+			// map; it does not read an untrusted one. Treating its keys as source
+			// chains marked every hand-built map — every test fixture and mock
+			// request — as untrusted input. A keyword is a source only in FUNCTION
+			// position, `(:headers req)`, which the call branch above handles.
+			if v := clojureSymbolRead(code, ch); v != "" {
+				st.reads = appendUnique(st.reads, v)
+			}
+			if t := clojureAtomText(code, ch); strings.Contains(t, "/") && !strings.HasPrefix(t, ":") {
+				st.chains = appendUnique(st.chains, t)
+			}
+			continue
+		}
 		clojureCollectExpr(code, ch, st)
 	}
 }

--- a/core/taint/engine/extract_clojure_test.go
+++ b/core/taint/engine/extract_clojure_test.go
@@ -222,3 +222,38 @@ func TestExtractClojureThreadingRebinds(t *testing.T) {
 		t.Errorf("expected the threaded variable to be bound then rebound per stage, got %d: %+v", rebinds, u.stmts)
 	}
 }
+
+// TestClojureLiteralMapKeysAreNotSources: a keyword is a source only in
+// FUNCTION position — `(:headers req)` READS a request. As a KEY in a map
+// literal it CONSTRUCTS one, which every test fixture, mock and benchmark does.
+// Treating literal keys as source reads marked those fixtures untrusted; 8 false
+// positives were measured on real Clojure projects before this was fixed.
+func TestClojureLiteralMapKeysAreNotSources(t *testing.T) {
+	// A hand-built request map must not taint the binding.
+	built := []byte("(defn f []\n  (let [request {:headers {\"a\" \"b\"} :body \"x\" :uri \"/p\"}]\n    (slurp request)))\n")
+	units := extractUnits(lexctx.LangClojure, built)
+	u := findUnit(t, units, "f")
+	for _, st := range u.stmts {
+		for _, c := range st.chains {
+			if c == "headers" || c == "body" || c == "uri" {
+				t.Errorf("literal map key %q recorded as a source chain: %+v", c, st)
+			}
+		}
+	}
+
+	// A keyword ACCESS on a request must still resolve as a source.
+	access := []byte("(defn g [req]\n  (let [h (:headers req)]\n    (slurp h)))\n")
+	units2 := extractUnits(lexctx.LangClojure, access)
+	u2 := findUnit(t, units2, "g")
+	sawSource := false
+	for _, st := range u2.stmts {
+		for _, c := range st.chains {
+			if c == "headers" {
+				sawSource = true
+			}
+		}
+	}
+	if !sawSource {
+		t.Errorf("a keyword ACCESS must still resolve as a source: %+v", u2.stmts)
+	}
+}

--- a/testdata/precision-suite-clojure/clean_request_literals.clj
+++ b/testdata/precision-suite-clojure/clean_request_literals.clj
@@ -1,0 +1,41 @@
+(ns app.clean-request-literals
+  "Clean stressor: HAND-BUILT request/response maps. Every Clojure test suite,
+   mock and benchmark constructs maps with Ring's own key names — `:headers`,
+   `:body`, `:params`, `:uri`, `:query-string`. CONSTRUCTING such a map is not
+   READING untrusted input, but a keyword is a source only in FUNCTION position
+   (`(:headers req)`), never as a map key.
+
+   Treating literal keys as source reads marked every fixture in a codebase as
+   untrusted, which then flowed into any sink the value reached. This sample was
+   added after exactly that was measured on real Clojure projects (reitit,
+   compojure): 8 false positives, all on hand-built maps in tests. Any finding
+   here is a false positive."
+  (:require [clojure.java.io :as io]))
+
+;; A response fixture — the shape compojure's own tests use.
+(def expected-response
+  {:status  200
+   :headers {"Content-Type" "text/html; charset=utf-8"}
+   :body    "<h1>Foo</h1>"})
+
+;; A mock request threaded into a handler and read back — the shape reitit's
+;; benchmarks use. `slurp` here consumes a response stream, not a path.
+(defn exercise [app]
+  (let [request {:request-method :post
+                 :uri            "/plus"
+                 :headers        {"content-type" "application/json"}
+                 :body           "{\"x\":1,\"y\":2}"}]
+    (-> request app :body slurp)))
+
+;; Threading a literal map through pure data shaping.
+(defn describe []
+  (-> {:params {:x 1} :query-string "x=1"}
+      (assoc :checked true)
+      (dissoc :query-string)))
+
+;; A vector literal holding Ring-ish keywords as DATA.
+(def tracked-keys [:headers :body :params :uri])
+
+;; Reading a fixture file by a constant path is not traversal.
+(defn load-fixture []
+  (slurp (io/resource "fixtures/sample.json")))


### PR DESCRIPTION
Found by finally validating the threading model from #419 against **real** Clojure code — the thing I flagged as untested when it landed, because this machine had 3 external `.clj` files.

Cloned ring, compojure, clj-http, reitit, leiningen, clojure, babashka and malli: **1191 files, 2648 threading forms, 2937 higher-order dispatch calls, 498 Ring-style source reads.**

## The threading model held up. Something behind it did not.

No finding was lost, and the flows threading added were the flows actually written. But it surfaced **7 false positives**, all one shape:

```clojure
request {:request-method :post
         :uri "/plus"
         :headers {"content-type" "application/json"}
         :body (j/write-value-as-string {:x 1, :y 2})}
...
(-> request app :body slurp)
```

reported as *"untrusted input (http_header) reaches path_traversal sink slurp"*.

**The cause isn't threading.** Every keyword inside a data literal was recorded as a source chain, so *constructing* a request map marked the value untrusted. Threading merely made that latent bad taint reach a sink — the same pattern as the shell work in #416, where a recall fix exposed dormant sink bugs.

A keyword is a source only in **function position** — `(:headers req)` *reads* a request. As a **key** it *constructs* one, which every test fixture, mock and benchmark in the ecosystem does.

Bare atoms inside a vector/map literal no longer contribute source chains. Nested **calls** inside a literal still do (a jdbc bind vector holding `(:params req)` is unaffected) and symbol reads are still collected, so this removes only the fabricated source.

## Verification

Against the commit before **any** of this session's Clojure work, on the same 1191 files:

```
before all clojure work : 591 findings
after #417 + #419       : 598   (+7 false positives)
with this fix           : 590   (0 new, 1 fewer)
```

**Zero new findings, and one fewer than the baseline.** The extra removal is compojure's own `expected-response` — a hardcoded test fixture reported as untrusted input *before this session began*. So this fixes a pre-existing false positive as well as the ones I exposed.

All 20 precision suites: precision 1.000, FP 0; recall unchanged.

## New corpus guard

`clean_request_literals.clj` — hand-built request/response maps in the shapes reitit and compojure actually use, including `(-> request app :body slurp)`. It's the sample that would have caught this.

It also answers the complaint I've repeated all session: the suites had drifted to a flat 1.0 and stopped indicting anything. A clean stressor is the addition that *raises* the bar. The lesson generalises — the curated suites were green for this the entire time; only real code found it.

`go build`, `go vet`, `gofmt`, `go test ./...`, `golangci-lint` all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
