### PR TITLE
fix(fix): never plan a downgrade, and fail if one lands anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`nox fix` could downgrade a dependency, reintroducing the vulnerabilities
+  it was meant to remove.** `planUpgrades` used each advisory's `fixed_in`
+  directly as the target and never compared it with the installed version.
+
+  An advisory's `fixed_in` is the version that closed *that* advisory, not the
+  newest safe version, so a package with several advisories yields several
+  fix versions — routinely including ones below what is already installed. The
+  planner emitted one action per advisory and applied them in sequence, so the
+  **last one won by accident**. That is order, not safety.
+
+  felixgeelhaar/specular#51 was this: `golang.org/x/crypto` 0.54.0 → 0.51.0,
+  putting nine critical advisories into a repo that scanned clean — in a PR
+  titled `chore(security): nox remediation`.
+
+  Candidates are now aggregated per package and the **highest** fix chosen,
+  which clears every advisory below it in one move, and three refusals apply:
+
+  - never a version at or below the installed one;
+  - never a prerelease when the install is a stable release
+    (felixgeelhaar/orbita#49 pinned `google.golang.org/grpc` to `v1.81.0-dev`,
+    a real upstream tag but a development marker);
+  - never a non-empty installed version nox cannot order — no ordering means
+    no way to know the move is forward.
+
+  An *absent* installed version is deliberately treated differently from an
+  unparseable one: some scanners do not report it, and refusing there would
+  silently stop remediating whole ecosystems. Absence is not evidence of a
+  downgrade, so only the prerelease guard applies.
+
+  Both incidents are covered by regression tests built from their real
+  advisory sets.
+
 ## [1.27.0] - 2026-08-08
 
 The action can install the plugins a project requires.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both incidents are covered by regression tests built from their real
   advisory sets.
 
+- **`nox fix` now verifies what actually landed, not just what it planned.**
+  After applying, it re-reads the manifests and fails if any package ended up
+  below where it started.
+
+  Planning correctly is not landing correctly: `go get` resolves against the
+  whole module graph, so a constraint elsewhere can pull a package under the
+  requested version, and a package manager can simply do something other than
+  what was asked. The planner cannot see either.
+
+  Ecosystems whose resolved version nox cannot yet read are reported as
+  **unverified** rather than counted clean — unchecked is not the same as
+  verified, and a guarantee that quietly covers less than it claims is the
+  failure mode this whole change exists to prevent.
+
 ## [1.27.0] - 2026-08-08
 
 The action can install the plugins a project requires.

--- a/cli/fix_cmd.go
+++ b/cli/fix_cmd.go
@@ -144,6 +144,29 @@ func runDepsFix(inputPath, manifestRoot string, dryRun, includeMajor bool) int {
 	if failed > 0 {
 		return 1
 	}
+
+	// Postcondition: re-read the manifests and confirm nothing moved backwards.
+	//
+	// planUpgrades refuses to ASK for a downgrade; this refuses to SHIP one.
+	// Both are needed, because the planner cannot see what the package manager
+	// actually did — `go get` resolves against the whole module graph, and a
+	// constraint elsewhere can land a package below the requested version.
+	//
+	// Failing here is the point. A remediation that lowered a dependency is
+	// worse than no remediation: it arrives titled "chore(security)", which is
+	// exactly what stops a reviewer looking closely.
+	bad, unchecked := verifyNoRegression(manifestRoot, plan.actions)
+	for _, u := range unchecked {
+		fmt.Printf("unverified: %s — nox cannot yet read this ecosystem's resolved version\n", u)
+	}
+	if len(bad) > 0 {
+		for _, r := range bad {
+			fmt.Fprintf(os.Stderr, "error: %s went backwards: %s -> %s\n", r.pkg, r.from, r.actual)
+		}
+		fmt.Fprintln(os.Stderr, "error: refusing to report success — these changes reintroduce whatever was fixed between those versions. Inspect the manifest before committing.")
+		return 1
+	}
+
 	return 0
 }
 

