### PR TITLE
docs(changelog): the two help fixes that shipped in 1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ A source that stays silent about a CVE, and a kernel two repositories can share.
   `github.com/nox-hq/nox-core/...` instead. These packages were never documented
   as a public API, which is why this is a minor release rather than a major one.
 
+### Fixed
+
+- **`scan --help` did not mention `--format`,** the flag that makes nox emit
+  an SBOM. It and five others — `--output`, `--rules`, `--quiet`/`-q`,
+  `--verbose`/`-v`, `--version` — are registered on the root flag set, while
+  `scan --help` printed only the scan set. All six worked; none were listed
+  where somebody would look for them, so `nox scan . --format cdx` writing a
+  CycloneDX 1.5 document read as a capability nox did not have. Scan's usage
+  now renders them under a "Global flags" heading, from the same description
+  constants the real registrations use.
+
+- **`vex init --product` described itself as "typically the Go module path".**
+  nox is not Go-only, and a bare module path is not what OpenVEX products
+  look like: they are package URLs, or for a container its digest. A module
+  path carries no version, so two releases produce VEX statements that cannot
+  be told apart — the one thing a product identifier exists to prevent. The
+  help now says so, and names the forms. No behaviour change.
+
 ### Build
 
 - **warden gates this repository.** Lint runs at pre-commit; tests and the


### PR DESCRIPTION
#491 and #492 merged before the 1.31.0 section was written, so they are not
in it. Tagging as-is would ship a release whose notes omit two user-facing
changes — including the one that makes SBOM output findable at all, which is
the more useful of the two for somebody reading the notes to decide whether
to upgrade.

No code change. The entries describe what already merged.

Flagging rather than assuming: I wrote both fixes, so if you would rather
the 1.31.0 notes stay as authored and these land in 1.31.1, say so and I
will move them.
