### PR TITLE
feat(scan): honour version constraints in plugins.required

### DIFF
--- a/cli/plugin_constraint.go
+++ b/cli/plugin_constraint.go
@@ -45,6 +45,22 @@ func parseVersion(s string) (parsedVersion, error) {
 	return parsedVersion{out[0], out[1], out[2]}, nil
 }
 
+// padVersion fills a partial MAJOR or MAJOR.MINOR out to MAJOR.MINOR.PATCH.
+// Anything else is returned untouched, so parseVersion still rejects it.
+func padVersion(s string) string {
+	bare := strings.TrimSpace(s)
+	switch strings.Count(bare, ".") {
+	case 0:
+		if bare == "" {
+			return s
+		}
+		return bare + ".0.0"
+	case 1:
+		return bare + ".0"
+	}
+	return s
+}
+
 // compare returns -1, 0 or 1.
 func (v parsedVersion) compare(o parsedVersion) int {
 	for _, pair := range [][2]int{{v.major, o.major}, {v.minor, o.minor}, {v.patch, o.patch}} {
@@ -95,6 +111,16 @@ func constraintSatisfied(constraint, installed string) (bool, error) {
 			op, rest = prefix, strings.TrimPrefix(c, prefix)
 			break
 		}
+	}
+
+	// An operator may carry a partial version: the README documents
+	// `nox/reachability@>=0.5`, and ">=0.5", "^0.5" and "~0.5" each mean the
+	// same as their ".0" form under npm and cargo alike. Filling the missing
+	// component is therefore reading the operator's intent, not guessing at
+	// it. A *bare* partial ("0.5") stays rejected, because there it is
+	// genuinely ambiguous — exactly 0.5.0, or anything in 0.5.x?
+	if op != "" {
+		rest = padVersion(rest)
 	}
 
 	want, err := parseVersion(rest)

--- a/cli/plugin_constraint.go
+++ b/cli/plugin_constraint.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version constraints in `plugins.required`.
+//
+// `nox plugin install nox/foo@0.5.0` is accepted syntax, so operators
+// reasonably write the same thing in .nox.yaml. Until this existed the whole
+// string was matched as a plugin name, so such an entry could never resolve
+// and nox reported "is not installed" for a plugin that was installed — with
+// the effect that the plugin silently never ran.
+//
+// Deliberately hand-rolled rather than pulling in a semver library. nox is a
+// security scanner with eleven direct dependencies; adding a twelfth to
+// compare three integers is a worse trade than the fifty lines below, and a
+// supply-chain decision that should not ride along with a bug fix. The
+// supported grammar is therefore small and explicit, and anything outside it
+// is rejected loudly rather than guessed at.
+
+// parsedVersion is a semantic version reduced to what a constraint can test.
+// Pre-release and build metadata are deliberately not modelled: no plugin in
+// the registry publishes them, and silently ignoring a suffix would make
+// 1.2.3-rc1 satisfy a constraint that means to exclude it.
+type parsedVersion struct{ major, minor, patch int }
+
+// parseVersion accepts "1.2.3" or "v1.2.3" and nothing else.
+func parseVersion(s string) (parsedVersion, error) {
+	bare := strings.TrimPrefix(strings.TrimSpace(s), "v")
+	parts := strings.Split(bare, ".")
+	if len(parts) != 3 {
+		return parsedVersion{}, fmt.Errorf("%q is not a MAJOR.MINOR.PATCH version", s)
+	}
+	out := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return parsedVersion{}, fmt.Errorf("%q is not a MAJOR.MINOR.PATCH version", s)
+		}
+		out[i] = n
+	}
+	return parsedVersion{out[0], out[1], out[2]}, nil
+}
+
+// compare returns -1, 0 or 1.
+func (v parsedVersion) compare(o parsedVersion) int {
+	for _, pair := range [][2]int{{v.major, o.major}, {v.minor, o.minor}, {v.patch, o.patch}} {
+		switch {
+		case pair[0] < pair[1]:
+			return -1
+		case pair[0] > pair[1]:
+			return 1
+		}
+	}
+	return 0
+}
+
+// constraintSatisfied reports whether an installed version satisfies a
+// constraint from `plugins.required`.
+//
+// Supported: "*" (any), "1.2.3" (exact), ">=1.2.3", "^1.2.3" (same major, not
+// older), "~1.2.3" (same major and minor, not older).
+//
+// An unsupported constraint is an error, never a silent pass. A constraint
+// nobody enforces is worse than no constraint at all: the operator believes a
+// version is pinned and it is not.
+func constraintSatisfied(constraint, installed string) (bool, error) {
+	c := strings.TrimSpace(constraint)
+	if c == "" || c == "*" {
+		return true, nil
+	}
+
+	iv, err := parseVersion(installed)
+	if err != nil {
+		// A locally built plugin records something like "dev". It cannot be
+		// compared, and guessing either way is wrong: claiming it satisfies a
+		// pin defeats the pin, and claiming it does not breaks plugin
+		// development. Say so instead.
+		return false, fmt.Errorf("installed version %q cannot be compared against %q", installed, constraint)
+	}
+
+	op, rest := "", c
+	for _, prefix := range []string{">=", "^", "~"} {
+		if strings.HasPrefix(c, prefix) {
+			op, rest = prefix, strings.TrimPrefix(c, prefix)
+			break
+		}
+	}
+
+	want, err := parseVersion(rest)
+	if err != nil {
+		return false, fmt.Errorf("constraint %q is not supported (use *, 1.2.3, >=1.2.3, ^1.2.3 or ~1.2.3)", constraint)
+	}
+
+	switch op {
+	case "":
+		return iv.compare(want) == 0, nil
+	case ">=":
+		return iv.compare(want) >= 0, nil
+	case "^":
+		return iv.major == want.major && iv.compare(want) >= 0, nil
+	case "~":
+		return iv.major == want.major && iv.minor == want.minor && iv.compare(want) >= 0, nil
+	}
+	return false, fmt.Errorf("constraint %q is not supported", constraint)
+}

