### PR TITLE
D: name what nox can establish, and what it cannot

### DIFF
--- a/cli/capabilities_cmd.go
+++ b/cli/capabilities_cmd.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// runAnalysisCapabilities prints what this installation can establish, and —
+// more usefully — what it cannot.
+//
+// The second half is the reason the command exists. An operator reading a clean
+// scan has no way to tell whether nox looked for something and found nothing,
+// or never had the ability to look. Documentation could say so, and the
+// documentation would drift; this is generated from the registry the scan
+// itself uses, so it cannot describe a capability the scan does not have.
+//
+// It is deliberately NOT called `nox capabilities`. core/analyzers/ai uses
+// "capability" for what an AI agent's tools can do, rendered by
+// `nox agent-graph`, and two commands a letter apart meaning different things
+// is a documentation problem that no amount of documentation fixes.
+func runAnalysisCapabilities(args []string) int {
+	fs := flag.NewFlagSet("analysis-capabilities", flag.ContinueOnError)
+	jsonOut := fs.Bool("json", false, "emit the matrix as JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	registry := capability.DefaultRegistry()
+
+	type row struct {
+		Capability string   `json:"capability"`
+		Provided   bool     `json:"provided"`
+		Providers  []string `json:"providers,omitempty"`
+	}
+	rows := make([]row, 0, len(capability.All()))
+	for _, c := range capability.All() {
+		rows = append(rows, row{
+			Capability: string(c),
+			Provided:   registry.Provided(c),
+			Providers:  registry.ProvidedBy(c),
+		})
+	}
+
+	if *jsonOut {
+		out, err := json.MarshalIndent(struct {
+			Capabilities []row    `json:"capabilities"`
+			Missing      []string `json:"missing"`
+		}{rows, capsToStrings(registry.Missing())}, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 2
+		}
+		fmt.Println(string(out))
+		return 0
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ANALYSIS CAPABILITY\tPROVIDED BY")
+	for _, r := range rows {
+		provided := "— not provided"
+		if r.Provided {
+			provided = strings.Join(r.Providers, ", ")
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", r.Capability, provided)
+	}
+	if err := w.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+
+	missing := registry.Missing()
+	if len(missing) == 0 {
+		return 0
+	}
+
+	// The wording here matters more than the list. An operator who reads
+	// "not provided" as "not a problem" has drawn exactly the inference this
+	// whole model exists to prevent.
+	fmt.Printf("\n%d capabilit%s no implementation on this installation:\n",
+		len(missing), map[bool]string{true: "y has", false: "ies have"}[len(missing) == 1])
+	for _, c := range missing {
+		fmt.Printf("  %s\n", c)
+	}
+	fmt.Println("\nA scan cannot answer these questions, and its silence about them is not\n" +
+		"an all-clear. Install a plugin that provides them, or read findings that\n" +
+		"depend on them as unevaluated rather than as cleared.")
+	return 0
+}
+
+func capsToStrings(cs []capability.AnalysisCapability) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, string(c))
+	}
+	return out
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -164,6 +164,7 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "  fix              Apply OSV dep upgrades (--actions also bumps GitHub Actions pins)\n")
 		fmt.Fprintf(os.Stderr, "  doctor           Report environment, plugin state, config sanity\n")
 		fmt.Fprintf(os.Stderr, "  agent-graph      Render agent capability lattice (mermaid/dot)\n")
+		fmt.Fprintf(os.Stderr, "  analysis-capabilities  Report what this installation can establish, and what it cannot\n")
 		fmt.Fprintf(os.Stderr, "  bench            Scan a corpus directory; report rule fire-rates (--precision <dir> scores P/R/F1 against a labeled corpus)\n")
 		fmt.Fprintf(os.Stderr, "  calibrate        Suggest severity overrides from a bench report\n")
 		fmt.Fprintf(os.Stderr, "  install          Install plugins listed in .nox.yaml plugins.required\n")
