### PR TITLE
fix(deps): brace-expansion 5.0.8 -> 5.0.9 (GHSA high, DoS)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
The security badge dropped **B → C** in #448. The badge is right — GitHub reports one high vulnerability on the default branch:

```
high  brace-expansion  DoS via unbounded intermediate arrays  fixed_in=5.0.9
```

reached through `editors/vscode`.

This fixes the cause rather than publishing the downgrade. `npm audit` in `editors/vscode` now reports **0 vulnerabilities**, so the badge should return to B on its next refresh.

Suggest merging this before #448 — otherwise the badge PR records a grade drop that no longer reflects reality.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D