### PR TITLE
Record candidates removed by configuration

### DIFF
--- a/core/reasoning/reasoning.go
+++ b/core/reasoning/reasoning.go
@@ -189,3 +189,28 @@ func (s *Store) Support(subject evidence.Subject, kind evidence.Kind, source, to
 		Provenance: evidence.Provenance{Source: source, Tool: tool},
 	})
 }
+
+// Withheld records that a candidate was removed from the results by
+// CONFIGURATION rather than by evidence.
+//
+// The polarity is Unknown, and that is the considered choice rather than a
+// default. A rule the operator disabled, a path they excluded, a directory
+// they marked generated — none of these say anything about whether the finding
+// was true. Recording them as refutations would put fabricated evidence in the
+// ledger: nox would appear to have established something it never examined,
+// which is precisely the confusion the polarity distinction exists to prevent,
+// committed by the code that introduced the distinction.
+//
+// Unknown weighs nothing in either direction, which is correct — a
+// configuration decision is not evidence — while still leaving a trail. An
+// operator can then tell "nox found nothing here" from "nox found it and my
+// config removed it", which they currently cannot.
+func (s *Store) Withheld(subject evidence.Subject, source, tool, statement string) {
+	s.Record(evidence.Claim{
+		Kind:       evidence.KindHeuristic,
+		Statement:  statement,
+		Polarity:   evidence.PolarityUnknown,
+		Subject:    subject,
+		Provenance: evidence.Provenance{Source: source, Tool: tool},
+	})
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -786,7 +786,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	for i := range artifacts {
 		scannedPaths = append(scannedPaths, artifacts[i].Path)
 	}
-	if err := refineFindings(allFindings, cfg, opts, target, degradations, scannedPaths); err != nil {
+	if err := refineFindings(allFindings, cfg, opts, target, degradations, scannedPaths, reasons); err != nil {
 		return nil, err
 	}
 
@@ -1135,10 +1135,23 @@ func singleFileArtifacts(path string, cfg *ScanConfig) ([]discovery.Artifact, er
 // conditional severity, dedup + deterministic sort, inline suppressions,
 // optional terraform-plan findings, baseline matching, and VEX. It is stage 3
 // of the scan pipeline.
-func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts ScanOptions, target string, deg *degrade.Degradations, scanned []string) error {
+func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts ScanOptions, target string, deg *degrade.Degradations, scanned []string, reasons *reasoning.Store) error {
+	// Every config-driven removal below is wrapped so the candidate it deleted
+	// leaves a trail. Without it an operator cannot tell "nox found nothing
+	// here" from "nox found it and my config removed it", and those are very
+	// different states to be in.
+	//
+	// The wrapper is a no-op on a nil store, so a scan that did not ask for
+	// reasoning does not pay for the snapshots.
+	withheld := func(reason string, remove func()) {
+		recordWithheld(reasons, allFindings, reason, remove)
+	}
+
 	// Config rule disabling and severity overrides.
 	if len(cfg.Scan.Rules.Disable) > 0 {
-		allFindings.RemoveByRuleIDs(cfg.Scan.Rules.Disable)
+		withheld("removed by scan.rules.disable in .nox.yaml", func() {
+			allFindings.RemoveByRuleIDs(cfg.Scan.Rules.Disable)
+		})
 	}
 	for ruleID, sev := range cfg.Scan.Rules.SeverityOverride {
 		allFindings.OverrideSeverity(ruleID, findings.Severity(sev))
@@ -1151,7 +1164,9 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		switch ar.Action {
 		case "disable":
 			if len(ar.Rules) > 0 && len(ar.Paths) > 0 {
-				allFindings.RemoveByRuleIDsAndPaths(ar.Rules, ar.Paths)
+				withheld("removed by scan.analyzer_rules disable in .nox.yaml", func() {
+					allFindings.RemoveByRuleIDsAndPaths(ar.Rules, ar.Paths)
+				})
 			}
 		case "skip_analyzer":
 			patterns := analyzerRulePatterns(ar.Analyzer)
@@ -1162,7 +1177,9 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 			if len(paths) == 0 {
 				paths = []string{"*"} // all files
 			}
-			allFindings.RemoveByRuleIDsAndPaths(patterns, paths)
+			withheld("removed by scan.analyzer_rules skip_analyzer "+ar.Analyzer+" in .nox.yaml", func() {
+				allFindings.RemoveByRuleIDsAndPaths(patterns, paths)
+			})
 		}
 	}
 
@@ -1170,10 +1187,14 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	// inside test/fixture/example trees — false-positive sources. Dependency
 	// scanning already ran against the same lockfiles, so no real CVE is hidden.
 	if genPaths := cfg.Scan.GeneratedPaths.ResolveGeneratedPaths(); len(genPaths) > 0 {
-		allFindings.RemoveByRuleIDsAndPaths([]string{"AI-*", "MCP-*"}, genPaths)
+		withheld("content rule dropped on a generated or vendored path", func() {
+			allFindings.RemoveByRuleIDsAndPaths([]string{"AI-*", "MCP-*"}, genPaths)
+		})
 	}
 	if noiseDirs := cfg.Scan.GeneratedPaths.ResolveNoiseDirs(); len(noiseDirs) > 0 {
-		allFindings.RemoveByRuleIDsInDirs([]string{"AI-*", "MCP-*"}, noiseDirs)
+		withheld("content rule dropped inside a test, fixture or example tree", func() {
+			allFindings.RemoveByRuleIDsInDirs([]string{"AI-*", "MCP-*"}, noiseDirs)
+		})
 	}
 
 	// conditional_severity overrides based on rule + path.
@@ -2071,5 +2092,38 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 		case "false":
 			cov.Record(subject, capability.Reachability, capability.Negative)
 		}
+	}
+}
+
+// recordWithheld runs a removal and records which candidates it deleted.
+//
+// The removal functions on FindingSet do not report what they took, and giving
+// each of them a reporting variant would be a wide change to a much-used API
+// for one caller's benefit. Diffing around the call gets the same answer at the
+// one place that needs it.
+//
+// It is a no-op on a nil store, and that guard is what keeps the cost honest:
+// the snapshot is O(findings) per removal step, which is not something to pay
+// on a six-million-finding scan that never asked for the trail.
+func recordWithheld(store *reasoning.Store, fs *findings.FindingSet, reason string, remove func()) {
+	if store == nil {
+		remove()
+		return
+	}
+
+	before := make(map[evidence.Subject]findings.Finding, len(fs.Findings()))
+	for _, f := range fs.Findings() {
+		before[SubjectForFinding(f)] = f
+	}
+
+	remove()
+
+	for _, f := range fs.Findings() {
+		delete(before, SubjectForFinding(f))
+	}
+	for subject, f := range before {
+		store.Withheld(subject, "nox-scan", "config",
+			fmt.Sprintf("%s (%s at %s:%d)", reason, f.RuleID,
+				f.Location.FilePath, f.Location.StartLine))
 	}
 }

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nox-hq/nox-core/evidence"
@@ -413,5 +414,112 @@ func TestUnevaluatedNeverReadsAsCleared(t *testing.T) {
 					"negative may", s, c)
 			}
 		}
+	}
+}
+
+// TestConfigDrivenRemovalsLeaveATrail closes the gap C1 left open.
+//
+// Suppression, baselining and VEX were never actually silent — each sets a
+// Status the reporters carry. The genuinely silent removals are the
+// config-driven ones: a disabled rule, an excluded path, a generated-file
+// filter. Those delete the finding outright, and an operator reading a clean
+// scan cannot tell "nox found nothing here" from "nox found it and my config
+// removed it".
+func TestConfigDrivenRemovalsLeaveATrail(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "creds.py"),
+		[]byte("GITHUB_TOKEN = \"ghp_7Kd2mQ9xR4tB1nZ6wY3vC8hL5jF0gS2pA9eU\"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// First establish the finding exists, so the assertion below cannot pass
+	// because nothing was ever found.
+	base, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var ruleID string
+	for _, f := range base.Findings.Findings() {
+		ruleID = f.RuleID
+	}
+	if ruleID == "" {
+		t.Fatal("the fixture produced no finding; this test would assert nothing")
+	}
+
+	// Now disable the rule that produced it.
+	cfgYAML := "scan:\n  rules:\n    disable:\n      - " + ruleID + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range res.Findings.Findings() {
+		if f.RuleID == ruleID {
+			t.Fatalf("%s was not removed; the fixture does not exercise the path", ruleID)
+		}
+	}
+
+	var trail int
+	for _, subject := range res.Reasoning.Subjects() {
+		for _, c := range res.Reasoning.About(subject).Claims {
+			if c.Polarity.Effective() != evidence.PolarityUnknown {
+				continue
+			}
+			if !strings.Contains(c.Statement, ruleID) {
+				continue
+			}
+			trail++
+			// The claim must not weigh as evidence in either direction. A
+			// configuration decision says nothing about whether the finding was
+			// true, and recording it as a refutation would put fabricated
+			// evidence in the ledger.
+			if c.Refutes() || c.Supports() {
+				t.Errorf("a config removal was recorded as %s; it is not evidence",
+					c.Polarity.Effective())
+			}
+			if !strings.Contains(c.Statement, ".nox.yaml") {
+				t.Errorf("the trail does not name the configuration that removed it: %q",
+					c.Statement)
+			}
+		}
+	}
+	if trail == 0 {
+		t.Errorf("%s was removed by configuration and left no trail; an operator "+
+			"cannot tell this from nox never having found it", ruleID)
+	}
+}
+
+// TestRemovalTrailCostsNothingWhenUnasked. The snapshot is O(findings) per
+// removal step, which is not a price to pay on a scan that never asked for the
+// trail.
+func TestRemovalTrailCostsNothingWhenUnasked(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "creds.py"),
+		[]byte("GITHUB_TOKEN = \"ghp_7Kd2mQ9xR4tB1nZ6wY3vC8hL5jF0gS2pA9eU\"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"),
+		[]byte("scan:\n  rules:\n    disable:\n      - SEC-003\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	quiet, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	loud, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if quiet.Reasoning != nil {
+		t.Error("a scan that did not ask for reasoning allocated a store")
+	}
+	if len(quiet.Findings.Findings()) != len(loud.Findings.Findings()) {
+		t.Errorf("recording changed the finding count: %d vs %d",
+			len(quiet.Findings.Findings()), len(loud.Findings.Findings()))
 	}
 }

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2423,7 +2423,7 @@ func TestRefineFindings_ContextDowngrade_Default(t *testing.T) {
 	t.Parallel()
 
 	fs := refineContextDowngradeFixture()
-	if err := refineFindings(fs, &ScanConfig{}, ScanOptions{}, t.TempDir(), nil, nil); err != nil {
+	if err := refineFindings(fs, &ScanConfig{}, ScanOptions{}, t.TempDir(), nil, nil, nil); err != nil {
 		t.Fatalf("refineFindings: %v", err)
 	}
 
@@ -2471,7 +2471,7 @@ func TestRefineFindings_ContextDowngrade_Disabled(t *testing.T) {
 	off := false
 	cfg := &ScanConfig{}
 	cfg.Scan.ContextDowngrade = &off
-	if err := refineFindings(fs, cfg, ScanOptions{}, t.TempDir(), nil, nil); err != nil {
+	if err := refineFindings(fs, cfg, ScanOptions{}, t.TempDir(), nil, nil, nil); err != nil {
 		t.Fatalf("refineFindings: %v", err)
 	}
 


### PR DESCRIPTION
Closes what C1 left open — and **the gap was narrower than I described it**.

## A correction first

When I opened C1 I wrote that "refinement's own drops — suppression, baseline
matching, VEX, dedup — are still silent". Reading the code properly:
suppression, baselining and VEX were never silent. Each sets a `Status` the
reporters carry. I was wrong about three of the four.

The genuinely silent removals are the **config-driven** ones: a disabled rule,
an excluded path, a generated-file filter. Those delete the finding outright,
so an operator reading a clean scan cannot tell *"nox found nothing here"* from
*"nox found it and my config removed it"*.

## The change

Those removals now leave a trail naming the rule, the mechanism and the
location:

```
removed by scan.rules.disable in .nox.yaml (SEC-001 at tp_secrets.go:17)
```

**The polarity is `Unknown`, and that is the considered choice rather than a
default.** A rule the operator disabled says nothing about whether the finding
was true. Recording it as a refutation would put fabricated evidence in the
ledger — nox would appear to have established something it never examined,
which is precisely the confusion the polarity distinction exists to prevent.
Committing that in the code that introduced the distinction would be a poor
start. `Unknown` weighs nothing in either direction while still leaving the
trail.

`recordWithheld` diffs around the removal rather than giving every `Remove*`
helper on `FindingSet` a reporting variant — a wide change to a much-used API
for one caller's benefit. It is a **no-op on a nil store**: the snapshot is
O(findings) per removal step, which is not a price to pay on a
six-million-finding scan that never asked for the trail.

## Verified end to end

On the precision suite with two rules disabled:

- 37 findings → 33
- 4 withheld claims recorded, each naming rule + mechanism + location
- polarity `unknown`, not `refutes` — asserted in the test
- byte-identical output between a scan that records and one that does not
- **deterministic across three runs** — `recordWithheld` iterates a map, and
  while that is safe (subjects are separate keys, `Subjects()` sorts), that is
  an argument and three identical runs are evidence

Also: `go build ./...` clean, `golangci-lint` 0 issues, full suite green,
precision suite 37/0/0, refutation suite 10/0/0, `TestEndToEndEvidenceChain`
passing.

## Still open after this

**Dedup and flow-merge remain unrecorded**, deliberately. `Deduplicate`,
`DeduplicateFlows` and `SuppressDuplicateVulnClass` do not refute anything —
they assert that two findings describe one condition. That is a *merge*, not a
refutation, and recording it as either polarity would be wrong. It belongs to
Track F, which is where flow identity gets modelled.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW