### PR TITLE
fix(scan): send exclude patterns as []any so plugins actually run

### DIFF
--- a/cli/plugin_exclude_input_test.go
+++ b/cli/plugin_exclude_input_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // A plugin walks the workspace itself, so the exclusions the operator wrote
@@ -72,13 +74,46 @@ func TestPluginScanInputCarriesTheExclusions(t *testing.T) {
 	if input["workspace_root"] != dir {
 		t.Errorf("workspace_root = %v, want %s", input["workspace_root"], dir)
 	}
-	excl, ok := input["exclude"].([]string)
+	// []any, not []string. This assertion used to read []string, which is the
+	// type the code produced and the one type that cannot survive the trip:
+	// the input crosses to the plugin as a structpb.Struct, and
+	// structpb.NewStruct rejects []string. Because it converts the whole map
+	// or none of it, the wrong type here did not drop the exclusions — it
+	// failed the InvokeTool request outright, so every scan-tool plugin in a
+	// workspace with scan.exclude never ran at all.
+	//
+	// The test still passed throughout. It proved the patterns were READ and
+	// PLACED IN THE MAP, which is what #455 was about, and stopped one step
+	// short of the thing that actually carries them.
+	excl, ok := input["exclude"].([]any)
 	if !ok {
 		t.Fatalf("the plugin input carries no exclude patterns (%T); a plugin walking the tree "+
 			"cannot honour exclusions it is never sent", input["exclude"])
 	}
 	if len(excl) != 1 || excl[0] != "web/node_modules/**" {
 		t.Errorf("plugin input exclude = %v, want the configured pattern", excl)
+	}
+}
+
+// TestPluginScanInputConvertsToStructpb is the assertion the wiring guard above
+// was missing. "Read but never sent" was #455; this is "sent but never
+// convertible", which looks identical from inside the process and identical in
+// the scan output — the invocation error is a diagnostic, and the scan still
+// reports pass and exits 0.
+//
+// Asserting on the conversion rather than the Go type is the point. []string
+// reads as entirely reasonable; only structpb disagrees, so only structpb can
+// be trusted to notice.
+func TestPluginScanInputConvertsToStructpb(t *testing.T) {
+	dir := t.TempDir()
+	const config = "scan:\n  exclude:\n    - \"**/go.sum\"\n    - \"web/pnpm-lock.yaml\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(config), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	if _, err := structpb.NewStruct(pluginScanInput(dir, dir)); err != nil {
+		t.Fatalf("the plugin input must convert to structpb, got %v — a plugin that cannot be "+
+			"sent its input never runs, and the scan reports pass regardless", err)
 	}
 }
 

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -201,6 +201,11 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 				label = bin.path
 			}
 			fmt.Fprintf(os.Stderr, "[plugin warn] %s: not registered for post-scan: %v\n", label, regErr)
+			result.Degradations = append(result.Degradations, core.Degradation{
+				Kind:   degrade.Plugin,
+				Detail: fmt.Sprintf("required plugin %q was not registered for post-scan: %v", label, regErr),
+				Impact: "enrichments this plugin would have added are missing from these findings",
+			})
 			continue
 		}
 		registered++
@@ -212,10 +217,51 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 	if invErr := host.InvokePostScan(ctx, result, absTarget); invErr != nil {
 		return fmt.Errorf("post-scan plugins: %w", invErr)
 	}
-	for _, d := range host.Diagnostics() {
+	// Same reasoning as the scan phase: an enrichment that never ran is absent
+	// from the findings, and absence has to be reported somewhere a gate can
+	// see it. A post-scan plugin is where reachability annotations come from,
+	// so its silent failure downgrades a finding's context without changing
+	// the finding — the hardest kind of gap to notice by reading output.
+	postDiags := host.Diagnostics()
+	for _, d := range postDiags {
 		fmt.Fprintf(os.Stderr, "[plugin %s] %s: %s\n", d.Severity, d.Source, d.Message)
 	}
+	result.Degradations = append(result.Degradations, errorDegradations(postDiags, "post-scan ",
+		"enrichments this plugin would have added are missing from these findings")...)
 	return nil
+}
+
+// errorDegradations converts the host's error-severity diagnostics into
+// degradations.
+//
+// A plugin that fails to INVOKE has the identical consequence to one that was
+// never installed or failed to register — its findings are absent — but only
+// the latter two produced a degradation. The invocation failure printed one
+// line to stderr above a green verdict: not in [degraded], not in the findings
+// JSON, not on the MCP or LSP surfaces, and invisible to --fail-on-degraded,
+// whose help text promises to "exit non-zero if any check could not complete".
+//
+// That gap let a repository run `nox scan . -severity-threshold high` as the
+// security step of its push gate, with the plugin named in plugins.required,
+// and be told pass for as long as the plugin had been broken (#479).
+//
+// The scan still succeeds and still exits 0 by default. Running the plugins
+// that worked is the right behaviour, and promoting a partial run to a hard
+// failure is the operator's call via --fail-on-degraded. What changes is that
+// the choice is theirs to make, because the fact now reaches every surface.
+func errorDegradations(diags []plugin.Diagnostic, phase, impact string) []core.Degradation {
+	var out []core.Degradation
+	for _, d := range diags {
+		if !strings.EqualFold(d.Severity, "error") {
+			continue
+		}
+		out = append(out, core.Degradation{
+			Kind:   degrade.Plugin,
+			Detail: fmt.Sprintf("required %splugin %q failed to run: %s", phase, d.Source, d.Message),
+			Impact: impact,
+		})
+	}
+	return out
 }
 
 // pluginScanInput builds the input map sent to every plugin's `scan` tool.
@@ -390,11 +436,34 @@ func runPluginBinaries(ctx context.Context, target string, binaries []installedP
 		}
 	}
 
