### PR TITLE
docs: point the kernel references at nox-core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,15 @@ Four top-level packages with strict dependency direction (`core` depends on noth
 
 ### Evidence Spine
 
-`core/evidence` is the foundation under dynamic exploit validation, and the
-model a future intelligence service will share with the CLI. It owns the
-exploitability lifecycle (POTENTIAL, PLAUSIBLE, PREVENTED, INCONCLUSIVE,
-CONFIRMED), evidence kinds with explicit strengths, provenance, and confidence
-aggregation.
+The evidence model lives in `github.com/nox-hq/nox-core/evidence`, a separate
+module pinned here at `v0.1.1` — not in this repository. It is the foundation
+under dynamic exploit validation, and the model the intelligence service shares
+with the CLI; it sits in its own module precisely so neither side depends on the
+other. It owns the exploitability lifecycle (POTENTIAL, PLAUSIBLE, PREVENTED,
+INCONCLUSIVE, CONFIRMED), evidence kinds with explicit strengths, provenance, and
+confidence aggregation.
 
-Two rules are enforced here and must not be re-implemented elsewhere:
+Two rules are enforced there and must not be re-implemented here:
 
 - CONFIRMED requires deterministic evidence at reproduction strength or above. No
   quantity of heuristics, repeated observations, or LLM judgments reaches it.

--- a/docs/design/intelligence-program.md
+++ b/docs/design/intelligence-program.md
@@ -203,7 +203,7 @@ logical issue carries the same ID everywhere.
 ## Phase 3 — The intelligence service
 
 New module `github.com/nox-hq/nox-intelligence` at `oss/nox-intelligence`,
-importing `github.com/nox-hq/nox/core/evidence` so both sides agree on what
+importing `github.com/nox-hq/nox-core/evidence` so both sides agree on what
 CONFIRMED means. Separate deployable, per ADR 0002.
 
 ### Stack


### PR DESCRIPTION
Follow-up to #485 (kernel move) and #487 (1.31.0). Documentation only — no code.

Two documents still described the shared kernel as living in this repository:

- **`docs/design/intelligence-program.md`** told the reader to import
  `github.com/nox-hq/nox/core/evidence`. That path no longer exists in any
  module. It was the only fully-qualified reference left pointing at a deleted
  package.
- **`CLAUDE.md`** introduced `core/evidence` as a package of this repo and
  called the intelligence service "future". This one matters more than its size
  suggests: the file is loaded into every session in this repository, so a wrong
  map of where the code lives misdirects work before it starts.

### What is deliberately not changed

- **ADRs and the other design docs** keep their `core/evidence` references. They
  record what was decided at the time; #485 is the record of the move. Editing
  them would rewrite history rather than describe it.
- **`CHANGELOG.md`** keeps `github.com/nox-hq/nox/core/{evidence,vulnsource}`
  verbatim — it names them as the paths being removed, which is the migration
  instruction for anyone upgrading.

### Verification

`github.com/nox-hq/nox-core v0.1.1` is pinned in `go.mod` with 46 import sites
in Go code, so the move is complete in fact and not only on paper. After this
change, no fully-qualified reference to a deleted path remains outside the
changelog entry that documents its removal.