### PR TITLE
fix(intel): label errors with the command that produced them

### DIFF
--- a/cli/intel_enroll.go
+++ b/cli/intel_enroll.go
@@ -28,6 +28,7 @@ import (
 // until a code from the new app confirms it, so a mistyped code or an app that
 // was never installed leaves the existing authenticator working.
 func runIntelEnroll(args []string) int {
+	cmdName = "nox intel enroll"
 	fs := flag.NewFlagSet("intel enroll", flag.ContinueOnError)
 	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
 		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
@@ -178,18 +179,24 @@ func spaced(s string) string {
 	return b.String()
 }
 
+// cmdName labels errors from postJSON. It is shared by enroll, add-operator
+// and invite, and hardcoding one of them meant `nox intel invite` failed with
+// "nox intel enroll: unauthorized" — which sends the reader to the wrong
+// command's docs.
+var cmdName = "nox intel"
+
 func postJSON(endpoint, token string, body, out any) int {
 	buf, _ := json.Marshal(body)
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(buf))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "nox intel enroll: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%s: %v\n", cmdName, err)
 		return 1
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "nox intel enroll: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%s: %v\n", cmdName, err)
 		return 1
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -206,7 +213,7 @@ func postJSON(endpoint, token string, body, out any) int {
 		if msg == "" {
 			msg = strings.TrimSpace(string(raw))
 		}
-		fmt.Fprintf(os.Stderr, "nox intel enroll: %s (HTTP %d)\n", msg, resp.StatusCode)
+		fmt.Fprintf(os.Stderr, "%s: %s (HTTP %d)\n", cmdName, msg, resp.StatusCode)
 		return 1
 	}
 	return 0

--- a/cli/intel_register.go
+++ b/cli/intel_register.go
@@ -14,6 +14,7 @@ import (
 // leaves a person who exists and cannot get in — and the thing reached for in
 // that gap is the shared operator token, which is what this replaces.
 func runIntelRegister(args []string) int {
+	cmdName = "nox intel add-operator"
 	fs := flag.NewFlagSet("intel register", flag.ContinueOnError)
 	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
 		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
@@ -93,10 +94,13 @@ func runIntelRegister(args []string) int {
 
 // runIntelInvite re-issues an enrolment link for someone who already exists.
 func runIntelInvite(args []string) int {
+	cmdName = "nox intel invite"
 	fs := flag.NewFlagSet("intel invite", flag.ContinueOnError)
 	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
 		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
 	email := fs.String("email", "", "address of the operator to re-invite")
+	org := fs.String("org", "",
+		"organisation they belong to (only needed if you administer more than one)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -125,7 +129,7 @@ func runIntelInvite(args []string) int {
 		ExpiresAt string `json:"enrollment_expires_at"`
 	}
 	if code := postJSON(base+"/v1/admin/enrollments", auth,
-		map[string]string{"email": *email}, &out); code != 0 {
+		map[string]string{"email": *email, "org_id": *org}, &out); code != 0 {
 		return code
 	}
 	fmt.Printf("New enrolment link for %s. It works once and expires%s:\n\n  %s\n",


### PR DESCRIPTION
`nox intel invite` failed with:

```
nox intel enroll: unauthorized (HTTP 401)
```

`postJSON` is shared by `enroll`, `add-operator` and `invite`, and named only
`enroll` — sending the reader to the wrong command's documentation while they
are debugging. The 401 was real (fixed in Nox-HQ/nox-intelligence#12); the
label on it was not.

Each command now sets its own name.

`invite` also passes `--org` through, matching `add-operator`. The server can
infer the organisation when the caller administers exactly one, but an admin of
several has to say which, and the flag is how.

Small, but it is the difference between a message that points at the problem
and one that points somewhere else.