### PR TITLE
feat(intel): enrol from an invitation instead of the operator token

### DIFF
--- a/cli/intel_cmd.go
+++ b/cli/intel_cmd.go
@@ -22,6 +22,16 @@ func runIntel(args []string) int {
 		return runIntelPreview(args[1:])
 	case "id":
 		return runIntelID()
+	case "login":
+		return runIntelLogin(args[1:])
+	case "logout":
+		return runIntelLogout(args[1:])
+	case "whoami":
+		return runIntelWhoami(args[1:])
+	case "register":
+		return runIntelRegister(args[1:])
+	case "invite":
+		return runIntelInvite(args[1:])
 	case "enroll":
 		return runIntelEnroll(args[1:])
 	default:
@@ -36,7 +46,13 @@ func printIntelUsage() {
 	fmt.Fprintf(os.Stderr, "  allowlist        print every field an observation may carry\n")
 	fmt.Fprintf(os.Stderr, "  preview <path>   show exactly what a scan of <path> would contribute\n")
 	fmt.Fprintf(os.Stderr, "  id               print this installation's opaque reporter id\n")
-	fmt.Fprintf(os.Stderr, "  enroll           register a second factor for an operator account\n\n")
+	fmt.Fprintf(os.Stderr, "\nOperator accounts:\n")
+	fmt.Fprintf(os.Stderr, "  login            sign in with your authenticator and store the session\n")
+	fmt.Fprintf(os.Stderr, "  logout           revoke the session, on the server as well as here\n")
+	fmt.Fprintf(os.Stderr, "  whoami           show who this machine is signed in as\n")
+	fmt.Fprintf(os.Stderr, "  register         create an operator and print their enrolment link\n")
+	fmt.Fprintf(os.Stderr, "  invite           re-issue an enrolment link that expired\n")
+	fmt.Fprintf(os.Stderr, "  enroll           bind an authenticator using an enrolment link\n\n")
 	fmt.Fprintf(os.Stderr, "Contribution is off unless scan.intelligence.contribute is set,\n")
 	fmt.Fprintf(os.Stderr, "and is a separate decision from querying an intelligence endpoint.\n")
 }

--- a/cli/intel_enroll.go
+++ b/cli/intel_enroll.go
@@ -34,19 +34,32 @@ func runIntelEnroll(args []string) int {
 	email := fs.String("email", "", "operator address to enrol")
 	yes := fs.Bool("no-confirm", false,
 		"print the URI and exit without confirming (the new factor stays inactive)")
+	invite := fs.String("code", "",
+		"single-use enrolment code from your invitation (no operator token needed)")
+	save := fs.String("save-recovery-codes", "",
+		"write the recovery codes to this file (created 0600) as well as printing them")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *endpoint == "" || *email == "" {
-		fmt.Fprintf(os.Stderr, "Usage: nox intel enroll --endpoint URL --email you@example.com\n\n")
-		fmt.Fprintf(os.Stderr, "The operator token is read from NOX_INTEL_TOKEN. It is required:\n")
-		fmt.Fprintf(os.Stderr, "enrolment is the account-recovery path, so it cannot be anonymous.\n")
+	// An invitation names its own subject, so --email is neither needed nor
+	// honoured with one: the address comes from the code server-side.
+	if *endpoint == "" || (*email == "" && *invite == "") {
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  nox intel enroll --endpoint URL --code CODE          # from an invitation\n")
+		fmt.Fprintf(os.Stderr, "  nox intel enroll --endpoint URL --email you@example.com   # break-glass\n\n")
+		fmt.Fprintf(os.Stderr, "An invitation is the ordinary path and needs no operator token.\n")
+		fmt.Fprintf(os.Stderr, "The token (NOX_INTEL_TOKEN) is for the case an invitation cannot cover:\n")
+		fmt.Fprintf(os.Stderr, "an operator who has lost their phone and holds no valid link.\n")
 		return 2
 	}
+	// The operator token is required only without an invitation. Demanding it
+	// in both cases is what trains people to keep it somewhere convenient,
+	// which is the habit this flow exists to remove.
 	token := os.Getenv("NOX_INTEL_TOKEN")
-	if token == "" {
-		fmt.Fprintf(os.Stderr, "nox intel enroll: NOX_INTEL_TOKEN is not set.\n")
-		fmt.Fprintf(os.Stderr, "Enrolment replaces a second factor, so it requires the operator token.\n")
+	if token == "" && *invite == "" {
+		fmt.Fprintf(os.Stderr, "nox intel enroll: no --code, and NOX_INTEL_TOKEN is not set.\n")
+		fmt.Fprintf(os.Stderr, "Use the enrolment code from your invitation, or set the operator\n")
+		fmt.Fprintf(os.Stderr, "token if you are recovering an account with no valid invitation.\n")
 		return 2
 	}
 	base := strings.TrimRight(*endpoint, "/")
@@ -61,8 +74,11 @@ func runIntelEnroll(args []string) int {
 		ExpiresIn       int    `json:"expires_in"`
 		Error           string `json:"error"`
 	}
-	if code := postJSON(base+"/v1/auth/enroll", token,
-		map[string]string{"email": *email}, &begin); code != 0 {
+	beginBody := map[string]string{"email": *email}
+	if *invite != "" {
+		beginBody = map[string]string{"enrollment_code": *invite}
+	}
+	if code := postJSON(base+"/v1/auth/enroll", token, beginBody, &begin); code != 0 {
 		return code
 	}
 	if begin.ProvisioningURI == "" {
@@ -96,6 +112,7 @@ func runIntelEnroll(args []string) int {
 	}
 	var done struct {
 		Enrolled           bool     `json:"enrolled"`
+		Email              string   `json:"email"`
 		RecoveryCodes      []string `json:"recovery_codes"`
 		RecoveryCodesError string   `json:"recovery_codes_error"`
 		Error              string   `json:"error"`
@@ -120,6 +137,26 @@ func runIntelEnroll(args []string) int {
 		}
 		fmt.Printf("\nWithout them, a lost phone means the operator token is the only\n")
 		fmt.Printf("way back in — which is how this service's own lockout had to be fixed.\n")
+		// Writing them out is offered because "save these now" is advice people
+		// postpone, and there is no second showing. 0600 and O_EXCL: this file
+		// holds every way back into the account, and silently overwriting an
+		// existing set of codes would destroy the ones already in use.
+		if *save != "" {
+			f, err := os.OpenFile(*save, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "\nwarning: could not write %s: %v\n", *save, err)
+				fmt.Fprintf(os.Stderr, "The codes above are still valid — copy them now, they are not shown again.\n")
+			} else {
+				_, werr := fmt.Fprintf(f, "NOX Intelligence recovery codes for %s\nEach works once, in place of a code from your authenticator.\n\n%s\n",
+					done.Email, strings.Join(done.RecoveryCodes, "\n"))
+				cerr := f.Close()
+				if werr != nil || cerr != nil {
+					fmt.Fprintf(os.Stderr, "\nwarning: %s may be incomplete; copy the codes above instead\n", *save)
+				} else {
+					fmt.Printf("\nAlso written to %s (mode 0600).\n", *save)
+				}
+			}
+		}
 	} else if done.RecoveryCodesError != "" {
 		fmt.Fprintf(os.Stderr, "\nwarning: %s\n", done.RecoveryCodesError)
 	}

--- a/cli/intel_login.go
+++ b/cli/intel_login.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// runIntelLogin signs an operator in and stores the session.
+//
+// This exists so that operating the intelligence service does not mean pasting
+// a shared token into curl. A session is per-person, carries the second factor,
+// and can be revoked for one operator without disturbing anyone else.
+func runIntelLogin(args []string) int {
+	fs := flag.NewFlagSet("intel login", flag.ContinueOnError)
+	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
+		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	email := fs.String("email", "", "your operator address")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *endpoint == "" || *email == "" {
+		fmt.Fprintf(os.Stderr, "Usage: nox intel login --endpoint URL --email you@example.com\n\n")
+		fmt.Fprintf(os.Stderr, "You will be asked for a code from your authenticator.\n")
+		fmt.Fprintf(os.Stderr, "A recovery code works here too, and is spent when you use it.\n")
+		return 2
+	}
+	base := strings.TrimRight(*endpoint, "/")
+
+	fmt.Printf("Code from your authenticator (or a recovery code): ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		fmt.Fprintf(os.Stderr, "\nnox intel login: no code entered.\n")
+		return 2
+	}
+	code := strings.TrimSpace(line)
+
+	// The session cookie is what the browser uses; the CLI asks for the same
+	// credential as a bearer token so it can be stored without a cookie jar.
+	buf, _ := json.Marshal(map[string]string{"email": *email, "code": code})
+	req, err := http.NewRequest(http.MethodPost, base+"/v1/auth/login", bytes.NewReader(buf))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nox intel login: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nox intel login: %v\n", err)
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	if resp.StatusCode >= 300 {
+		// The service does not say whether the address exists or the code was
+		// wrong, and neither does this: repeating a deliberately vague answer
+		// more precisely would undo the reason it is vague.
+		fmt.Fprintf(os.Stderr, "nox intel login: invalid credentials (HTTP %d)\n", resp.StatusCode)
+		fmt.Fprintf(os.Stderr, "If the code looked right, check the clock on your phone —\n")
+		fmt.Fprintf(os.Stderr, "TOTP allows only a small window of drift.\n")
+		return 1
+	}
+
+	tok := sessionTokenFrom(resp, raw)
+	if tok == "" {
+		fmt.Fprintf(os.Stderr, "nox intel login: signed in, but the service returned no session token\n")
+		return 1
+	}
+	s := session{Endpoint: base, Email: *email, Token: tok}
+	var body struct {
+		ExpiresAt string `json:"expires_at"`
+	}
+	if json.Unmarshal(raw, &body) == nil {
+		s.ExpiresAt = body.ExpiresAt
+	}
+	if err := saveSession(s); err != nil {
+		fmt.Fprintf(os.Stderr, "nox intel login: signed in, but the session could not be stored: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Signed in to %s as %s.\n", base, *email)
+	if s.ExpiresAt != "" {
+		fmt.Printf("The session expires at %s.\n", s.ExpiresAt)
+	}
+	return 0
+}
+
+// sessionTokenFrom finds the session credential in a login response.
+//
+// Preferring an explicit field and falling back to the cookie, because the
+// console is the primary client and is cookie-based; a CLI that only understood
+// one of the two would break the moment the other changed.
+func sessionTokenFrom(resp *http.Response, raw []byte) string {
+	var body struct {
+		Token   string `json:"token"`
+		Session string `json:"session"`
+	}
+	if json.Unmarshal(raw, &body) == nil {
+		if body.Token != "" {
+			return body.Token
+		}
+		if body.Session != "" {
+			return body.Session
+		}
+	}
+	for _, ck := range resp.Cookies() {
+		if strings.Contains(ck.Name, "nox_session") {
+			return ck.Value
+		}
+	}
+	return ""
+}
+
+// runIntelLogout revokes the session server-side, then forgets it.
+//
+// Server first: a token dropped locally but still valid on the server is a live
+// credential the operator believes they have destroyed. If the revocation call
+// fails the local copy is still removed, and the failure is reported rather
+// than swallowed.
+func runIntelLogout(args []string) int {
+	fs := flag.NewFlagSet("intel logout", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	s, ok := loadSession()
+	if !ok {
+		fmt.Println("Not signed in.")
+		return 0
+	}
+	req, err := http.NewRequest(http.MethodPost, s.Endpoint+"/v1/auth/logout", nil)
+	if err == nil {
+		req.Header.Set("Authorization", "Bearer "+s.Token)
+		if resp, derr := (&http.Client{Timeout: 30 * time.Second}).Do(req); derr == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 300 {
+				fmt.Fprintf(os.Stderr,
+					"warning: the service did not confirm revocation (HTTP %d); the local copy is gone but the session may still be valid\n",
+					resp.StatusCode)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not reach the service to revoke the session: %v\n", derr)
+		}
+	}
+	clearSession()
+	fmt.Printf("Signed out of %s.\n", s.Endpoint)
+	return 0
+}
+
+// runIntelWhoami reports the stored session without making a request unless it
+// has to, so "am I signed in?" is answerable offline.
+func runIntelWhoami(args []string) int {
+	fs := flag.NewFlagSet("intel whoami", flag.ContinueOnError)
+	check := fs.Bool("check", false, "ask the service whether the session is still valid")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	s, ok := loadSession()
+	if !ok {
+		fmt.Println("Not signed in. Run: nox intel login --endpoint URL --email you@example.com")
+		return 1
+	}
+	fmt.Printf("%s at %s\n", s.Email, s.Endpoint)
+	if sessionExpired(s) {
+		fmt.Println("This session has expired. Sign in again.")
+		return 1
+	}
+	if s.ExpiresAt != "" {
+		fmt.Printf("Expires at %s.\n", s.ExpiresAt)
+	}
+	if !*check {
+		return 0
+	}
+	req, err := http.NewRequest(http.MethodGet, s.Endpoint+"/v1/auth/session", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nox intel whoami: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nox intel whoami: %v\n", err)
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		fmt.Println("The service rejected this session. Sign in again.")
+		return 1
+	}
+	fmt.Println("The service accepts this session.")
+	return 0
+}

--- a/cli/intel_login.go
+++ b/cli/intel_login.go
@@ -134,7 +134,7 @@ func runIntelLogout(args []string) int {
 		fmt.Println("Not signed in.")
 		return 0
 	}
-	req, err := http.NewRequest(http.MethodPost, s.Endpoint+"/v1/auth/logout", nil)
+	req, err := http.NewRequest(http.MethodPost, s.Endpoint+"/v1/auth/logout", http.NoBody)
 	if err == nil {
 		req.Header.Set("Authorization", "Bearer "+s.Token)
 		if resp, derr := (&http.Client{Timeout: 30 * time.Second}).Do(req); derr == nil {
@@ -178,7 +178,7 @@ func runIntelWhoami(args []string) int {
 	if !*check {
 		return 0
 	}
-	req, err := http.NewRequest(http.MethodGet, s.Endpoint+"/v1/auth/session", nil)
+	req, err := http.NewRequest(http.MethodGet, s.Endpoint+"/v1/auth/session", http.NoBody)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "nox intel whoami: %v\n", err)
 		return 1

--- a/cli/intel_register.go
+++ b/cli/intel_register.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runIntelRegister creates an operator and prints their enrolment link.
+//
+// Registration and second-factor setup are one act. An account with no
+// authenticator cannot sign in at all, so creating one without an invitation
+// leaves a person who exists and cannot get in — and the thing reached for in
+// that gap is the shared operator token, which is what this replaces.
+func runIntelRegister(args []string) int {
+	fs := flag.NewFlagSet("intel register", flag.ContinueOnError)
+	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
+		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	email := fs.String("email", "", "address of the operator to register")
+	org := fs.String("org", "", "organisation to register them into")
+	role := fs.String("role", "member", "member or admin")
+	verified := fs.Bool("verified", true,
+		"mark the address proven (you are vouching for it by registering them)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	// A session is the ordinary path. The operator token remains for the first
+	// admin, who by definition cannot sign in as one yet.
+	s, signedIn := loadSession()
+	base := strings.TrimRight(*endpoint, "/")
+	if base == "" && signedIn {
+		base = s.Endpoint
+	}
+	token := os.Getenv("NOX_INTEL_TOKEN")
+
+	if base == "" || *email == "" || *org == "" {
+		fmt.Fprintf(os.Stderr, "Usage: nox intel register --email them@example.com --org ORG [--role admin]\n\n")
+		fmt.Fprintf(os.Stderr, "Sign in first with `nox intel login`; the endpoint is then remembered.\n")
+		fmt.Fprintf(os.Stderr, "--org is required: a role is held in an organisation, so registering\n")
+		fmt.Fprintf(os.Stderr, "without one would leave the account with no owner.\n")
+		return 2
+	}
+	if *role != "member" && *role != "admin" {
+		fmt.Fprintf(os.Stderr, "nox intel register: --role must be member or admin\n")
+		return 2
+	}
+	if !signedIn && token == "" {
+		fmt.Fprintf(os.Stderr, "nox intel register: not signed in, and NOX_INTEL_TOKEN is not set.\n")
+		fmt.Fprintf(os.Stderr, "Run `nox intel login`. The operator token is only for registering\n")
+		fmt.Fprintf(os.Stderr, "the very first admin, when there is no admin to sign in as.\n")
+		return 2
+	}
+	if signedIn && sessionExpired(s) {
+		fmt.Fprintf(os.Stderr, "nox intel register: your session has expired. Run `nox intel login`.\n")
+		return 2
+	}
+
+	auth := token
+	if signedIn {
+		auth = s.Token
+	}
+	var out struct {
+		Email     string `json:"email"`
+		URL       string `json:"enrollment_url"`
+		ExpiresAt string `json:"enrollment_expires_at"`
+		EnrolErr  string `json:"enrollment_error"`
+		Error     string `json:"error"`
+	}
+	if code := postJSON(base+"/v1/admin/subjects", auth, map[string]any{
+		"email": *email, "org_id": *org, "role": *role, "verified": *verified,
+	}, &out); code != 0 {
+		return code
+	}
+
+	fmt.Printf("Registered %s in %s as %s.\n", *email, *org, *role)
+	if out.EnrolErr != "" {
+		fmt.Fprintf(os.Stderr, "\nwarning: %s\n", out.EnrolErr)
+		fmt.Fprintf(os.Stderr, "They exist but cannot sign in yet. Issue a link with:\n")
+		fmt.Fprintf(os.Stderr, "  nox intel invite --email %s\n", *email)
+		return 1
+	}
+	if out.URL == "" {
+		fmt.Fprintf(os.Stderr, "\nwarning: no enrolment link was returned; they cannot sign in yet.\n")
+		return 1
+	}
+	fmt.Printf("\nSend them this link. It works once and expires%s:\n\n  %s\n\n",
+		expiryPhrase(out.ExpiresAt), out.URL)
+	fmt.Printf("Or they can run:\n\n  nox intel enroll --endpoint %s --code <code from the link>\n", base)
+	return 0
+}
+
+// runIntelInvite re-issues an enrolment link for someone who already exists.
+func runIntelInvite(args []string) int {
+	fs := flag.NewFlagSet("intel invite", flag.ContinueOnError)
+	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
+		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	email := fs.String("email", "", "address of the operator to re-invite")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	s, signedIn := loadSession()
+	base := strings.TrimRight(*endpoint, "/")
+	if base == "" && signedIn {
+		base = s.Endpoint
+	}
+	token := os.Getenv("NOX_INTEL_TOKEN")
+	if base == "" || *email == "" {
+		fmt.Fprintf(os.Stderr, "Usage: nox intel invite --email them@example.com\n\n")
+		fmt.Fprintf(os.Stderr, "Issues a fresh enrolment link. Any previous link for that\n")
+		fmt.Fprintf(os.Stderr, "address stops working, so two live invitations never coexist.\n")
+		return 2
+	}
+	auth := token
+	if signedIn {
+		auth = s.Token
+	}
+	if auth == "" {
+		fmt.Fprintf(os.Stderr, "nox intel invite: not signed in, and NOX_INTEL_TOKEN is not set.\n")
+		return 2
+	}
+	var out struct {
+		URL       string `json:"enrollment_url"`
+		ExpiresAt string `json:"enrollment_expires_at"`
+	}
+	if code := postJSON(base+"/v1/admin/enrollments", auth,
+		map[string]string{"email": *email}, &out); code != 0 {
+		return code
+	}
+	fmt.Printf("New enrolment link for %s. It works once and expires%s:\n\n  %s\n",
+		*email, expiryPhrase(out.ExpiresAt), out.URL)
+	fmt.Printf("\nAny earlier link for this address is now invalid.\n")
+	return 0
+}
+
+func expiryPhrase(at string) string {
+	if at == "" {
+		return ""
+	}
+	return " at " + at
+}

--- a/cli/intel_session.go
+++ b/cli/intel_session.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// A session is what the CLI uses instead of the shared operator token.
+//
+// The token authorises every administrative action, never expires and belongs
+// to no one. A session belongs to a person, carries their second factor, and
+// can be revoked for them alone — which is the difference between an audit
+// trail that names someone and one that says "whoever had the secret".
+
+// session is what `nox intel login` stores.
+type session struct {
+	Endpoint  string `json:"endpoint"`
+	Email     string `json:"email"`
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// keychainService is the entry name in the macOS keychain.
+const keychainService = "nox-intel-session"
+
+// sessionPath is the fallback store, used where there is no keychain.
+func sessionPath() string {
+	if d := os.Getenv("XDG_CONFIG_HOME"); d != "" {
+		return filepath.Join(d, "nox", "intel-session.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".nox-intel-session.json"
+	}
+	return filepath.Join(home, ".config", "nox", "intel-session.json")
+}
+
+// saveSession stores the session, preferring the OS keychain.
+//
+// A session token is a bearer credential: anything holding it is the operator
+// until it expires. On macOS the keychain keeps it out of the filesystem
+// entirely; elsewhere a 0600 file in the user's config directory is the honest
+// second best, and the file is written with O_TRUNC so a shorter token cannot
+// leave the tail of a longer one behind.
+func saveSession(s session) error {
+	blob, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS == "darwin" && keychainAvailable() {
+		if err := keychainStore(string(blob)); err == nil {
+			return nil
+		}
+		// Fall through to the file. A keychain that refuses is a reason to warn,
+		// not a reason to leave the operator unable to sign in.
+		fmt.Fprintf(os.Stderr, "warning: could not use the keychain; storing the session in %s instead\n", sessionPath())
+	}
+	p := sessionPath()
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(blob); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// loadSession returns the stored session, if there is one.
+func loadSession() (session, bool) {
+	var s session
+	if runtime.GOOS == "darwin" && keychainAvailable() {
+		if raw, err := keychainFetch(); err == nil && raw != "" {
+			if json.Unmarshal([]byte(raw), &s) == nil && s.Token != "" {
+				return s, true
+			}
+		}
+	}
+	blob, err := os.ReadFile(sessionPath())
+	if err != nil {
+		return session{}, false
+	}
+	if json.Unmarshal(blob, &s) != nil || s.Token == "" {
+		return session{}, false
+	}
+	return s, true
+}
+
+// clearSession removes the stored session from both stores.
+//
+// Both, unconditionally: a token left in the file after a keychain logout is a
+// live credential that the operator believes they have destroyed.
+func clearSession() {
+	if runtime.GOOS == "darwin" && keychainAvailable() {
+		_ = exec.Command("security", "delete-generic-password", "-s", keychainService).Run()
+	}
+	_ = os.Remove(sessionPath())
+}
+
+func keychainAvailable() bool {
+	_, err := exec.LookPath("security")
+	return err == nil
+}
+
+func keychainStore(blob string) error {
+	// -U updates in place, so signing in twice does not leave two entries with
+	// only one of them current.
+	cmd := exec.Command("security", "add-generic-password",
+		"-a", os.Getenv("USER"), "-s", keychainService, "-U", "-w", blob)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("keychain: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func keychainFetch() (string, error) {
+	out, err := exec.Command("security", "find-generic-password",
+		"-a", os.Getenv("USER"), "-s", keychainService, "-w").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// sessionExpired reports whether a stored session is past its stated expiry.
+//
+// Checked locally so `nox intel whoami` can say "expired" rather than making a
+// request that fails with a 401 the operator then has to interpret. The server
+// remains the authority; this is a courtesy, not a security boundary.
+func sessionExpired(s session) bool {
+	if s.ExpiresAt == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, s.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return time.Now().UTC().After(t)
+}


### PR DESCRIPTION
Client side of Nox-HQ/nox-intelligence#2.

`nox intel enroll` required `NOX_INTEL_TOKEN` in every case. That token
authorises every administrative action in the intelligence service and never
expires, so the ordinary act of binding a phone cost the most powerful
credential we have — and needing it routinely is what teaches people to keep it
somewhere convenient.

### `--code`

Takes the single-use invitation issued when the operator was registered. An
invitation names its own subject, so `--email` is not required with one: the
address is read server-side from the stored record, and a code issued for one
operator cannot enrol another.

`NOX_INTEL_TOKEN` is now required only **without** `--code`, for the case it is
actually for: an operator who has lost their phone and holds no valid link.

### `--save-recovery-codes`

Writes the codes to a file as well as printing them. They are shown exactly
once, and "save these now" is advice people postpone until there is no second
showing.

`O_EXCL` and `0600`: the file holds every way back into an account, and
silently overwriting an existing set would destroy codes already in use. A
failed write says so and points back at the codes still on screen, rather than
reporting success over a missing file.

### Still no QR in the terminal

Unchanged and deliberate. The provisioning URI *is* the TOTP secret, and a
terminal puts it in scrollback, in tmux history, and in captured CI output. The
console renders the QR; the CLI prints a secret you can type.