@@ -250,6 +251,8 @@ func run(args []string) int {
 		return runDoctor(remaining[1:])
 	case "agent-graph":
 		return runAgentGraph(remaining[1:])
+	case "analysis-capabilities":
+		return runAnalysisCapabilities(remaining[1:])
 	case "bench":
 		return runBench(remaining[1:])
 	case "calibrate":

--- a/core/capability/capability.go
+++ b/core/capability/capability.go
@@ -1,0 +1,273 @@
+// Package capability names what an analysis can establish, records whether it
+// actually ran, and keeps "we did not look" from reading like "there is
+// nothing there".
+//
+// nox degrades gracefully in many places by design — an OSV outage should not
+// fail a build, a plugin that will not start should not stop the scan. The
+// degrade package already makes those failures visible. What it cannot express
+// is the positive half: which analyses were SUPPOSED to run over a given
+// subject, which of them did, and what they concluded.
+//
+// Without that half, the most dangerous state in a security scanner is
+// invisible. A finding that no reachability analysis ever examined and a
+// finding that reachability examined and cleared produce the same output —
+// silence — and silence is read as safety. That is the single failure this
+// package exists to prevent, and it becomes acute the moment refutation can
+// change what is reported: a refiner that never ran must never be mistaken for
+// one that ran and found nothing.
+//
+// # Why not "Capability"
+//
+// core/analyzers/ai already uses Capability for what an AI agent's TOOLS can
+// do — file_read, shell_exec, http_request — and renders it with
+// `nox agent-graph`. That is a different concept in the same neighbourhood,
+// about the software under scan rather than about nox. Naming this one
+// AnalysisCapability keeps a reader from having to guess which is meant, and
+// keeps `nox analysis-capabilities` from reading like a synonym for a command
+// that already exists.
+package capability
+
+import "sort"
+
+// AnalysisCapability names a question an analysis can answer.
+//
+// The set is closed and deliberately small. It describes what nox can
+// establish, not how — an implementation may be a core analyzer, a plugin, or
+// a language-specific engine, and several may provide the same capability for
+// different languages. The concept belongs to nox; the implementation does not
+// have to.
+type AnalysisCapability string
+
+// The capabilities nox reasons about, roughly in order of cost.
+const (
+	// LexicalContext distinguishes code from comments and string literals.
+	// The cheapest refutation there is, and the one most likely to be wrong in
+	// a language nobody has written a lexer for.
+	LexicalContext AnalysisCapability = "lexical_context"
+	// ConstantEvaluation resolves whether an expression is a compile-time
+	// constant. It is what separates a call that could take attacker input from
+	// one that demonstrably cannot.
+	ConstantEvaluation AnalysisCapability = "constant_evaluation"
+	// SymbolResolution binds a name to the thing it refers to. Everything below
+	// this line depends on it, which is why its absence is worth reporting
+	// rather than inferring from the silence of the analyses above it.
+	SymbolResolution AnalysisCapability = "symbol_resolution"
+	// Taint tracks untrusted values from sources to sinks.
+	Taint AnalysisCapability = "taint"
+	// CallGraph relates callers to callees across function boundaries.
+	CallGraph AnalysisCapability = "call_graph"
+	// EntryPoint identifies where externally-triggered execution begins.
+	EntryPoint AnalysisCapability = "entry_point"
+	// Reachability establishes whether a symbol or path can be executed at all.
+	Reachability AnalysisCapability = "reachability"
+	// AttackerReachability establishes whether an attacker can cause it to be
+	// executed. Strictly stronger than Reachability, and the two are separate
+	// because conflating them is how "the code runs" becomes "the code is
+	// exploitable".
+	AttackerReachability AnalysisCapability = "attacker_reachability"
+	// DynamicVerification observes a security invariant actually being
+	// violated. The only capability that can support a CONFIRMED verdict, and
+	// nox never exercises it during a scan.
+	DynamicVerification AnalysisCapability = "dynamic_verification"
+)
+
+// all is the closed set, in declaration order — cheapest first, which is also
+// the order a progressive pipeline should attempt them in.
+var all = []AnalysisCapability{
+	LexicalContext, ConstantEvaluation, SymbolResolution, Taint,
+	CallGraph, EntryPoint, Reachability, AttackerReachability, DynamicVerification,
+}
+
+var valid = func() map[AnalysisCapability]bool {
+	m := make(map[AnalysisCapability]bool, len(all))
+	for _, c := range all {
+		m[c] = true
+	}
+	return m
+}()
+
+// All returns every defined capability, cheapest first.
+func All() []AnalysisCapability {
+	out := make([]AnalysisCapability, len(all))
+	copy(out, all)
+	return out
+}
+
+// Valid reports whether c is a defined capability. An unrecognised capability
+// is never treated as provided: a producer claiming one nox does not know
+// about has told nox nothing, and reading it as coverage would be worse than
+// reading it as absence.
+func (c AnalysisCapability) Valid() bool { return valid[c] }
+
+// State is what happened when a capability met a subject.
+//
+// Six states, and the distinctions between them are the entire point. Five of
+// them would collapse into "no finding" without this type, and a security tool
+// that cannot tell them apart is one that reports its own blind spots as
+// all-clears.
+type State string
+
+// Evaluation states.
+const (
+	// NotEvaluated — the capability exists and nothing asked it. The default,
+	// and the one that must never be read as a result.
+	NotEvaluated State = "not_evaluated"
+	// Unsupported — the capability cannot apply here at all: no lexer for this
+	// language, no call graph for this ecosystem. Honest and permanent, as
+	// opposed to a failure.
+	Unsupported State = "unsupported"
+	// TimedOut — it started and was cut short. Distinct from Unknown because
+	// the answer was reachable and nox declined to pay for it, which is a
+	// budget decision an operator may want to revisit.
+	TimedOut State = "timed_out"
+	// Unknown — it ran to completion and could not decide. The most honest
+	// answer an analysis can give, and the one most easily mistaken for a
+	// clearance.
+	Unknown State = "unknown"
+	// Negative — it ran and established the condition does NOT hold. This is
+	// the only state that may support suppressing a finding.
+	Negative State = "negative"
+	// Positive — it ran and established the condition holds.
+	Positive State = "positive"
+)
+
+var validStates = map[State]bool{
+	NotEvaluated: true, Unsupported: true, TimedOut: true,
+	Unknown: true, Negative: true, Positive: true,
+}
+
+// Valid reports whether s is a defined state.
+func (s State) Valid() bool { return validStates[s] }
+
+// Conclusive reports whether the capability actually reached an answer.
+//
+// Only Positive and Negative are conclusive. Everything else — not evaluated,
+// unsupported, timed out, ran-and-could-not-tell — is an absence of knowledge,
+// and this method exists so no caller has to enumerate that list correctly.
+// Getting the enumeration wrong in one place is how a blind spot becomes a
+// clearance, and an unrecognised state is not conclusive either.
+func (s State) Conclusive() bool { return s == Positive || s == Negative }
+
+// SuppressesFinding reports whether this state may justify not reporting
+// something.
+//
+// Only Negative does. That is Gate B written as a method: deterministic
+// unreachability may suppress a finding; unknown, unsupported, timed-out and
+// never-evaluated may not, however much they resemble each other in the
+// output.
+func (s State) SuppressesFinding() bool { return s == Negative }
+
+// Describe renders a state for a person, in wording that never overstates it.
+func (s State) Describe() string {
+	switch s {
+	case NotEvaluated:
+		return "not evaluated — nothing asked this question"
+	case Unsupported:
+		return "unsupported — this analysis cannot apply here"
+	case TimedOut:
+		return "timed out — the analysis was cut short, not completed"
+	case Unknown:
+		return "evaluated, and could not determine an answer"
+	case Negative:
+		return "evaluated — the condition does not hold"
+	case Positive:
+		return "evaluated — the condition holds"
+	default:
+		return "unknown evaluation state"
+	}
+}
+
+// Provider is an implementation that declares which capabilities it offers.
+// A core analyzer, a plugin, and a language engine all satisfy it the same way.
+type Provider interface {
+	// Name identifies the implementation for reporting: "nox/taint-analysis",
+	// "core/lexctx".
+	Name() string
+	// Provides lists the capabilities this implementation can answer.
+	Provides() []AnalysisCapability
+}
+
+// Registry records which implementations provide which capabilities.
+//
+// It answers the question that makes NotEvaluated meaningful: a capability
+// nobody provides is honestly Unsupported, while a capability something
+// provides and that nevertheless said nothing is NotEvaluated — a gap rather
+// than a limit. Without the registry those two are indistinguishable, and the
+// difference is exactly what an operator needs to act on.
+//
+// The zero Registry is usable and provides nothing.
+type Registry struct {
+	providers map[AnalysisCapability][]string
+	names     map[string][]AnalysisCapability
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		providers: make(map[AnalysisCapability][]string),
+		names:     make(map[string][]AnalysisCapability),
+	}
+}
+
+// Register records what p provides. Capabilities nox does not recognise are
+// ignored rather than stored: a producer claiming an unknown capability has
+// told nox nothing, and recording it would make the matrix look more covered
+// than it is.
+func (r *Registry) Register(p Provider) {
+	if r == nil || p == nil {
+		return
+	}
+	if r.providers == nil {
+		r.providers = make(map[AnalysisCapability][]string)
+		r.names = make(map[string][]AnalysisCapability)
+	}
+	for _, c := range p.Provides() {
+		if !c.Valid() {
+			continue
+		}
+		r.providers[c] = append(r.providers[c], p.Name())
+		r.names[p.Name()] = append(r.names[p.Name()], c)
+	}
+}
+
+// ProvidedBy returns the implementations offering c, sorted for determinism.
+func (r *Registry) ProvidedBy(c AnalysisCapability) []string {
+	if r == nil {
+		return nil
+	}
+	out := append([]string(nil), r.providers[c]...)
+	sort.Strings(out)
+	return out
+}
+
+// Provided reports whether anything at all offers c. A capability nothing
+// provides is Unsupported rather than NotEvaluated — a limit nox can state
+// plainly, rather than a gap that looks like one.
+func (r *Registry) Provided(c AnalysisCapability) bool {
+	return len(r.ProvidedBy(c)) > 0
+}
+
+// Missing returns the defined capabilities nothing provides, cheapest first.
+// It is the honest answer to "what can this installation not tell you?".
+func (r *Registry) Missing() []AnalysisCapability {
+	var out []AnalysisCapability
+	for _, c := range All() {
+		if !r.Provided(c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Providers returns every registered implementation name, sorted.
+func (r *Registry) Providers() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.names))
+	for name := range r.names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/capability/capability_test.go
+++ b/core/capability/capability_test.go
@@ -1,0 +1,186 @@
+package capability_test
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+var subject = evidence.Subject{Kind: evidence.SubjectCandidate, ID: "SEC-003@app/creds.py:1:16"}
+
+// TestOnlyAConclusiveNegativeMaySuppress is Gate B written as a test. Four of
+// the six states resemble each other in the output — nothing is reported — and
+// exactly one of them is a reason to report nothing.
+func TestOnlyAConclusiveNegativeMaySuppress(t *testing.T) {
+	suppressing := map[capability.State]bool{capability.Negative: true}
+	conclusive := map[capability.State]bool{capability.Negative: true, capability.Positive: true}
+
+	for _, s := range []capability.State{
+		capability.NotEvaluated, capability.Unsupported, capability.TimedOut,
+		capability.Unknown, capability.Negative, capability.Positive,
+		capability.State("from-a-newer-build"),
+	} {
+		if got := s.SuppressesFinding(); got != suppressing[s] {
+			t.Errorf("%q.SuppressesFinding() = %v, want %v — only an analysis that "+
+				"RAN and established the condition does not hold may hide a finding",
+				s, got, suppressing[s])
+		}
+		if got := s.Conclusive(); got != conclusive[s] {
+			t.Errorf("%q.Conclusive() = %v, want %v", s, got, conclusive[s])
+		}
+	}
+}
+
+// TestDescribeNeverAssertsSafety. These strings reach an operator, and the
+// distinction the whole package draws is destroyed if the wording lets four
+// non-answers read as clearances.
+func TestDescribeNeverAssertsSafety(t *testing.T) {
+	banned := []string{"safe", "secure", "clean", "no risk", "not vulnerable"}
+	for _, s := range []capability.State{
+		capability.NotEvaluated, capability.Unsupported, capability.TimedOut,
+		capability.Unknown, capability.Negative, capability.Positive,
+		capability.State("unrecognised"),
+	} {
+		got := s.Describe()
+		if got == "" {
+			t.Errorf("%q has no description", s)
+		}
+		for _, w := range banned {
+			if contains(got, w) {
+				t.Errorf("%q describes itself as %q, which contains %q", s, got, w)
+			}
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestUnprovidedIsUnsupportedProvidedButSilentIsAGap is the distinction that
+// makes NotEvaluated worth having. Both look like silence; only one is
+// actionable.
+func TestUnprovidedIsUnsupportedProvidedButSilentIsAGap(t *testing.T) {
+	r := capability.NewRegistry()
+	r.Register(stubProvider{"stub", []capability.AnalysisCapability{capability.Reachability}})
+	cov := capability.NewCoverage(r)
+
+	if got := cov.State(subject, capability.Reachability); got != capability.NotEvaluated {
+		t.Errorf("a provided but silent capability = %q, want %q — it is a gap, not a limit",
+			got, capability.NotEvaluated)
+	}
+	if got := cov.State(subject, capability.CallGraph); got != capability.Unsupported {
+		t.Errorf("an unprovided capability = %q, want %q", got, capability.Unsupported)
+	}
+
+	cov.Record(subject, capability.Reachability, capability.Negative)
+	if got := cov.State(subject, capability.Reachability); got != capability.Negative {
+		t.Errorf("a recorded state = %q, want %q", got, capability.Negative)
+	}
+}
+
+// TestNilCoverageAnswersFromTheRegistry pins the property that lets recording
+// sites be unconditional, and checks the nil path still gives honest answers
+// rather than a convenient default.
+func TestNilCoverageAnswersFromTheRegistry(t *testing.T) {
+	var cov *capability.Coverage
+	cov.Record(subject, capability.Taint, capability.Positive)
+
+	if cov.Len() != 0 {
+		t.Error("a nil coverage retained a result")
+	}
+	if got := cov.State(subject, capability.Taint); got != capability.Unsupported {
+		t.Errorf("nil coverage reports %q; with no registry nothing is known to be "+
+			"provided, so the honest answer is %q", got, capability.Unsupported)
+	}
+	for _, g := range cov.Gaps(subject) {
+		if g.State.Conclusive() {
+			t.Errorf("nil coverage reported a conclusive gap: %+v", g)
+		}
+	}
+}
+
+// TestGapsListEverythingUnconcluded. This is what a finding's "what was not
+// evaluated?" answer is built from, and omitting one is how a blind spot stops
+// being visible.
+func TestGapsListEverythingUnconcluded(t *testing.T) {
+	cov := capability.NewCoverage(capability.DefaultRegistry())
+	cov.Record(subject, capability.LexicalContext, capability.Positive)
+	cov.Record(subject, capability.Taint, capability.Negative)
+
+	gaps := cov.Gaps(subject)
+	if want := len(capability.All()) - 2; len(gaps) != want {
+		t.Errorf("Gaps returned %d, want %d (every capability that did not conclude)",
+			len(gaps), want)
+	}
+	for _, g := range gaps {
+		if g.Capability == capability.LexicalContext || g.Capability == capability.Taint {
+			t.Errorf("%q concluded but was reported as a gap", g.Capability)
+		}
+		if g.Reason == "" {
+			t.Errorf("gap %q has no reason", g.Capability)
+		}
+	}
+}
+
+// TestUnknownCapabilitiesAreNeverTreatedAsCoverage. A producer claiming a
+// capability nox does not know about has told nox nothing, and recording it
+// would make the matrix look more covered than it is.
+func TestUnknownCapabilitiesAreNeverTreatedAsCoverage(t *testing.T) {
+	r := capability.NewRegistry()
+	r.Register(stubProvider{"optimist", []capability.AnalysisCapability{"solves_halting_problem"}})
+
+	if r.Provided("solves_halting_problem") {
+		t.Error("an undefined capability was registered as provided")
+	}
+	cov := capability.NewCoverage(r)
+	cov.Record(subject, "solves_halting_problem", capability.Negative)
+	if cov.Len() != 0 {
+		t.Error("a result for an undefined capability was recorded")
+	}
+	if got := cov.State(subject, "solves_halting_problem"); got.SuppressesFinding() {
+		t.Errorf("an undefined capability reported %q, which may suppress a finding", got)
+	}
+}
+
+// TestBuiltinsAreHonestAboutWhatIsMissing. The list is hand-written, so this
+// pins the claims that would be most damaging to get wrong: nox must not
+// declare capabilities a pattern scanner does not have.
+func TestBuiltinsAreHonestAboutWhatIsMissing(t *testing.T) {
+	r := capability.DefaultRegistry()
+
+	for _, c := range []capability.AnalysisCapability{
+		capability.CallGraph, capability.EntryPoint, capability.ConstantEvaluation,
+	} {
+		if r.Provided(c) {
+			t.Errorf("%q is declared as built-in; nox has no such analysis, and "+
+				"claiming one turns a limit into a false assurance", c)
+		}
+	}
+	for _, c := range []capability.AnalysisCapability{
+		capability.LexicalContext, capability.Taint, capability.Reachability,
+	} {
+		if !r.Provided(c) {
+			t.Errorf("%q is not declared but nox does provide it; an undeclared "+
+				"capability reads as Unsupported when it is really available", c)
+		}
+	}
+	if len(r.Missing()) == 0 {
+		t.Error("the registry claims nox is missing nothing, which cannot be true " +
+			"of a scanner that never executes the code it reads")
+	}
+}
+
+type stubProvider struct {
+	name     string
+	provides []capability.AnalysisCapability
+}
+
+func (s stubProvider) Name() string                              { return s.name }
+func (s stubProvider) Provides() []capability.AnalysisCapability { return s.provides }

--- a/core/capability/coverage.go
+++ b/core/capability/coverage.go
@@ -1,0 +1,163 @@
+package capability
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// Coverage records what each capability concluded about each subject.
+//
+// It stores only what actually happened. The default state is DERIVED from the
+// registry rather than written down: a capability something provides but which
+// said nothing about a subject is NotEvaluated, and one nothing provides at all
+// is Unsupported. That is not only a memory decision — though it is that too,
+// since a scan reaching six million findings cannot afford nine states written
+// per finding (docs/benchmarks/2026-Q3/ledger-budget.md) — it is also the
+// honest one. Pre-seeding every pair with NotEvaluated would make the absence
+// of an answer look like a recorded observation.
+//
+// A nil *Coverage is usable, records nothing, and answers every query from the
+// registry alone. That keeps recording sites unconditional, the same property
+// that makes reasoning.Store safe to call everywhere.
+//
+// Safe for concurrent use.
+type Coverage struct {
+	mu       sync.Mutex
+	registry *Registry
+	states   map[key]State
+}
+
+type key struct {
+	subject evidence.Subject
+	ac      AnalysisCapability
+}
+
+// NewCoverage returns a Coverage that resolves defaults against r.
+func NewCoverage(r *Registry) *Coverage {
+	return &Coverage{registry: r, states: make(map[key]State)}
+}
+
+// Record notes that cap reached state about subject.
+//
+// Recording NotEvaluated is a no-op: it is the default, and storing it would
+// grow the map without changing any answer. An invalid capability or state is
+// dropped, because a producer that cannot name what it did has not reported a
+// result — and storing it would make the matrix look more covered than it is.
+func (c *Coverage) Record(subject evidence.Subject, ac AnalysisCapability, state State) {
+	if c == nil || !ac.Valid() || !state.Valid() || state == NotEvaluated {
+		return
+	}
+	if !subject.Valid() {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.states == nil {
+		c.states = make(map[key]State)
+	}
+	c.states[key{subject, ac}] = state
+}
+
+// State returns what cap concluded about subject.
+//
+// The order of the fallbacks is the design. A recorded state wins. Otherwise a
+// capability nothing provides is Unsupported — a limit nox can state plainly.
+// Only a capability that IS provided and still said nothing is NotEvaluated: a
+// gap rather than a limit, and the one an operator can actually act on.
+func (c *Coverage) State(subject evidence.Subject, ac AnalysisCapability) State {
+	if !ac.Valid() {
+		return Unsupported
+	}
+	if c != nil {
+		c.mu.Lock()
+		s, ok := c.states[key{subject, ac}]
+		c.mu.Unlock()
+		if ok {
+			return s
+		}
+	}
+	var reg *Registry
+	if c != nil {
+		reg = c.registry
+	}
+	if !reg.Provided(ac) {
+		return Unsupported
+	}
+	return NotEvaluated
+}
+
+// Subjects returns every subject something was recorded about, sorted.
+func (c *Coverage) Subjects() []evidence.Subject {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	seen := make(map[evidence.Subject]bool, len(c.states))
+	for k := range c.states {
+		seen[k.subject] = true
+	}
+	out := make([]evidence.Subject, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+// Len returns how many (subject, capability) results were recorded.
+func (c *Coverage) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.states)
+}
+
+// Gap describes one capability that did not reach a conclusion about a subject,
+// and why.
+type Gap struct {
+	Capability AnalysisCapability `json:"capability"`
+	State      State              `json:"state"`
+	Reason     string             `json:"reason"`
+}
+
+// Gaps returns every capability that did not conclude about subject, cheapest
+// first.
+//
+// This is the answer to "what does nox not know about this finding?", and it is
+// the thing that has to be reported rather than implied. A finding with
+// Reachability in this list has NOT been shown to be reachable — and, far more
+// importantly, has not been shown to be unreachable either. Presenting it
+// without the gap invites the reader to supply the more comfortable of the two
+// readings.
+func (c *Coverage) Gaps(subject evidence.Subject) []Gap {
+	var out []Gap
+	for _, ac := range All() {
+		s := c.State(subject, ac)
+		if s.Conclusive() {
+			continue
+		}
+		out = append(out, Gap{Capability: ac, State: s, Reason: s.Describe()})
+	}
+	return out
+}
+
+// Summary counts how many results landed in each state across the whole scan.
+// Recorded results only — the derived defaults are not counted, because
+// counting a default as an observation is the error this type exists to avoid.
+func (c *Coverage) Summary() map[State]int {
+	out := make(map[State]int)
+	if c == nil {
+		return out
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.states {
+		out[s]++
+	}
+	return out
+}

--- a/core/capability/providers.go
+++ b/core/capability/providers.go
@@ -1,0 +1,65 @@
+package capability
+
+// This file declares what nox's own built-in analyses can establish.
+//
+// It is a hand-written list, and that is a liability worth naming: a new
+// analyzer that forgets to appear here is invisible to the matrix, and its
+// capability reads as Unsupported when it is in fact provided. The alternative
+// — deriving the list by reflection or by scanning imports — would be worse in
+// the direction that matters, because it would report capabilities as present
+// on the strength of a package existing rather than of it running.
+//
+// TestBuiltinsCoverWhatTheyClaim pins the entries that can be checked against
+// the code they describe.
+
+// builtin is a Provider defined by a static list.
+type builtin struct {
+	name     string
+	provides []AnalysisCapability
+}
+
+// Name identifies the built-in implementation for reporting.
+func (b builtin) Name() string { return b.name }
+
+// Provides lists the capabilities this built-in can establish.
+func (b builtin) Provides() []AnalysisCapability { return b.provides }
+
+// Builtins returns the capabilities nox provides without any plugin installed.
+//
+// The list is deliberately short, and its shortness is the honest reading of
+// what a pattern scanner is. nox lexes, it resolves constants where a language
+// engine exists, and it tracks taint. It does not build a call graph, does not
+// know entry points, and cannot establish reachability or attacker
+// reachability — those come from plugins, or from nowhere.
+//
+// Stating that plainly is the point. An operator running nox with no plugins
+// should be able to see that reachability was never on the table, rather than
+// inferring safety from its silence.
+func Builtins() []Provider {
+	return []Provider{
+		// core/lexctx classifies comment and string regions in 22 languages
+		// and is what the secrets refiners consult before dropping a match.
+		builtin{"core/lexctx", []AnalysisCapability{LexicalContext}},
+		// core/taint resolves source-to-sink dataflow, and its extractors
+		// resolve symbols within a file to do it.
+		builtin{"core/taint", []AnalysisCapability{Taint, SymbolResolution}},
+		// core/analyzers/deps answers reachability for Go only, via
+		// `go list -deps`, and answers it with (reachable, determined) so an
+		// undetermined result never reads as unreachable.
+		builtin{"core/analyzers/deps", []AnalysisCapability{Reachability}},
+		// core/attack constructs and executes exploit hypotheses. It is listed
+		// because it exists, NOT because a scan uses it: `nox scan` never
+		// executes anything, so DynamicVerification is NotEvaluated on every
+		// scan finding rather than absent from the installation.
+		builtin{"core/attack", []AnalysisCapability{DynamicVerification, AttackerReachability}},
+	}
+}
+
+// DefaultRegistry returns a registry holding nox's built-in providers.
+func DefaultRegistry() *Registry {
+	r := NewRegistry()
+	for _, p := range Builtins() {
+		r.Register(p)
+	}
+	return r
+}

--- a/core/e2e_evidence_test.go
+++ b/core/e2e_evidence_test.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// TestEndToEndEvidenceChain runs one real scan over the committed precision
+// suite and checks that every stage of the evidence pipeline actually produced
+// something.
+//
+// The unit tests each verify one stage in isolation, which is exactly how a
+// pipeline passes its whole test suite while being disconnected in the middle.
+// This is the test that fails if a stage stops being reached: refiners record,
+// findings carry supporting claims, adjudication runs, divergence is measured,
+// capability coverage is populated. Silence at any stage fails, because
+// silence is precisely what a disconnected stage looks like.
+//
+// The target is the committed corpus rather than an arbitrary repository, and
+// that choice is load-bearing. Running this against a real project first showed
+// two of these assertions failing on a codebase that simply had nothing to
+// refute and no diverging findings — legitimate outcomes that would make the
+// test flaky and, worse, would train a reader to ignore it. The corpus
+// guarantees the conditions the assertions depend on.
+func TestEndToEndEvidenceChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+
+	res, err := RunScanWithOptions("../testdata/precision-suite",
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	all := res.Findings.Findings()
+	if len(all) == 0 {
+		t.Fatal("the corpus produced no findings; every assertion below would be vacuous")
+	}
+
+	// Stage 1 — refiners record why they dropped a candidate.
+	recorded, unusable := res.Reasoning.Stats()
+	if recorded == 0 {
+		t.Error("no claims were recorded; the reasoning store is not being reached")
+	}
+	if unusable != 0 {
+		t.Errorf("%d claim(s) were filed against an unusable subject — unretrievable, "+
+			"which from every other angle looks exactly like working", unusable)
+	}
+
+	reported := make(map[evidence.Subject]bool, len(all))
+	for _, f := range all {
+		reported[SubjectForFinding(f)] = true
+	}
+
+	var refutations int
+	for _, s := range res.Reasoning.Subjects() {
+		if reported[s] {
+			continue
+		}
+		for _, c := range res.Reasoning.About(s).Claims {
+			if !c.Refutes() {
+				t.Errorf("dropped candidate %s recorded a %s claim; a drop is a refutation",
+					s, c.Polarity.Effective())
+				continue
+			}
+			if c.Statement == "" {
+				t.Errorf("dropped candidate %s recorded no reason", s)
+			}
+			refutations++
+		}
+	}
+	if refutations == 0 {
+		t.Error("no candidate was refuted across the whole corpus; either the refiners " +
+			"stopped recording, or they stopped running")
+	}
+
+	// Stage 2 — every reported finding has a recorded reason for existing.
+	for _, f := range all {
+		ledger := res.Reasoning.About(SubjectForFinding(f))
+		var supported bool
+		for _, c := range ledger.Claims {
+			if c.Supports() {
+				supported = true
+			}
+		}
+		if !supported {
+			t.Errorf("finding %s at %s:%d has no supporting claim",
+				f.RuleID, f.Location.FilePath, f.Location.StartLine)
+		}
+	}
+
+	// Stage 3 — adjudication ran, and never overstated what a scan can know.
+	for _, f := range all {
+		if f.Exploitability != string(evidence.Potential) {
+			t.Errorf("finding %s adjudicated to %q; a scan executes nothing, so "+
+				"POTENTIAL is the only honest state", f.RuleID, f.Exploitability)
+		}
+	}
+
+	// Stage 4 — divergence was measured, not assumed.
+	if len(res.Divergences) == 0 {
+		t.Error("no divergence reported across the corpus. Either every analyzer's " +
+			"confidence now matches its evidence — which would be remarkable — or " +
+			"the comparison stopped running")
+	}
+
+	// Stage 5 — capability coverage, and the rule that makes it worth having.
+	if res.Coverage.Len() == 0 {
+		t.Error("no capability results recorded")
+	}
+	if len(res.Capabilities.Missing()) == 0 {
+		t.Error("the scan claims to be missing no capability, which cannot be true " +
+			"of a scanner that never executes the code it reads")
+	}
+	for _, f := range all {
+		subject := SubjectForFinding(f)
+		if res.Coverage.State(subject, capability.DynamicVerification).Conclusive() {
+			t.Errorf("finding %s claims dynamic verification; nox scan executes nothing",
+				f.RuleID)
+		}
+		for _, g := range res.Coverage.Gaps(subject) {
+			if g.State.SuppressesFinding() {
+				t.Errorf("finding %s has gap %+v reported as suppressing; only a "+
+					"conclusive negative may hide a finding", f.RuleID, g)
+			}
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -37,11 +37,13 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/variants"
 	"github.com/nox-hq/nox/core/analyzers/weakcrypto"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/git"
 	"github.com/nox-hq/nox/core/graph"
 	"github.com/nox-hq/nox/core/intel"
+	"github.com/nox-hq/nox/core/lexctx"
 	"github.com/nox-hq/nox/core/policy"
 	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
@@ -87,6 +89,17 @@ type ScanResult struct {
 	// slice means every configured check completed; a non-empty one means the
 	// findings are incomplete and "no findings" must not be read as "clean".
 	Degradations []Degradation
+
+	// Capabilities is what this installation can establish at all, and
+	// Coverage is what each capability actually concluded about each subject.
+	//
+	// Both are populated on every scan, including one that did not record
+	// reasoning, because "what could nox not tell you?" is answerable without
+	// any evidence being collected and is worth answering unconditionally. A
+	// capability nothing provides is a limit; one that is provided and said
+	// nothing is a gap; and neither is a clearance.
+	Capabilities *capability.Registry
+	Coverage     *capability.Coverage
 
 	// Reasoning holds the claims for and against each candidate this scan
 	// considered: why a finding was reported, and why a dropped one was not.
@@ -327,6 +340,12 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	if opts.RecordReasoning {
 		reasons = reasoning.New()
 	}
+
+	// The capability registry is built unconditionally. It costs one small map
+	// and it answers a question every scan should be able to answer — what this
+	// installation cannot tell you — whether or not anybody asked for evidence.
+	capabilities := capability.DefaultRegistry()
+	coverage := capability.NewCoverage(capabilities)
 
 	// Initialize analyzers.
 	secretsAnalyzer := secrets.NewAnalyzer()
@@ -785,6 +804,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// refutation that ought to be recorded the way the analyzers' are. They are
 	// a larger change than this one and are left to the E track.
 	recordObservations(reasons, allFindings)
+	recordCapabilityCoverage(coverage, allFindings)
 	divergences := adjudicateFindings(reasons, allFindings)
 
 	// Stage 4: Evaluate policy gates.
@@ -796,6 +816,8 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	contributeObservations(ctx, cfg, opts, allFindings.Findings(), degradations)
 
 	return &ScanResult{
+		Capabilities: capabilities,
+		Coverage:     coverage,
 		Reasoning:    reasons,
 		Divergences:  divergences,
 		Findings:     allFindings,
@@ -2000,4 +2022,54 @@ func adjudicateFindings(store *reasoning.Store, fs *findings.FindingSet) []adjud
 		})
 	}
 	return out
+}
+
+// recordCapabilityCoverage records, per reported finding, what the analyses
+// that ran actually concluded about it.
+//
+// It records only what is TRUE of a scan, which is a much shorter list than it
+// looks. A finding exists because a rule matched, so lexical context was
+// consulted wherever a lexer exists for the language — that is Positive. Taint
+// concluded about a finding the taint engine produced, and about nothing else.
+// Everything not recorded here resolves through the registry: provided but
+// silent is NotEvaluated, unprovided is Unsupported.
+//
+// Dynamic verification is the case worth being explicit about. `nox scan`
+// executes nothing, ever, so it is never conclusive here — which is exactly why
+// every scan finding adjudicates to POTENTIAL, and why an operator reading a
+// clean scan should be able to see that nox did not try.
+func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet) {
+	if cov == nil || fs == nil {
+		return
+	}
+	for _, f := range fs.Findings() {
+		subject := SubjectForFinding(f)
+
+		// A rule fired on this location, so the lexer either classified the
+		// file or could not. LangUnknown means no lexer exists for it, which is
+		// a limit rather than a gap.
+		if lexctx.LangFromPath(f.Location.FilePath) == lexctx.LangUnknown {
+			cov.Record(subject, capability.LexicalContext, capability.Unsupported)
+		} else {
+			cov.Record(subject, capability.LexicalContext, capability.Positive)
+		}
+
+		// The taint engine concluded about the findings it produced, and said
+		// nothing about the rest — which stays NotEvaluated rather than being
+		// asserted as anything.
+		if strings.HasPrefix(f.RuleID, "TAINT-") {
+			cov.Record(subject, capability.Taint, capability.Positive)
+			cov.Record(subject, capability.SymbolResolution, capability.Positive)
+		}
+
+		// Dependency reachability answers only where it was determined, and the
+		// deps analyzer already refuses to answer otherwise: goVulnReachable
+		// returns false only on positive evidence.
+		switch f.Metadata["reachable"] {
+		case "true":
+			cov.Record(subject, capability.Reachability, capability.Positive)
+		case "false":
+			cov.Record(subject, capability.Reachability, capability.Negative)
+		}
+	}
 }

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/reasoning"
 )
 
@@ -342,5 +343,75 @@ func TestDivergenceIsMeasuredNotAssumed(t *testing.T) {
 	}
 	if len(off.Divergences) != 0 {
 		t.Error("a scan without reasoning reported divergences it could not have measured")
+	}
+}
+
+// TestCapabilityCoverageIsReportedOnEveryScan. "What could nox not tell you?"
+// is answerable without collecting any evidence, so it is answered
+// unconditionally — including on a scan that did not record reasoning.
+func TestCapabilityCoverageIsReportedOnEveryScan(t *testing.T) {
+	dir := reasoningFixture(t)
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Capabilities == nil || res.Coverage == nil {
+		t.Fatal("a scan without reasoning reported no capability registry or coverage")
+	}
+	if len(res.Capabilities.Missing()) == 0 {
+		t.Error("the scan claims nox is missing no capability, which cannot be true " +
+			"of a scanner that never executes the code it reads")
+	}
+
+	reported := res.Findings.Findings()
+	if len(reported) == 0 {
+		t.Fatal("fixture produced no findings; this test asserts nothing")
+	}
+	for _, f := range reported {
+		subject := SubjectForFinding(f)
+
+		// Nothing executed, so no finding may claim dynamic verification.
+		if got := res.Coverage.State(subject, capability.DynamicVerification); got.Conclusive() {
+			t.Errorf("finding %s reports dynamic verification as %q; nox scan "+
+				"executes nothing", f.RuleID, got)
+		}
+		// And the gap must be visible rather than implied by silence.
+		var sawDynamic bool
+		for _, g := range res.Coverage.Gaps(subject) {
+			if g.Capability == capability.DynamicVerification {
+				sawDynamic = true
+			}
+			if g.State.SuppressesFinding() {
+				t.Errorf("gap %+v is reported as suppressing; only a conclusive "+
+					"negative may do that", g)
+			}
+		}
+		if !sawDynamic {
+			t.Errorf("finding %s does not list dynamic verification as unevaluated", f.RuleID)
+		}
+	}
+}
+
+// TestUnevaluatedNeverReadsAsCleared is Track D's exit criterion, at pipeline
+// level: breaking or uninstalling an analyzer must not be able to make a build
+// look better than it is.
+func TestUnevaluatedNeverReadsAsCleared(t *testing.T) {
+	dir := reasoningFixture(t)
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range res.Findings.Findings() {
+		subject := SubjectForFinding(f)
+		for _, c := range capability.All() {
+			s := res.Coverage.State(subject, c)
+			if !s.Valid() {
+				t.Errorf("capability %q reported an undefined state %q", c, s)
+			}
+			if s.SuppressesFinding() && s != capability.Negative {
+				t.Errorf("state %q for %q may suppress a finding; only a conclusive "+
+					"negative may", s, c)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Track D (D1–D4) of `docs/design/evidence-native-nox.md`. **D5 is deliberately
not here** — see the end.

## Why this lands before any output flip

`degrade` already makes it visible when part of a scan *fails*. What it cannot
express is the positive half: which analyses were supposed to run over a
subject, which did, and what they concluded.

Without that half, the most dangerous state in a security scanner is invisible.
A finding no reachability analysis ever examined and a finding reachability
examined and cleared produce **the same output — silence** — and silence is
read as safety. That becomes acute the moment refutation can change what is
reported, which is why D precedes C5 rather than following it.

## The model

Nine analysis capabilities, six evaluation states. The states are the point:
five of the six would collapse into "no finding" without this type.

```go
func (s State) SuppressesFinding() bool { return s == Negative }
```

That is Gate B written as a method. Unknown, unsupported, timed-out and
never-evaluated cannot be mistaken for a clearance however much they resemble
one in the output.

**The default state is derived, not stored.** A capability something provides
but which said nothing is `NotEvaluated` — a gap. One nothing provides is
`Unsupported` — a limit. That is a memory decision (six million findings cannot
afford nine states written per finding) and also the honest one: pre-seeding
every pair with `NotEvaluated` would make the absence of an answer look like a
recorded observation.

**Named `AnalysisCapability`, not `Capability`.** `core/analyzers/ai` already
uses that word for what an AI agent's *tools* can do, rendered by
`nox agent-graph`. Two commands a letter apart meaning different things is a
documentation problem no amount of documentation fixes.

## `nox analysis-capabilities`

Generated from the registry the scan itself uses, so it cannot describe a
capability the scan does not have:

```
ANALYSIS CAPABILITY    PROVIDED BY
lexical_context        core/lexctx
constant_evaluation    — not provided
symbol_resolution      core/taint
taint                  core/taint
call_graph             — not provided
entry_point            — not provided
reachability           core/analyzers/deps
attacker_reachability  core/attack
dynamic_verification   core/attack

3 capabilities have no implementation on this installation:
  constant_evaluation, call_graph, entry_point

A scan cannot answer these questions, and its silence about them is not
an all-clear.
```

## An end-to-end test, and what it caught

The unit tests each verify one stage in isolation — which is exactly how a
pipeline passes its whole suite while being disconnected in the middle. The new
`TestEndToEndEvidenceChain` runs one real scan and fails if any stage stops
producing: refiners recording, findings carrying supporting claims,
adjudication running, divergence measured, coverage populated.

I ran it against three real local projects before committing it. On
`agent-go` (681 Go files) all twelve checks passed. On `scout`, **two failed** —
no candidates refuted, no divergences — and both were *legitimate outcomes* for
a codebase with nothing to refute and no diverging findings.

So the committed test targets the corpus, not an arbitrary repository.
Assertions that can fail for a correct reason train a reader to ignore the
test, which is the same defect as a test that passes for no reason — just
pointed the other way. The real-project sweep stays a manual exercise.

Observed end to end on the corpus: 37 findings, 49 claims, 12 candidates
refuted with reasons, 15 divergences, 71 coverage results, 0 claims filed
against an unusable subject.

## Verification

- `go build ./...` clean, `golangci-lint` 0 issues
- `./core/... ./cli/... ./server/...` green
- precision suite 37/0/0, refutation suite 10/0/0 — unchanged

## What is not here

**D5 (`policy.uncertainty`).** It changes CI gating and carries the adoption
cliff flagged in §1.5 — making uncertainty fail-closed by default turns red, on
upgrade, every repository gated on a severity threshold. It deserves its own
review and its own release note.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW