### PR TITLE
docs(changelog): 1.11.1 is tagged now, restore its links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1409,8 +1409,10 @@ stays at 1.000/1.000 throughout.
 
 ## [1.11.1] - 2026-07-19
 
-> No `v1.11.1` tag was ever pushed, so this version has no compare link and
-> no release artifacts. Its changes shipped to users as part of 1.12.0.
+> Retro-tagged on 2026-07-28. No `v1.11.1` tag was pushed at the time, so the
+> changelog documented a version that could not be fetched; the tag now points
+> at the commit that added this section. No release ARTIFACTS were published
+> for 1.11.1 then and none exist now — its changes reached users inside 1.12.0.
 
 A post-release review found that three of 1.11.0's own promises did not hold.
 Each had full unit-test coverage of the function involved while the defect sat
@@ -2427,7 +2429,8 @@ secrets-pattern noise inside npm bundles.
 [1.13.0]: https://github.com/nox-hq/nox/compare/v1.12.2...v1.13.0
 [1.12.2]: https://github.com/nox-hq/nox/compare/v1.12.1...v1.12.2
 [1.12.1]: https://github.com/nox-hq/nox/compare/v1.12.0...v1.12.1
-[1.12.0]: https://github.com/nox-hq/nox/compare/v1.11.0...v1.12.0
+[1.12.0]: https://github.com/nox-hq/nox/compare/v1.11.1...v1.12.0
+[1.11.1]: https://github.com/nox-hq/nox/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/nox-hq/nox/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/nox-hq/nox/compare/v1.9.2...v1.10.0
 [1.9.2]: https://github.com/nox-hq/nox/compare/v1.9.1...v1.9.2


### PR DESCRIPTION
`v1.11.1` was documented as released on 2026-07-19 but **never tagged**, so the changelog promised a version nobody could fetch and two compare links 404'd. The tag now exists, pointing at `871f3fd` (#251) — the commit that added the 1.11.1 changelog section.

```
[1.11.1] restored: compare/v1.11.0...v1.11.1
[1.12.0] restored to its correct base: compare/v1.11.1...v1.12.0
```

All **55 version refs resolve to real tags** and every heading has one.

The heading note is updated rather than removed: the tag exists, but **no release artifacts were published for 1.11.1 then and none exist now** — its changes reached users inside v1.12.0. Better to say that than let a bare tag imply a binary release that never happened.

## How it was pushed matters, because the obvious way would have caused damage

The release workflow fires on any `v*` tag, and its `update-major-tag` job runs unconditionally:

```bash
git tag -fa v1 -m "v1 -> ${GITHUB_REF_NAME}"
git push origin v1 --force
```

**Pushing `v1.11.1` normally would have force-moved the floating `v1` action tag from v1.25.0 back to a July commit**, regressing every consumer of `nox-hq/nox@v1`. It would also have built an ancient release from old code and pushed a stale ghcr image.

So the release workflow was disabled for the push and re-enabled immediately after. Verified afterwards:

| Check | Result |
|---|---|
| Release run for v1.11.1 | none |
| `v1` target | `75b2a1f` — unchanged |
| `v1.11.1` dereferences to | `871f3fd` — correct |
| GitHub release object | none created |

## Follow-up worth doing separately

**`update-major-tag` should refuse to move `v1` backwards.** A tag push is the one event that job cannot distinguish between "this is the newest release" and "someone is retro-tagging history" — and today it assumes the former. A version comparison before the force-push would make retro-tagging safe by default instead of dependent on someone remembering to disable the workflow.

I didn't bundle that fix here: it changes release behaviour and belongs in its own reviewable change, not inside a docs PR.

https://claude.ai/code/session_01Ey31gDFxxYh26B3w3fcCcb
