### PR TITLE
docs(taint): record the partial-URL SSRF decision and the dart sample defect

### DIFF
--- a/docs/design/sast-taint.md
+++ b/docs/design/sast-taint.md
@@ -261,3 +261,52 @@ F1 0.933** (14 TP, 0 FP, 2 FN). The two recall gaps are honest and documented
 `render plain:` by call name; cross-method flow through an `@ivar` — outside the
 local-summary interprocedural model). Ruby inherits every intraprocedural limit
 above and is module/`def`-scoped like Python.
+
+## Semantics: a partially tainted URL is still reported (SSRF, TAINT-006)
+
+A recurring shape, found in three languages while validating the engine against
+real repositories:
+
+```elixir
+[tag] = System.argv()
+Req.get!("https://api.github.com/repos/elixir-lang/elixir/releases/tags/#{tag}")
+```
+
+```bash
+local path="$1"
+curl "${NEXUS_URL}/service/local/${path}"     # NEXUS_URL is a literal
+```
+
+```bash
+curl -fSL -o "$tarball" "https://go.dev/dl/go${version}.src.tar.gz"
+```
+
+In each, an untrusted value reaches a network fetch, but the URL's **scheme and
+host are literal** — only a path segment is attacker-controlled. Whether that is
+CWE-918 is genuinely arguable: SSRF classically means the attacker chooses the
+DESTINATION, and here they cannot redirect the request to another host.
+
+**nox reports it.** The reasoning:
+
+- The dataflow is real. An untrusted value does reach a URL passed to an HTTP
+  client, and that is the flow the rule describes.
+- Attacker control of a path segment is not nothing: `../` escapes, an injected
+  `?`/`#`, or a `@` that some URL parsers read as an authority separator can all
+  change what is fetched. Proving the host is fixed needs a URL-structure model
+  the engine does not have.
+- Silently dropping the class would trade a debatable finding for a silent miss,
+  which is the wrong direction for a scanner whose whole premise is that
+  degradation must be visible.
+
+**Why this is documented rather than narrowed.** Suppressing it requires
+modelling URL structure — parsing the literal prefix, deciding which
+interpolation positions are authority-changing, and getting that right in every
+language. That is a real feature. Measured against it: across ~14,000 real files
+(Clojure, Dart, Groovy, Elixir corpora) the engine emits **8 TAINT-006 findings
+in total, of which 2 are this class**. Building URL-structure analysis for two
+findings is not a good trade.
+
+What would change the decision: if a corpus sweep shows this class dominating
+TAINT-006 volume, or a downstream user reports it as their top noise source,
+narrow it then — and pin the corpus number here so the trade is re-checked
+against evidence rather than intuition.

--- a/testdata/precision-suite-dart/README.md
+++ b/testdata/precision-suite-dart/README.md
@@ -71,20 +71,41 @@ string.
 | `clean_rawstring_blob.dart` | a base64 `data:` URI and a regex token in `r'...'` raw strings — data blobs, not code |
 | `clean_generated.dart` | `Process.run` / `db.rawQuery` appear only in comments (incl. a nested block comment) — lexctx classifies them as comment, never code |
 
-## The recall gap (honest false negative)
+## The recall gap — and a question about this sample's ground truth
 
