### PR TITLE
feat(action): install the plugins .nox.yaml requires

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -211,6 +211,35 @@ install_nox() {
   echo "Installed nox v${version} to ${install_dir}"
 }
 
+# --- Install required plugins ---
+
+# nox runs only the plugins listed under plugins.required in .nox.yaml.
+# Anything not listed is reported as [degraded] with its findings simply
+# absent, so a scan whose plugins were never installed looks exactly like a
+# scan that found nothing.
+#
+# `nox install` reads that block and installs what it names — idempotent, and
+# a no-op when the project declares no plugins. Without this the action could
+# never satisfy a plugins.required entry, which meant any repository scanning
+# through this action silently lost its plugin coverage: nox-plugin-freshness
+# had to delete its requirement outright, and klarlabs-studio/roady kept
+# hand-rolled install steps rather than adopt the action.
+install_plugins() {
+  local scan_path="$1"
+  local install_dir="${GITHUB_ACTION_PATH:-.}"
+  local root="${scan_path}"
+  [[ -d "${root}" ]] || root="."
+
+  if [[ ! -f "${root}/.nox.yaml" ]]; then
+    return 0
+  fi
+
+  if ! "${install_dir}/nox" install --root "${root}" --quiet; then
+    echo "::error::nox install failed for a plugin named in ${root}/.nox.yaml plugins.required. The scan would run without it and report findings that are absent rather than missing."
+    return 1
+  fi
+}
+
 # --- Run scan ---
 
 run_scan() {
@@ -353,6 +382,7 @@ main() {
   version="$(resolve_version "${INPUT_VERSION}")"
 
   install_nox "${version}" "${platform}"
+  install_plugins "${INPUT_PATH}"
 
   local scan_exit=0
   run_scan "${INPUT_PATH}" "${INPUT_FORMAT}" "${INPUT_OUTPUT}" "${INPUT_FAIL_ON_FINDINGS}" || scan_exit=$?

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,15 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # nox verifies plugin signatures by shelling out to cosign; without it a
+    # signed plugin cannot be promoted past "unverified" and install is refused
+    # under the default community-trust policy. Only needed when the project
+    # declares plugins, so it is skipped for the common case of a repo with no
+    # .nox.yaml — keeping a plain scan as fast as it was.
+    - name: Install cosign (only when the project declares plugins)
+      if: hashFiles(format('{0}/.nox.yaml', inputs.path)) != ''
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
     - name: Run Nox Security Scanner
       id: scan
       shell: bash


### PR DESCRIPTION
The action installs nox and scans. It never installs plugins — and nox runs **only** the plugins listed under `plugins.required`, reporting anything unlisted as `[degraded]` with its findings simply absent.

So a repository scanning through this action cannot satisfy a `plugins.required` entry at all. Declaring one makes every run degraded; declaring none silently gives up the coverage. Both outcomes happened:

- **`nox-plugin-freshness`** deleted its requirement outright and now runs with no SAST.
- **`klarlabs-studio/roady`** kept hand-rolled steps — download tarball, verify sha256, install cosign, `sed` `plugins.required` out of `.nox.yaml` — rather than adopt the action, purely because of this.

## The capability already existed

`nox install` reads the `plugins.required` block and installs what it names, idempotently. This wires it in rather than adding a `plugins` input and a second implementation of the same thing.

```
[install] nox/taint-analysis@*
[install] nox/reachability@*
[install] 2 plugins resolved.
```

## Behaviour

| case | result |
|---|---|
| no `.nox.yaml` | returns immediately — plain scans unchanged |
| `plugins.required` present | installed before the scan |
| install fails | **fatal**, with `::error::` |

Install failure is deliberately fatal: a scan missing a whole analysis reports findings that are *absent* rather than *missing*, which is the failure this scanner exists to prevent — and it is the framing `fail-on-degraded` already uses.

cosign is installed **only when the project declares plugins** (`hashFiles(.nox.yaml)`), since nox shells out to it to verify plugin signatures and without it a signed plugin cannot be promoted past "unverified". Gating keeps the common no-plugin scan as fast as it was.

## Verification

Against the released 1.26.0 CLI, all three paths:

```
repo with plugins.required   → rc=0, 2 plugins resolved
repo with no .nox.yaml       → rc=0, skipped cleanly
.nox.yaml naming a bad plugin → rc=1, ::error::  (does not scan without it)
```

`bash -n` clean; `action.yml` parses.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D