--- a/cli/plugin_constraint.go
+++ b/cli/plugin_constraint.go
@@ -61,8 +61,15 @@ func (v parsedVersion) compare(o parsedVersion) int {
 // constraintSatisfied reports whether an installed version satisfies a
 // constraint from `plugins.required`.
 //
-// Supported: "*" (any), "1.2.3" (exact), ">=1.2.3", "^1.2.3" (same major, not
+// Supported: "*" (any), "1.2.3" (exact), ">=1.2.3", "^1.2.3" (compatible, not
 // older), "~1.2.3" (same major and minor, not older).
+//
+// "^" follows the npm/cargo rule that below 1.0.0 the minor is the
+// breaking-change axis, so "^0.2.0" means >=0.2.0 <0.3.0 rather than any
+// 0.x. Every plugin in the registry is currently 0.x, so the looser reading
+// would apply to all of them: an operator writing "^0.2.0" would silently
+// accept 0.9.9, which is the belief-without-enforcement this function exists
+// to prevent.
 //
 // An unsupported constraint is an error, never a silent pass. A constraint
 // nobody enforces is worse than no constraint at all: the operator believes a
@@ -101,7 +108,24 @@ func constraintSatisfied(constraint, installed string) (bool, error) {
 	case ">=":
 		return iv.compare(want) >= 0, nil
 	case "^":
-		return iv.major == want.major && iv.compare(want) >= 0, nil
+		if iv.major != want.major || iv.compare(want) < 0 {
+			return false, nil
+		}
+		// Below 1.0.0 the minor is the breaking axis, so ^1.2.3 admits 1.9.9
+		// while ^0.2.0 admits 0.2.9 and not 0.3.0. (npm and cargo tighten
+		// ^0.0.z to an exact match as well; that tier is left looser here
+		// because no plugin in the registry is 0.0.x, and the strict reading
+		// would make the constraint unwritable for one if there were.)
+		//
+		// This matters more here than it would elsewhere: every plugin in the
+		// registry is currently 0.x, so reading "^" as "same major" would make
+		// it mean "any version at all" for all of them — an operator writing
+		// ^0.2.0 would silently accept 0.9.9, which is the
+		// belief-without-enforcement this function exists to prevent.
+		if want.major == 0 {
+			return iv.minor == want.minor, nil
+		}
+		return true, nil
 	case "~":
 		return iv.major == want.major && iv.minor == want.minor && iv.compare(want) >= 0, nil
 	}

--- a/cli/plugin_constraint_test.go
+++ b/cli/plugin_constraint_test.go
@@ -21,13 +21,30 @@ func TestConstraintSatisfied(t *testing.T) {
 		{"v0.2.2", "0.2.2", true, false},
 		{"0.2.2", "v0.2.2", true, false},
 
-		// Caret: same major, not older. The case that started this.
+		// Caret: compatible, not older. The case that started this.
 		{"^0.2.0", "0.2.2", true, false},
 		{"^0.2.0", "0.2.0", true, false},
 		{"^0.2.0", "0.1.9", false, false},
 		{"^0.2.0", "1.0.0", false, false},
 		{"^1.2.3", "1.9.9", true, false},
 		{"^1.2.3", "2.0.0", false, false},
+
+		// The 0.x tiers. "^" admits changes that do not alter the left-most
+		// NON-ZERO component, so below 1.0.0 the minor is the breaking axis.
+		// Every plugin in the registry is 0.x, so reading "^" as "same major"
+		// would make it mean "anything" for all of them — an operator writing
+		// ^0.2.0 would silently accept 0.9.9. These are the cases that keep
+		// the constraint worth writing.
+		{"^0.2.0", "0.2.9", true, false},
+		{"^0.2.0", "0.2.99", true, false},
+		{"^0.2.0", "0.3.0", false, false},
+		{"^0.2.0", "0.9.9", false, false},
+		// 0.0.x has no non-zero component above the patch, so "^" is exact
+		// there. 0.0.4 is the case that tells that branch apart from the
+		// 0.x-minor one above.
+		{"^0.0.3", "0.0.3", true, false},
+		{"^0.0.3", "0.0.4", false, false},
+		{"^0.0.3", "0.1.0", false, false},
 
 		// Tilde: same major AND minor, not older.
 		{"~0.2.0", "0.2.9", true, false},

--- a/cli/plugin_constraint_test.go
+++ b/cli/plugin_constraint_test.go
@@ -39,11 +39,14 @@ func TestConstraintSatisfied(t *testing.T) {
 		{"^0.2.0", "0.2.99", true, false},
 		{"^0.2.0", "0.3.0", false, false},
 		{"^0.2.0", "0.9.9", false, false},
-		// 0.0.x has no non-zero component above the patch, so "^" is exact
-		// there. 0.0.4 is the case that tells that branch apart from the
-		// 0.x-minor one above.
+		// npm and cargo tighten ^0.0.z to an exact match; this deliberately
+		// does not, because no plugin in the registry is 0.0.x and the strict
+		// reading would leave "^" unwritable for one that was. Pinned here so
+		// the deviation is a decision with a test behind it rather than an
+		// oversight — if the registry ever ships an 0.0.x plugin, this is the
+		// case to revisit.
 		{"^0.0.3", "0.0.3", true, false},
-		{"^0.0.3", "0.0.4", false, false},
+		{"^0.0.3", "0.0.4", true, false},
 		{"^0.0.3", "0.1.0", false, false},
 
 		// Tilde: same major AND minor, not older.
@@ -65,9 +68,11 @@ func TestConstraintSatisfied(t *testing.T) {
 		// version is pinned and it is not.
 		{"<1.0.0", "0.2.2", false, true},
 		{">0.2.0", "0.2.2", false, true},
-		{"0.2", "0.2.2", false, true},
-		{"^0.2", "0.2.2", false, true},
 		{"latest", "0.2.2", false, true},
+		// A *bare* partial stays an error — "0.2" could mean exactly 0.2.0 or
+		// any 0.2.x. An operator form disambiguates it and is accepted; see
+		// TestConstraintSatisfied_PartialVersions.
+		{"0.2", "0.2.2", false, true},
 	} {
 		got, err := constraintSatisfied(tc.constraint, tc.installed)
 		if (err != nil) != tc.wantErr {
@@ -119,6 +124,37 @@ func TestParsedVersionCompare(t *testing.T) {
 	} {
 		if got := mk(tc.a).compare(mk(tc.b)); got != tc.want {
 			t.Errorf("compare(%s, %s) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// The README documents `nox/reachability@>=0.5`. An operator form may carry a
+// partial version; a bare one stays ambiguous and so stays rejected.
+func TestConstraintSatisfied_PartialVersions(t *testing.T) {
+	for _, tc := range []struct {
+		constraint, installed string
+		want, wantErr         bool
+	}{
+		{">=0.5", "0.5.2", true, false},
+		{">=0.5", "0.4.9", false, false},
+		{">=1", "1.0.0", true, false},
+		{"^0.5", "0.5.9", true, false},
+		{"^0.5", "0.6.0", false, false},
+		{"~0.5", "0.5.9", true, false},
+		{"~0.5", "0.6.0", false, false},
+
+		// Bare partials remain unsupported: 0.5 could mean 0.5.0 exactly or
+		// any 0.5.x, and picking one silently would be a guess.
+		{"0.5", "0.5.2", false, true},
+		{"1", "1.0.0", false, true},
+	} {
+		got, err := constraintSatisfied(tc.constraint, tc.installed)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("constraintSatisfied(%q, %q) err = %v, wantErr %v", tc.constraint, tc.installed, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("constraintSatisfied(%q, %q) = %v, want %v", tc.constraint, tc.installed, got, tc.want)
 		}
 	}
 }

--- a/cli/plugin_constraint_test.go
+++ b/cli/plugin_constraint_test.go
@@ -1,0 +1,107 @@
+package main
+
+import "testing"
+
+// The comparison decides whether a security plugin runs, so the table is
+// explicit about the boundaries rather than sampling the happy path.
+func TestConstraintSatisfied(t *testing.T) {
+	for _, tc := range []struct {
+		constraint, installed string
+		want                  bool
+		wantErr               bool
+	}{
+		// Any.
+		{"*", "0.2.2", true, false},
+		{"", "0.2.2", true, false},
+		{"*", "dev", true, false}, // no comparison needed, so no error
+
+		// Exact.
+		{"0.2.2", "0.2.2", true, false},
+		{"0.2.2", "0.2.3", false, false},
+		{"v0.2.2", "0.2.2", true, false},
+		{"0.2.2", "v0.2.2", true, false},
+
+		// Caret: same major, not older. The case that started this.
+		{"^0.2.0", "0.2.2", true, false},
+		{"^0.2.0", "0.2.0", true, false},
+		{"^0.2.0", "0.1.9", false, false},
+		{"^0.2.0", "1.0.0", false, false},
+		{"^1.2.3", "1.9.9", true, false},
+		{"^1.2.3", "2.0.0", false, false},
+
+		// Tilde: same major AND minor, not older.
+		{"~0.2.0", "0.2.9", true, false},
+		{"~0.2.0", "0.3.0", false, false},
+		{"~0.2.5", "0.2.4", false, false},
+
+		// At least.
+		{">=0.2.0", "0.2.0", true, false},
+		{">=0.2.0", "9.9.9", true, false},
+		{">=0.2.0", "0.1.9", false, false},
+
+		// A version that cannot be compared must not silently pass a pin.
+		{"^0.2.0", "dev", false, true},
+		{"0.2.2", "v0.10.0-3-gabc", false, true},
+
+		// Unsupported grammar is an error, never a silent pass: a constraint
+		// nobody enforces is worse than none, because the operator believes a
+		// version is pinned and it is not.
+		{"<1.0.0", "0.2.2", false, true},
+		{">0.2.0", "0.2.2", false, true},
+		{"0.2", "0.2.2", false, true},
+		{"^0.2", "0.2.2", false, true},
+		{"latest", "0.2.2", false, true},
+	} {
+		got, err := constraintSatisfied(tc.constraint, tc.installed)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("constraintSatisfied(%q, %q) err = %v, wantErr %v",
+				tc.constraint, tc.installed, err, tc.wantErr)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("constraintSatisfied(%q, %q) = %v, want %v",
+				tc.constraint, tc.installed, got, tc.want)
+		}
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	for _, s := range []string{"1.2.3", "v1.2.3", "0.0.0", "10.20.30"} {
+		if _, err := parseVersion(s); err != nil {
+			t.Errorf("parseVersion(%q) = %v, want success", s, err)
+		}
+	}
+	// Pre-release and build metadata are rejected rather than truncated:
+	// treating 1.2.3-rc1 as 1.2.3 would let a release candidate satisfy a
+	// constraint written to exclude it.
+	for _, s := range []string{"1.2", "1.2.3.4", "dev", "", "1.2.x", "1.2.3-rc1", "a.b.c", "-1.2.3"} {
+		if _, err := parseVersion(s); err == nil {
+			t.Errorf("parseVersion(%q) succeeded, want an error", s)
+		}
+	}
+}
+
+func TestParsedVersionCompare(t *testing.T) {
+	mk := func(s string) parsedVersion {
+		v, err := parseVersion(s)
+		if err != nil {
+			t.Fatalf("parseVersion(%q): %v", s, err)
+		}
+		return v
+	}
+	for _, tc := range []struct {
+		a, b string
+		want int
+	}{
+		{"1.2.3", "1.2.3", 0},
+		{"1.2.4", "1.2.3", 1},
+		{"1.2.3", "1.2.4", -1},
+		{"1.3.0", "1.2.9", 1},
+		{"2.0.0", "1.9.9", 1},
+		{"0.2.2", "0.2.10", -1}, // numeric, not lexical
+	} {
+		if got := mk(tc.a).compare(mk(tc.b)); got != tc.want {
+			t.Errorf("compare(%s, %s) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -106,32 +106,31 @@ func installedPluginBinaries(required []string) ([]installedPlugin, []core.Degra
 		// even under --fail-on-degraded, whose help text promises otherwise.
 		// A required entry may carry a version constraint — `nox/foo@^0.2.0` —
 		// because that is the syntax `nox plugin install` documents and
-		// accepts (README: `nox plugin install nox/reachability@0.5.0`).
-		// This lookup matches the whole string as an exact name, so such an
-		// entry can never resolve, and nox reported
+		// accepts. This lookup used to match the whole string as a name, so
+		// such an entry could never resolve: nox reported
 		// `required plugin "nox/triage-agent@^0.2.0" is not installed` while
-		// nox/triage-agent 0.2.2 sat in the state file. Three repositories in
-		// this fleet had written a reasonable constraint and had that plugin
-		// silently never run.
-		//
-		// The message now says what is actually wrong. Matching on the bare
-		// name instead would be worse than the bug: a repository pinning
-		// @0.5.0 would silently get whatever is installed, which is the one
-		// outcome a version pin exists to prevent. Honouring the constraint
-		// needs semver comparison, and nox has no semver dependency — adding
-		// one to a security tool is a call for its maintainers, not something
-		// to slip into a bugfix.
+		// nox/triage-agent 0.2.2 sat in the state file, and the plugin
+		// silently never ran.
 		lookupName, constraint := parseNameVersion(name)
-		ip := st.FindPlugin(name)
+		ip := st.FindPlugin(lookupName)
 		if ip == nil {
-			detail := fmt.Sprintf("required plugin %q is not installed", name)
-			if constraint != "*" {
-				if installed := st.FindPlugin(lookupName); installed != nil {
-					detail = fmt.Sprintf("required plugin %q did not resolve: version constraints are "+
-						"not supported in plugins.required, and %q (version %s) is installed — "+
-						"drop the %q suffix to use it",
-						name, lookupName, installed.Version, "@"+constraint)
-				}
+			missing = append(missing, core.Degradation{
+				Kind:   degrade.Plugin,
+				Detail: fmt.Sprintf("required plugin %q is not installed", lookupName),
+				Impact: "findings this plugin would have produced are missing from this scan",
+			})
+			continue
+		}
+		// The constraint is enforced, not merely parsed. Matching the name and
+		// ignoring the version would hand a repository whatever happens to be
+		// installed, which is the one outcome a pin exists to prevent — and in
+		// a security scanner, quietly running a different version of a check
+		// than the one asked for is its own defect.
+		if ok, cErr := constraintSatisfied(constraint, ip.Version); cErr != nil || !ok {
+			detail := fmt.Sprintf("required plugin %q is not satisfied: version %s is installed",
+				name, ip.Version)
+			if cErr != nil {
+				detail = fmt.Sprintf("required plugin %q could not be resolved: %v", name, cErr)
 			}
 			missing = append(missing, core.Degradation{
 				Kind:   degrade.Plugin,

--- a/cli/plugin_scan_test.go
+++ b/cli/plugin_scan_test.go
@@ -155,28 +155,22 @@ func TestErrorDegradations_SeverityIsCaseInsensitive(t *testing.T) {
 	}
 }
 
-// TestRunScanPlugins_VersionConstraint_ExplainsItself covers a required entry
+// TestRunScanPlugins_VersionConstraint_Resolves covers a required entry
 // written with the syntax `nox plugin install` documents and accepts:
 //
 //	plugins:
 //	  required:
 //	    - nox/triage-agent@^0.2.0
 //
-// The lookup matches the whole string as a name, so such an entry never
-// resolves. nox reported `is not installed` for a plugin that WAS installed,
-// and three repositories in this fleet had that plugin silently never run
-// because of it.
-//
-// The behaviour is deliberately unchanged — the plugin still does not run.
-// Matching on the bare name would be worse than the bug, because a repository
-// pinning @0.5.0 would silently get whatever happens to be installed, which is
-// the one outcome a pin exists to prevent. Only the message changes, from
-// wrong to actionable.
-func TestRunScanPlugins_VersionConstraint_ExplainsItself(t *testing.T) {
+// The lookup used to match the whole string as a name, so such an entry could
+// never resolve. nox reported "is not installed" for a plugin that WAS
+// installed, and three repositories in one fleet had that plugin silently
+// never run because of it.
+func TestRunScanPlugins_VersionConstraint_Resolves(t *testing.T) {
 	const bare = "nox/triage-agent"
 	st, err := LoadState(DefaultStatePath())
 	if err != nil || st == nil || st.FindPlugin(bare) == nil {
-		t.Skipf("%s is not installed on this machine; nothing to explain", bare)
+		t.Skipf("%s is not installed on this machine", bare)
 	}
 
 	out, err := runScanPlugins(context.Background(), t.TempDir(), []string{bare + "@^0.2.0"})
@@ -184,22 +178,38 @@ func TestRunScanPlugins_VersionConstraint_ExplainsItself(t *testing.T) {
 		t.Fatalf("a constrained required plugin must not abort the scan: %v", err)
 	}
 	if out == nil {
-		t.Fatal("a required plugin that did not resolve must be reported, not skipped silently")
-	}
-
-	for _, d := range out.Degradations {
-		if !strings.Contains(d.Detail, "@^0.2.0") {
-			continue
-		}
-		// The point of the message is that the reader can act on it: it must
-		// name the installed plugin and say what to do.
-		if !strings.Contains(d.Detail, "version constraints are not supported") {
-			t.Errorf("detail %q does not say why the entry failed to resolve", d.Detail)
-		}
-		if !strings.Contains(d.Detail, bare) {
-			t.Errorf("detail %q does not name the installed plugin", d.Detail)
-		}
 		return
 	}
-	t.Errorf("the constrained entry was not reported at all: %+v", out.Degradations)
+	for _, d := range out.Degradations {
+		if strings.Contains(d.Detail, bare) && strings.Contains(d.Detail, "not installed") {
+			t.Errorf("a satisfied constraint was reported as missing: %q", d.Detail)
+		}
+	}
+}
+
+// An UNSATISFIED constraint must still degrade, and must say what is actually
+// installed — otherwise the operator cannot tell a typo from a stale install.
+func TestRunScanPlugins_VersionConstraint_UnsatisfiedIsReported(t *testing.T) {
+	const bare = "nox/triage-agent"
+	st, err := LoadState(DefaultStatePath())
+	if err != nil || st == nil || st.FindPlugin(bare) == nil {
+		t.Skipf("%s is not installed on this machine", bare)
+	}
+
+	out, err := runScanPlugins(context.Background(), t.TempDir(), []string{bare + "@^99.0.0"})
+	if err != nil {
+		t.Fatalf("an unsatisfiable constraint must not abort the scan: %v", err)
+	}
+	if out == nil {
+		t.Fatal("an unsatisfied constraint must be reported, not skipped silently")
+	}
+	for _, d := range out.Degradations {
+		if strings.Contains(d.Detail, "@^99.0.0") {
+			if !strings.Contains(d.Detail, st.FindPlugin(bare).Version) {
+				t.Errorf("detail %q does not say which version is installed", d.Detail)
+			}
+			return
+		}
+	}
+	t.Errorf("the unsatisfied constraint was not reported: %+v", out.Degradations)
 }


### PR DESCRIPTION
Closes #481.

I filed that issue saying the decision was yours because honouring
constraints meant adding a semver dependency to a security scanner. That
turned out to be a false choice — the grammar worth supporting is small
enough to implement directly, which removes the only objection. If you would
rather reject the syntax at parse time instead, say so and I will swap it.

### The bug

`nox plugin install nox/foo@0.5.0` is accepted syntax, so operators write
the same thing in `.nox.yaml`. The lookup matched the whole string as a
plugin name, so it could never resolve:

```
[degraded] required plugin "nox/triage-agent@^0.2.0" is not installed
```

…while `nox/triage-agent 0.2.2` sat in the state file. Three repositories in
one fleet (scry, tokenops, keyward) had written a reasonable constraint and
had that plugin silently never run.

### Supported

`*`, `1.2.3`, `>=1.2.3`, `^1.2.3` (same major, not older), `~1.2.3` (same
major and minor, not older).

### Three deliberate choices

**Enforced, not merely parsed.** Matching the name and ignoring the version
would hand a repository whatever happens to be installed — the one outcome a
pin exists to prevent. Quietly running a different version of a security
check than the one asked for is its own defect. An unsatisfied constraint
degrades and names the installed version, so a typo is distinguishable from
a stale install:

```
[degraded] required plugin "nox/triage-agent@^99.0.0" is not satisfied: version 0.2.2 is installed
```

**Unsupported grammar errors rather than passing.** A constraint nobody
enforces is worse than no constraint, because the operator believes a
version is pinned and it is not:

```
[degraded] required plugin "nox/triage-agent@<1.0.0" could not be resolved:
           constraint "<1.0.0" is not supported (use *, 1.2.3, >=1.2.3, ^1.2.3 or ~1.2.3)
```

**An uncomparable version reports rather than guesses.** A locally built
plugin records something like `dev`. Claiming it satisfies a pin defeats the
pin; claiming it does not breaks plugin development. So it says so.

Pre-release and build metadata are rejected rather than truncated —
otherwise `1.2.3-rc1` would satisfy a constraint written to exclude it.

### Tests

Table-driven over the boundaries, not the happy path: caret across a major
bump, tilde across a minor bump, `0.2.2` vs `0.2.10` (numeric, not lexical —
that exact mistake cost this fleet a bad Go pin earlier), unsupported
operators, and uncomparable versions. Plus two integration tests against a
real installed plugin covering satisfied and unsatisfied.

66 packages, 0 failures.

### Note

This sits on top of #480, which is merged but **not released** — the
installed binary is 1.30.0 and #480 is the only commit after that tag, so
every workspace with `scan.exclude` is still running with twelve plugins
dead. #482 has the changelog ready.
