### PR TITLE
build: bump nox-core to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/nox-hq/nox-core v0.1.1
+	github.com/nox-hq/nox-core v0.2.0
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/nox-hq/nox-core v0.1.1 h1:jAy69lLWtH2S+BFtRYw0sF9bf+qkWoGJfRsailZtass=
 github.com/nox-hq/nox-core v0.1.1/go.mod h1:MQ6xDjQeSts2TGYEqGu3nzshk1mDlj/cAGT1I1KI8Ao=
+github.com/nox-hq/nox-core v0.2.0 h1:ksBQhVTCErAENWFQe4Le7cJb9F9KvAjXMgjqNtHFTMw=
+github.com/nox-hq/nox-core v0.2.0/go.mod h1:MQ6xDjQeSts2TGYEqGu3nzshk1mDlj/cAGT1I1KI8Ao=
 github.com/openai/openai-go/v3 v3.52.0 h1:VDSjIvI5Sr2/AzGJI6219sM2Il+zBWuopvluMy6KdjE=
 github.com/openai/openai-go/v3 v3.52.0/go.mod h1:Vy3y2/I2H/MbqvJGXEK8VbN5+avZV6zxux4I3eBdvaA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Bumps the shared kernel to [v0.2.0](https://github.com/Nox-HQ/nox-core/releases/tag/v0.2.0)
(Nox-HQ/nox-core#1) — Track B of `docs/design/evidence-native-nox.md`.

**No nox code changes.** `go.mod` / `go.sum` only.

## Why this is safe

The kernel gains typed subjects, relations, claim polarity, a claim lifecycle
and producer authority. Every new field has a zero value that reads as the
v0.1.x behaviour:

| field | zero value means |
|---|---|
| `Claim.Subject` | the unattributed subject — one bucket, as before |
| `Claim.Polarity` | supporting, which every pre-existing claim was |
| `Claim.Status` | active |
| `Authority{}` | non-enforcing; permits everything |

So every ledger nox writes today aggregates to exactly what it did before. The
kernel pins that with `TestLegacyLedgersAreUnchanged` rather than asserting it
in a changelog, and its 19 pre-existing tests pass unmodified.

## Verification

- Built and tested against the kernel tree via local `replace` **before** the
  tag existed, then again here against the released `v0.2.0`
- `go build ./...` clean
- `./core/... ./cli/... ./server/...` green
- **Topology invariant re-checked:** `git archive` of this branch, extracted to
  a directory with no sibling checkout present, builds clean. No `replace`
  directive in `go.mod`.

## What it unblocks

Track C. `core/attack` is the only consumer of the evidence model today — 64
call sites, none of them in the scan pipeline — and the adjudicator that closes
that gap needs subjects and polarity to exist first.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW