### PR TITLE
fix(policy): a failing gate names the finding that failed it

### DIFF
--- a/core/policy/policy.go
+++ b/core/policy/policy.go
@@ -4,6 +4,7 @@ package policy
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -166,10 +167,70 @@ func Evaluate(cfg Config, all []findings.Finding) *Result {
 	if r.Pass {
 		r.Summary = fmt.Sprintf("policy: pass (%s)", strings.Join(parts, ", "))
 	} else {
-		r.Summary = fmt.Sprintf("policy: fail (%s)", strings.Join(parts, ", "))
+		// A failure names what failed it. "policy: fail (70 new, 753
+		// baselined)" states two counts and omits the only fact the reader
+		// needs, and the counts actively mislead: most of those new findings
+		// are below fail_on and gate nothing, so a large number next to the
+		// word "fail" reads as a systemic problem rather than as one finding
+		// somebody just introduced. Observed doing exactly that — the count
+		// sent a reader off to hunt for baseline drift that did not exist,
+		// while the single critical that failed the run went unmentioned.
+		r.Summary = fmt.Sprintf("policy: fail (%s)%s", strings.Join(parts, ", "), gatingSuffix(r, cfg))
 	}
 
 	return r
+}
+
+// gatingSuffix names the findings that failed the policy.
+//
+// Bounded at three, with a count for the rest: the point is to identify the
+// problem, and a wall of findings pushes the summary off the top of a CI log
+// as surely as saying nothing does.
+func gatingSuffix(r *Result, cfg Config) string {
+	gating := gatingFindings(r, cfg)
+	if len(gating) == 0 {
+		// The baseline modes fail without any new finding to point at. Saying
+		// nothing is right there — the existing warnings already explain it.
+		return ""
+	}
+
+	const show = 3
+	shown := gating
+	if len(shown) > show {
+		shown = shown[:show]
+	}
+
+	named := make([]string, 0, len(shown))
+	for i := range shown {
+		f := shown[i]
+		where := f.Location.FilePath
+		if f.Location.StartLine > 0 {
+			where = fmt.Sprintf("%s:%d", where, f.Location.StartLine)
+		}
+		named = append(named, fmt.Sprintf("%s %s at %s", f.Severity, f.RuleID, where))
+	}
+
+	suffix := " — " + strings.Join(named, "; ")
+	if rest := len(gating) - len(shown); rest > 0 {
+		suffix += fmt.Sprintf("; and %d more", rest)
+	}
+	return suffix
+}
+
+// gatingFindings are the new findings that actually failed the gate: the ones
+// at or above fail_on, in severity order so the worst is named first.
+func gatingFindings(r *Result, cfg Config) []findings.Finding {
+	var out []findings.Finding
+	for i := range r.New {
+		f := r.New[i]
+		if cfg.FailOn == "" || meetsThreshold(f.Severity, cfg.FailOn) {
+			out = append(out, f)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return severityRank[out[i].Severity] < severityRank[out[j].Severity]
+	})
+	return out
 }
 
 // meetsThreshold returns true if severity is at or above the threshold.

--- a/core/policy/policy_test.go
+++ b/core/policy/policy_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox/core/findings"
@@ -239,4 +240,82 @@ func TestMeetsThreshold(t *testing.T) {
 			t.Errorf("meetsThreshold(%s, %s) = %v, want %v", tt.severity, tt.threshold, got, tt.want)
 		}
 	}
+}
+
+// at builds a finding with a location, so the summary has something to name.
+func at(sev findings.Severity, rule, file string, line int) findings.Finding {
+	return findings.Finding{
+		RuleID:   rule,
+		Severity: sev,
+		Status:   findings.StatusNew,
+		Location: findings.Location{FilePath: file, StartLine: line},
+	}
+}
+
+func TestSummaryNamesWhatFailedTheGate(t *testing.T) {
+	cfg := Config{FailOn: findings.SeverityHigh}
+	// The shape that caused the confusion: one critical hidden among a crowd
+	// of findings that gate nothing.
+	all := append(newN(findings.SeverityLow, 70),
+		at(findings.SeverityCritical, "SEC-073", "scripts/test-integration.sh", 88))
+
+	r := Evaluate(cfg, all)
+
+	if r.Pass {
+		t.Fatalf("a new critical did not fail the gate: %s", r.Summary)
+	}
+	for _, want := range []string{"SEC-073", "scripts/test-integration.sh:88", "critical"} {
+		if !contains(r.Summary, want) {
+			t.Errorf("Summary = %q, want it to mention %q", r.Summary, want)
+		}
+	}
+}
+
+func TestSummaryDoesNotNameFindingsThatGateNothing(t *testing.T) {
+	cfg := Config{FailOn: findings.SeverityHigh}
+	all := append(newN(findings.SeverityLow, 5),
+		at(findings.SeverityHigh, "SEC-100", "internal/a.go", 3))
+
+	r := Evaluate(cfg, all)
+
+	// The low findings are the noise that made the old message misleading;
+	// naming them would reproduce the problem in a longer form.
+	if contains(r.Summary, "SEC-001") {
+		t.Errorf("Summary = %q, want only the gating finding named", r.Summary)
+	}
+}
+
+func TestManyGatingFindingsAreTruncated(t *testing.T) {
+	cfg := Config{FailOn: findings.SeverityHigh}
+	var all []findings.Finding
+	for i := range 10 {
+		all = append(all, at(findings.SeverityHigh, "SEC-200", "internal/a.go", i+1))
+	}
+
+	r := Evaluate(cfg, all)
+
+	// A wall of findings pushes the summary off the top of a CI log as surely
+	// as saying nothing does.
+	if !contains(r.Summary, "and 7 more") {
+		t.Errorf("Summary = %q, want the tail summarised", r.Summary)
+	}
+}
+
+func TestAPassingSummaryIsUnchanged(t *testing.T) {
+	cfg := Config{FailOn: findings.SeverityHigh}
+
+	r := Evaluate(cfg, newN(findings.SeverityLow, 77))
+
+	if !r.Pass {
+		t.Fatalf("low findings failed a high gate: %s", r.Summary)
+	}
+	// Nothing failed, so there is nothing to name — and a pass should not grow
+	// a dash and a list.
+	if contains(r.Summary, "—") {
+		t.Errorf("Summary = %q, want the passing form untouched", r.Summary)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && strings.Contains(haystack, needle)
 }


### PR DESCRIPTION
```
[policy] policy: fail (70 new, 753 baselined)
```

Two counts, and not the one fact the reader needs. Worse, the counts actively mislead: with `fail_on` set, most new findings sit below the threshold and gate nothing, so a large number beside the word **fail** reads as a systemic problem rather than as one finding somebody just introduced.

Not hypothetical — this message cost an hour today. It sent me off to investigate baseline drift across a repository, on the theory the gate had gone red for every author. It had not: `main` reported **77 new** and passed. Exactly one of the 70 was a new critical, in a file that same commit had touched, and the summary never mentioned it.

After:

```
[policy] policy: fail (70 new, 753 baselined) — critical SEC-073 at scripts/test-integration.sh:88
```

Decisions worth reviewing:

- **Only findings at or above `fail_on` are named** — they are the ones that failed the run. Naming the rest would reproduce the original problem at greater length.
- **Sorted worst-first, capped at three** with `and N more`. A wall of findings pushes the summary off the top of a CI log as surely as saying nothing does.
- **A pass is untouched.** No dash, no list.
- **A baseline-mode failure with no gating finding** adds nothing rather than a trailing empty dash; the existing warnings already explain those.

## Verification, and its limit

Four unit tests pin the behaviour: the crowd-of-noise case (70 lows and one critical, only the critical named), that sub-threshold findings are never named, truncation at three, and that a passing summary is byte-identical to before. `./core/...` is green.

I could **not** reproduce the failing summary against the real repository locally — its baseline and scan cache resolve that finding differently there, and the full scan passes with the offending file restored. So the end-to-end shape above is from the unit tests, not from a live failing scan. Worth someone confirming against a repo that does fail today.

https://claude.ai/code/session_01N9cWx4ZEypDzzhvnnTiHdy