### PR TITLE
fix(cli): scan --help shows the flags that make it emit an SBOM

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -133,14 +134,14 @@ func run(args []string) int {
 	// "flag explicitly set to the default". The built-in defaults are applied by
 	// resolveOutputFormat/resolveOutputDir after config is read. See the comment
 	// on those functions.
-	fs.StringVar(&formatFlag, "format", "", "output formats: json,sarif,cdx,spdx,all (comma-separated) (default \"json\")")
-	fs.StringVar(&outputDir, "output", "", "output directory for report files (default \".\")")
-	fs.StringVar(&rulesFlag, "rules", "", "path to custom rules YAML file or directory")
-	fs.BoolVar(&quietFlag, "quiet", false, "suppress all output except errors")
-	fs.BoolVar(&quietFlag, "q", false, "suppress all output except errors (shorthand)")
-	fs.BoolVar(&verboseFlag, "verbose", false, "enable verbose output")
-	fs.BoolVar(&verboseFlag, "v", false, "enable verbose output (shorthand)")
-	fs.BoolVar(&versionFlag, "version", false, "print version and exit")
+	fs.StringVar(&formatFlag, "format", "", usageFormat)
+	fs.StringVar(&outputDir, "output", "", usageOutput)
+	fs.StringVar(&rulesFlag, "rules", "", usageRules)
+	fs.BoolVar(&quietFlag, "quiet", false, usageQuiet)
+	fs.BoolVar(&quietFlag, "q", false, usageQuietSh)
+	fs.BoolVar(&verboseFlag, "verbose", false, usageVerbose)
+	fs.BoolVar(&verboseFlag, "v", false, usageVerbSh)
+	fs.BoolVar(&versionFlag, "version", false, usageVersion)
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: nox <command> [flags]\n\n")
@@ -364,6 +365,52 @@ func absAgainst(root, p string) string {
 	return filepath.Join(root, p)
 }
 
+// Descriptions for the flags nox accepts before a subcommand.
+//
+// Constants rather than literals at the registration sites, because
+// `nox scan --help` renders the same set (see scanFS.Usage) and two copies of
+// a flag's description drift. The registrations themselves stay inline in
+// run(), where the alias-drift guard in toplevel_flag_efficacy_test.go can see
+// them: -q and --quiet must keep binding one variable, and that guard reads
+// the source.
+const (
+	usageFormat  = "output formats: json,sarif,cdx,spdx,all (comma-separated) (default \"json\")"
+	usageOutput  = "output directory for report files (default \".\")"
+	usageRules   = "path to custom rules YAML file or directory"
+	usageQuiet   = "suppress all output except errors"
+	usageQuietSh = "suppress all output except errors (shorthand)"
+	usageVerbose = "enable verbose output"
+	usageVerbSh  = "enable verbose output (shorthand)"
+	usageVersion = "print version and exit"
+)
+
+// printGlobalFlags renders the pre-subcommand flags for a subcommand's usage.
+//
+// They are real and they work — `nox scan . --format cdx` writes an SBOM — but
+// they live on the root flag set, so `nox scan --help` listed only the scan set
+// and never mentioned them. --format is how nox emits an SBOM at all, which
+// made the SBOM look like a capability nox does not have (#489).
+//
+// Rendered from a throwaway set so this stays a display concern: nothing here
+// parses anything, and the descriptions come from the same constants the real
+// registrations use.
+func printGlobalFlags(out io.Writer) {
+	var s1, s2, s3 string
+	var b1, b2, b3 bool
+	tmp := flag.NewFlagSet("global", flag.ContinueOnError)
+	tmp.SetOutput(out)
+	tmp.StringVar(&s1, "format", "", usageFormat)
+	tmp.StringVar(&s2, "output", "", usageOutput)
+	tmp.StringVar(&s3, "rules", "", usageRules)
+	tmp.BoolVar(&b1, "quiet", false, usageQuiet)
+	tmp.BoolVar(&b1, "q", false, usageQuietSh)
+	tmp.BoolVar(&b2, "verbose", false, usageVerbose)
+	tmp.BoolVar(&b2, "v", false, usageVerbSh)
+	tmp.BoolVar(&b3, "version", false, usageVersion)
+	_, _ = fmt.Fprintln(out, "\nGlobal flags (accepted before or after the subcommand):")
+	tmp.PrintDefaults()
+}
+
 func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verbose bool) int {
 	// Parse scan-specific flags.
 	scanFS := flag.NewFlagSet("scan", flag.ContinueOnError)
@@ -417,6 +464,12 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	scanFS.StringVar(&sortFlag, "sort", "deterministic", "findings.json order: 'deterministic' (rule/path/line) or 'priority' (severity, then reachability, then confidence — most actionable first)")
 	var fingerprintVersionFlag string
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
+	scanFS.Usage = func() {
+		out := scanFS.Output()
+		_, _ = fmt.Fprintln(out, "Usage of scan:")
+		scanFS.PrintDefaults()
+		printGlobalFlags(out)
+	}
 	positionals, err := parseInterspersed(scanFS, args)
 	if err != nil {
 		// flag.ErrHelp means the user asked for -h/--help; the flag package


### PR DESCRIPTION
Closes #489.

`nox scan --format cdx` writes a valid CycloneDX 1.5 SBOM. `nox scan --help`
never mentioned `--format` — nor `--output`, `--rules`, `--quiet/-q`,
`--verbose/-v`, `--version`, all of which work. They are registered on the
root flag set (`cli/main.go:121`) while `scan --help` printed only `scanFS`
(`:369`), so the split was structural rather than one missing description.

`--format` is how nox emits an SBOM at all, which made the SBOM read as a
capability nox does not have. I went looking for one, read the help, checked
for a `nox sbom` subcommand, found neither, and had started planning the
feature before finding `sbom.NewCycloneDXReporter` already wired at
`cli/main.go:650`. A capability that exists and cannot be found is close to
a capability that does not exist.

```
Usage of scan:
  -baseline string
        …

Global flags (accepted before or after the subcommand):
  -format string
        output formats: json,sarif,cdx,spdx,all (comma-separated) (default "json")
  -output string
        output directory for report files (default ".")
  …
```

Descriptions are constants shared by the real registrations and by scan's
usage, so the two cannot drift.

### What I did not do, and why

My first version moved the registrations into a `registerGlobalFlags` helper
— tidier, and it broke `toplevel_flag_efficacy_test.go`. That test reads the
source to prove `-q` and `--quiet` still bind one variable, guarding against
a shorthand silently binding its own variable and quietly doing nothing. A
helper taking pointer parameters would have had it matching names like
`format` and `output`, ordinary enough words to make the guard imprecise.

Sharing the text costs nothing. Moving the bindings would have cost a guard
that exists to catch exactly the class of bug this PR is about, so the
registrations stay inline.

### Verified

Both invocation forms still write `sbom.cdx.json` after the change:

```
nox scan . --format cdx --output o1     → o1/sbom.cdx.json
nox --format cdx --output o2 scan .     → o2/sbom.cdx.json
```

66 packages, 0 failures. The gate caught two unchecked `fmt.Fprintln` returns
on the first push; fixed.
