### PR TITLE
fix(report): serialize plugin enrichments to findings.json

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -630,6 +630,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			r.Prioritize = sortFlag == "priority"
 			r.SASTLanguages = result.SASTProfile
 			r.Degradations = degradationsForReport(result.Degradations)
+			r.Enrichments = result.Enrichments
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2

--- a/core/findings/enrichment.go
+++ b/core/findings/enrichment.go
@@ -4,12 +4,19 @@ package findings
 // without modifying the original finding fields. This preserves
 // determinism of the core scan engine while allowing plugins to
 // layer on triage decisions, reachability analysis, or explanations.
+//
+// The JSON tags matter as much as the fields do. Enrichments were populated on
+// ScanResult and then dropped — no reporter serialized them — so a post-scan
+// plugin's entire output was computed and discarded. Any plugin emitting
+// enrichments rather than findings, which is the correct shape for one that
+// annotates rather than detects, was silently a no-op to every consumer
+// reading findings.json.
 type Enrichment struct {
-	FindingFingerprint string // links to Finding.Fingerprint
-	Kind               string // "triage", "reachability", "explanation"
-	Title              string
-	Body               string // markdown content
-	Metadata           map[string]string
-	Confidence         Confidence
-	Source             string // plugin name that produced it
+	FindingFingerprint string            `json:"finding_fingerprint"` // links to Finding.Fingerprint
+	Kind               string            `json:"kind"`                // "triage", "reachability", "explanation"
+	Title              string            `json:"title"`
+	Body               string            `json:"body,omitempty"` // markdown content
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Confidence         Confidence        `json:"confidence,omitempty"`
+	Source             string            `json:"source,omitempty"` // plugin name that produced it
 }

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -79,6 +79,9 @@ type Degradation struct {
 type JSONReport struct {
 	Meta     Meta               `json:"meta"`
 	Findings []findings.Finding `json:"findings"`
+	// Enrichments are plugin annotations keyed to a finding's fingerprint.
+	// Omitted when empty so scans without post-scan plugins are unchanged.
+	Enrichments []findings.Enrichment `json:"enrichments,omitempty"`
 }
 
 // JSONReporter produces deterministic JSON output from a FindingSet.
@@ -99,6 +102,11 @@ type JSONReporter struct {
 	// ScanResult.Degradations before Generate so a consumer reading only the
 	// artifact can tell a clean scan from one that could not run.
 	Degradations []Degradation
+	// Enrichments are plugin annotations attached to findings by fingerprint.
+	// Set from ScanResult.Enrichments before Generate. Without this a post-scan
+	// plugin's output never reaches the artifact, which makes a plugin that
+	// annotates rather than detects indistinguishable from one that did not run.
+	Enrichments []findings.Enrichment
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -135,7 +143,8 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			SASTLanguages: r.SASTLanguages,
 			Degradations:  r.Degradations,
 		},
-		Findings: f,
+		Findings:    f,
+		Enrichments: r.Enrichments,
 	}
 
 	return json.MarshalIndent(report, "", "  ")

