### PR TITLE
fix(AI-007): suppress absence-notification log FPs + queue update (sotw phidata)

### DIFF
--- a/core/analyzers/ai/ai_test.go
+++ b/core/analyzers/ai/ai_test.go
@@ -222,6 +222,30 @@ func TestDetect_APIKeyLogged(t *testing.T) {
 	}
 }
 
+// TestNoDetect_APIKeyNotSetMessage verifies that AI-007 does not fire when a log
+// statement reports that an API key is MISSING rather than logging its value.
+// Pattern: log_error("OPENAI_API_KEY not set") should not be flagged.
+func TestNoDetect_APIKeyNotSetMessage(t *testing.T) {
+	cases := []string{
+		`log_error("OPENAI_API_KEY not set. Please set the OPENAI_API_KEY environment variable.")`,
+		`log_error("AZURE_OPENAI_API_KEY not set")`,
+		`logger.warning("api_key not found, skipping LLM call")`,
+		`print("anthropic_api_key is not configured")`,
+	}
+	a := NewAnalyzer()
+	for _, code := range cases {
+		results, err := a.ScanFile("tools.py", []byte(code))
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", code, err)
+		}
+		for _, f := range results {
+			if f.RuleID == "AI-007" {
+				t.Errorf("AI-007 fired on absence-notification log %q — should be suppressed by ExcludeContextKeywords", code)
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // AI-008: Unpinned model reference
 // ---------------------------------------------------------------------------

--- a/core/analyzers/ai/rules.go
+++ b/core/analyzers/ai/rules.go
@@ -8,18 +8,19 @@ import (
 // aiRule is a compact representation used to define built-in AI security rules
 // in a table. Each entry is converted to a rules.Rule by builtinAIRules().
 type aiRule struct {
-	id                 string
-	severity           findings.Severity
-	confidence         findings.Confidence
-	pattern            string
-	description        string
-	cwe                string
-	keywords           []string
-	filePatterns       []string
-	ignoreFilePatterns []string
-	tags               []string
-	remediation        string
-	references         []string
+	id                     string
+	severity               findings.Severity
+	confidence             findings.Confidence
+	pattern                string
+	description            string
+	cwe                    string
+	keywords               []string
+	filePatterns           []string
+	ignoreFilePatterns     []string
+	excludeContextKeywords []string
+	tags                   []string
+	remediation            string
+	references             []string
 }
 
 // builtinAIRules returns all built-in AI security rules.
@@ -103,6 +104,11 @@ func builtinAIRules() []*rules.Rule {
 			pattern:     `(?i)(log|logger|print|console\.log|fmt\.Print)\S*\(.*?(openai_api_key|anthropic_api_key|api_key|bearer_token)`,
 			description: "LLM API key or token logged or printed",
 			cwe:         "CWE-532", keywords: []string{"openai_api_key", "anthropic_api_key"},
+			// Suppress matches where the key is not being logged but rather described as
+			// missing — e.g. log_error("OPENAI_API_KEY not set"). The pattern fires on
+			// the key name inside the message string, but these are absence notifications,
+			// not credential leaks.
+			excludeContextKeywords: []string{"not set", "not found", "is not set", "isn't set", "not configured", "not provided"},
 			tags:        []string{"ai", "logging", "secrets"},
 			remediation: "Never log API keys or tokens. Use secret masking in your logging framework. Store credentials in environment variables and reference them by name only.",
 			references:  []string{"https://cwe.mitre.org/data/definitions/532.html"},
@@ -1093,20 +1099,21 @@ func builtinAIRules() []*rules.Rule {
 	out := make([]*rules.Rule, len(defs))
 	for i := range defs {
 		out[i] = &rules.Rule{
-			ID:                 defs[i].id,
-			Version:            "1.0",
-			Description:        defs[i].description,
-			Severity:           defs[i].severity,
-			Confidence:         defs[i].confidence,
-			MatcherType:        "regex",
-			Pattern:            defs[i].pattern,
-			FilePatterns:       defs[i].filePatterns,
-			IgnoreFilePatterns: defs[i].ignoreFilePatterns,
-			Keywords:           defs[i].keywords,
-			Tags:               defs[i].tags,
-			Metadata:           map[string]string{"cwe": defs[i].cwe},
-			Remediation:        defs[i].remediation,
-			References:         defs[i].references,
+			ID:                     defs[i].id,
+			Version:                "1.0",
+			Description:            defs[i].description,
+			Severity:               defs[i].severity,
+			Confidence:             defs[i].confidence,
+			MatcherType:            "regex",
+			Pattern:                defs[i].pattern,
+			FilePatterns:           defs[i].filePatterns,
+			IgnoreFilePatterns:     defs[i].ignoreFilePatterns,
+			ExcludeContextKeywords: defs[i].excludeContextKeywords,
+			Keywords:               defs[i].keywords,
+			Tags:                   defs[i].tags,
+			Metadata:               map[string]string{"cwe": defs[i].cwe},
+			Remediation:            defs[i].remediation,
+			References:             defs[i].references,
 		}
 	}
 

--- a/docs/scan-of-the-week-queue.txt
+++ b/docs/scan-of-the-week-queue.txt
@@ -26,7 +26,7 @@
 # DONE 2026-07-05: microsoft/autogen — 304,629 findings (99.5% SVG/lock/notebook FPs); 1 low-sev AI-019 model-hash gap; fixed 10 broad-pattern SEC rules missing \b+secretShape
 # DONE 2026-07-15: modelcontextprotocol/servers — 41 findings (2 critical FPs: IAC-351 on id-token permission; 3 real high: mutable GH Action tags); fixed IAC-351 line-anchor FP
 # DONE 2026-08-01: openai/openai-agents-python — 378 findings (0 true positives); SEC-163 snake_case/f-string FP fixed
-phidatahq/phidata
+# DONE 2026-08-15: phidatahq/phidata — 1,277 findings (53% cookbook examples); 0 true positives; AI-007 absence-notification FP fixed; MCP-009 guardrail-context FP tracked
 princeton-nlp/SWE-agent
 pydantic/pydantic-ai
 ragflow-io/ragflow


### PR DESCRIPTION
## Summary

- **Rule fix:** AI-007 now has `ExcludeContextKeywords` to suppress false positives where the log call reports that a key is *missing* rather than logging its *value*.
- **Queue update:** `phidatahq/phidata` marked DONE in `docs/scan-of-the-week-queue.txt`.

## The false positive

Scanning `phidatahq/phidata` produced 3 AI-007 findings, all of this shape:

```python
log_error("OPENAI_API_KEY not set. Please set the OPENAI_API_KEY environment variable.")
log_error("AZURE_OPENAI_API_KEY not set")
```

AI-007's pattern fires on any log call containing `openai_api_key` or similar. These lines do not log the credential value — they report its *absence*. The fix adds:

```go
excludeContextKeywords: []string{
    "not set", "not found", "is not set", "isn't set",
    "not configured", "not provided",
},
```

When any of these phrases appears on or near (within 4 lines of) a matched line, the finding is suppressed. The mechanism uses the existing `ExcludeContextKeywords` / `contextHasKeyword` path in the rule engine.

## Changes

| File | Change |
|---|---|
| `core/analyzers/ai/rules.go` | Add `excludeContextKeywords` field to `aiRule` struct; map it in `builtinAIRules()`; set it on AI-007 |
| `core/analyzers/ai/ai_test.go` | `TestNoDetect_APIKeyNotSetMessage` — regression test for 4 absence-notification patterns |
| `docs/scan-of-the-week-queue.txt` | Mark `phidatahq/phidata` DONE |

## Test results

```
go test ./core/analyzers/ai/... 
ok  github.com/nox-hq/nox/core/analyzers/ai (all pass)
```

`go test ./core/...` passes on all packages. Two pre-existing chmod-based tests (`TestRunScanWithOptions_SecretsReadError`, `TestRunScanWithOptions_CustomRulesFileReadError`) fail in root-user environments where `chmod 0o000` does not prevent read access; these failures predate this PR.

## Scan summary (phidata b889441)

| Metric | Value |
|---|---|
| Total findings | 1,277 |
| AI-*/MCP-* findings | 397 |
| Critical findings | 25 (all FP) |
| True positives (lib code) | 0 |
| IAC-011 pull_request_target | 1 (low severity, not exploitable as written) |
| Disclosure required | No |

Notable FP not fixed here: **MCP-009 fires on `PromptInjectionGuardrail.injection_patterns` list** — a class that stores injection detection phrases as string literals. The `IgnoreInComments` flag already set on MCP-009 does not suppress list literals. Tracked for a precision pass (possible fix: `ExcludeContextKeywords` including `"injection_patterns"`, `"guardrail"`, `"detection_patterns"`, with a context window check).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4W5jS68NzQfaXfLKqRtqq)_