-`tp_ssrf_field.dart` is a **genuine SSRF bug nox does not catch**, kept in the
-corpus and labeled rather than deleted. The tainted value is laundered through a
-member **field** (`req`'s headers/redirect state) and the fetch is issued by a
-later bare `req.close()` that carries no tainted argument at its call site. nox's
-Dart extractor is a line/statement **recognizer** (only Go gets a real AST): it
-tracks taint through assignments whose LHS is a bare identifier, so an assignment
-into a member field is not modeled as a distinct binding and the tainted value
-never associates with the receiver. Closing this needs **field / receiver taint
-tracking** — future work, not a curation trick. This is the same documented class
-of limit as the Swift property-assignment and Kotlin scope-function false
-negatives. Removing this hard true positive to inflate recall would defeat the
-purpose of an honest measurement suite.
+`tp_ssrf_field.dart` is the corpus's one unmet expectation. Its stated premise is
+field/receiver taint: a tainted URL stored into a member field, fetched later by
+a bare call. That class of limit is real, and it was closed for Swift and
+Objective-C by receiver taint (a field assignment now binds the receiver).
+
+**It did not close here, and inspection suggests the sample itself is the
+problem — not the engine.** Recorded rather than quietly fixed, because
+repairing it is a corpus-design decision:
+
+- The header comment says the tainted URL is stored into `req.url` and fetched
+  by `client.send(req)`. **The code does neither.** The URL is the constant
+  `Uri.parse('http://internal/')`; the tainted value reaches a request HEADER via
+  `req.headers.add('X-Forwarded', raw)`; and `req.followRedirects = true` assigns
+  a literal, so its `// tainted redirect target laundered via a field` comment
+  does not describe the line it sits on.
+- Attacker data therefore never influences WHERE the request goes, so the
+  annotated **CWE-918 does not hold for the code as written**. Making nox fire
+  here would mean treating any taint reaching an HTTP request object as SSRF,
+  which generalises into false positives on every request carrying a
+  user-supplied header value.
+- The comment also mixes two libraries: `client.send(req)` is a `package:http`
+  idiom, while the code uses `dart:io`'s `HttpClient.openUrl`.
+- The field-assignment premise does not appear in real code. Across **1213 real
+  Dart files** (dart-lang http/shelf/args/collection, flutter/samples,
+  json_serializable) there is **not one** `request.url = ...` assignment; a URL
+  is set through the constructor. `client.send(request)` is common (122 uses),
+  but the request is built with its URL, not mutated into one.
+
+Three repairs are defensible and they are not equivalent — rewrite the code to
+match the comment, reclassify away from CWE-918, or drop the sample. Each is a
+different claim about what nox should detect, so the choice belongs to whoever
+owns the corpus. Until then the expectation stands unmet and recall stays below
+1.0, which is the honest state.
 
 ## Why precision is the gate
 


### PR DESCRIPTION
Two findings from validating the engine against ~14,000 real files. **Neither changes behaviour.** Both were living only in PR descriptions, which is the wrong place for decisions someone will have to re-litigate.

## 1. A partially tainted URL is still reported (TAINT-006)

A shape that turned up in three languages while sweeping real repos:

```elixir
[tag] = System.argv()
Req.get!("https://api.github.com/repos/elixir-lang/elixir/releases/tags/#{tag}")
```
```bash
local path="$1"
curl "${NEXUS_URL}/service/local/${path}"     # NEXUS_URL is a literal
```

An untrusted value reaches a network fetch, but the URL's **scheme and host are literal** — only a path segment is controlled. Whether that's CWE-918 is genuinely arguable: SSRF classically means the attacker picks the destination, and here they can't.

**nox reports it**, and the doc now says why: the dataflow is real; path control isn't nothing (`../`, an injected `?`/`#`, a `@` that some URL parsers read as an authority separator); and proving the host fixed needs URL-structure modelling the engine doesn't have. Dropping the class trades a debatable finding for a silent miss — wrong direction for a scanner whose premise is that degradation stays visible.

**Documented rather than narrowed, because the trade is measurable:** across ~14,000 real files the engine emits **8 TAINT-006 findings total, 2 of them this class**. Building URL-structure analysis for two findings is a bad deal. The doc pins that number and names what would flip the decision, so it gets re-checked against evidence rather than intuition.

## 2. The Dart gap is a corpus defect, not an engine gap

`tp_ssrf_field.dart` is annotated CWE-918 on a field/receiver-taint premise. Receiver taint landed in #418 and closed exactly that class for Swift and Objective-C. It didn't close here — and the sample is why:

| Its comment says | The code does |
|---|---|
| tainted URL stored into `req.url` | URL is the constant `Uri.parse('http://internal/')` |
| fetched by `client.send(req)` | `req.close()` |
| `// tainted redirect target laundered via a field` | `req.followRedirects = true` — a literal |

So attacker data never influences **where** the request goes; the annotated CWE doesn't hold for the code as written. Firing here would mean treating *any* taint reaching a request object as SSRF — a false positive on every request carrying a user-supplied header.

Two further points, both checked rather than assumed:

- The comment **mixes two libraries**: `client.send(req)` is `package:http`; the code uses `dart:io`'s `HttpClient.openUrl`.
- The premise **doesn't occur in practice**. Across **1213 real Dart files** (dart-lang http/shelf/args/collection, flutter/samples, json_serializable) there is **not one** `request.url = ...` assignment — URLs are constructor-set. `client.send(request)` is common (122 uses), but the request is *built* with its URL, not mutated into one.

## What I deliberately did not do

I did not repair the sample. Three fixes are defensible and **not equivalent** — rewrite the code to match the comment, reclassify away from CWE-918, or drop it — and each is a different claim about what nox should detect. That's a corpus-design decision.

It also fails the test I've been applying to fixture edits all along: *would I make this change if it made my numbers worse?* Every available repair here either improves dart recall or removes the failing expectation, so I'm the beneficiary either way. That's precisely when the call shouldn't be mine.

Dart recall stays below 1.0 with the expectation unmet — the honest state rather than a curated one. Tell me which repair you want and I'll do it.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