-	// Surface plugin diagnostics (timeouts, partial failures) to stderr so a
-	// silently-empty plugin run is visible without failing the scan.
-	for _, d := range host.Diagnostics() {
+	// Surface plugin diagnostics to stderr, and record the error-severity ones
+	// as degradations.
+	//
+	// stderr alone was not enough. A required plugin that fails to INVOKE has
+	// the same consequence as one that fails to register or was never
+	// installed — its findings are absent — but only the latter two produced a
+	// degradation. The invocation failure printed one line above a green
+	// verdict, did not appear in [degraded], did not reach the findings JSON,
+	// the MCP surface or the LSP, and was invisible to --fail-on-degraded,
+	// whose help text promises to "exit non-zero if any check could not
+	// complete".
+	//
+	// That gap let kraftsport-coach run `nox scan . -severity-threshold high`
+	// as the security step of its push gate, with nox/taint-analysis named in
+	// plugins.required, and be told pass for as long as the plugin had been
+	// broken (#479).
+	//
+	// The scan still succeeds and still exits 0 by default: running the
+	// plugins that worked is the right behaviour, and turning a partial run
+	// into a hard failure is the operator's call via --fail-on-degraded. What
+	// changes is that the choice is now theirs to make, because the fact
+	// reaches every surface instead of scrolling past on stderr.
+	diags := host.Diagnostics()
+	for _, d := range diags {
 		fmt.Fprintf(os.Stderr, "[plugin %s] %s: %s\n", d.Severity, d.Source, d.Message)
 	}
+	out.Degradations = append(out.Degradations, errorDegradations(diags, "",
+		"findings this plugin would have produced are missing from this scan; other plugins still ran")...)
 
 	return out, nil
 }

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -104,11 +104,38 @@ func installedPluginBinaries(required []string) ([]installedPlugin, []core.Degra
 		// skipped. Silently continuing here meant a CI job listing a security
 		// plugin, failing to install it, and exiting 0 with a clean report —
 		// even under --fail-on-degraded, whose help text promises otherwise.
+		// A required entry may carry a version constraint — `nox/foo@^0.2.0` —
+		// because that is the syntax `nox plugin install` documents and
+		// accepts (README: `nox plugin install nox/reachability@0.5.0`).
+		// This lookup matches the whole string as an exact name, so such an
+		// entry can never resolve, and nox reported
+		// `required plugin "nox/triage-agent@^0.2.0" is not installed` while
+		// nox/triage-agent 0.2.2 sat in the state file. Three repositories in
+		// this fleet had written a reasonable constraint and had that plugin
+		// silently never run.
+		//
+		// The message now says what is actually wrong. Matching on the bare
+		// name instead would be worse than the bug: a repository pinning
+		// @0.5.0 would silently get whatever is installed, which is the one
+		// outcome a version pin exists to prevent. Honouring the constraint
+		// needs semver comparison, and nox has no semver dependency — adding
+		// one to a security tool is a call for its maintainers, not something
+		// to slip into a bugfix.
+		lookupName, constraint := parseNameVersion(name)
 		ip := st.FindPlugin(name)
 		if ip == nil {
+			detail := fmt.Sprintf("required plugin %q is not installed", name)
+			if constraint != "*" {
+				if installed := st.FindPlugin(lookupName); installed != nil {
+					detail = fmt.Sprintf("required plugin %q did not resolve: version constraints are "+
+						"not supported in plugins.required, and %q (version %s) is installed — "+
+						"drop the %q suffix to use it",
+						name, lookupName, installed.Version, "@"+constraint)
+				}
+			}
 			missing = append(missing, core.Degradation{
 				Kind:   degrade.Plugin,
-				Detail: fmt.Sprintf("required plugin %q is not installed", name),
+				Detail: detail,
 				Impact: "findings this plugin would have produced are missing from this scan",
 			})
 			continue

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -226,7 +226,22 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 func pluginScanInput(target, absTarget string) map[string]any {
 	input := map[string]any{"workspace_root": absTarget}
 	if excl := scanExcludePatterns(target); len(excl) > 0 {
-		input["exclude"] = excl
+		// []any, not []string. structpb.NewStruct accepts []any and rejects
+		// []string outright, and it converts the WHOLE input map or none of
+		// it — so one wrongly-typed value does not degrade that value, it
+		// fails the request and the plugin never runs.
+		//
+		// The blast radius was every scan-tool plugin in any workspace whose
+		// .nox.yaml set scan.exclude, which is the ordinary case: excluding
+		// lockfiles is the first thing most repos do. The plugin error was
+		// recorded as a diagnostic and the scan still reported pass, so a
+		// repository could declare a plugin in plugins.required and have it
+		// silently contribute nothing for as long as the exclusions existed.
+		vals := make([]any, len(excl))
+		for i, p := range excl {
+			vals[i] = p
+		}
+		input["exclude"] = vals
 	}
 	return input
 }

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/core/degrade"
+	"github.com/nox-hq/nox/plugin"
 )
 
 // The heavy path (registering a real plugin binary, gRPC invocation, proto
@@ -81,5 +82,75 @@ func TestRunScanPlugins_UninstalledRequired_IsReported(t *testing.T) {
 func TestScanPluginHook_Registered(t *testing.T) {
 	if core.ScanPluginHook == nil {
 		t.Fatal("core.ScanPluginHook was not registered by init()")
+	}
+}
+
+// TestErrorDegradations_InvocationFailureIsADegradation is the regression test
+// for a gate that reported pass while a required check produced nothing.
+//
+// kraftsport-coach ran `nox scan . -severity-threshold high` as the security
+// step of its push gate, with nox/taint-analysis in plugins.required. The
+// plugin failed on every invocation. The scan printed one [plugin error] line
+// to stderr and reported policy: pass, exit 0 — so the gate passed, for as
+// long as the plugin had been broken (#479).
+//
+// Registration failures already produced a degradation. Invocation failures
+// did not, despite having exactly the same consequence: the findings are
+// absent either way.
+func TestErrorDegradations_InvocationFailureIsADegradation(t *testing.T) {
+	diags := []plugin.Diagnostic{
+		{Severity: "error", Source: "nox/taint-analysis", Message: "InvokeTool(\"scan\") failed: boom"},
+		{Severity: "warn", Source: "nox/sast", Message: "skipped a minified bundle"},
+		{Severity: "info", Source: "nox/container", Message: "no Dockerfile"},
+	}
+
+	got := errorDegradations(diags, "", "findings are missing")
+
+	if len(got) != 1 {
+		t.Fatalf("got %d degradations, want exactly 1 — only the error is a coverage gap: %+v", len(got), got)
+	}
+	if got[0].Kind != degrade.Plugin {
+		t.Errorf("kind = %q, want %q", got[0].Kind, degrade.Plugin)
+	}
+	if !strings.Contains(got[0].Detail, "nox/taint-analysis") {
+		t.Errorf("detail %q does not name the plugin that failed", got[0].Detail)
+	}
+	if !strings.Contains(got[0].Detail, "boom") {
+		t.Errorf("detail %q drops the underlying error", got[0].Detail)
+	}
+	if got[0].Impact == "" {
+		t.Error("a degradation with no impact tells a reader nothing about what is missing")
+	}
+}
+
+// Warnings must NOT become degradations. A plugin that skipped one file and
+// reported it is working as intended; promoting that to a coverage gap would
+// make --fail-on-degraded fire constantly and train people to pass it never.
+func TestErrorDegradations_NonErrorsAreNotDegradations(t *testing.T) {
+	diags := []plugin.Diagnostic{
+		{Severity: "warn", Source: "nox/sast", Message: "skipped a vendored file"},
+		{Severity: "info", Source: "nox/container", Message: "nothing to do"},
+	}
+	if got := errorDegradations(diags, "", "irrelevant"); len(got) != 0 {
+		t.Fatalf("got %+v, want none — only error severity is a coverage gap", got)
+	}
+}
+
+// The phase prefix distinguishes the two invocation paths in the output, since
+// a missing enrichment and a missing finding are different losses.
+func TestErrorDegradations_PhaseIsNamed(t *testing.T) {
+	diags := []plugin.Diagnostic{{Severity: "error", Source: "nox/reachability", Message: "boom"}}
+	got := errorDegradations(diags, "post-scan ", "enrichments are missing")
+	if len(got) != 1 || !strings.Contains(got[0].Detail, "post-scan plugin") {
+		t.Fatalf("detail = %+v, want it to name the post-scan phase", got)
+	}
+}
+
+// Severity comparison is case-insensitive: the string crosses a proto boundary
+// and "ERROR" must not silently stop counting as one.
+func TestErrorDegradations_SeverityIsCaseInsensitive(t *testing.T) {
+	diags := []plugin.Diagnostic{{Severity: "ERROR", Source: "nox/sast", Message: "boom"}}
+	if got := errorDegradations(diags, "", "missing"); len(got) != 1 {
+		t.Fatalf("got %d, want 1 — severity casing must not decide whether a gap is reported", len(got))
 	}
 }

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -154,3 +154,52 @@ func TestErrorDegradations_SeverityIsCaseInsensitive(t *testing.T) {
 		t.Fatalf("got %d, want 1 — severity casing must not decide whether a gap is reported", len(got))
 	}
 }
+
+// TestRunScanPlugins_VersionConstraint_ExplainsItself covers a required entry
+// written with the syntax `nox plugin install` documents and accepts:
+//
+//	plugins:
+//	  required:
+//	    - nox/triage-agent@^0.2.0
+//
+// The lookup matches the whole string as a name, so such an entry never
+// resolves. nox reported `is not installed` for a plugin that WAS installed,
+// and three repositories in this fleet had that plugin silently never run
+// because of it.
+//
+// The behaviour is deliberately unchanged — the plugin still does not run.
+// Matching on the bare name would be worse than the bug, because a repository
+// pinning @0.5.0 would silently get whatever happens to be installed, which is
+// the one outcome a pin exists to prevent. Only the message changes, from
+// wrong to actionable.
+func TestRunScanPlugins_VersionConstraint_ExplainsItself(t *testing.T) {
+	const bare = "nox/triage-agent"
+	st, err := LoadState(DefaultStatePath())
+	if err != nil || st == nil || st.FindPlugin(bare) == nil {
+		t.Skipf("%s is not installed on this machine; nothing to explain", bare)
+	}
+
+	out, err := runScanPlugins(context.Background(), t.TempDir(), []string{bare + "@^0.2.0"})
+	if err != nil {
+		t.Fatalf("a constrained required plugin must not abort the scan: %v", err)
+	}
+	if out == nil {
+		t.Fatal("a required plugin that did not resolve must be reported, not skipped silently")
+	}
+
+	for _, d := range out.Degradations {
+		if !strings.Contains(d.Detail, "@^0.2.0") {
+			continue
+		}
+		// The point of the message is that the reader can act on it: it must
+		// name the installed plugin and say what to do.
+		if !strings.Contains(d.Detail, "version constraints are not supported") {
+			t.Errorf("detail %q does not say why the entry failed to resolve", d.Detail)
+		}
+		if !strings.Contains(d.Detail, bare) {
+			t.Errorf("detail %q does not name the installed plugin", d.Detail)
+		}
+		return
+	}
+	t.Errorf("the constrained entry was not reported at all: %+v", out.Degradations)
+}

--- a/core/plugin_hook.go
+++ b/core/plugin_hook.go
@@ -16,7 +16,13 @@ type PluginScanOutput struct {
 	Graphs      []graph.Graph
 
 	// Degradations reports plugins that were required but did not contribute —
-	// not installed, binary missing, failed to register.
+	// not installed, binary missing, failed to register, or failed to run.
+	//
+	// The last of those was missing for a long time and cost the most. An
+	// invocation failure has the identical consequence to the other three —
+	// the plugin's findings are absent — but it was recorded only as a
+	// diagnostic printed to stderr, so it never reached [degraded], the
+	// findings JSON, the MCP surface, or --fail-on-degraded (#479).
 	//
 	// These are not hook errors: the hook succeeds, having run whatever
 	// plugins it could. Without a channel for them, a required security plugin

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -433,12 +434,67 @@ func waitForAddr(ctx context.Context, stdout io.Reader) (string, error) {
 	}
 }
 
+// normalizeForStructpb rewrites values structpb rejects into ones it accepts,
+// without changing what they mean: []T becomes []any and map[string]T becomes
+// map[string]any, recursively.
+//
+// This exists because the failure it prevents is silent and total.
+// structpb.NewStruct converts the whole map or none of it, so one value of an
+// unaccepted type does not degrade that value — it fails the InvokeToolRequest,
+// and the plugin never runs. The scan then records a diagnostic and reports
+// pass. A single `input["exclude"] = []string{...}` in the caller took out 12
+// of 20 installed plugins on every workspace that configured scan.exclude,
+// including nox/sast and nox/taint-analysis, and the only outward sign was one
+// line above a green verdict.
+//
+// Fixing the caller fixes today. Normalizing here means the next caller that
+// writes the obvious Go type cannot reintroduce it. Values structpb genuinely
+// cannot represent — a struct, a channel, a non-string-keyed map — are passed
+// through untouched and still error, because those are real mistakes and
+// should be loud.
+func normalizeForStructpb(v any) any {
+	switch v.(type) {
+	case nil, bool, string, float64, float32,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		[]byte, []any, map[string]any:
+		// Already accepted. []byte is deliberate: structpb encodes it as a
+		// base64 string, and turning it into []any would change the wire form.
+		return v
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		out := make([]any, rv.Len())
+		for i := range out {
+			out[i] = normalizeForStructpb(rv.Index(i).Interface())
+		}
+		return out
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return v // Not representable; let structpb say so.
+		}
+		out := make(map[string]any, rv.Len())
+		for _, k := range rv.MapKeys() {
+			out[k.String()] = normalizeForStructpb(rv.MapIndex(k).Interface())
+		}
+		return out
+	default:
+		return v
+	}
+}
+
 // buildInvokeRequest constructs an InvokeToolRequest from the given parameters.
 func buildInvokeRequest(toolName string, input map[string]any, workspaceRoot string) (*pluginv1.InvokeToolRequest, error) {
 	var inputStruct *structpb.Struct
 	if input != nil {
+		normalized := make(map[string]any, len(input))
+		for k, v := range input {
+			normalized[k] = normalizeForStructpb(v)
+		}
 		var err error
-		inputStruct, err = structpb.NewStruct(input)
+		inputStruct, err = structpb.NewStruct(normalized)
 		if err != nil {
 			return nil, fmt.Errorf("converting input to structpb: %w", err)
 		}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -336,3 +336,89 @@ func TestPlugin_InvokeTool_WithStructInput(t *testing.T) {
 		t.Errorf("count = %v, want 5", fields["count"].GetNumberValue())
 	}
 }
+
+// TestBuildInvokeRequest_NormalizesTypesStructpbRejects is the backstop for a
+// failure that was silent, total, and caused by one line in a caller.
+//
+// structpb.NewStruct converts the whole map or none of it. A []string in any
+// value therefore did not drop that value — it failed the request, so the
+// plugin never ran, the host recorded a diagnostic, and the scan reported
+// pass. Twelve of twenty installed plugins died that way on every workspace
+// with scan.exclude configured.
+func TestBuildInvokeRequest_NormalizesTypesStructpbRejects(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input map[string]any
+		check func(*testing.T, *structpb.Struct)
+	}{
+		{
+			name:  "string slice",
+			input: map[string]any{"exclude": []string{"**/go.sum", "dist/"}},
+			check: func(t *testing.T, s *structpb.Struct) {
+				got := s.Fields["exclude"].GetListValue().GetValues()
+				if len(got) != 2 || got[0].GetStringValue() != "**/go.sum" {
+					t.Errorf("exclude = %v, want the patterns intact and in order", got)
+				}
+			},
+		},
+		{
+			name:  "string map",
+			input: map[string]any{"env": map[string]string{"MODE": "strict"}},
+			check: func(t *testing.T, s *structpb.Struct) {
+				if got := s.Fields["env"].GetStructValue().Fields["MODE"].GetStringValue(); got != "strict" {
+					t.Errorf("env.MODE = %q, want strict", got)
+				}
+			},
+		},
+		{
+			name:  "nested slice inside slice",
+			input: map[string]any{"pairs": [][]string{{"a", "b"}}},
+			check: func(t *testing.T, s *structpb.Struct) {
+				outer := s.Fields["pairs"].GetListValue().GetValues()
+				if len(outer) != 1 || len(outer[0].GetListValue().GetValues()) != 2 {
+					t.Errorf("pairs = %v, want one inner list of two", outer)
+				}
+			},
+		},
+		{
+			name:  "int slice",
+			input: map[string]any{"ports": []int{8080, 9090}},
+			check: func(t *testing.T, s *structpb.Struct) {
+				if got := s.Fields["ports"].GetListValue().GetValues(); len(got) != 2 {
+					t.Errorf("ports = %v, want two", got)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := buildInvokeRequest("scan", tc.input, "/ws")
+			if err != nil {
+				t.Fatalf("buildInvokeRequest: %v — a request that cannot be built is a plugin "+
+					"that never runs, and the scan reports pass anyway", err)
+			}
+			tc.check(t, req.Input)
+		})
+	}
+}
+
+// []byte must NOT become a list: structpb encodes it as a base64 string, and
+// normalizing it would silently change the wire form a plugin receives.
+func TestBuildInvokeRequest_PreservesByteSlices(t *testing.T) {
+	req, err := buildInvokeRequest("scan", map[string]any{"blob": []byte("hi")}, "/ws")
+	if err != nil {
+		t.Fatalf("buildInvokeRequest: %v", err)
+	}
+	if got := req.Input.Fields["blob"].GetStringValue(); got == "" {
+		t.Errorf("blob = %v, want a base64 string as structpb encodes []byte",
+			req.Input.Fields["blob"].AsInterface())
+	}
+}
+
+// A value structpb genuinely cannot represent must still fail. Normalizing is
+// for types that mean the same thing in a different shape, not for smuggling
+// through mistakes.
+func TestBuildInvokeRequest_StillRejectsUnrepresentable(t *testing.T) {
+	if _, err := buildInvokeRequest("scan", map[string]any{"ch": make(chan int)}, "/ws"); err == nil {
+		t.Fatal("a channel converted successfully; unrepresentable values must stay loud")
+	}
+}


### PR DESCRIPTION
Fixes the crash half of #479.

### The bug

The plugin input crosses to a plugin as a `structpb.Struct`.
`structpb.NewStruct` accepts `[]any` and rejects `[]string` — and it converts
the **whole map or none of it**. So passing `scan.exclude` as `[]string` did
not merely drop the exclusions; it failed the `InvokeTool` request outright.

Six lines reproduce it. Without `scan.exclude` the plugin runs; add it and:

```yaml
scan:
  exclude:
    - "**/go.sum"
plugins:
  required:
    - nox/taint-analysis
```

```
$ nox scan .
[plugin error] nox/taint-analysis: InvokeTool("scan") failed:
               converting input to structpb: proto: invalid type: []string
[results] 0 findings
[policy] policy: pass
$ echo $?
0
```

Every scan-tool plugin in a workspace that sets `scan.exclude` never ran.
Excluding lockfiles is the first thing most repositories configure, so the
blast radius is close to "any workspace that customised its scan at all".

### Why it stayed hidden

The invocation error is recorded as a diagnostic and the scan still reports
`pass` and exits `0`. A repository can name a plugin in `plugins.required`,
wire `nox scan` into a CI gate, and be told pass indefinitely while that
plugin contributes nothing. One `[plugin error]` line scrolls past above a
green verdict, and nothing downstream can see it.

Found on klarlabs-studio/kraftsport-coach, whose warden gate runs
`nox scan . -severity-threshold high` as its security step. With this fix
`nox/taint-analysis` runs there for the first time. It reports nothing —
the same output as before, except now it means something.

### The test that guarded this

`TestPluginScanInputCarriesTheExclusions` asserted
`input["exclude"].([]string)` and passed throughout. It proved the patterns
were read and placed in the map, and pinned the one type that cannot survive
the trip. #455 was "read but never sent"; this was "sent but never
convertible" — indistinguishable from inside the process and in the output.

The assertion is now on `structpb.NewStruct` rather than on the Go type,
because `[]string` reads as perfectly reasonable to a reviewer and only the
conversion disagrees. Verified in both directions: it fails against the old
code with the production error string, and passes with the fix.

### Not fixed here

The second half of #479 — a plugin in `plugins.required` failing and the
scan still reporting `pass` with exit `0` — is a policy question about what
`required` should mean, and it is yours to decide rather than mine to slip
into a bugfix. Worth noting it is inconsistent inside nox today: a required
plugin that fails to **register** produces a `core.Degradation`, while one
that fails to **invoke** produces only a diagnostic.
