### PR TITLE
fix(secrets): stop the entropy matcher reading a method call as a value

### DIFF
--- a/core/rules/entropy.go
+++ b/core/rules/entropy.go
@@ -246,6 +246,20 @@ func extractAssignmentRHS(line string, addFn func(col int, text string)) {
 		}
 
 		token := line[rhsStart:rhsEnd]
+		// A token immediately followed by '(' is a function or method call, not
+		// a value. This matters because ':' is treated as an assignment operator
+		// above, which is correct for YAML/JSON (`api_key: abc…`) but also fires
+		// on a struct-literal field in Go, Rust or Swift:
+		//
+		//	Hook: domain.PrePush.ConfigKey(),
+		//
+		// There the "RHS" is the selector expression `domain.PrePush.ConfigKey`,
+		// which has no value at scan time. A literal secret is never followed by
+		// an open paren, so skipping calls costs no recall.
+		if rhsEnd < len(line) && line[rhsEnd] == '(' {
+			i = rhsEnd
+			continue
+		}
 		if len(token) >= 16 {
 			addFn(rhsStart+1, token) // 1-based column
 		}

--- a/core/rules/entropy_test.go
+++ b/core/rules/entropy_test.go
@@ -184,6 +184,47 @@ func TestEntropyMatcher_ColonAssignment(t *testing.T) {
 	}
 }
 
+// A struct-literal field in Go/Rust/Swift uses the same `name: value` shape as
+// YAML, so the colon tokenizer picks up the field's expression as if it were a
+// value. `domain.PrePush.ConfigKey` is a selector expression with no value at
+// scan time — but it is 24 chars of mixed case with dots (so the camelCase
+// guard, which rejects non-alphanumerics, does not catch it) and its entropy is
+// 4.085, over SEC-163's context-boosted 4.0. It was reported as a "high-entropy
+// hex string" despite containing no hex, and because such findings surface as
+// code-scanning review comments it blocked a PR from merging.
+func TestEntropyMatcher_SkipsMethodCallInStructLiteral(t *testing.T) {
+	m := &EntropyMatcher{}
+	rule := Rule{MatcherType: "entropy", Metadata: map[string]string{
+		"entropy_threshold": "4.5", "require_context": "true",
+	}}
+
+	for _, line := range []string{
+		"\t\tHook:          domain.PrePush.ConfigKey(),",
+		"\t\tToken: config.Provider.SecretToken(),",
+		"\t\tkey: obj.Nested.CredentialLookup(),",
+	} {
+		if results := m.Match([]byte(line+"\n"), &rule); len(results) != 0 {
+			t.Errorf("flagged a method call as a secret in %q: %+v", strings.TrimSpace(line), results)
+		}
+	}
+}
+
+// The paren guard must not cost recall: a real secret is never followed by '('.
+func TestEntropyMatcher_CallGuardKeepsRealSecrets(t *testing.T) {
+	m := &EntropyMatcher{}
+	rule := Rule{MatcherType: "entropy"}
+
+	for _, line := range []string{
+		"api_key: aK3jR8mZ2pL5nW9xQ4vB7yD1sF6hT0c",          // colon, unquoted
+		"api_key = aK3jR8mZ2pL5nW9xQ4vB7yD1sF6hT0c",         // equals, unquoted
+		"secret: aK3jR8mZ2pL5nW9xQ4vB7yD1sF6hT0c(notacall)", // paren later, not adjacent
+	} {
+		if results := m.Match([]byte(line+"\n"), &rule); len(results) == 0 {
+			t.Errorf("lost a real secret in %q", line)
+		}
+	}
+}
+
 func TestEntropyMatcher_FatArrowAssignment(t *testing.T) {
 	m := &EntropyMatcher{}
 


### PR DESCRIPTION
Fixes #431.

## The bug

`extractAssignmentRHS` treats `:` as an assignment operator — correct for YAML/JSON (`api_key: abc…`), but it also fires on a struct-literal field in Go, Rust or Swift:

```go
Hook: domain.PrePush.ConfigKey(),
```

The "RHS" extracted is the selector expression `domain.PrePush.ConfigKey`, which **has no value at scan time**. Nothing downstream rejects it:

| guard | why it doesn't catch this |
|---|---|
| `isTokenChar` | accepts `.`, so the whole chain is captured as one token |
| `isLikelyNotSecret` → `isCamelOrPascalCase` | returns `false` on the first non-alphanumeric, so a *dotted* identifier is never recognised as an identifier |
| entropy threshold | 24 chars → Shannon entropy **4.085**, over SEC-163's context-boosted **4.0** |
| `require_context` | the line contains `key`, so it's satisfied |

It's then reported as a **"high-entropy hex string"** despite containing no hex.

## The fix

A token immediately followed by `(` is a call, and a literal secret is never followed by an open paren. Skipping those costs no recall. That's the whole change — four lines plus the comment explaining why.

## Measured, not assumed

Both binaries built from **this tree**, so the only difference is this commit. (My first attempt compared against the released 1.24.0 binary and showed a spurious `DATA-001` delta that was version drift, not this change.)

| corpus | baseline | patched | removed | new |
|---|---|---|---|---|
| [klarlabs-studio/warden](https://github.com/klarlabs-studio/warden) | 39 | 34 | **5** | **0** |
| nox self-scan (648 Go files) | 69 | 68 | **1** | **0** |

Every removed finding is a method call:

```
4x  base64.StdEncoding.EncodeToString    ← Go stdlib
1x  domain.PrePush.ConfigKey
1x  domain.PrePush.ConfigKey             ← the example in this PR's own comment
```

`base64.StdEncoding.EncodeToString` being reported as a possible secret key is, I think, the clearest statement of the problem.

## Recall is pinned

`TestEntropyMatcher_CallGuardKeepsRealSecrets` asserts the guard doesn't cost detection — unquoted colon and equals assignments still fire, as does a value with a paren later in the line but not adjacent. `TestEntropyMatcher_SkipsMethodCallInStructLiteral` **fails without the fix** (verified by reverting it).

`make check` passes: lint 0 issues, all tests, vet.

## Two things deliberately left out

**1. Selector chains without call parens.** `Hook: domain.Config.SomeKey,` still reaches the entropy check. Filtering dotted identifier chains generally is riskier than it looks — a JWT is also dot-separated, and its header segment (`eyJhbGciOiJIUzI1NiJ9`, 20 chars) is short enough and camel-ish enough to pass a naive identifier test, so a broad filter could quietly cost JWT recall. That wants its own change with JWT recall pinned first. I have no real-world instance of that shape; every case I measured had the parens.

**2. Substring keyword matching.** `hasSecretContext` uses `strings.Contains`, so `ConfigKeyword` matches on `key` — as would `monkey`, `keyboard`, `tokenize`. That's #431's second point. It changes which *lines* are eligible at all, so it belongs in a separate change with its own measurement.

## Why this one mattered enough to fix

Because nox findings surface as `github-advanced-security` review comments, and a repo with `required_conversation_resolution: true` will **block a merge** on them — this `low`-confidence `medium` finding stopped [warden#152](https://github.com/klarlabs-studio/warden/pull/152) from merging, even though it sits below the severity threshold that repo's own gate uses.

https://claude.ai/code/session_014MdmjtEoya1PpaYiFLtTkz