--- a/cli/fix_cmd.go
+++ b/cli/fix_cmd.go
@@ -180,7 +180,25 @@ var supportedFixEcosystems = map[string]string{
 // and major-version-boundary upgrades unless includeMajor is set.
 func planUpgrades(items []findings.Finding, includeMajor bool) upgradePlan {
 	var plan upgradePlan
-	seen := map[string]bool{}
+
+	// Collect every candidate fix per package BEFORE deciding anything.
+	//
+	// Advisories are independent and each names the version that closed it, so
+	// one package routinely carries several different fixed_in values. The old
+	// code emitted an action per advisory and applied them in sequence, which
+	// let the last one win by accident — order, not safety. Aggregating first
+	// means one move per package, to the highest fix, which clears every
+	// advisory below it.
+	type candidate struct {
+		ruleID    string
+		from      string
+		ecosystem string
+		action    string
+		fixes     []string
+	}
+	order := []string{}
+	byPkg := map[string]*candidate{}
+
 	for i := range items {
 		f := &items[i]
 		if f.RuleID != "VULN-001" {
@@ -199,24 +217,49 @@ func planUpgrades(items []findings.Finding, includeMajor bool) upgradePlan {
 			plan.skipped++
 			continue
 		}
-		if !includeMajor && isMajorBump(from, fixed) {
+		key := eco + ":" + pkg
+		c, seen := byPkg[key]
+		if !seen {
+			c = &candidate{ruleID: f.RuleID, from: from, ecosystem: eco, action: action}
+			byPkg[key] = c
+			order = append(order, key)
+		}
+		c.fixes = append(c.fixes, fixed)
+	}
+
+	for _, key := range order {
+		c := byPkg[key]
+		pkg := strings.SplitN(key, ":", 2)[1]
+
+		target := bestFix(c.fixes)
+		if target == "" {
+			plan.skipped++
+			continue
+		}
+
+		// Never move a package backwards, sideways, or onto a prerelease from
+		// a stable release. See isUpgrade for the two production incidents
+		// each of those refusals comes from.
+		if !isUpgrade(c.from, target) {
+			plan.skipped++
+			continue
+		}
+
+		if !includeMajor && isMajorBump(c.from, target) {
 			plan.majorSkipped++
 			continue
 		}
-		key := eco + ":" + pkg + "@" + fixed
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
+
 		plan.actions = append(plan.actions, upgradeAction{
-			ruleID:    f.RuleID,
+			ruleID:    c.ruleID,
 			pkg:       pkg,
-			fromVer:   from,
-			toVersion: fixed,
-			ecosystem: eco,
-			action:    action,
+			fromVer:   c.from,
+			toVersion: target,
+			ecosystem: c.ecosystem,
+			action:    c.action,
 		})
 	}
+
 	return plan
 }
 

--- a/cli/fix_verify.go
+++ b/cli/fix_verify.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// regression is a package that ended up lower than where nox found it.
+type regression struct {
+	pkg    string
+	from   string
+	actual string
+}
+
+// verifyNoRegression re-reads the manifests after the upgrades were applied and
+// checks that nothing moved backwards.
+//
+// Planning correctly is not the same as landing correctly. `go get` resolves
+// against the whole module graph, so a constraint elsewhere can pull a package
+// below the requested version; a package manager can also simply do something
+// other than what was asked. Either way the result is a "chore(security)" diff
+// that lowers a dependency, which is how felixgeelhaar/specular#51 reached a
+// reviewer.
+//
+// This is the postcondition to the planner's precondition: planUpgrades refuses
+// to *ask* for a downgrade, and this refuses to *ship* one. Both are needed —
+// the planner cannot see what the package manager actually did.
+//
+// Returns the regressions found and the packages it could not check. Those are
+// reported separately and deliberately: an ecosystem whose manifest nox cannot
+// yet read is unverified, which is not the same as verified clean, and saying
+// so is the difference between a guarantee and a hope.
+func verifyNoRegression(manifestRoot string, actions []upgradeAction) (bad []regression, unchecked []string) {
+	for _, a := range actions {
+		actual, ok := installedVersion(manifestRoot, a)
+		if !ok {
+			unchecked = append(unchecked, fmt.Sprintf("%s [%s]", a.pkg, a.ecosystem))
+			continue
+		}
+		// Only flag a genuine backwards move. Landing above the requested
+		// target is fine — a newer version already satisfies the advisory.
+		if a.fromVer != "" && !isUpgrade(a.fromVer, actual) && actual != a.fromVer {
+			bad = append(bad, regression{pkg: a.pkg, from: a.fromVer, actual: actual})
+		}
+	}
+	return bad, unchecked
+}
+
+// installedVersion reads a package's resolved version from the manifest after
+// an upgrade. Reports ok=false for ecosystems it cannot read rather than
+// guessing — see verifyNoRegression on why that distinction is kept.
+func installedVersion(manifestRoot string, a upgradeAction) (string, bool) {
+	if a.ecosystem != "go" {
+		// Other ecosystems resolve through lockfiles with their own formats;
+		// until each is parsed, they are reported as unchecked.
+		return "", false
+	}
+	return goModVersion(filepath.Join(manifestRoot, "go.mod"), a.pkg)
+}
+
+// goModVersion finds a module's version in a go.mod require line.
+func goModVersion(path, module string) (string, bool) {
+	f, err := os.Open(path) // #nosec G304 -- path derives from the caller's manifest root
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		// "require example.com/m v1.2.3" or, inside a block, "example.com/m v1.2.3"
+		line = strings.TrimPrefix(line, "require ")
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != module {
+			continue
+		}
+		return strings.TrimPrefix(fields[1], "v"), true
+	}
+	return "", false
+}

--- a/cli/fix_verify_test.go
+++ b/cli/fix_verify_test.go
@@ -51,8 +51,8 @@ func TestVerifyNoRegression(t *testing.T) {
 			action: upgradeAction{pkg: "golang.org/x/crypto", fromVer: "0.54.0", toVersion: "0.56.0", ecosystem: "go"},
 		},
 		{
-			name:  "require block form is parsed",
-			goMod: "module m\n\nrequire (\n\tgolang.org/x/crypto v0.54.0\n\tgolang.org/x/text v0.40.0\n)\n",
+			name:   "require block form is parsed",
+			goMod:  "module m\n\nrequire (\n\tgolang.org/x/crypto v0.54.0\n\tgolang.org/x/text v0.40.0\n)\n",
 			action: upgradeAction{pkg: "golang.org/x/text", fromVer: "0.39.0", toVersion: "0.40.0", ecosystem: "go"},
 		},
 		{

--- a/cli/fix_verify_test.go
+++ b/cli/fix_verify_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Planning correctly is not landing correctly. `go get` resolves against the
+// whole module graph, so a constraint elsewhere can put a package below the
+// requested version — and the result is a "chore(security)" diff that lowers a
+// dependency, which is precisely the diff a reviewer does not scrutinise.
+func TestVerifyNoRegression(t *testing.T) {
+	tests := []struct {
+		name        string
+		goMod       string
+		action      upgradeAction
+		wantBad     bool
+		wantUnknown bool
+	}{
+		{
+			name:   "landed where asked",
+			goMod:  "module m\n\nrequire golang.org/x/crypto v0.54.0\n",
+			action: upgradeAction{pkg: "golang.org/x/crypto", fromVer: "0.51.0", toVersion: "0.54.0", ecosystem: "go"},
+		},
+		{
+			name:   "landed above the target is fine — it still clears the advisory",
+			goMod:  "module m\n\nrequire golang.org/x/crypto v0.55.0\n",
+			action: upgradeAction{pkg: "golang.org/x/crypto", fromVer: "0.51.0", toVersion: "0.54.0", ecosystem: "go"},
+		},
+		{
+			// The failure this exists for: the manager resolved lower than
+			// where we started.
+			name:    "landed below where it started",
+			goMod:   "module m\n\nrequire golang.org/x/crypto v0.51.0\n",
+			action:  upgradeAction{pkg: "golang.org/x/crypto", fromVer: "0.54.0", toVersion: "0.56.0", ecosystem: "go"},
+			wantBad: true,
+		},
+		{
+			// Unchanged is not a regression — the upgrade simply did not take,
+			// which the apply step already reports.
+			name:   "unchanged is not a regression",
+			goMod:  "module m\n\nrequire golang.org/x/crypto v0.54.0\n",
+			action: upgradeAction{pkg: "golang.org/x/crypto", fromVer: "0.54.0", toVersion: "0.56.0", ecosystem: "go"},
+		},
+		{
+			name:  "require block form is parsed",
+			goMod: "module m\n\nrequire (\n\tgolang.org/x/crypto v0.54.0\n\tgolang.org/x/text v0.40.0\n)\n",
+			action: upgradeAction{pkg: "golang.org/x/text", fromVer: "0.39.0", toVersion: "0.40.0", ecosystem: "go"},
+		},
+		{
+			// Must be reported as unverified, never folded in with the clean
+			// results — unchecked is not the same as verified.
+			name:        "an ecosystem nox cannot read is unverified, not clean",
+			goMod:       "module m\n",
+			action:      upgradeAction{pkg: "express", fromVer: "4.18.0", toVersion: "4.19.0", ecosystem: "npm"},
+			wantUnknown: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeGoMod(t, dir, tc.goMod)
+
+			bad, unchecked := verifyNoRegression(dir, []upgradeAction{tc.action})
+
+			if got := len(bad) > 0; got != tc.wantBad {
+				t.Errorf("regressions=%v, want %v (%+v)", got, tc.wantBad, bad)
+			}
+			if got := len(unchecked) > 0; got != tc.wantUnknown {
+				t.Errorf("unchecked=%v, want %v (%v)", got, tc.wantUnknown, unchecked)
+			}
+		})
+	}
+}
+
+// The specular shape end to end: a plan that somehow lowered x/crypto must be
+// caught after the fact, not reported as a successful security fix.
+func TestVerifyCatchesTheSpecularRegression(t *testing.T) {
+	dir := t.TempDir()
+	writeGoMod(t, dir, "module m\n\nrequire golang.org/x/crypto v0.51.0\n")
+
+	bad, _ := verifyNoRegression(dir, []upgradeAction{
+		{pkg: "golang.org/x/crypto", fromVer: "0.54.0", toVersion: "0.51.0", ecosystem: "go"},
+	})
+	if len(bad) != 1 {
+		t.Fatalf("expected the downgrade to be caught, got %+v", bad)
+	}
+	if bad[0].from != "0.54.0" || bad[0].actual != "0.51.0" {
+		t.Errorf("report = %+v, want from 0.54.0 actual 0.51.0", bad[0])
+	}
+}

--- a/cli/fix_version.go
+++ b/cli/fix_version.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parsedVersion is the comparable part of a version string: its numeric
+// release components plus whether a prerelease suffix was present.
+type parsedVersion struct {
+	nums       []int
+	prerelease bool
+	ok         bool
+}
+
+// parseVersion reads a dotted numeric version, tolerating a leading "v" and a
+// trailing prerelease or build suffix.
+//
+// Deliberately strict about the numeric core: a version whose leading segment
+// is not a number (a branch name, a date stamp, a pseudo-version) returns
+// ok=false, and callers skip it. Guessing at an ordering nox cannot actually
+// determine is how a "fix" ends up moving a dependency somewhere nobody asked
+// for.
+func parseVersion(s string) parsedVersion {
+	s = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(s), "v"))
+	if s == "" {
+		return parsedVersion{}
+	}
+
+	// Split off prerelease ("-dev", "-rc.1") and build ("+meta") metadata.
+	core := s
+	pre := false
+	if i := strings.IndexAny(core, "-+"); i >= 0 {
+		pre = core[i] == '-'
+		core = core[:i]
+	}
+
+	parts := strings.Split(core, ".")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return parsedVersion{}
+		}
+		nums = append(nums, n)
+	}
+	if len(nums) == 0 {
+		return parsedVersion{}
+	}
+	return parsedVersion{nums: nums, prerelease: pre, ok: true}
+}
+
+// compareVersions returns -1, 0 or 1 comparing a to b by numeric components,
+// then treating a prerelease as lower than the release it precedes (1.2.0-dev
+// < 1.2.0), per semver.
+func compareVersions(a, b parsedVersion) int {
+	n := len(a.nums)
+	if len(b.nums) > n {
+		n = len(b.nums)
+	}
+	for i := 0; i < n; i++ {
+		var x, y int
+		if i < len(a.nums) {
+			x = a.nums[i]
+		}
+		if i < len(b.nums) {
+			y = b.nums[i]
+		}
+		if x != y {
+			if x < y {
+				return -1
+			}
+			return 1
+		}
+	}
+	switch {
+	case a.prerelease && !b.prerelease:
+		return -1
+	case !a.prerelease && b.prerelease:
+		return 1
+	}
+	return 0
+}
+
+// isUpgrade reports whether moving from -> to is a genuine forward move that
+// nox should apply.
+//
+// Three refusals, each one a bug seen in production:
+//
+//   - to <= from. An advisory's fixed_in is the version that closed THAT
+//     advisory, not the newest safe version. A package with several advisories
+//     yields several fixed_in values, and the lowest is routinely below what is
+//     already installed — felixgeelhaar/specular#51 downgraded
+//     golang.org/x/crypto 0.54.0 -> 0.51.0 that way and reintroduced nine
+//     critical advisories into a repo that scanned clean.
+//   - a prerelease target when the install is stable.
+//     felixgeelhaar/orbita#49 pinned google.golang.org/grpc to v1.81.0-dev, a
+//     real upstream tag but a development marker. Production code should not
+//     start tracking one because a scanner suggested it.
+//   - a non-empty installed version nox cannot order. Without an ordering
+//     there is no way to know the move is forward, and a security-titled PR is
+//     the worst place to guess.
+//
+// An ABSENT installed version is treated differently from an unparseable one.
+// Some scanners do not populate it at all; refusing there would silently stop
+// remediating whole ecosystems, which is its own quiet failure. Absence is not
+// evidence of a downgrade, so the direction check is skipped — but the
+// prerelease guard still applies, because that one needs no ordering.
+func isUpgrade(from, to string) bool {
+	t := parseVersion(to)
+	if !t.ok {
+		return false
+	}
+
+	f := parseVersion(from)
+
+	// Never adopt a prerelease from a stable release. Decidable without
+	// knowing the installed version, so it is checked first and always.
+	if t.prerelease && !f.prerelease {
+		return false
+	}
+
+	// No installed version reported: apply, and count on the prerelease guard
+	// above. Refusing here would drop coverage for scanners that omit it.
+	if strings.TrimSpace(from) == "" {
+		return true
+	}
+
+	// A value we cannot order is not a licence to guess.
+	if !f.ok {
+		return false
+	}
+
+	return compareVersions(t, f) > 0
+}
+
+// bestFix picks the highest of several candidate fix versions.
+//
+// Advisories are independent: each names the version that closed it. Applying
+// them one at a time lets the last one win by accident, which is order, not
+// safety. The highest fix clears every advisory below it in one move.
+func bestFix(candidates []string) string {
+	best := ""
+	var bestParsed parsedVersion
+	for _, c := range candidates {
+		p := parseVersion(c)
+		if !p.ok {
+			continue
+		}
+		if best == "" || compareVersions(p, bestParsed) > 0 {
+			best, bestParsed = c, p
+		}
+	}
+	return best
+}

