### PR TITLE
docs(changelog): 1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.1] - 2026-08-27
+
+Plugins that were configured, required, and silently not running.
+
 ### Fixed
 
 - **Plugins did not run in any workspace that configured `scan.exclude`.**
@@ -2836,7 +2840,8 @@ secrets-pattern noise inside npm bundles.
 - Interspersed flags and positional args handled correctly.
 - Timeout added to `nox explain` to prevent indefinite hangs.
 
-[Unreleased]: https://github.com/nox-hq/nox/compare/v1.26.0...HEAD
+[Unreleased]: https://github.com/nox-hq/nox/compare/v1.30.1...HEAD
+[1.30.1]: https://github.com/nox-hq/nox/compare/v1.30.0...v1.30.1
 [1.26.0]: https://github.com/nox-hq/nox/compare/v1.25.2...v1.26.0
 [1.25.2]: https://github.com/nox-hq/nox/compare/v1.25.1...v1.25.2
 [1.25.1]: https://github.com/nox-hq/nox/compare/v1.25.0...v1.25.1


### PR DESCRIPTION
Cuts the `[Unreleased]` section as 1.30.1, so the tagged commit carries its
own notes the way 1.30.0 did.

Three fixes, all the same shape: a plugin that was configured, required, and
silently not running.

- `scan.exclude` was sent to plugins as `[]string`, which structpb rejects
  wholesale — twelve of twenty installed plugins never ran in any workspace
  that configured exclusions.
- A required plugin that failed to invoke reported `policy: pass`.
- A version constraint in `plugins.required` could never resolve, and now
  does, enforced.

Also repoints the `[Unreleased]` compare link, which had been left at
v1.26.0. The refs for 1.27 through 1.30 are still missing — pre-existing and
deliberately not swept up here.

Once merged I will tag `v1.30.1` on the merge commit, which is what triggers
`release.yml`.
