### PR TITLE
test(rules): make a FuzzScanFile stall diagnosable instead of opaque

### DIFF
--- a/core/rules/engine_fuzz_test.go
+++ b/core/rules/engine_fuzz_test.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"testing"
+	"time"
 )
 
 // FuzzScanFile fuzzes arbitrary content through the rule engine with a
@@ -51,9 +52,45 @@ func FuzzScanFile(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, content []byte, path string) {
 		// Must not panic regardless of input.
+		start := time.Now()
 		_, _ = engine.ScanFile(path, content)
+		elapsed := time.Since(start)
+
+		// ...and must not HANG on any input either.
+		//
+		// This bound exists because a stall here is otherwise undiagnosable.
+		// When ScanFile takes long enough, the fuzzing coordinator gives up on
+		// the worker and reports "context deadline exceeded" — which reads like
+		// flaky infrastructure, names no input, and writes NO corpus entry, so
+		// there is nothing to reproduce from. That is exactly what happened on
+		// main at 28e0ca79: repeated "0/sec" windows, then a timeout, and no
+		// reproducer. A quadratic in findLine was found and fixed afterwards by
+		// benchmarking, but whether it was the cause was never established.
+		//
+		// Failing INSIDE the fuzz function instead names the input in the test
+		// output, and — when the offender is one the fuzzer DISCOVERED rather
+		// than a seed — Go writes it to testdata/fuzz/FuzzScanFile/ as a
+		// checked-in regression case. (A seed that trips this is reported but
+		// not written, since it already lives in the source.) Either way the
+		// failure stops being a bare timeout with nothing attached.
+		//
+		// The bound is deliberately enormous — six orders of magnitude above the
+		// microseconds a real scan of a fuzz-sized input takes — so a loaded
+		// runner cannot trip it. A tight bound on a path that normally costs
+		// nothing is how you manufacture a flake; only a genuine stall reaches
+		// this.
+		if elapsed > maxScanFileDuration {
+			t.Fatalf("ScanFile took %v for %d bytes and path %q, over the %v bound; "+
+				"a scan this slow is a pathological input. If the fuzzer discovered it, "+
+				"Go has written it to testdata/fuzz/FuzzScanFile for reproduction",
+				elapsed, len(content), path, maxScanFileDuration)
+		}
 	})
 }
+
+// maxScanFileDuration bounds a single ScanFile call under fuzzing. See the
+// comment in FuzzScanFile for why it is this generous.
+const maxScanFileDuration = 10 * time.Second
 
 // FuzzContainsAnyKeyword fuzzes the keyword matching function with
 // arbitrary content and keyword combinations.


### PR DESCRIPTION
## The problem

`FuzzScanFile` failed once on `main` (`28e0ca79`) with repeated `0/sec` windows and then:

```
--- FAIL: FuzzScanFile (31.01s)
    context deadline exceeded
```

That is the fuzzing coordinator giving up on a stuck worker. It **names no input, writes no corpus entry**, and reads like flaky infrastructure. There was nothing to reproduce from.

A quadratic in `findLine` was found and fixed by benchmarking afterwards (150ms → 51ms at 16k lines), but **whether it caused that timeout was never established** — and the evidence cannot settle it. The job failed once in twelve runs on `main`, and the greens on either side include greens from *before* the fix:

```
455fcd0f  success   <- post-fix
d9620dd8  success   <- post-fix
9314b56e  success   <- PRE-fix
28e0ca79  failure   <- the one investigated
cbb79620  success   <- PRE-fix
```

## What this changes

The target now times its own `ScanFile` call and fails if it exceeds a bound, so the next occurrence is diagnosable:

- the input's **size and path** appear in the test output;
- for an input the fuzzer **discovered** (as opposed to a seed), Go writes it to `testdata/fuzz/FuzzScanFile` as a checked-in regression case.

The bound is **10s** — six orders of magnitude above the microseconds a real scan of a fuzz-sized input takes, so a loaded runner cannot trip it. That asymmetry is deliberate, and is the same lesson the rate-limiter deadlines taught: a tight bound on a path that normally costs nothing manufactures a flake rather than catching one.

## Verification

- **Mutation-checked**: with the bound at `1ns` the guard fires and reports elapsed time, size and path.
- A failure on a **seed** entry is reported but **not** written to `testdata` — the input already lives in the source. The first draft of the failure message claimed the input "is now recorded" unconditionally, which is false for that case; the message now says what actually happens.

Build, vet, full suite and lint all clean.