### PR TITLE
test(corpus): add failing samples so the suites measure something again

### DIFF
--- a/core/taint/engine/extract_powershell.go
+++ b/core/taint/engine/extract_powershell.go
@@ -44,9 +44,10 @@ import "strings"
 //     binding to a cmdlet's pipeline input is a real argument position.
 //
 // Its honest limits (documented in testdata/precision-suite-powershell/README.md):
-// splatting (`@params`) hides arguments inside an untracked hashtable, and
 // method-suffix sinks are matched by name rather than by proving the receiver's
-// .NET type.
+// .NET type. Splatting (`@params`) was once listed here and is NOT a limit: a
+// hashtable assigned from a source is tainted and carries into the splatted
+// call, so `$p = @{Uri = $args[0]}; Invoke-WebRequest @p` is reported.
 func extractPowerShell(lines []logicalLine) []unitDraft {
 	module := &unitDraft{funcName: ""}
 	units := []*unitDraft{module}

--- a/core/taint/engine/extract_shell.go
+++ b/core/taint/engine/extract_shell.go
@@ -21,10 +21,14 @@ import "strings"
 // A declaration builtin that INITIALIZES (`local x="$1"`, `export u="$2"`) is an
 // assignment and is recognized as one; a bare declaration (`local a b`) is not.
 //
-// HONEST LIMITS (by design): word-splitting, globbing, arrays, `${var//a/b}`
-// transforms, arithmetic re-entry, and `xargs`/pipeline-fed commands are
-// constructs a flat, per-line recognizer cannot follow. A miss only weakens recall (a false negative), never
-// correctness — an unrecognized line simply yields no statement. Precision is
+// HONEST LIMITS (by design): word-splitting, globbing, arithmetic re-entry and
+// `xargs`/pipeline-fed commands are constructs a flat, per-line recognizer
+// cannot follow. Arrays and `${var//a/b}` transforms were once listed here and
+// are NOT limits — both propagate today (see tp_known_fns.sh); the claim was
+// stale, and tp_pipeline_fed.sh now pins the one that is real.
+//
+// A miss only weakens recall (a false negative), never correctness — an
+// unrecognized line simply yields no statement. Precision is
 // defended: a properly QUOTED expansion `"$var"` passed to a NON-sink command is
 // naturally clean because that command is not in the catalog, and the actual
 // sinks (`eval`, `sh -c`/`bash -c`, `source`/`.`, `curl`/`wget`) are exactly the

--- a/testdata/precision-suite-clojure/README.md
+++ b/testdata/precision-suite-clojure/README.md
@@ -44,15 +44,21 @@ where the honest false negatives live (see below).
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-clojure` scores
-**precision 1.00 / recall 1.00 / F1 1.00** (13 TP, 0 FP, 0 FN). Precision is
+**precision 1.00 / recall 0.81 / F1 0.90** (13 TP, 0 FP, 3 FN). Precision is
 perfect — every finding nox emits is a true positive, and every clean stressor
 (parameterized jdbc vector, `Integer/parseInt` coercion, placeholder creds,
 data-URI blob, generated banner) fires nothing — while recall is the lowest of any
 language. The last gap — the threading-macro form — is now closed, alongside the
 two higher-order-dispatch gaps (`apply`, `map`).
 
-A 1.0 means this corpus has stopped indicting anything, not that a Lisp is
-solved without a reader. `clean_threading.clj` was added as the guard: threading
+Recall is deliberately BELOW 1.0 again. It reached 1.0 when the threading model
+landed, at which point the corpus could only catch regressions — so
+`tp_hof_construction.clj` was added, pinning three real misses. `apply` and `map`
+DISPATCH a function and are modeled; `partial` and `comp` instead BUILD one, and
+`as->` renames the threaded value, so in all three the sink is a value rather
+than a call head the recognizer tracks. The drop from 1.00 to 0.81 is the corpus
+getting harder, not the engine getting worse: precision is still 1.000 with zero
+false positives. `clean_threading.clj` was added as the guard: threading
 is THE idiomatic Clojure shape, so modeling it is exactly where an engine risks
 inventing noise, and that sample asserts silence across `->`, `->>`, `some->`
 and `cond->` chains over constants, coerced numbers and pure data transforms.

--- a/testdata/precision-suite-clojure/baseline.json
+++ b/testdata/precision-suite-clojure/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 1,
-  "f1": 1,
+  "recall": 0.8125,
+  "f1": 0.896551724137931,
   "fp": 0,
   "tp": 13,
-  "fn": 0,
-  "findings_per_issue": 1,
+  "fn": 3,
+  "findings_per_issue": 0.8125,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 1
+      "recall": 0.6666666666666666
     },
     {
       "rule_id": "TAINT-004",
@@ -30,7 +30,7 @@
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 1
+      "recall": 0.75
     }
   ]
 }

--- a/testdata/precision-suite-clojure/tp_hof_construction.clj
+++ b/testdata/precision-suite-clojure/tp_hof_construction.clj
@@ -1,0 +1,36 @@
+(ns app.hof-construction
+  "Honest FALSE NEGATIVES: higher-order CONSTRUCTION. `apply` and `map` DISPATCH
+   a function and are modeled — the statement is re-attributed to the dispatched
+   symbol. `partial`, `comp` and `as->` instead BUILD a function (or rename the
+   threaded value) and invoke it through a local binding, so the sink never
+   appears as a call head under any name the recognizer tracks.
+
+   All three are real vulnerabilities a correct scanner reports. They are added
+   deliberately: this suite had reached recall 1.0, at which point it could only
+   catch regressions and could no longer say what a Lisp recognizer still cannot
+   follow. Closing them is the way to raise the number; deleting them is not."
+  (:require [clojure.java.shell :as shell]
+            [clj-http.client :as client]
+            [clojure.string :as str]))
+
+;; FN: `partial` closes over the sink and returns a new function bound to `f`.
+;; The call head is `f`, a local, so the shell sink is never named at the site.
+(defn run-partial [req]
+  (let [cmd (:params req)
+        f   (partial shell/sh "sh" "-c")]
+    (f cmd))) ; nox-expect: TAINT-002
+
+;; FN: `comp` composes the sink into a new function bound to `g`. Same shape as
+;; partial — the sink is a value, not a call head.
+(defn fetch-composed [req]
+  (let [url (:params req)
+        g   (comp client/get str)]
+    (g url))) ; nox-expect: TAINT-006
+
+;; FN: `as->` threads like `->`/`->>` but binds the value to a NAME the author
+;; chooses, so the threaded value is a normal local rather than the synthetic
+;; binding the other threading macros are modeled with.
+(defn run-as-> [req]
+  (as-> (:params req) v
+        (str/trim v)
+        (shell/sh "sh" "-c" v))) ; nox-expect: TAINT-002

--- a/testdata/precision-suite-powershell/README.md
+++ b/testdata/precision-suite-powershell/README.md
@@ -42,7 +42,7 @@ dataflow), not by deleting the failing sample. `tp_pipeline_fn.ps1` is retained
 as a regression test for exactly that flow.
 
 A 1.0 here means this corpus has stopped measuring — it no longer indicts
-anything. The open limits below (splatting, `-match` semantics, receiver typing)
+anything. The open limits below (`-match` semantics, receiver typing)
 are real and simply lack a sample; adding one that fails is the way to keep the
 number honest.
 
@@ -119,8 +119,11 @@ What nox catches in PowerShell today:
   blanked, so a regex alternation (`'^start|stop$'`) is never mistaken for a
   pipeline; `||`, the PowerShell 7 pipeline-CHAIN operator, is skipped because
   it passes no value.
-- **Splatting.** `Invoke-WebRequest @params` where `$params` is a hashtable of
-  arguments hides the tainted URL inside an untracked structure.
+- **Splatting — NOT a limit (this entry was stale).** `Invoke-WebRequest @params`
+  where `$params` is a hashtable built from a source IS reported: the hashtable
+  is tainted at its assignment and carries into the splatted call. Verified with
+  `$p = @{Uri = $args[0]}; Invoke-WebRequest @p`, which fires TAINT-006. The
+  claim is corrected rather than deleted so the record shows it was checked.
 - **`-match` is not a laundering sanitizer.** Regex validation with `-match` does
   not reclassify the validated variable; `clean_validated.ps1` is clean because
   the sink argument is a constant, not because `-match` neutralizes the input.

--- a/testdata/precision-suite-shell/README.md
+++ b/testdata/precision-suite-shell/README.md
@@ -20,18 +20,26 @@ As committed, `nox bench --precision testdata/precision-suite-shell` scores:
 | Metric | Value |
 | --- | --- |
 | **Precision** | **1.00** (0 false positives) |
-| **Recall** | **1.00** |
-| **F1** | **1.00** |
-| TP / FP / FN | 11 / 0 / 0 |
-| findings-per-issue | 1.00 |
+| **Recall** | **0.85** |
+| **F1** | **0.92** |
+| TP / FP / FN | 11 / 0 / 2 |
+| findings-per-issue | 0.85 |
 
 Per rule: TAINT-002 (cmd injection) 4/4, TAINT-004 (traversal) 2/2, TAINT-005
 (code injection) 3/3, TAINT-006 (SSRF) 2/2. **Precision is 1.00** — every finding
 nox emits is a true positive, and all four clean stressors fire nothing.
 
-A 1.0 does NOT mean shell dataflow is solved — it means this corpus has stopped
-indicting anything. The limits below are real and simply lack a failing sample;
-adding one is how the number stays honest.
+Recall is deliberately BELOW 1.0 again. It reached 1.0 when the `local`
+laundering gap closed, at which point the corpus could only catch regressions and
+could no longer say what the recognizer still cannot do — so `tp_pipeline_fed.sh`
+was added, pinning two real misses where a tainted value reaches a sink through a
+PIPELINE rather than as a literal argument (`xargs curl`, `xargs -I{} sh -c`).
+The drop from 1.00 to 0.85 is the corpus getting harder, not the engine getting
+worse: precision is still 1.000 with zero false positives.
+
+Two entries that used to appear in the limits list — ARRAYS and `${var//a/b}`
+transforms — were checked and are NOT limits; both propagate today. The stale
+claims are corrected rather than left standing.
 
 ## Why shell recall is the hardest of any supported language
 

--- a/testdata/precision-suite-shell/baseline.json
+++ b/testdata/precision-suite-shell/baseline.json
@@ -1,16 +1,16 @@
 {
   "precision": 1,
-  "recall": 1,
-  "f1": 1,
+  "recall": 0.8461538461538461,
+  "f1": 0.9166666666666666,
   "fp": 0,
   "tp": 11,
-  "fn": 0,
-  "findings_per_issue": 1,
+  "fn": 2,
+  "findings_per_issue": 0.8461538461538461,
   "rules": [
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 1
+      "recall": 0.8
     },
     {
       "rule_id": "TAINT-004",
@@ -25,7 +25,7 @@
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 1
+      "recall": 0.6666666666666666
     }
   ]
 }

--- a/testdata/precision-suite-shell/tp_pipeline_fed.sh
+++ b/testdata/precision-suite-shell/tp_pipeline_fed.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Honest FALSE NEGATIVES: a tainted value reaching a sink through a PIPELINE
+# rather than as a literal argument of it. Both are real vulnerabilities a
+# correct scanner reports; nox does not, and they are annotated so the corpus
+# scores the gap rather than staying silent about it.
+#
+# These were added deliberately to give this suite something to indict again: it
+# had reached recall 1.0, at which point it could only detect regressions and
+# could no longer say what the recognizer still cannot do. The way to raise the
+# number is to close these, never to delete them.
+set -euo pipefail
+
+# FN: the tainted value is piped into `xargs`, which invokes curl with it as an
+# argument. The recognizer models a command's OWN argument words; a value that
+# arrives through the pipe is not one of them, so the curl call looks argument-
+# less. An attacker controls which URLs are fetched.
+fetch_all() {
+  local urls="$1"
+  echo "$urls" | xargs curl -fsSL # nox-expect: TAINT-006
+}
+
+# FN: `xargs -I{}` builds a command STRING that interpolates a tainted positional
+# parameter and hands it to `sh -c`. The sink is real command injection, but the
+# string is assembled as an argument of xargs rather than at an `sh -c` call the
+# recognizer can attribute.
+process_all() {
+  find . -name '*.txt' -print0 | xargs -0 -I{} sh -c "process {} $1" # nox-expect: TAINT-002
+}
+
+fetch_all "$1"
+process_all "$2"


### PR DESCRIPTION
Eighteen of nineteen suites had reached recall 1.0. At that point a corpus can only detect regressions — it can no longer say what the engine still cannot do. **Every gap closed this session was one a suite had been pointing at**, so the suites running out of things to point at is a real loss, not a finish line.

## Failing samples, verified to actually fail

A sample that already passes documents nothing, so each was checked to **miss** before being added.

**`tp_pipeline_fed.sh`** (shell, 2 FN) — `echo "$urls" | xargs curl` and `xargs -0 -I{} sh -c "... $1"`. The recognizer models a command's *own* argument words; a value arriving through a pipe isn't one, so the sink looks argument-less.

**`tp_hof_construction.clj`** (clojure, 3 FN) — `partial`, `comp`, `as->`. `apply` and `map` *dispatch* a function and are modeled (#417). These instead *build* one, or rename the threaded value, so the sink is a value rather than a call head under any tracked name.

```
shell    recall 1.000 -> 0.846   (11 TP, 0 FP, 2 FN)
clojure  recall 1.000 -> 0.812   (13 TP, 0 FP, 3 FN)
```

## The recall drop is the corpus getting harder, not the engine getting worse

Worth stating plainly, because a recall drop normally means a regression and **this one does not**:

- **Precision stays 1.000 with zero false positives** in both suites
- No other suite moved
- Baselines are regenerated because the *corpus* changed, so the snapshot must

If you'd rather these land as a separate tracked-debt list than as scored FNs, say so — but scored is what makes them visible in CI rather than in a document nobody re-reads.

## It also found the mirror-image defect

Three limits were documented that **no longer exist**. Checked, and corrected rather than left standing:

| Claimed limit | Reality |
|---|---|
| shell **arrays** | `args=("$@"); eval "${args[0]}"` **is** reported |
| shell **`${var//a/b}` transforms** | `clean="${raw//foo/bar}"; eval "$clean"` **is** reported |
| powershell **splatting** | `$p = @{Uri = $args[0]}; Invoke-WebRequest @p` **is** reported |

All three sat in extractor comments or suite READMEs as open limits. Documenting a gap that isn't there is the same failure as claiming a guard that never runs (#422): an untested assertion that reads as fact. I only found them because I tried to write samples for them and they passed.

## Deliberately not done

Converting those three into *passing* regression tests. They belong in the corpus, but adding caught samples in the same change that adds missed ones would net the recall arithmetic out and obscure both. Good follow-up.

`go build`, `go vet`, `gofmt`, `go test ./...`, `golangci-lint` all clean.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