--- a/core/report/report_test.go
+++ b/core/report/report_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -303,5 +304,67 @@ func TestWriteToFile_ErrorOnInvalidPath(t *testing.T) {
 	err := r.WriteToFile(fs, "/nonexistent/dir/report.json")
 	if err == nil {
 		t.Fatal("expected error writing to invalid path, got nil")
+	}
+}
+
+// Enrichments were populated on ScanResult and then dropped: no reporter
+// serialized them, so a post-scan plugin's entire output was computed and
+// discarded. That made a plugin which annotates rather than detects — the
+// correct shape for triage and threat-intel — indistinguishable from one that
+// never ran, for any consumer reading findings.json.
+func TestJSONReporter_SerializesEnrichments(t *testing.T) {
+	fs := findings.NewFindingSet()
+	r := NewJSONReporter("test")
+	r.Enrichments = []findings.Enrichment{{
+		FindingFingerprint: "abc123",
+		Kind:               "triage",
+		Title:              "Triage: immediate",
+		Body:               "**Priority: immediate**",
+		Metadata:           map[string]string{"priority": "immediate", "rank": "0"},
+		Source:             "nox/triage-agent",
+	}}
+
+	data, err := r.Generate(fs)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var got struct {
+		Enrichments []struct {
+			FindingFingerprint string            `json:"finding_fingerprint"`
+			Kind               string            `json:"kind"`
+			Metadata           map[string]string `json:"metadata"`
+			Source             string            `json:"source"`
+		} `json:"enrichments"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Enrichments) != 1 {
+		t.Fatalf("expected the enrichment to reach the artifact, got %d", len(got.Enrichments))
+	}
+	e := got.Enrichments[0]
+	// The fingerprint is the whole link. Without it the annotation cannot be
+	// attached to anything, whatever else survives serialization.
+	if e.FindingFingerprint != "abc123" {
+		t.Errorf("finding_fingerprint = %q, want abc123", e.FindingFingerprint)
+	}
+	if e.Kind != "triage" || e.Source != "nox/triage-agent" {
+		t.Errorf("kind/source lost: %q / %q", e.Kind, e.Source)
+	}
+	if e.Metadata["priority"] != "immediate" {
+		t.Errorf("metadata lost: %v", e.Metadata)
+	}
+}
+
+// A scan with no post-scan plugins must be byte-identical to before, so the
+// key is omitted rather than emitted as null or [].
+func TestJSONReporter_OmitsEnrichmentsWhenEmpty(t *testing.T) {
+	data, err := NewJSONReporter("test").Generate(findings.NewFindingSet())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(string(data), "enrichments") {
+		t.Errorf("empty enrichments must be omitted entirely, got:\n%s", data)
 	}
 }


### PR DESCRIPTION
## The gap

`ScanResult.Enrichments` was populated and then **dropped**. No reporter serialized it; only `assist/` ever read it. A post-scan plugin's entire output was computed and discarded.

That failure is invisible rather than loud: a plugin emitting **enrichments instead of findings** — the correct shape for one that annotates rather than detects — was indistinguishable from a plugin that never ran, for any consumer reading `findings.json` or the SARIF.

## It bit immediately

triage-agent 0.3.0 and threat-enrich 0.3.0 were converted this week to post-scan tools emitting only enrichments. Measured against `testdata/precision-suite`, they produce **71 enrichments** — every one of which reached nothing.

```
enrichments: 71
kinds:       threat-intel, triage
sources:     nox/threat-enrich, nox/triage-agent
```

## The fix

- JSON tags on `findings.Enrichment`. It had **none**, so serializing would have leaked Go field casing (`FindingFingerprint`) into the artifact.
- `Enrichments` on `JSONReport`, `omitempty`.
- Wiring from `ScanResult` through the CLI, alongside `Degradations`.

Scans without post-scan plugins are byte-identical — a test pins that the key is **omitted**, not emitted as `null` or `[]`.

## Also measured while here

Precision suite, nox at this commit:

| | TP | FP | FN | Precision | Recall |
|---|---|---|---|---|---|
| no plugins | 37 | 0 | 0 | 1.000 | 1.000 |
| + the three 0.3.0 plugins | 37 | 0 | 0 | 1.000 | 1.000 |

Against **0.407** when the enrichment plugins re-derived findings, and 0.597 after the guard fixes. The plugins no longer contribute findings at all, so they can no longer contribute false positives.

Two caveats I did not paper over:
- `nox/api-abuse` is still **policy-rejected** at load (`risk_class: active`, `needs_confirmation`), so it contributed nothing to this measurement either way.
- A stray gitignored `findings.json` left in `testdata/precision-suite/` by an earlier scan was being counted as a corpus sample, adding 4 phantom false negatives and reporting recall as 0.902. The bench harness treats any file in the corpus dir as a sample, including gitignored scan output. Worth hardening separately.

https://claude.ai/code/session_014MdmjtEoya1PpaYiFLtTkz