--- a/cli/fix_version_test.go
+++ b/cli/fix_version_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+func vuln(pkg, from, fixed string) findings.Finding {
+	return findings.Finding{
+		RuleID: "VULN-001",
+		Metadata: map[string]string{
+			"ecosystem": "go", "package": pkg, "version": from, "fixed_in": fixed,
+		},
+	}
+}
+
+// A remediation must never move a package backwards.
+//
+// planUpgrades took fixed_in straight from the advisory and never compared it
+// to the installed version. When several advisories cover one package — nine,
+// for golang.org/x/crypto — each produced its own action, they were applied in
+// sequence, and the LAST one won regardless of order. felixgeelhaar/specular#51
+// was that: x/crypto v0.54.0 -> v0.51.0, introducing nine critical advisories
+// into a repo that scanned clean, in a PR titled "chore(security)".
+func TestPlanUpgradesNeverDowngrades(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []findings.Finding
+		want  string // expected toVersion; "" means no action planned
+	}{
+		{
+			name:  "an ordinary forward fix is planned",
+			items: []findings.Finding{vuln("golang.org/x/crypto", "0.51.0", "0.54.0")},
+			want:  "0.54.0",
+		},
+		{
+			name:  "a fixed_in below the installed version is not an upgrade",
+			items: []findings.Finding{vuln("golang.org/x/crypto", "0.54.0", "0.51.0")},
+			want:  "",
+		},
+		{
+			name:  "fixed_in equal to installed is already satisfied",
+			items: []findings.Finding{vuln("golang.org/x/crypto", "0.54.0", "0.54.0")},
+			want:  "",
+		},
+		{
+			// The specular shape: many advisories, one package, mixed fix
+			// versions. The highest wins, and it must clear every advisory.
+			name: "several advisories on one package resolve to the highest fix",
+			items: []findings.Finding{
+				vuln("golang.org/x/crypto", "0.50.0", "0.51.0"),
+				vuln("golang.org/x/crypto", "0.50.0", "0.54.0"),
+				vuln("golang.org/x/crypto", "0.50.0", "0.52.0"),
+			},
+			want: "0.54.0",
+		},
+		{
+			// Same, with the highest listed first — order must not decide it.
+			name: "highest wins regardless of advisory order",
+			items: []findings.Finding{
+				vuln("golang.org/x/crypto", "0.50.0", "0.54.0"),
+				vuln("golang.org/x/crypto", "0.50.0", "0.51.0"),
+			},
+			want: "0.54.0",
+		},
+		{
+			// felixgeelhaar/orbita#49: grpc pinned to v1.81.0-dev, a real
+			// upstream tag but a development marker, not a release.
+			name:  "a prerelease fix is not selected for a stable install",
+			items: []findings.Finding{vuln("google.golang.org/grpc", "1.79.3", "1.81.0-dev")},
+			want:  "",
+		},
+		{
+			// If the install is already a prerelease, moving within them is
+			// the caller's own territory and not ours to block.
+			name:  "a prerelease install may move to a prerelease fix",
+			items: []findings.Finding{vuln("google.golang.org/grpc", "1.80.0-dev", "1.81.0-dev")},
+			want:  "1.81.0-dev",
+		},
+		{
+			// Unknown/unparseable versions must not be silently "upgraded"
+			// on a guess.
+			name:  "an unparseable installed version is skipped",
+			items: []findings.Finding{vuln("example.com/x", "main-20260101", "1.2.3")},
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planUpgrades(tc.items, true)
+
+			if tc.want == "" {
+				if len(plan.actions) != 0 {
+					t.Fatalf("expected no action, got %s -> %s",
+						plan.actions[0].fromVer, plan.actions[0].toVersion)
+				}
+				return
+			}
+			if len(plan.actions) != 1 {
+				t.Fatalf("expected exactly 1 action, got %d: %+v", len(plan.actions), plan.actions)
+			}
+			if got := plan.actions[0].toVersion; got != tc.want {
+				t.Errorf("toVersion = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsUpgrade(t *testing.T) {
+	tests := []struct {
+		from, to string
+		want     bool
+		why      string
+	}{
+		{"0.51.0", "0.54.0", true, "ordinary forward move"},
+		{"0.54.0", "0.51.0", false, "downgrade — specular#51"},
+		{"0.54.0", "0.54.0", false, "already satisfied"},
+		{"1.79.3", "1.81.0-dev", false, "stable must not adopt a prerelease — orbita#49"},
+		{"1.80.0-dev", "1.81.0-dev", true, "prerelease may move within prereleases"},
+		{"1.2.0-dev", "1.2.0", true, "prerelease to its release is forward"},
+		{"1.9.0", "1.10.0", true, "numeric compare, not lexical: 10 > 9"},
+		{"1.10.0", "1.9.0", false, "numeric compare, not lexical: 9 < 10"},
+		{"v1.2.3", "v1.2.4", true, "leading v tolerated"},
+		{"1.2", "1.2.1", true, "uneven component counts"},
+		{"main-20260101", "1.2.3", false, "unparseable install"},
+		{"1.2.3", "latest", false, "unparseable target"},
+		{"", "1.2.3", true, "absent install version: apply, do not silently drop coverage"},
+		{"", "1.2.3-dev", false, "absent install version still refuses a prerelease"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.why, func(t *testing.T) {
+			if got := isUpgrade(tc.from, tc.to); got != tc.want {
+				t.Errorf("isUpgrade(%q, %q) = %v, want %v — %s", tc.from, tc.to, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+func TestBestFix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"highest of several", []string{"0.51.0", "0.54.0", "0.52.0"}, "0.54.0"},
+		{"order does not matter", []string{"0.54.0", "0.51.0"}, "0.54.0"},
+		{"numeric not lexical", []string{"1.9.0", "1.10.0"}, "1.10.0"},
+		{"release beats its prerelease", []string{"1.2.0-dev", "1.2.0"}, "1.2.0"},
+		{"unparseable entries ignored", []string{"latest", "1.2.3"}, "1.2.3"},
+		{"all unparseable yields nothing", []string{"latest", "main"}, ""},
+		{"empty yields nothing", nil, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bestFix(tc.in); got != tc.want {
+				t.Errorf("bestFix(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/regression_test.go
+++ b/cli/regression_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// The exact shape that produced felixgeelhaar/specular#51: nine advisories on
+// golang.org/x/crypto, installed at 0.54.0, each naming the version that
+// closed it. Several are below what is installed.
+func TestRegressionSpecular51(t *testing.T) {
+	fixes := []string{"0.51.0", "0.44.0", "0.35.0", "0.51.0", "0.31.0", "0.17.0", "0.51.0", "0.50.0", "0.49.0"}
+	var items []findings.Finding
+	for _, f := range fixes {
+		items = append(items, findings.Finding{
+			RuleID: "VULN-001",
+			Metadata: map[string]string{
+				"ecosystem": "go", "package": "golang.org/x/crypto",
+				"version": "0.54.0", "fixed_in": f,
+			},
+		})
+	}
+
+	plan := planUpgrades(items, true)
+	for _, a := range plan.actions {
+		t.Errorf("planned a move from %s to %s — every candidate is below the installed version",
+			a.fromVer, a.toVersion)
+	}
+	if len(plan.actions) == 0 {
+		t.Logf("correctly planned nothing; %d skipped", plan.skipped)
+	}
+}
+
+// felixgeelhaar/orbita#49: grpc 1.79.3 installed, advisory fixed_in a real but
+// development-marker tag.
+func TestRegressionOrbita49(t *testing.T) {
+	items := []findings.Finding{{
+		RuleID: "VULN-001",
+		Metadata: map[string]string{
+			"ecosystem": "go", "package": "google.golang.org/grpc",
+			"version": "1.79.3", "fixed_in": "1.81.0-dev",
+		},
+	}}
+	plan := planUpgrades(items, true)
+	for _, a := range plan.actions {
+		t.Errorf("planned %s -> %s; a stable install must not adopt a prerelease", a.fromVer, a.toVersion)
+	}
+}


### PR DESCRIPTION
Fixes #451.

`planUpgrades` used each advisory's `fixed_in` directly as the upgrade target and **never compared it with the installed version**.

## Why that downgrades

`fixed_in` is the version that closed *that* advisory — not the newest safe version. A package with several advisories yields several fix versions, routinely including ones below what is already installed. The planner emitted **one action per advisory**, applied them in sequence, and let the **last one win**.

That is order deciding the outcome, not safety.

[felixgeelhaar/specular#51](https://github.com/felixgeelhaar/specular/pull/51) was this: `golang.org/x/crypto` **0.54.0 → 0.51.0**, putting nine critical advisories into a repo that scanned clean — in a PR titled `chore(security): nox remediation`. The consumer's gate caught it. The fix belongs here.

## Change

Candidates are aggregated **per package** and the **highest** fix chosen, which clears every advisory below it in one move rather than racing them. Then three refusals:

| refusal | incident |
|---|---|
| at or below the installed version | specular#51 — the downgrade |
| a prerelease target from a stable install | [orbita#49](https://github.com/felixgeelhaar/orbita/pull/49) — `grpc` pinned to `v1.81.0-dev`, a real upstream tag but a development marker |
| a non-empty installed version that cannot be ordered | no ordering, no way to know the move is forward |

**An absent installed version is deliberately treated differently from an unparseable one.** Some scanners omit it, and refusing there would quietly stop remediating whole ecosystems — the same silent-coverage-loss shape this change exists to prevent. Absence is not evidence of a downgrade, so only the prerelease guard applies. Three existing tests (`npm`/`PyPI`/`Cargo`) exercise that path and pass unchanged.

## Details worth noting

- Comparison is **numeric per component, not lexical**, so `1.10.0 > 1.9.0`; a prerelease sorts below its release per semver.
- Written rather than pulled in — nox has no semver dependency and this needs ~60 lines.
- **Regression tests reconstruct both incidents from their real advisory sets**, including specular's nine `x/crypto` advisories. Both now plan *nothing* instead of something harmful.

Full `cli` and `core` suites pass.

## The stronger fix, not in here

#451 also suggests nox **re-scan the remediated tree before opening a PR** and abort if findings increased. That turns this class into an impossibility rather than relying on the resolver being right every time, and I'd still recommend it — but it is a change to the remediation flow rather than the planner, and worth its own PR and review.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D