### PR TITLE
feat(config): report .nox.yaml keys nox does not recognise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Unrecognised `.nox.yaml` keys are now reported as a degradation.** A key
+  nox does not understand was silently ignored, so a config could describe a
+  policy that was not in force while the scan reported success.
+
+  Two cases seen in the wild, both accepted without comment:
+
+  - `suppressions:` is not a key nox has. Writing it suppressed nothing and
+    passed — indistinguishable from a scan whose suppressions all applied.
+  - a misspelled `plugins.required` (`reqiured:`) left every plugin
+    undeclared, so none ran and their findings were absent rather than clean.
+
+  Both now print on the same `[degraded]` channel as an undeclared plugin,
+  naming the offending keys and the impact, on stderr and not suppressed by
+  `--quiet`.
+
+  Reported rather than fatal, deliberately: erroring would break every existing
+  config carrying a stray key the moment a fleet upgrades, and a scanner that
+  refuses to run is its own coverage loss. Verified against the real configs in
+  this repo, fortify and statekit — none produce a warning.
+
 ## [1.28.0] - 2026-08-10
 
 Minor rather than patch: `nox fix` now **fails a run it would previously have

--- a/cli/main.go
+++ b/cli/main.go
@@ -615,6 +615,21 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		fmt.Fprintf(os.Stderr, "[degraded] %s\n  impact: %s\n", d.Detail, d.Impact)
 	}
 
+	// A key nox does not understand is ignored, so .nox.yaml can describe a
+	// policy that is not in force while the scan reports success. `suppressions:`
+	// is not a real key — write it and nox suppresses nothing and passes,
+	// indistinguishable from a scan whose suppressions all applied. Misspell
+	// `plugins.required` and every plugin silently stops being declared.
+	//
+	// Same channel and same reasoning as the degradations above: stderr, and
+	// not suppressed by --quiet, because this says the results describe
+	// something other than what was asked for.
+	if unknown := nox.UnknownConfigKeys(target); len(unknown) > 0 {
+		fmt.Fprintf(os.Stderr, "[degraded] .nox.yaml has %d key(s) nox does not recognise: %s\n",
+			len(unknown), strings.Join(unknown, ", "))
+		fmt.Fprintf(os.Stderr, "  impact: they are ignored, so whatever they were meant to configure is not in effect. Check for a typo against the documented keys.\n")
+	}
+
 	// Generate reports.
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "error: creating output directory: %v\n", err)

--- a/core/config_strict.go
+++ b/core/config_strict.go
@@ -1,0 +1,119 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// unknownFieldRE pulls the offending key out of yaml.v3's strict-mode error,
+// which reads: line 4: field suppressions not found in type core.ScanConfig
+var unknownFieldRE = regexp.MustCompile(`field (\S+) not found`)
+
+// UnknownConfigKeys returns the keys in .nox.yaml that nox does not understand.
+//
+// A security tool that silently ignores configuration is not merely untidy: it
+// reports on a policy the operator did not ask for, while they believe the one
+// they wrote is in force.
+//
+// Two real examples, both accepted without comment before this existed:
+//
+//   - `suppressions:` is not a key nox has. Write it and nox suppresses
+//     nothing, scans everything, and passes — looking exactly like a scan whose
+//     suppressions all applied.
+//   - misspell `plugins.required` and every plugin stops being declared, so
+//     none of them run and their findings are absent rather than clean.
+//
+// nox already handles the equivalent case honestly elsewhere: an
+// installed-but-undeclared plugin emits a [degraded] line naming the impact
+// instead of quietly passing. This brings config typos up to that standard.
+//
+// Reported rather than fatal, deliberately. Erroring would break every existing
+// config carrying a stray key at the moment a fleet upgrades, and a scanner
+// that refuses to run is its own kind of coverage loss. The operator gets a
+// named list and decides.
+func UnknownConfigKeys(root string) []string {
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		root = filepath.Dir(root)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".nox.yaml")) // #nosec G304 -- caller's scan root
+	if err != nil {
+		// Absent or unreadable is the loader's business, not this check's.
+		// Reporting here would double up on an error the caller already has.
+		return nil
+	}
+
+	seen := map[string]bool{}
+	var keys []string
+
+	// yaml.v3 reports one unknown field per decode, so decode repeatedly,
+	// stripping each offender, until it stops complaining. Bounded by the
+	// number of keys found so a pathological file cannot spin.
+	remaining := data
+	for i := 0; i < 64; i++ {
+		dec := yaml.NewDecoder(bytes.NewReader(remaining))
+		dec.KnownFields(true)
+
+		var cfg ScanConfig
+		err := dec.Decode(&cfg)
+		if err == nil || errors.Is(err, os.ErrClosed) {
+			break
+		}
+
+		m := unknownFieldRE.FindStringSubmatch(err.Error())
+		if m == nil {
+			// A genuine syntax error, not an unknown key. The loader surfaces
+			// that separately with a better message.
+			break
+		}
+		key := m[1]
+		if seen[key] {
+			break
+		}
+		seen[key] = true
+		keys = append(keys, key)
+
+		remaining = stripKey(remaining, key)
+	}
+
+	sort.Strings(keys)
+	return keys
+}
+
+// stripKey removes the mapping entry for key so the next strict decode can
+// reach the following unknown key rather than stopping at the same one.
+//
+// Line-based on purpose: this runs only to enumerate typos, never to produce
+// the config nox actually uses, so it needs to be robust rather than exact.
+func stripKey(data []byte, key string) []byte {
+	lines := strings.Split(string(data), "\n")
+	out := make([]string, 0, len(lines))
+
+	dropIndent := -1
+	for _, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		indent := len(line) - len(trimmed)
+
+		if dropIndent >= 0 {
+			// Keep dropping the removed key's nested block.
+			if trimmed == "" || indent > dropIndent {
+				continue
+			}
+			dropIndent = -1
+		}
+
+		if strings.HasPrefix(trimmed, key+":") {
+			dropIndent = indent
+			continue
+		}
+		out = append(out, line)
+	}
+	return []byte(strings.Join(out, "\n"))
+}

