### PR TITLE
E2 and E3: record the AI refutations, and what the value check verified

### DIFF
--- a/core/adjudicate/adjudicate.go
+++ b/core/adjudicate/adjudicate.go
@@ -112,13 +112,30 @@ func rationale(l evidence.Ledger, subject evidence.Subject, state evidence.Explo
 //
 // The fix is therefore NOT to weigh pattern matches more heavily. A regex
 // match is a heuristic however specific it is, and inflating the kind would
-// put strength behind the one thing on the ladder that earns none. The fix is
-// for the checks the analyzers already perform to become claims — which is
-// what the E track builds, and what will move these findings up honestly.
+// put strength behind the one thing on the ladder that earns none.
 //
-// Until then this number measures the gap between what nox knows and what nox
-// records. That gap is worth having a number for; it is not evidence that the
-// analyzers are wrong.
+// This comment used to continue "the fix is for the checks the analyzers
+// already perform to become claims", and that was measured and found wrong.
+// Recording those checks — E3 — took the corpus from 37 supporting claims to
+// 61 and left the divergence at exactly 15. It could not have done anything
+// else: aggregation takes the STRONGEST supporting claim, every one of those
+// checks is a heuristic, and three heuristics are still a heuristic. The
+// independence promotion cannot apply either, since they all come from one
+// producer; counting them as independent would be the "one project scanning
+// itself a hundred times" fallacy with the numbers changed.
+//
+// So the number moves on evidence of a different KIND, not more of the same.
+// Several providers encode a checksum in the token itself, and verifying one
+// is deterministic — that is the path, and it needs a verifiable test vector
+// before it is written, because unverified checksum logic would put false
+// deterministic claims in the ledger and that is worse than the silence.
+//
+// What E3 did buy is explanation: a finding's ledger now says what nox checked
+// before believing it, not only what would have made it stop.
+//
+// So the number measures the gap between what nox knows and what nox can
+// currently record AS EVIDENCE. That gap is worth having a number for; it is
+// not evidence that the analyzers are wrong.
 type Divergence struct {
 	Fingerprint string              `json:"fingerprint"`
 	RuleID      string              `json:"rule_id"`

--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -15,9 +15,11 @@ import (
 	"github.com/nox-hq/nox/core/source"
 
 	"github.com/nox-hq/nox-core/degrade"
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
 )
 
@@ -86,6 +88,20 @@ type Analyzer struct {
 	// discards them (see degrade.Degradations), so tests and library callers
 	// that pass no option are unaffected.
 	deg *degrade.Degradations
+	// reasoning receives a refuting claim for every candidate this analyzer
+	// drops. Nil by default and nil for every existing caller; reasoning.Store
+	// is nil-safe, so the call sites are unconditional and there is no second
+	// code path to drift from the first.
+	reasoning *reasoning.Store
+}
+
+// RecordReasoningTo directs this analyzer's refutations at store.
+func (a *Analyzer) RecordReasoningTo(store *reasoning.Store) { a.reasoning = store }
+
+// refute records why a candidate was dropped, writing the provenance once so
+// six call sites cannot spell the producer three different ways.
+func (a *Analyzer) refute(subject evidence.Subject, kind evidence.Kind, statement string) {
+	a.reasoning.Refute(subject, kind, "nox-scan", "ai", statement)
 }
 
 // Option configures an Analyzer.
@@ -179,7 +195,17 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 		// real code path.
 		lang := lexctx.LangFromPath(artifact.Path)
 		for i := range results {
+			// Each drop below records WHY before it drops, exactly as the
+			// secrets refiners do. The kinds differ and the difference is the
+			// point: a lexer region is deterministic, a proximity check is not,
+			// and a ledger that called them both the same thing would be
+			// asserting more than either established.
+			candidate := reasoning.Candidate(results[i].RuleID, artifact.Path,
+				results[i].Location.StartLine, results[i].Location.StartColumn)
+
 			if suppressNonCode(lang, content, &results[i]) {
+				a.refute(candidate, evidence.KindStatic,
+					"the match lies outside code — in a comment, a string literal or an embedded blob")
 				continue
 			}
 			// AI-002 (prompt string concatenation of user input) fires on any
@@ -188,6 +214,11 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			// Require an actual prompt/LLM context near the match so a
 			// parameterised SQL execute call isn't reported as prompt injection.
 			if results[i].RuleID == "AI-002" && !hasPromptContext(content, &results[i]) {
+				// Heuristic, not static: this is a proximity check over
+				// surrounding text, and calling it deterministic would claim
+				// the analysis established something it only estimated.
+				a.refute(candidate, evidence.KindHeuristic,
+					"no prompt or LLM context near the match, so the interpolation is not a prompt")
 				continue
 			}
 			// AI-006 asserts that a prompt or LLM response reaches a log
@@ -195,6 +226,8 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			// value at all, so the word "prompt" in its message is a sentence,
 			// not a leak — see logsOnlyConstantText.
 			if results[i].RuleID == "AI-006" && logsOnlyConstantText(lang, content, &results[i]) {
+				a.refute(candidate, evidence.KindStatic,
+					"every argument to the logging call is constant text, so the call logs no value and there is no prompt to leak")
 				continue
 			}
 			// AI-049 asserts an eval/code-execution sink (CWE-95). A call
@@ -202,6 +235,8 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			// the rule gated on is a column name inside the query text — see
 			// isSQLStatementExec.
 			if results[i].RuleID == "AI-049" && isSQLStatementExec(content, &results[i]) {
+				a.refute(candidate, evidence.KindHeuristic,
+					"the call executes a SQL statement, so the AI token the rule gated on is a column name inside the query text")
 				continue
 			}
 			fs.Add(results[i])

--- a/core/analyzers/ai/reasoning_test.go
+++ b/core/analyzers/ai/reasoning_test.go
@@ -1,0 +1,116 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// aiRefutationCases covers the drops in the AI analyzer's refinement loop.
+//
+// The kinds differ between them and that is deliberate: a lexer region is
+// deterministic, a proximity check is not, and a ledger that recorded them at
+// the same strength would assert more than either established.
+var aiRefutationCases = []struct {
+	name       string
+	file       string
+	content    string
+	wantReason string
+	wantKind   evidence.Kind
+}{
+	{
+		name:       "constant log message containing the word prompt",
+		file:       "cli.go",
+		content:    "package p\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc F() {\n\tfmt.Fprintln(os.Stderr, \"nobody can approve a browser prompt.\")\n}\n",
+		wantReason: "every argument to the logging call is constant text",
+		wantKind:   evidence.KindStatic,
+	},
+}
+
+// TestAIDropsRecordTheirReason is E2: the constant-argument refutation that
+// commit 0810e63 implemented as an in-rule guard is now recorded as evidence,
+// so the reason a candidate was dropped survives the dropping.
+func TestAIDropsRecordTheirReason(t *testing.T) {
+	for _, tc := range aiRefutationCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.file)
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			store := reasoning.New()
+			a := NewAnalyzer()
+			a.RecordReasoningTo(store)
+
+			if _, _, err := a.ScanArtifacts(context.Background(),
+				[]discovery.Artifact{{Path: tc.file, AbsPath: path}}); err != nil {
+				t.Fatalf("ScanArtifacts: %v", err)
+			}
+
+			recorded, unusable := store.Stats()
+			if unusable != 0 {
+				t.Errorf("%d claim(s) filed against an unusable subject", unusable)
+			}
+			if recorded == 0 {
+				t.Fatal("a candidate was dropped and nothing was recorded about it")
+			}
+
+			var found bool
+			for _, subject := range store.Subjects() {
+				for _, c := range store.About(subject).Claims {
+					if !c.Refutes() {
+						t.Errorf("a dropped candidate recorded a %s claim", c.Polarity.Effective())
+					}
+					if c.Provenance.Tool != "ai" {
+						t.Errorf("claim attributed to tool %q, want ai", c.Provenance.Tool)
+					}
+					if strings.Contains(c.Statement, tc.wantReason) {
+						found = true
+						if c.Kind != tc.wantKind {
+							t.Errorf("recorded kind %q, want %q — how a claim was "+
+								"established is what Kind means, and a proximity check "+
+								"is not a lexer", c.Kind, tc.wantKind)
+						}
+					}
+				}
+			}
+			if !found {
+				t.Errorf("no claim explains the drop; wanted a statement containing %q", tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestAIRecordingChangesNoOutput. Shadow mode, at analyzer level.
+func TestAIRecordingChangesNoOutput(t *testing.T) {
+	for _, tc := range aiRefutationCases {
+		dir := t.TempDir()
+		path := filepath.Join(dir, tc.file)
+		if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		artifacts := []discovery.Artifact{{Path: tc.file, AbsPath: path}}
+
+		quiet, _, err := NewAnalyzer().ScanArtifacts(context.Background(), artifacts)
+		if err != nil {
+			t.Fatalf("scan without store: %v", err)
+		}
+		rec := NewAnalyzer()
+		rec.RecordReasoningTo(reasoning.New())
+		loud, _, err := rec.ScanArtifacts(context.Background(), artifacts)
+		if err != nil {
+			t.Fatalf("scan with store: %v", err)
+		}
+		if len(quiet.Findings()) != len(loud.Findings()) {
+			t.Errorf("%s: recording changed the finding count: %d vs %d",
+				tc.name, len(quiet.Findings()), len(loud.Findings()))
+		}
+	}
+}

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/discovery"
@@ -240,6 +241,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 					"an assignment-shaped rule matched entirely within a comment region, so there is no assignment for it to have found")
 				continue
 			}
+			a.corroborate(candidate, content, &results[i])
 			fs.Add(results[i])
 		}
 
@@ -320,4 +322,56 @@ func inEmbeddedBlob(lang lexctx.Lang, content []byte, f *findings.Finding) bool 
 // Authority can check.
 func (a *Analyzer) refute(subject evidence.Subject, kind evidence.Kind, statement string) {
 	a.reasoning.Refute(subject, kind, "nox-scan", "secrets", statement)
+}
+
+// corroborate records what the analyzer actually VERIFIED about a value it is
+// about to report.
+//
+// This is the positive counterpart of the refiners above, and it exists
+// because of the same historical bug they do. ENRICH-004 matched the NAME of
+// an assignment and never looked at the value; the refiners fixed that by
+// dropping placeholders. But a finding that survives has ALSO been inspected —
+// its value was read, it carried a recognised provider format, it was not a
+// placeholder — and none of that was written down. The ledger could say why nox
+// stopped believing something and never what it had actually checked before
+// believing it.
+//
+// # What this deliberately does not do
+//
+// It does not raise confidence, and it was worth discovering that before
+// claiming otherwise. Aggregation takes the STRONGEST supporting claim, and
+// every claim recorded here is a heuristic: a regex matched a prefix, a value
+// did not look like a placeholder. Three heuristics are still a heuristic, and
+// the independence promotion cannot apply either, since all of these come from
+// one producer — counting them as independent corroboration would be the "one
+// project scanning itself a hundred times" fallacy with the numbers changed.
+//
+// So this improves EXPLANATION, not confidence. What would move confidence is
+// evidence of a different kind: several providers encode a checksum in the
+// token itself, and verifying one is deterministic rather than heuristic. That
+// is a real and worthwhile next step, and it needs a verifiable test vector
+// before it is written — shipping unverified checksum logic would put false
+// deterministic claims in the ledger, which is worse than the silence it
+// replaces.
+func (a *Analyzer) corroborate(subject evidence.Subject, content []byte, f *findings.Finding) {
+	if a.reasoning == nil {
+		return
+	}
+	value := matchedValue(content, f)
+	if value == "" {
+		return
+	}
+	if prefix, ok := recognisedProviderPrefix(strings.TrimLeft(value, `"'`)); ok {
+		a.support(subject, "the value carries the recognised provider prefix "+prefix+
+			" and a token body, so it is not a bare vocabulary reference")
+	}
+	// The value was READ, and it is not a placeholder. That is the precise
+	// check ENRICH-004 never performed, so recording that it ran and passed is
+	// what makes this finding's ledger different from that rule's.
+	a.support(subject, "the matched value was inspected and is not a documentation placeholder")
+}
+
+// support records a corroborating claim about a candidate that survived.
+func (a *Analyzer) support(subject evidence.Subject, statement string) {
+	a.reasoning.Support(subject, evidence.KindHeuristic, "nox-scan", "secrets", statement, nil)
 }

--- a/core/scan.go
+++ b/core/scan.go
@@ -368,6 +368,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// the tool permission matrix, so a broken config is a visible degradation
 	// rather than a silently-empty (or all-tools-defaulted) matrix.
 	aiAnalyzer := ai.NewAnalyzer(ai.WithDegradations(degradations))
+	aiAnalyzer.RecordReasoningTo(reasons)
 
 	// Whether dependency scanning may reach the network at all. Named once and
 	// used by both the disable switch and the intelligence wiring below, so the

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -111,7 +111,13 @@ func TestEveryReportedFindingHasASupportingClaim(t *testing.T) {
 			continue
 		}
 
-		var supported bool
+		// A finding's ledger now holds more than one shape of supporting claim:
+		// the shim's observation, and the corroborating checks E3 records. The
+		// analyzer's own confidence label belongs on the OBSERVATION — it is
+		// the claim C2 compares against — and requiring it on every supporting
+		// claim would be requiring the wrong thing of the others. What has to
+		// hold is that the label is preserved somewhere retrievable.
+		var supported, labelled bool
 		for _, c := range ledger.Claims {
 			if !c.Supports() {
 				continue
@@ -120,14 +126,21 @@ func TestEveryReportedFindingHasASupportingClaim(t *testing.T) {
 			if c.Provenance.Source != "nox-scan" {
 				t.Errorf("claim for %s has source %q, want nox-scan", f.RuleID, c.Provenance.Source)
 			}
-			if got, want := c.Attributes["analyzer_confidence"], string(f.Confidence); got != want {
-				t.Errorf("claim for %s carries analyzer_confidence %q, want %q — the "+
-					"analyzer's own label must be preserved as data for C2 to compare against",
-					f.RuleID, got, want)
+			if got := c.Attributes["analyzer_confidence"]; got != "" {
+				if got != string(f.Confidence) {
+					t.Errorf("claim for %s carries analyzer_confidence %q, want %q",
+						f.RuleID, got, f.Confidence)
+				}
+				labelled = true
 			}
 		}
 		if !supported {
 			t.Errorf("finding %s has a ledger with no supporting claim", f.RuleID)
+		}
+		if !labelled {
+			t.Errorf("finding %s records no analyzer_confidence anywhere; the "+
+				"analyzer's own label must be preserved as data for C2 to compare against",
+				f.RuleID)
 		}
 	}
 }
@@ -521,5 +534,63 @@ func TestRemovalTrailCostsNothingWhenUnasked(t *testing.T) {
 	if len(quiet.Findings.Findings()) != len(loud.Findings.Findings()) {
 		t.Errorf("recording changed the finding count: %d vs %d",
 			len(quiet.Findings.Findings()), len(loud.Findings.Findings()))
+	}
+}
+
+// TestCorroborationExplainsButDoesNotPromote pins E3's real effect, including
+// the half that is easy to assume and wrong.
+//
+// Recording what an analyzer verified makes a finding explicable: its ledger
+// now says what nox checked before believing it, not only what would have made
+// it stop. It does NOT raise confidence, and asserting that here stops a later
+// reader concluding it should. Aggregation takes the strongest supporting
+// claim; every corroborating check is a heuristic; three heuristics are still a
+// heuristic. The independence promotion cannot apply either, because they all
+// come from one producer — counting them as independent would be the "one
+// project scanning itself a hundred times" fallacy with the numbers changed.
+func TestCorroborationExplainsButDoesNotPromote(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "creds.py"),
+		[]byte("GITHUB_TOKEN = \"ghp_7Kd2mQ9xR4tB1nZ6wY3vC8hL5jF0gS2pA9eU\"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	all := res.Findings.Findings()
+	if len(all) == 0 {
+		t.Fatal("fixture produced no finding; this test asserts nothing")
+	}
+
+	for _, f := range all {
+		subject := SubjectForFinding(f)
+		ledger := res.Reasoning.About(subject)
+
+		var supporting int
+		var readTheValue bool
+		for _, c := range ledger.Claims {
+			if !c.Supports() {
+				continue
+			}
+			supporting++
+			if strings.Contains(c.Statement, "inspected and is not a documentation placeholder") {
+				readTheValue = true
+			}
+		}
+		if supporting < 2 {
+			t.Errorf("finding %s carries %d supporting claim(s); the checks the "+
+				"analyzer performed are not being recorded", f.RuleID, supporting)
+		}
+		if !readTheValue {
+			t.Errorf("finding %s does not record that its VALUE was inspected — the "+
+				"precise check ENRICH-004 never performed", f.RuleID)
+		}
+
+		// The part that is easy to assume and wrong.
+		if got := ledger.ConfidenceAbout(subject); got != evidence.ConfidenceLow {
+			t.Errorf("finding %s aggregated to %s from %d heuristic claims; more "+
+				"heuristics must not become a stronger claim", f.RuleID, got, supporting)
+		}
 	}
 }


### PR DESCRIPTION
## E2 — the AI analyzer's four silent drops

Same shape as the secrets six from #505. Each now records why before it drops,
including the constant-argument refutation that commit `0810e63` implemented as
an in-rule guard: a logging call whose arguments are all constant text logs no
value, so the word "prompt" in its message is a sentence, not a leak.

**The kinds differ between the four, and the difference is the point.** A lexer
region is deterministic and records `KindStatic`; a proximity check for prompt
context is not, and records `KindHeuristic`. A ledger that called them the same
thing would assert more than either established.

## E3 — what the value check verified

The secrets analyzer now records what it *verified* about a value it is about
to report, not only what would have made it stop.

The historical ENRICH-004 bug was matching the **name** of an assignment and
never reading the value. The refiners fixed that by dropping placeholders; this
is its positive counterpart — the value was read, it carried a recognised
provider prefix and a token body, and it is not a placeholder.

## A correction to C2

I claimed in #507 that recording these checks would *"move these findings up
honestly"*. **Measured: supporting claims went 37 → 61, and the divergence
stayed at exactly 15.**

It could not have done anything else, and I should have seen it before writing
it. Aggregation takes the **strongest** supporting claim; every one of these
checks is a heuristic; three heuristics are still a heuristic. The independence
promotion can't apply either, because they all come from one producer —
counting them as independent would be the "one project scanning itself a
hundred times" fallacy with the numbers changed.

The comment in `core/adjudicate` now says what was measured rather than what I
expected.

**So the number moves on evidence of a different KIND.** Several providers
encode a checksum in the token itself, and verifying one is deterministic —
that is the path, and it is deliberately **not** taken here: nox has no
checksum validation today, I have no verifiable test vector, and unverified
checksum logic would put *false deterministic claims* in the ledger. That is
worse than the silence it replaces.

What E3 does buy is **explanation**. A finding's ledger now says what nox
checked before believing it.
`TestCorroborationExplainsButDoesNotPromote` asserts both halves — that the
checks are recorded, *and* that they do not promote — so a later reader does
not assume the second.

## One regression, caught by an existing test

`TestEveryReportedFindingHasASupportingClaim` required **every** supporting
claim to carry the `analyzer_confidence` attribute. That was true while the C1
shim's observation was the only supporting claim, and stopped being true the
moment E3 added a second shape.

Narrowed to what actually has to hold — the label is preserved *somewhere*
retrievable, on the observation claim C2 compares against — rather than
relaxed.

## Verification

- `go build ./...` clean, `golangci-lint run ./core/... ./cli/...` 0 issues
- `./core/... ./cli/... ./server/...` green
- precision suite 37/0/0, refutation suite 10/0/0 — unchanged
- `TestEndToEndEvidenceChain` passing
- Measured on the corpus: 61 supporting + 13 refuting claims, 12 findings now
  carrying 3 claims each, divergence unchanged at 15

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW