### PR TITLE
ci(rule-diff): cover the taint engine, and give the corpus a language

### DIFF
--- a/.github/workflows/rule-diff.yml
+++ b/.github/workflows/rule-diff.yml
@@ -15,6 +15,12 @@ on:
     paths:
       - 'core/analyzers/**'
       - 'core/rules/**'
+      # The taint engine and the lexer that feeds it change rule behaviour just
+      # as directly as an analyzer does, and were outside this filter: a run of
+      # taint-model PRs shipped without this job ever firing, and one of them
+      # carried a false-positive class that every precision suite scored 1.00 on.
+      - 'core/taint/**'
+      - 'core/lexctx/**'
       - 'scripts/rule-diff.sh'
       - 'scripts/rule-diff-corpus.json'
       - '.github/workflows/rule-diff.yml'

--- a/scripts/rule-diff-corpus.json
+++ b/scripts/rule-diff-corpus.json
@@ -3,8 +3,13 @@
     "Real repositories scanned by scripts/rule-diff.sh to detect rule-behaviour",
     "changes between two nox builds. Chosen for VARIETY of the surfaces nox",
     "actually gets pointed at -- Go services, Terraform/Kubernetes manifests,",
-    "Dockerfiles, GitHub Actions workflows, JS/TS dependency trees -- not for",
-    "being clean. A repo with real findings is more useful here than one without.",
+    "Dockerfiles, GitHub Actions workflows, JS/TS dependency trees, and the",
+    "LANGUAGES the taint engine models -- not for being clean. A repo with real",
+    "findings is more useful here than one without.",
+    "",
+    "Language coverage matters as much as artifact variety: the taint engine",
+    "models 15+ languages, and a corpus of only Go/IaC repos cannot show a taint",
+    "regression in any of them. Two entries here exist for that reason alone.",
     "",
     "Pinned by commit sha so the diff reflects a change in NOX, never a change in",
     "the repo. Bumping a sha is a deliberate act: re-read the delta it produces",
@@ -25,6 +30,24 @@
       "url": "https://github.com/klarlabs-studio/warden",
       "sha": "f3af9e3a2f9bc85c2513845368f06049586525d6",
       "why": "Go CLI with signing/provenance code -- dense in crypto and credential-shaped strings, which is where secret rules over-fire"
+    },
+    {
+      "name": "ring",
+      "url": "https://github.com/ring-clojure/ring",
+      "sha": "75914ca942330ae6f8499b0ab9adda4664ad5f1b",
+      "why": "Clojure request/response middleware. Carries 2 standing TAINT-004 findings, so it controls the RECALL direction: if the clojure taint model stops following a flow, those drop to 0 and the diff fires"
+    },
+    {
+      "name": "reitit",
+      "url": "https://github.com/metosin/reitit",
+      "sha": "5d5c965deb3c7c8d64b8dd636432eaa14f0324ec",
+      "why": "Clojure routing, dense in hand-built request maps and threading macros. Baseline is ZERO taint findings, so it controls the PRECISION direction -- it fired 7 false TAINT-004 before the literal-map source fix, and any rise from 0 is that class returning"
+    },
+    {
+      "name": "plug",
+      "url": "https://github.com/elixir-plug/plug",
+      "sha": "2463704245eccacb2c528d7651cf86120b9f0543",
+      "why": "Elixir conn pipeline, dense in the pipe operator and pattern-match destructuring the elixir taint model binds. Baseline is zero taint findings; it exists because no Go/IaC repo exercises elixir at all, and elixir taint changes shipped this session with no real-world control"
     }
   ]
 }


### PR DESCRIPTION
## The guard already existed. It never ran.

`rule-diff.yml`'s own header describes precisely the failure mode this session kept hitting:

> *nox's corpus precision is measured at 1.00, and that number does not predict behaviour on real repositories. Synthetic fixtures cannot show that, because they contain exactly what the rule author expected.*

**Six taint PRs merged without this job firing once:**

| PR | Rule behaviour diff |
|---|---|
| #413 (touched `core/analyzers`) | ✅ ran |
| #414, #416, #417, #419, #420, #421 | ❌ **not triggered** |

The path filter covered `core/analyzers/**` and `core/rules/**`. Every taint change lives in `core/taint/**`. One missing path put the entire taint engine outside the safety net.

**The cost was measurable.** #419 shipped a Clojure threading model I stated in the PR I could not validate. #421 later found it had exposed a false-positive class that **all 20 precision suites scored 1.000 on** — 7 bad `TAINT-004` in reitit, plus one pre-existing in compojure. This job would have shown it at review time.

## 1. The taint engine joins the trigger paths

`core/taint/**` and `core/lexctx/**` — the engine and the lexer feeding it change rule behaviour as directly as an analyzer does.

## 2. The corpus gets a language

It held two Go/IaC repositories. Even if the job *had* run, it could not have shown a taint regression in any of the 15+ languages the engine models.

Three entries added, each controlling a different direction — **verified by running the script, not assumed**:

| Repo | Baseline | Controls |
|---|---|---|
| `ring` | 2 standing `TAINT-004` | **Recall** — if the model stops following a flow, they drop to 0 |
| `reitit` | **zero** taint findings | **Precision** — produced the 7 false `TAINT-004` before the fix; any rise from 0 is that class returning |
| `plug` | zero taint findings | **Elixir coverage** — pipe operator and destructuring, which no Go/IaC repo exercises |

## Verified end to end

Running `scripts/rule-diff.sh` with the buggy build against the fixed one:

```
── chronos @ d969c13e     no change (23 rules fired)
── warden  @ f3af9e3a     no change (9 rules fired)
── ring    @ 75914ca9     no change (3 rules fired)
── reitit  @ 5d5c965d     TAINT-004: 7 -> 0
── plug    @ 24637042     no change (5 rules fired)

1 rule(s) changed across 5 repo(s) -- each needs an explanation
```

The corpus now catches the exact bug the precision suites missed, and the existing entries stay stable.

## One thing worth flagging about my own process

My first pick for this was **`ring` alone**, on the reasoning that it's the canonical Ring-idiom repo. Running the script reported **"no change"** — the bug's findings were in reitit and compojure, not ring.

So the entries above are the ones *measured* to produce signal. Given this PR is about not trusting untested assumptions, picking corpus repos by intuition and asserting they'd work would have been the wrong way to write it.

## Cost

Two extra clones and four extra scans on PRs touching taint or rules. The manifest asks the list be kept small; I checked each addition earns its slot rather than adding breadth for its own sake.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
