### PR TITLE
fix(findings): make SortDeterministic a total order

### DIFF
--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -462,9 +462,28 @@ func (fs *FindingSet) SuppressDuplicateVulnClass(suppressRulePrefix string) {
 	fs.items = kept
 }
 
-// SortDeterministic orders findings by RuleID, then FilePath, then StartLine.
-// This guarantees stable, reproducible output regardless of the order in which
-// analyzers emit their results.
+// SortDeterministic orders findings by RuleID, then FilePath, then StartLine,
+// then Fingerprint. This guarantees stable, reproducible output regardless of
+// the order in which analyzers emit their results.
+//
+// Fingerprint is the tiebreak and is not optional. RuleID/FilePath/StartLine is
+// not a total order: every dependency vulnerability in one lockfile shares a
+// rule, a path, and line 1, so a lockfile with 114 VULN-001 findings had 114
+// findings tied on all three. Their relative order then came from whatever
+// order the analyzer happened to emit them in — which, for dependency
+// scanning, is Go map iteration, deliberately randomised. Two scans of
+// identical inputs produced identically-sized but differently-ordered
+// findings.json.
+//
+// That breaks nox's first stated constraint, that same inputs produce same
+// outputs, and it breaks every consumer that compares two scans rather than
+// reading one: nox diff, baseline drift, and any before/after comparison see
+// pure reordering as change.
+//
+// Fingerprint is content-derived and assigned in Add, so it is populated for
+// every finding by the time any sort runs, and it is unique per finding — which
+// is what makes the ordering total rather than merely longer. preferFlowFinding
+// already breaks its ties this way, for the same reason.
 func (fs *FindingSet) SortDeterministic() {
 	sort.Slice(fs.items, func(i, j int) bool {
 		a, b := fs.items[i], fs.items[j]
@@ -474,7 +493,10 @@ func (fs *FindingSet) SortDeterministic() {
 		if a.Location.FilePath != b.Location.FilePath {
 			return a.Location.FilePath < b.Location.FilePath
 		}
-		return a.Location.StartLine < b.Location.StartLine
+		if a.Location.StartLine != b.Location.StartLine {
+			return a.Location.StartLine < b.Location.StartLine
+		}
+		return a.Fingerprint < b.Fingerprint
 	})
 }
 

--- a/core/findings/sort_total_order_test.go
+++ b/core/findings/sort_total_order_test.go
@@ -1,0 +1,75 @@
+package findings
+
+import (
+	"testing"
+)
+
+// SortDeterministic must impose a total order, not merely a longer one.
+//
+// Dependency findings are the case that exposed this: every VULN-001 in one
+// lockfile carries the same rule, the same path, and line 1. Sorting by
+// rule/path/line alone leaves them all tied, so their order in findings.json
+// came from the order the analyzer emitted them — Go map iteration, which is
+// randomised. Same inputs, different output.
+func TestSortDeterministic_TotalOrderOnTiedLocation(t *testing.T) {
+	build := func(ids []string) *FindingSet {
+		fs := NewFindingSet()
+		for _, id := range ids {
+			fs.Add(Finding{
+				RuleID:   "VULN-001",
+				Severity: SeverityMedium,
+				Location: Location{FilePath: "package-lock.json", StartLine: 1},
+				Message:  "Known vulnerability " + id,
+			})
+		}
+		fs.SortDeterministic()
+		return fs
+	}
+
+	forward := []string{"GHSA-aaa", "GHSA-bbb", "GHSA-ccc", "GHSA-ddd", "GHSA-eee"}
+	reverse := []string{"GHSA-eee", "GHSA-ddd", "GHSA-ccc", "GHSA-bbb", "GHSA-aaa"}
+	shuffled := []string{"GHSA-ccc", "GHSA-aaa", "GHSA-eee", "GHSA-bbb", "GHSA-ddd"}
+
+	want := build(forward).Findings()
+	for name, order := range map[string][]string{"reverse": reverse, "shuffled": shuffled} {
+		got := build(order).Findings()
+		if len(got) != len(want) {
+			t.Fatalf("%s: got %d findings, want %d", name, len(got), len(want))
+		}
+		for i := range got {
+			if got[i].Fingerprint != want[i].Fingerprint {
+				t.Errorf("%s: position %d = %s, want %s — emission order changed the output",
+					name, i, got[i].Fingerprint, want[i].Fingerprint)
+			}
+		}
+	}
+}
+
+// The primary keys still win over the tiebreak: a finding earlier by rule,
+// path, or line sorts first however its fingerprint compares.
+func TestSortDeterministic_PrimaryKeysOutrankFingerprint(t *testing.T) {
+	fs := NewFindingSet()
+	fs.Add(Finding{RuleID: "SEC-002", Location: Location{FilePath: "b.go", StartLine: 9}, Message: "z"})
+	fs.Add(Finding{RuleID: "SEC-001", Location: Location{FilePath: "z.go", StartLine: 99}, Message: "a"})
+	fs.Add(Finding{RuleID: "SEC-002", Location: Location{FilePath: "a.go", StartLine: 1}, Message: "y"})
+	fs.Add(Finding{RuleID: "SEC-002", Location: Location{FilePath: "b.go", StartLine: 2}, Message: "x"})
+	fs.SortDeterministic()
+
+	type key struct {
+		rule, path string
+		line       int
+	}
+	want := []key{
+		{"SEC-001", "z.go", 99},
+		{"SEC-002", "a.go", 1},
+		{"SEC-002", "b.go", 2},
+		{"SEC-002", "b.go", 9},
+	}
+	got := fs.Findings()
+	for i, w := range want {
+		g := key{got[i].RuleID, got[i].Location.FilePath, got[i].Location.StartLine}
+		if g != w {
+			t.Errorf("position %d = %+v, want %+v", i, g, w)
+		}
+	}
+}


### PR DESCRIPTION
`SortDeterministic` sorted by `RuleID`, then `FilePath`, then `StartLine`, and stopped. That is not a total order, and dependency scanning is where it shows: every `VULN-001` finding for one lockfile shares a rule, a path, and line 1.

A corpus with 114 such findings had 114 findings tied on all three sort keys, so their relative order came from whatever order the analyzer emitted them in — for deps, iteration over a map keyed by package index, which Go deliberately randomises.

## Reproduction

Three scans of an unchanged corpus, same binary, `generated_at` stripped:

```
f4cf123c80a51c9f
505c94f3113ca0f3
dec31241cd7a43a2
```

Same 114 findings each time. Three different `findings.json` files.

## Why it matters

This breaks the first constraint nox states about itself — *deterministic: same inputs produce same outputs, no hidden state* — and it breaks every consumer that compares two scans rather than reading one. `nox diff`, baseline drift, and any before/after comparison see pure reordering as change.

## Fix

Break the tie on `Fingerprint`: content-derived, assigned in `Add` so it is populated before any sort runs, and unique per finding — which makes the ordering total rather than merely longer. `preferFlowFinding` already breaks its ties this way, for the same stated reason.

After the fix the same three runs agree byte for byte (`861b1a9d7722d353`), and the **finding set is unchanged**: identical 114 fingerprints before and after. This reorders output without altering what is reported.

## Test

Asserts the property, not a fixture: the same findings emitted in forward, reverse, and shuffled order must produce identical output. Verified to fail against the previous implementation.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW