### PR TITLE
fix(test): stop git auto-gc racing t.TempDir cleanup and failing releases

### DIFF
--- a/cli/annotate_cmd_test.go
+++ b/cli/annotate_cmd_test.go
@@ -255,7 +255,11 @@ func TestGetChangedFilesSet_InGitRepo(t *testing.T) {
 	// Initialize a git repo.
 	cmd := exec.Command("git", "init", "-b", "main")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir,
+		// See core/diff: git may fork `gc --auto`, racing t.TempDir cleanup.
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=gc.auto", "GIT_CONFIG_VALUE_0=0",
+		"GIT_CONFIG_KEY_1=maintenance.auto", "GIT_CONFIG_VALUE_1=false")
 	if err := cmd.Run(); err != nil {
 		t.Skipf("git not available: %v", err)
 	}

--- a/core/diff/diff_test.go
+++ b/core/diff/diff_test.go
@@ -161,7 +161,14 @@ func runGitCmd(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir,
+		// Git may fork `gc --auto` on commit, which keeps writing into
+		// .git/objects after the command returns. t.TempDir cleanup then races
+		// it and RemoveAll fails with "directory not empty", failing a test
+		// that had already passed. Disabling auto-maintenance removes the race.
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=gc.auto", "GIT_CONFIG_VALUE_0=0",
+		"GIT_CONFIG_KEY_1=maintenance.auto", "GIT_CONFIG_VALUE_1=false")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %v: %v\n%s", name, args, err, out)

--- a/core/git/git_test.go
+++ b/core/git/git_test.go
@@ -268,7 +268,14 @@ func run(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "HOME="+dir,
+		// Git may fork `gc --auto` on commit, which keeps writing into
+		// .git/objects after the command returns. t.TempDir cleanup then races
+		// it and RemoveAll fails with "directory not empty", failing a test
+		// that had already passed. Disabling auto-maintenance removes the race.
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=gc.auto", "GIT_CONFIG_VALUE_0=0",
+		"GIT_CONFIG_KEY_1=maintenance.auto", "GIT_CONFIG_VALUE_1=false")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %v: %v\n%s", name, args, err, out)

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2023,6 +2023,13 @@ func initGitRepo(t *testing.T, files map[string]string) string {
 	// git init
 	cmd := exec.Command("git", "init")
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		// Git may fork `gc --auto` on commit, which keeps writing into
+		// .git/objects after the command returns; t.TempDir cleanup then
+		// races it and RemoveAll fails with "directory not empty".
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=gc.auto", "GIT_CONFIG_VALUE_0=0",
+		"GIT_CONFIG_KEY_1=maintenance.auto", "GIT_CONFIG_VALUE_1=false")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
@@ -2149,6 +2156,13 @@ func TestRunHistoryScan_EmptyRepo(t *testing.T) {
 	// Init an empty repo with no commits.
 	cmd := exec.Command("git", "init")
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		// Git may fork `gc --auto` on commit, which keeps writing into
+		// .git/objects after the command returns; t.TempDir cleanup then
+		// races it and RemoveAll fails with "directory not empty".
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=gc.auto", "GIT_CONFIG_VALUE_0=0",
+		"GIT_CONFIG_KEY_1=maintenance.auto", "GIT_CONFIG_VALUE_1=false")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}


### PR DESCRIPTION
**The v1.25.0 release failed on its first attempt because of this.** goreleaser runs `go test ./...` as a before-hook, and one test failed on a cleanup unrelated to what it asserts:

```
--- FAIL: TestRun_WithChangedFiles (0.05s)
    TempDir RemoveAll cleanup: unlinkat
    /tmp/TestRun_WithChangedFiles.../001/.git/objects: directory not empty
FAIL github.com/nox-hq/nox/core/diff
```

**The test had already passed.** `git commit` may fork `gc --auto`, which keeps writing into `.git/objects` after the command returns. `t.TempDir`'s cleanup then races that process and `RemoveAll` fails on a directory that isn't empty.

Nothing in `core/diff` changed in this release — it's a latent race that surfaces under whatever timing the runner happens to give it, which is why it had never appeared on a PR and why it appeared on the one job where failing is most expensive.

## Fix

Every test helper that builds a git repo in a temp dir now disables git's auto-maintenance, via `GIT_CONFIG_COUNT` rather than a config write so it covers every git invocation the helper makes:

| File | Site |
|---|---|
| `core/diff/diff_test.go` | `runGitCmd` |
| `core/git/git_test.go` | `run` |
| `core/scan_test.go` | two inline `git init` sites |
| `cli/annotate_cmd_test.go` | inline `git init` |

Verified by running the affected packages repeatedly — 0 failures in 8 runs — and the full suite is clean. **A race can't be proven absent by repetition**, which is why the fix removes the cause (the forked gc) rather than trying to outwait it.

## About the release

Recovered by re-running the workflow, which passed and **published v1.25.0** with cosign signing and the major-tag update.

**I left the tag untouched.** Moving a tag that cosign has signed and that SLSA provenance refers to would be worse than the flake — so this fix lands after v1.25.0 and takes effect for the next release rather than being retro-fitted into a signed one.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