--- a/core/config_strict_test.go
+++ b/core/config_strict_test.go
@@ -1,0 +1,97 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCfg(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A key nox does not understand is silently ignored, so a .nox.yaml can
+// describe a policy that is not in force and nothing says so.
+//
+// This matters more here than in an ordinary tool. `suppressions:` is not a
+// real key — write it and nox accepts the file, suppresses nothing, and scans
+// as though you had asked for nothing. Misspell `plugins.required` and every
+// plugin silently stops running. In both cases the operator believes the
+// config is doing something it is not, and the scan reports success.
+//
+// nox already models this correctly elsewhere: an installed-but-undeclared
+// plugin produces a [degraded] line naming the impact rather than a quiet
+// pass. Config typos deserve the same treatment.
+func TestUnknownConfigKeysAreReported(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     string
+		wantKey []string
+	}{
+		{
+			name:    "a key that does not exist at all",
+			cfg:     "version: 1\nsuppressions:\n  - rule: VULN-001\n",
+			wantKey: []string{"suppressions"},
+		},
+		{
+			name:    "a misspelled top-level key",
+			cfg:     "excludes_paths:\n  - vendor/\n",
+			wantKey: []string{"excludes_paths"},
+		},
+		{
+			name:    "a misspelled nested key",
+			cfg:     "plugins:\n  reqiured:\n    - nox/sast\n",
+			wantKey: []string{"reqiured"},
+		},
+		{
+			name:    "several at once are all named",
+			cfg:     "suppressions: []\nexcludes_paths: []\n",
+			wantKey: []string{"suppressions", "excludes_paths"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeCfg(t, dir, tc.cfg)
+
+			unknown := UnknownConfigKeys(dir)
+			joined := strings.Join(unknown, " ")
+			for _, k := range tc.wantKey {
+				if !strings.Contains(joined, k) {
+					t.Errorf("unknown keys %v do not mention %q", unknown, k)
+				}
+			}
+		})
+	}
+}
+
+// A correct config must stay silent, or the warning becomes noise and gets
+// filtered out — which would leave the real case invisible again.
+func TestValidConfigReportsNoUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	writeCfg(t, dir, `scan:
+  exclude:
+    - vendor/
+plugins:
+  required:
+    - nox/taint-analysis
+output:
+  format: json
+`)
+	if got := UnknownConfigKeys(dir); len(got) != 0 {
+		t.Errorf("a valid config reported unknown keys: %v", got)
+	}
+}
+
+// No config, or an unreadable one, is not an unknown-key problem — the loader
+// already handles those, and reporting here would double up.
+func TestMissingConfigReportsNothing(t *testing.T) {
+	if got := UnknownConfigKeys(t.TempDir()); len(got) != 0 {
+		t.Errorf("absent config reported unknown keys: %v", got)
+	}
+}


### PR DESCRIPTION
A key nox does not understand was accepted **in silence**, so a config could describe a policy that was not in force while the scan reported success.

## Two cases, both real

```yaml
suppressions:            # not a key nox has
  - rule: VULN-001
plugins:
  reqiured:              # one letter
    - nox/taint-analysis
```

- **`suppressions:`** suppressed nothing and passed — indistinguishable from a scan whose suppressions all applied.
- **`reqiured:`** left every plugin undeclared, so none ran and their findings were **absent, not clean**.

For a security tool that is close to the worst failure available: it reports on a policy the operator did not ask for, while they believe the one they wrote is in force.

## nox already gets this right elsewhere

An installed-but-undeclared plugin produces:

```
[degraded] 21 installed plugin(s) are not listed in plugins.required and did not run: ...
  impact: their findings are absent from this scan
```

That is exactly the honest shape — it names the impact rather than quietly passing. Config typos now use the same channel, on stderr, not suppressed by `--quiet`:

```
[degraded] .nox.yaml has 3 key(s) nox does not recognise: excludes_paths, reqiured, suppressions
  impact: they are ignored, so whatever they were meant to configure is not in
  effect. Check for a typo against the documented keys.
```

## Reported, not fatal — deliberately

Erroring would break every existing config carrying a stray key the moment a fleet upgrades, and **a scanner that refuses to run is its own coverage loss**. The operator gets a named list and decides.

## Verified against real configs

Ran against the `.nox.yaml` in this repo, `fortify` and `statekit` — **none warn**. That check mattered: a warning that cried wolf would get filtered out, which would put the real case back in the dark.

## Implementation note

`yaml.v3` reports one unknown field per decode, so the check decodes repeatedly, stripping each offender, bounded so a pathological file cannot spin. The stripping is line-based and deliberately approximate — it only ever *enumerates typos* and never produces the config nox actually uses.

## Why this, for trustworthiness

Nearly every nox defect found today was the same shape: a result that looked clean because something silently did not happen — plugins not run, `fixed_in` applied backwards, a lockfile not refreshed. The fixes that hold are the ones that make silence impossible. This is one more.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D