### PR TITLE
docs(vex): describe --product as what OpenVEX actually takes

### DIFF
--- a/cli/vex_cmd.go
+++ b/cli/vex_cmd.go
@@ -38,7 +38,10 @@ func runVexInit(args []string) int {
 	)
 	fs.StringVar(&inputPath, "input", "findings.json", "path to findings.json from a previous scan")
 	fs.StringVar(&outputPath, "output", "vex.json", "destination path for the generated stub")
-	fs.StringVar(&product, "product", "", "product identifier to embed in each statement (typically the Go module path)")
+	fs.StringVar(&product, "product", "", "product identifier to embed in each statement: a package URL "+
+		"(pkg:npm/foo@1.2.3, pkg:golang/example.com/m@v1.2.3) or, for a container, its digest "+
+		"(pkg:oci/app@sha256:...). Use the most specific identifier you have — one without a version "+
+		"cannot tell two releases apart")
 	fs.BoolVar(&force, "force", false, "overwrite output if it already exists")
 	if err := fs.Parse(args); err != nil {
 		return 2


### PR DESCRIPTION
Closes #488.

The help said `--product` is "typically the Go module path". Two problems.

**nox is not Go-only.** It reports findings for npm, pypi and docker
ecosystems alongside IaC, secrets, container and AI-inventory families. A
user scanning a TypeScript service reads that and reasonably concludes
either that `vex init` is a Go feature, or that they should invent something
module-path-shaped.

**It is not what OpenVEX products look like.** They are package URLs, or for
a container its digest:

```
pkg:npm/%40acme/api@1.4.2
pkg:golang/go.klarlabs.de/kiln@v0.4.1
pkg:oci/api@sha256:e8e81905…
```

A bare module path carries no version and no ecosystem, so two releases of
the same module produce VEX statements that cannot be told apart — the one
thing a product identifier exists to prevent.

### Why it matters past the wording

The identifier is a join key. When a deploy-time verifier records the digest
a release actually shipped, and the VEX for that release names the same
digest, "what shipped" and "what is exploitable in it" answer with one
lookup instead of two teams reconstructing it. Help text steering people
toward a version-less module path steers them away from the identifier that
makes the join work.

No behaviour change — the flag already accepts any string.
