### PR TITLE
D5: gate on what nox did not establish

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -89,6 +89,22 @@ type PolicySettings struct {
 	// baselining every finding. Keys are severity names (critical/high/medium/
 	// low/info).
 	Budget map[string]int `yaml:"budget"`
+
+	// Uncertainty says what to do about what the scan did not establish:
+	// "warn" (default), "fail", or "ignore". It reads the axis the gate never
+	// has — not how bad a finding would be if true, but how much nox actually
+	// determined.
+	Uncertainty string `yaml:"uncertainty"`
+
+	// RequireCapabilities names the analysis capabilities this project's triage
+	// depends on ("reachability", "taint", …; see `nox analysis-capabilities`).
+	//
+	// Empty for every existing repository, and empty changes nothing. Listing
+	// one asserts that this project relies on that question being answered —
+	// so that uninstalling the plugin which answers it can no longer make the
+	// build quietly greener, which is the whole failure this setting exists to
+	// close.
+	RequireCapabilities []string `yaml:"require_capabilities"`
 }
 
 // ComplianceSettings controls compliance framework filtering.

--- a/core/policy/policy.go
+++ b/core/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/findings"
 )
 
@@ -32,6 +33,21 @@ type Config struct {
 	// entries default to 0 (fail on the first), so an empty Budget reproduces
 	// the pre-budget max-severity gate exactly.
 	Budget map[findings.Severity]int `yaml:"budget"`
+
+	// Uncertainty says what to do about what nox did not establish. It gates
+	// the second axis the policy has never read: not how bad a finding would be
+	// if true, but how much nox actually determined. Defaults to warn.
+	Uncertainty Uncertainty `yaml:"uncertainty"`
+
+	// RequireCapabilities lists the analysis capabilities this project's triage
+	// depends on. Empty by default, which is every existing repository and
+	// changes nothing for them. A project that lists one is asserting it relies
+	// on that question being answered, and will be told when it stops being.
+	//
+	// Deliberately a declaration rather than an inference: see
+	// EvaluateCapabilities for why "fail on anything unevaluated" cannot be the
+	// design.
+	RequireCapabilities []string `yaml:"require_capabilities"`
 }
 
 // Validate rejects a policy configuration whose gate keywords are not
@@ -53,6 +69,18 @@ func (c Config) Validate() error {
 	if c.WarnOn != "" {
 		if !c.WarnOn.IsValid() {
 			return fmt.Errorf("policy.warn_on: %q is not a valid severity (want one of critical, high, medium, low, info)", c.WarnOn)
+		}
+	}
+	// An unrecognised uncertainty mode must not silently pick a behaviour. The
+	// same reasoning as fail_on above: a mistyped value that quietly resolves
+	// to the permissive default looks configured and is not.
+	if !c.Uncertainty.Valid() {
+		return fmt.Errorf("policy.uncertainty: %q is not valid (want one of warn, fail, ignore)", c.Uncertainty)
+	}
+	for _, name := range c.RequireCapabilities {
+		if !capability.AnalysisCapability(name).Valid() {
+			return fmt.Errorf("policy.require_capabilities: %q is not a known analysis capability "+
+				"(run `nox analysis-capabilities` for the list)", name)
 		}
 	}
 	switch c.BaselineMode {

--- a/core/policy/uncertainty.go
+++ b/core/policy/uncertainty.go
@@ -1,0 +1,155 @@
+package policy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// Uncertainty says what a build should do about what nox did not establish.
+//
+// The gate nox has always had reads severity: how bad this would be if true.
+// It has never read the other axis — how much nox actually determined — and
+// that axis is where the dangerous failure lives. Uninstall the reachability
+// plugin and every finding it would have classified simply stops being
+// classified. Nothing goes red. The build is greener than it was, and it is
+// greener because nox now knows less.
+type Uncertainty string
+
+// Uncertainty modes.
+const (
+	// UncertaintyWarn reports what was not evaluated and does not gate. The
+	// default, and deliberately so — see RequireCapabilities for why the
+	// stricter setting cannot be the default yet.
+	UncertaintyWarn Uncertainty = "warn"
+	// UncertaintyFail treats an unmet capability requirement as a failure.
+	UncertaintyFail Uncertainty = "fail"
+	// UncertaintyIgnore says nothing at all. It exists because an operator who
+	// has genuinely decided they do not want this signal should be able to turn
+	// it off explicitly, rather than learning to skim past a warning — a
+	// warning that is always ignored is worse than one that was never printed,
+	// because it trains the reader to ignore its neighbours too.
+	UncertaintyIgnore Uncertainty = "ignore"
+)
+
+// Valid reports whether u is a defined mode. The empty string is valid and
+// means the default.
+func (u Uncertainty) Valid() bool {
+	switch u {
+	case "", UncertaintyWarn, UncertaintyFail, UncertaintyIgnore:
+		return true
+	}
+	return false
+}
+
+// Effective resolves the zero value to the default.
+func (u Uncertainty) Effective() Uncertainty {
+	if u == "" {
+		return UncertaintyWarn
+	}
+	return u
+}
+
+// CapabilityGate is the capability half of a policy decision.
+//
+// It is a small interface rather than a *capability.Registry so core/policy
+// does not have to import the registry's whole world, and so a test can state
+// the case it means in one line instead of assembling an installation.
+type CapabilityGate interface {
+	// Provided reports whether anything on this installation offers c.
+	Provided(c capability.AnalysisCapability) bool
+}
+
+// EvaluateCapabilities checks a project's declared capability requirements
+// against what the installation actually provides, and folds the outcome into
+// an existing policy Result.
+//
+// # Why requirements are declared rather than inferred
+//
+// The obvious design is to fail whenever anything is unevaluated. It cannot be
+// the design. Every scan today has three capabilities with no implementation —
+// constant evaluation, call graphs, entry points — so "fail on any gap" turns
+// every build on earth red on upgrade, and the setting gets switched off within
+// the hour. A gate everybody disables protects nothing.
+//
+// So the project says what it depends on. An empty list changes nothing, which
+// is what every existing repository has. A repository that lists reachability
+// is asserting that its triage depends on reachability being answered, and nox
+// will tell it — loudly, and at `fail` fatally — when that stops being true.
+// That is the narrow, real case: not "nox does not know everything", but
+// "nox stopped knowing something this project was relying on".
+func EvaluateCapabilities(cfg Config, gate CapabilityGate, r *Result) *Result {
+	if r == nil {
+		r = &Result{Pass: true, ExitCode: 0}
+	}
+	mode := cfg.Uncertainty.Effective()
+	if mode == UncertaintyIgnore || len(cfg.RequireCapabilities) == 0 {
+		return r
+	}
+
+	var missing []string
+	for _, name := range cfg.RequireCapabilities {
+		c := capability.AnalysisCapability(name)
+		if gate != nil && gate.Provided(c) {
+			continue
+		}
+		missing = append(missing, name)
+	}
+	if len(missing) == 0 {
+		return r
+	}
+	sort.Strings(missing)
+
+	// The wording carries the whole point. An operator who reads this as "nox
+	// is missing a feature" has drawn the wrong conclusion; what it means is
+	// that findings this project triages using that capability are now
+	// unclassified, and their silence is not a clearance.
+	detail := fmt.Sprintf(
+		"required analysis capabilit%s %s %s not provided by this installation: "+
+			"findings that depend on %s are unevaluated, not cleared",
+		plural(len(missing), "y", "ies"),
+		strings.Join(missing, ", "),
+		plural(len(missing), "is", "are"),
+		plural(len(missing), "it", "them"))
+
+	switch mode {
+	case UncertaintyFail:
+		r.Pass = false
+		if r.ExitCode == 0 {
+			r.ExitCode = 1
+		}
+		r.Warnings = append(r.Warnings, "policy.uncertainty=fail: "+detail)
+
+		// Both reasons have to survive. A build failing for two reasons that
+		// reports one leaves an operator fixing the finding, seeing the build
+		// still red, and having no idea why — so the capability reason is
+		// APPENDED to an existing failure rather than skipped, and the summary
+		// is only replaced when there was nothing there.
+		reason := fmt.Sprintf("unmet capability requirement: %s", strings.Join(missing, ", "))
+		switch {
+		case r.Summary == "":
+			r.Summary = "policy: fail (" + reason + ")"
+		case strings.HasPrefix(r.Summary, "policy: fail"):
+			r.Summary += "; " + reason
+		default:
+			r.Summary = "policy: fail (" + reason + "); " + r.Summary
+		}
+	default:
+		// The warning names the flag. §1.5 of the design doc requires a release
+		// in which the stricter behaviour is announced by the warning that
+		// precedes it, so that switching the default later surprises nobody.
+		r.Warnings = append(r.Warnings, detail+
+			" — set policy.uncertainty=fail to gate on this, or "+
+			"policy.uncertainty=ignore to silence it")
+	}
+	return r
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/core/policy/uncertainty_test.go
+++ b/core/policy/uncertainty_test.go
@@ -1,0 +1,230 @@
+package policy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/policy"
+)
+
+// gate is a CapabilityGate stating exactly the case a test means, rather than
+// assembling an installation to imply it.
+type gate map[capability.AnalysisCapability]bool
+
+func (g gate) Provided(c capability.AnalysisCapability) bool { return g[c] }
+
+func highFinding() findings.Finding {
+	return findings.Finding{
+		RuleID: "SEC-003", Severity: findings.SeverityHigh,
+		Location: findings.Location{FilePath: "app/creds.py", StartLine: 1},
+	}
+}
+
+// TestNoAdoptionCliff is the most important test in this file.
+//
+// Making uncertainty fail-closed by default would turn red, on upgrade, every
+// repository gated on a severity threshold — which is most of them. A gate
+// everybody switches off within the hour protects nothing, so the default has
+// to be inert, and "inert" has to be asserted rather than believed.
+func TestNoAdoptionCliff(t *testing.T) {
+	before := policy.Evaluate(policy.Config{FailOn: findings.SeverityCritical},
+		[]findings.Finding{highFinding()})
+
+	// The same config a repository already has, evaluated through the new path
+	// against an installation that provides nothing at all.
+	after := policy.EvaluateCapabilities(
+		policy.Config{FailOn: findings.SeverityCritical}, gate{},
+		policy.Evaluate(policy.Config{FailOn: findings.SeverityCritical},
+			[]findings.Finding{highFinding()}))
+
+	if after.Pass != before.Pass || after.ExitCode != before.ExitCode {
+		t.Errorf("an unchanged config changed outcome: pass %v->%v, exit %d->%d",
+			before.Pass, after.Pass, before.ExitCode, after.ExitCode)
+	}
+	if len(after.Warnings) != len(before.Warnings) {
+		t.Errorf("an unchanged config gained %d warning(s); a project that declared "+
+			"no capability requirement must hear nothing",
+			len(after.Warnings)-len(before.Warnings))
+	}
+}
+
+// TestUnmetRequirementWarnsByDefaultAndNamesTheFlag. §1.5 of the design doc
+// requires a release in which the stricter behaviour is announced by the
+// warning that precedes it, so switching the default later surprises nobody.
+func TestUnmetRequirementWarnsByDefaultAndNamesTheFlag(t *testing.T) {
+	cfg := policy.Config{
+		FailOn:              findings.SeverityCritical,
+		RequireCapabilities: []string{"reachability"},
+	}
+	r := policy.EvaluateCapabilities(cfg, gate{}, policy.Evaluate(cfg, nil))
+
+	if !r.Pass {
+		t.Error("the default mode failed the build; warn must not gate")
+	}
+	if len(r.Warnings) == 0 {
+		t.Fatal("an unmet requirement produced no warning")
+	}
+	joined := strings.Join(r.Warnings, " ")
+	if !strings.Contains(joined, "reachability") {
+		t.Errorf("the warning does not name the missing capability: %q", joined)
+	}
+	if !strings.Contains(joined, "policy.uncertainty=fail") {
+		t.Errorf("the warning does not name the flag that would gate on it: %q", joined)
+	}
+	// The wording has to stop a reader concluding the finding was cleared.
+	if !strings.Contains(joined, "unevaluated, not cleared") {
+		t.Errorf("the warning does not distinguish unevaluated from cleared: %q", joined)
+	}
+}
+
+// TestFailModeGatesOnAnUnmetRequirement is Track D's exit criterion: losing an
+// analyzer the project declared it depends on cannot make the build greener.
+func TestFailModeGatesOnAnUnmetRequirement(t *testing.T) {
+	cfg := policy.Config{
+		FailOn:              findings.SeverityCritical,
+		Uncertainty:         policy.UncertaintyFail,
+		RequireCapabilities: []string{"reachability"},
+	}
+
+	// With the capability present, a clean scan passes.
+	present := policy.EvaluateCapabilities(cfg,
+		gate{capability.Reachability: true}, policy.Evaluate(cfg, nil))
+	if !present.Pass {
+		t.Fatalf("a met requirement failed the build: %+v", present.Warnings)
+	}
+
+	// Uninstall the analyzer and the same clean scan does NOT go green.
+	absent := policy.EvaluateCapabilities(cfg, gate{}, policy.Evaluate(cfg, nil))
+	if absent.Pass {
+		t.Error("removing a required analyzer left the build passing — the exact " +
+			"failure this setting exists to close")
+	}
+	if absent.ExitCode == 0 {
+		t.Error("the build failed but exited 0")
+	}
+	if !strings.Contains(absent.Summary, "fail") {
+		t.Errorf("summary %q does not report the failure", absent.Summary)
+	}
+}
+
+// TestIgnoreIsSilent. An operator who has genuinely decided they do not want
+// this signal should be able to turn it off, rather than learning to skim past
+// a warning — a warning always ignored trains a reader to ignore its
+// neighbours too.
+func TestIgnoreIsSilent(t *testing.T) {
+	cfg := policy.Config{
+		Uncertainty:         policy.UncertaintyIgnore,
+		RequireCapabilities: []string{"reachability", "call_graph"},
+	}
+	r := policy.EvaluateCapabilities(cfg, gate{}, policy.Evaluate(cfg, nil))
+	if !r.Pass {
+		t.Error("ignore mode failed the build")
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("ignore mode emitted %d warning(s)", len(r.Warnings))
+	}
+}
+
+// TestAMistypedSettingIsRejectedNotGuessed. The reasoning is the one already
+// written for fail_on: a value that quietly resolves to the permissive default
+// looks configured and is not, which is strictly worse than having no policy.
+func TestAMistypedSettingIsRejectedNotGuessed(t *testing.T) {
+	for _, bad := range []string{"Fail", "FAIL", "strict", "true", "yes", " fail"} {
+		cfg := policy.Config{Uncertainty: policy.Uncertainty(bad)}
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("policy.uncertainty=%q was accepted; a mistyped mode must be "+
+				"rejected rather than resolved to the permissive default", bad)
+		}
+	}
+	for _, good := range []string{"", "warn", "fail", "ignore"} {
+		if err := (policy.Config{Uncertainty: policy.Uncertainty(good)}).Validate(); err != nil {
+			t.Errorf("policy.uncertainty=%q was rejected: %v", good, err)
+		}
+	}
+
+	// The same for a capability nobody defines: silently accepting it would
+	// declare a requirement that can never be met and never be reported.
+	bad := policy.Config{RequireCapabilities: []string{"solves_halting_problem"}}
+	if err := bad.Validate(); err == nil {
+		t.Error("an undefined capability was accepted in require_capabilities")
+	}
+	good := policy.Config{RequireCapabilities: []string{"reachability", "taint"}}
+	if err := good.Validate(); err != nil {
+		t.Errorf("a valid requirement was rejected: %v", err)
+	}
+}
+
+// TestFailModePreservesAnExistingFailure. Folding the capability verdict into
+// an existing Result must not overwrite why the build was already failing.
+func TestFailModePreservesAnExistingFailure(t *testing.T) {
+	cfg := policy.Config{
+		FailOn:              findings.SeverityHigh,
+		Uncertainty:         policy.UncertaintyFail,
+		RequireCapabilities: []string{"reachability"},
+	}
+	base := policy.Evaluate(cfg, []findings.Finding{highFinding()})
+	if base.Pass {
+		t.Fatal("a high finding at fail_on=high did not fail; the fixture is wrong")
+	}
+	r := policy.EvaluateCapabilities(cfg, gate{}, base)
+
+	if r.Pass {
+		t.Error("the combined result passed")
+	}
+	if !strings.Contains(r.Summary, "SEC-003") && !strings.Contains(r.Summary, "high") {
+		t.Errorf("summary %q lost the finding that was already failing the gate", r.Summary)
+	}
+	if !strings.Contains(r.Summary, "capability") {
+		t.Errorf("summary %q does not mention the unmet requirement", r.Summary)
+	}
+}
+
+// TestNilGateIsTreatedAsProvidingNothing. A caller that forgot to pass a
+// registry must not be handed a pass; the honest reading of "no registry" is
+// "nothing is known to be provided".
+func TestNilGateIsTreatedAsProvidingNothing(t *testing.T) {
+	cfg := policy.Config{
+		Uncertainty:         policy.UncertaintyFail,
+		RequireCapabilities: []string{"reachability"},
+	}
+	r := policy.EvaluateCapabilities(cfg, nil, policy.Evaluate(cfg, nil))
+	if r.Pass {
+		t.Error("a nil capability gate passed a declared requirement")
+	}
+}
+
+// TestValidationSeesEveryGateField guards the defect this file's own
+// development produced.
+//
+// The uncertainty validation was written correctly and was unreachable: the
+// loader built its policy.Config from a separate literal that omitted the new
+// fields, so `uncertainty: Fail` was accepted and silently resolved to the
+// permissive default — precisely the failure the fail_on validation exists to
+// prevent, reproduced one field over. A validator that cannot see a field
+// validates nothing about it, and two struct literals side by side make that
+// invisible.
+//
+// This asserts the property directly: every gate-affecting field must be
+// rejectable. If a future field is added to Config and not to whatever builds
+// it, this is the test that should notice.
+func TestValidationSeesEveryGateField(t *testing.T) {
+	cases := []struct {
+		field string
+		cfg   policy.Config
+	}{
+		{"fail_on", policy.Config{FailOn: findings.Severity("High")}},
+		{"warn_on", policy.Config{WarnOn: findings.Severity("Medium")}},
+		{"baseline_mode", policy.Config{BaselineMode: policy.BaselineMode("Strict")}},
+		{"budget", policy.Config{Budget: map[findings.Severity]int{"Critical": 1}}},
+		{"uncertainty", policy.Config{Uncertainty: policy.Uncertainty("Fail")}},
+		{"require_capabilities", policy.Config{RequireCapabilities: []string{"reachabilty"}}},
+	}
+	for _, tc := range cases {
+		if err := tc.cfg.Validate(); err == nil {
+			t.Errorf("policy.%s accepted an invalid value; a gate keyword that "+
+				"silently resolves to a default is worse than no policy at all", tc.field)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -283,12 +283,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// Fail loudly on an invalid policy gate keyword. An unrecognized fail_on
 	// silently disables the gate — a capitalized "High" or a typo turns CI
 	// green on critical findings — so reject it at load rather than at exit.
-	if err := (policy.Config{
-		FailOn:       findings.Severity(cfg.Policy.FailOn),
-		WarnOn:       findings.Severity(cfg.Policy.WarnOn),
-		BaselineMode: policy.BaselineMode(cfg.Policy.BaselineMode),
-		Budget:       policyBudget(cfg.Policy.Budget),
-	}).Validate(); err != nil {
+	if err := policyConfigFrom(cfg).Validate(); err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
@@ -808,7 +803,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	divergences := adjudicateFindings(reasons, allFindings)
 
 	// Stage 4: Evaluate policy gates.
-	policyResult := evaluatePolicy(cfg, allFindings)
+	policyResult := evaluatePolicy(cfg, allFindings, capabilities)
 
 	// Stage 5: Contribute observations, if this installation opted in. Runs
 	// last, over the refined findings, so what is shared is what the scan
@@ -1282,17 +1277,19 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 
 // evaluatePolicy runs the configured fail-on / baseline policy gate over the
 // refined findings. It returns nil when no policy is configured. Stage 4.
-func evaluatePolicy(cfg *ScanConfig, allFindings *findings.FindingSet) *policy.Result {
-	if cfg.Policy.FailOn == "" && cfg.Policy.BaselineMode == "" && len(cfg.Policy.Budget) == 0 {
+func evaluatePolicy(cfg *ScanConfig, allFindings *findings.FindingSet, caps *capability.Registry) *policy.Result {
+	// A project that declares a capability requirement has configured a policy,
+	// even with no severity threshold set. Leaving it out of this condition
+	// would accept the setting and never evaluate it — a gate that looks
+	// configured and is not, which is the exact defect Config.Validate exists
+	// to prevent for fail_on.
+	if cfg.Policy.FailOn == "" && cfg.Policy.BaselineMode == "" &&
+		len(cfg.Policy.Budget) == 0 && len(cfg.Policy.RequireCapabilities) == 0 {
 		return nil
 	}
-	policyCfg := policy.Config{
-		FailOn:       findings.Severity(cfg.Policy.FailOn),
-		WarnOn:       findings.Severity(cfg.Policy.WarnOn),
-		BaselineMode: policy.BaselineMode(cfg.Policy.BaselineMode),
-		Budget:       policyBudget(cfg.Policy.Budget),
-	}
-	return policy.Evaluate(policyCfg, allFindings.Findings())
+	policyCfg := policyConfigFrom(cfg)
+	result := policy.Evaluate(policyCfg, allFindings.Findings())
+	return policy.EvaluateCapabilities(policyCfg, caps, result)
 }
 
 // policyBudget converts the string-keyed budget from config into the
@@ -2071,5 +2068,27 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 		case "false":
 			cov.Record(subject, capability.Reachability, capability.Negative)
 		}
+	}
+}
+
+// policyConfigFrom builds the policy configuration from .nox.yaml.
+//
+// It exists because there are two callers — the loader, which validates, and
+// the gate, which evaluates — and they were separate literals. Adding a field
+// to one and not the other produced exactly the defect the validation is FOR:
+// `uncertainty: Fail` was accepted and silently resolved to the permissive
+// default, because the value never reached the function that would have
+// rejected it. A validator that cannot see a field validates nothing about it,
+// and nothing about the shape of two literals made that visible.
+//
+// One constructor, so the two cannot drift again.
+func policyConfigFrom(cfg *ScanConfig) policy.Config {
+	return policy.Config{
+		FailOn:              findings.Severity(cfg.Policy.FailOn),
+		WarnOn:              findings.Severity(cfg.Policy.WarnOn),
+		BaselineMode:        policy.BaselineMode(cfg.Policy.BaselineMode),
+		Budget:              policyBudget(cfg.Policy.Budget),
+		Uncertainty:         policy.Uncertainty(cfg.Policy.Uncertainty),
+		RequireCapabilities: cfg.Policy.RequireCapabilities,
 	}
 }


### PR DESCRIPTION
Track D5, the half deliberately held back from #509. It completes Track D's
exit criterion.

## The failure it closes

The gate has always read severity: *how bad this would be if true*. It has
never read the other axis — *how much nox actually determined* — and that is
where the dangerous failure lives.

Uninstall the reachability plugin and every finding it would have classified
simply stops being classified. Nothing goes red. **The build is greener than it
was, and it is greener because nox knows less.**

## Verified end to end on a clean scan

Not from unit tests — a real `nox scan` against a project with no findings and
the required capability absent:

| config | exit |
|---|---|
| no requirement declared | `0` |
| requirement + `uncertainty: warn` (default) | `0`, warning names the flag |
| requirement + `uncertainty: fail` | **`1`** |

The third row is the exit criterion. A clean scan does not go green when an
analyzer the project declared it depends on has gone missing.

## Requirements are declared, not inferred

This is the whole design, and the alternative is why.

Failing whenever *anything* is unevaluated cannot work. Every scan today has
three capabilities with no implementation — constant evaluation, call graphs,
entry points — so "fail on any gap" turns every build on earth red on upgrade,
and the setting is switched off within the hour. **A gate everybody disables
protects nothing.**

So an empty list — which is every existing repository — changes nothing.
`TestNoAdoptionCliff` asserts that rather than believing it. A project that
lists `reachability` is asserting its triage depends on that question being
answered, and will be told when it stops being.

`ignore` exists deliberately too: an operator who has genuinely decided they
don't want the signal should turn it off, rather than learn to skim past a
warning — a warning always ignored trains a reader to ignore its neighbours.

## Two defects found by testing, not by reading

**The summary dropped one of two failure reasons.** A build failing on both a
finding and an unmet requirement reported only the finding. An operator would
fix it, see the build still red, and have no idea why. Both reasons now
survive.

**The validation was correct and unreachable.** The loader built its
`policy.Config` from a *separate literal* that omitted the new fields, so
`uncertainty: Fail` was accepted and silently resolved to the permissive
default — precisely the failure the `fail_on` validation exists to prevent,
reproduced one field over. Two struct literals side by side made it invisible.

There is now one constructor, and `TestValidationSeesEveryGateField` asserts
every gate-affecting field is rejectable, so the next field added to one site
and not the other gets caught rather than shipping as a silently-disabled gate.

## Verification

- `go build ./...` clean, `golangci-lint run ./core/... ./cli/...` 0 issues
- `./core/... ./cli/... ./server/...` green
- precision suite 37/0/0, refutation suite 10/0/0 — unchanged
- `TestEndToEndEvidenceChain` passing
- Exit codes 0 / 0 / 1 / 2 confirmed against real scans, including the mistyped
  config now failing at load rather than at exit

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW