### PR TITLE
F: name the dataflow, so two findings can be one condition

### DIFF
--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -339,6 +339,32 @@ func flowIdentity(f *Finding) (flowKey, bool) {
 	}, true
 }
 
+// FlowID returns a stable identity for the dataflow a finding describes, and
+// whether it describes one at all.
+//
+// It is the same identity DeduplicateFlows merges on, exported so a caller can
+// name the flow as a SUBJECT rather than only use it to collapse duplicates.
+// That distinction is the whole of Track F: two findings that dedup collapses
+// are not two vulnerabilities, they are one condition observed twice — and
+// until the condition itself could be named, there was nowhere to say so.
+//
+// Deliberately NOT keyed on the rule ID, unlike flowKey. Two different rules
+// reporting the same source reaching the same sink are reporting one flow;
+// including the rule would give them different identities and reintroduce, at
+// the subject level, exactly the double-counting this is meant to expose.
+func FlowID(f *Finding) (string, bool) {
+	sourceLine, sourceVar := f.Metadata["source_line"], f.Metadata["source_var"]
+	if sourceLine == "" || sourceVar == "" {
+		return "", false
+	}
+	sinkLine := f.Metadata["sink_line"]
+	if sinkLine == "" {
+		sinkLine = strconv.Itoa(f.Location.StartLine)
+	}
+	return fmt.Sprintf("%s:%s->%s:%s", normaliseFilePath(f.Location.FilePath),
+		sourceLine, sinkLine, sourceVar), true
+}
+
 // anchoredAtSink reports whether a flow finding sits on its sink line.
 func anchoredAtSink(f *Finding) bool {
 	sinkLine := f.Metadata["sink_line"]

--- a/core/flow_identity_test.go
+++ b/core/flow_identity_test.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// flowFinding builds a finding that describes one dataflow, anchored wherever
+// the caller says.
+func flowFinding(ruleID string, anchorLine int, sourceLine, sinkLine, sourceVar string) findings.Finding {
+	return findings.Finding{
+		RuleID:   ruleID,
+		Severity: findings.SeverityHigh,
+		Location: findings.Location{FilePath: "app/handler.py", StartLine: anchorLine, StartColumn: 5},
+		Metadata: map[string]string{
+			"source_line": sourceLine,
+			"sink_line":   sinkLine,
+			"source_var":  sourceVar,
+		},
+	}
+}
+
+// TestTriage002IsOneFlowNotTwoVulnerabilities recreates the case Phase 5 names
+// as its exit criterion, and resolves it through the model.
+//
+// The history: TRIAGE-002 reported "missing input validation" on the SOURCE
+// line of a taint flow whose SINK was already reported one line below. All 12
+// of its corpus findings were that shape; it scored 0 true positives and 12
+// false positives, precision 0.000. It was not detecting anything — it was
+// re-reporting, one line up, what the taint engine had already found.
+//
+// It was fixed by deleting the rule family. That worked and taught nothing: the
+// next detector to re-report a flow from the other end would reproduce it
+// exactly, because nothing in the model could say the two were one condition.
+//
+// Now something can. Both candidates resolve to the SAME flow subject — that is
+// what FlowID being rule-independent buys — so "two findings" and "one
+// vulnerability" are both representable and the relationship between them is
+// recorded rather than inferred from a count going down.
+func TestTriage002IsOneFlowNotTwoVulnerabilities(t *testing.T) {
+	const (
+		sourceLine = "41"
+		sinkLine   = "42"
+		sourceVar  = "user_input"
+	)
+	// The taint engine, anchored at the sink.
+	sink := flowFinding("TAINT-002", 42, sourceLine, sinkLine, sourceVar)
+	// A triage-style rule, anchored one line up at the source — the exact
+	// TRIAGE-002 shape.
+	source := flowFinding("TRIAGE-002", 41, sourceLine, sinkLine, sourceVar)
+
+	sinkID, ok := findings.FlowID(&sink)
+	if !ok {
+		t.Fatal("the sink-anchored finding does not describe a flow")
+	}
+	sourceID, ok := findings.FlowID(&source)
+	if !ok {
+		t.Fatal("the source-anchored finding does not describe a flow")
+	}
+
+	if sinkID != sourceID {
+		t.Fatalf("the two ends of one flow got different identities:\n  sink:   %s\n  source: %s\n"+
+			"They must agree, or the model cannot say they are one condition and the "+
+			"only remaining move is to delete one of them — which is how this was "+
+			"resolved last time.", sinkID, sourceID)
+	}
+
+	// Recorded through the store, both candidates concern the one flow.
+	store := reasoning.New()
+	flow := reasoning.Flow(sinkID)
+	for _, f := range []findings.Finding{sink, source} {
+		var l evidence.Ledger
+		l.Add(evidence.Claim{
+			Kind: evidence.KindStatic, Subject: flow,
+			Statement:  f.RuleID + " reports this flow",
+			Provenance: evidence.Provenance{Source: "nox-scan", Tool: "taint"},
+		})
+		store.Relate(evidence.Relation{
+			From: SubjectForFinding(f), Kind: evidence.RelConcerns, To: flow, Ledger: l,
+		})
+	}
+
+	concerning := store.Concerning(flow, evidence.RelConcerns)
+	if len(concerning) != 2 {
+		t.Fatalf("%d candidate(s) recorded as concerning the flow, want 2", len(concerning))
+	}
+	// Two candidates, one flow. That is the sentence the model could not say
+	// before, and the reason it matters is that the count of FINDINGS and the
+	// count of VULNERABILITIES are now different numbers rather than the same
+	// number reported twice.
+	graph := store.Relations()
+	flows := map[evidence.Subject]bool{}
+	for _, r := range graph.Relations {
+		flows[r.To] = true
+	}
+	if len(flows) != 1 {
+		t.Errorf("%d distinct flows for one condition, want 1", len(flows))
+	}
+
+	if errs := graph.Validate(); len(errs) != 0 {
+		t.Errorf("the relation graph does not validate: %v", errs)
+	}
+}
+
+// TestFlowIdentityIgnoresTheRule pins the property the recreation depends on.
+//
+// flowKey — which DeduplicateFlows merges on — includes the rule ID, and must:
+// it decides whether to DELETE a finding, and deleting across rules would lose
+// a genuinely different report. FlowID must not, because it names the condition
+// rather than the report, and a condition does not change identity because a
+// second rule noticed it.
+func TestFlowIdentityIgnoresTheRule(t *testing.T) {
+	a := flowFinding("TAINT-002", 42, "41", "42", "user_input")
+	b := flowFinding("VARIANT-005", 42, "41", "42", "user_input")
+
+	idA, okA := findings.FlowID(&a)
+	idB, okB := findings.FlowID(&b)
+	if !okA || !okB {
+		t.Fatal("a flow finding did not yield an identity")
+	}
+	if idA != idB {
+		t.Errorf("two rules reporting one flow got different identities: %s vs %s", idA, idB)
+	}
+
+	// A genuinely different flow must not collide.
+	other := flowFinding("TAINT-002", 42, "41", "42", "other_var")
+	idOther, _ := findings.FlowID(&other)
+	if idOther == idA {
+		t.Error("two different tainted variables produced one flow identity")
+	}
+}
+
+// TestAFindingThatIsNotAFlowHasNoFlowIdentity. Most findings are not flows, and
+// inventing an identity for them would relate unrelated things.
+func TestAFindingThatIsNotAFlowHasNoFlowIdentity(t *testing.T) {
+	f := findings.Finding{
+		RuleID:   "SEC-003",
+		Location: findings.Location{FilePath: "app/creds.py", StartLine: 1},
+	}
+	if _, ok := findings.FlowID(&f); ok {
+		t.Error("a secrets finding was given a flow identity")
+	}
+	f.Metadata = map[string]string{"source_line": "3"} // half the evidence
+	if _, ok := findings.FlowID(&f); ok {
+		t.Error("a finding naming a source line but no variable was given a flow identity")
+	}
+}

--- a/core/reasoning/reasoning.go
+++ b/core/reasoning/reasoning.go
@@ -46,6 +46,7 @@ import (
 type Store struct {
 	mu       sync.Mutex
 	ledgers  map[evidence.Subject]*evidence.Ledger
+	graph    evidence.Graph
 	dropped  int
 	recorded int
 }
@@ -213,4 +214,69 @@ func (s *Store) Withheld(subject evidence.Subject, source, tool, statement strin
 		Subject:    subject,
 		Provenance: evidence.Provenance{Source: source, Tool: tool},
 	})
+}
+
+// Relate records a relationship between two subjects.
+//
+// The store holds relations alongside claims because they answer the question
+// claims alone cannot: not "what do we believe about this candidate?" but
+// "which candidates are about the same thing?". A source-line match and a
+// sink-line match are two candidates and one dataflow, and until the dataflow
+// could be named there was nowhere to say so — the only available move was to
+// delete one of them, which is what dedup does and why the relationship it
+// knows about is lost the moment it acts.
+//
+// A nil Store discards, like everything else here.
+func (s *Store) Relate(r evidence.Relation) {
+	if s == nil || !r.Valid() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graph.Add(r)
+}
+
+// Relations returns the relation graph, copied so a caller cannot mutate the
+// store's own.
+func (s *Store) Relations() evidence.Graph {
+	if s == nil {
+		return evidence.Graph{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := evidence.Graph{Relations: make([]evidence.Relation, len(s.graph.Relations))}
+	copy(out.Relations, s.graph.Relations)
+	return out
+}
+
+// Concerning returns the subjects related to target by kind, sorted for
+// determinism.
+//
+// The question it answers on a flow subject is the one Track F exists for:
+// how many candidates does this single security condition account for? Three
+// answers means one vulnerability was reported three times, not that there are
+// three.
+func (s *Store) Concerning(target evidence.Subject, kind evidence.RelationKind) []evidence.Subject {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := make(map[evidence.Subject]bool)
+	for _, r := range s.graph.Relations {
+		if r.To == target && r.Kind == kind {
+			seen[r.From] = true
+		}
+	}
+	out := make([]evidence.Subject, 0, len(seen))
+	for sub := range seen {
+		out = append(out, sub)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+// Flow names the dataflow subject a taint finding concerns.
+func Flow(id string) evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectFlow, ID: id}
 }

--- a/core/scan.go
+++ b/core/scan.go
@@ -1220,6 +1220,16 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 		)
 	}
 
+	// Name the dataflows BEFORE collapsing them, because collapsing is what
+	// destroys the evidence that there was ever more than one candidate.
+	//
+	// Dedup already knows that two findings describe one flow — that knowledge
+	// is the whole basis on which it deletes one of them — and then throws it
+	// away. Recording the relation first turns "two findings became one" into
+	// something a reader can see and check, rather than a count that silently
+	// went down.
+	recordFlowIdentity(reasons, allFindings)
+
 	// Collapse one dataflow reported from both ends. The built-in taint model
 	// anchors a flow at its sink; the taint-analysis plugin anchors the same
 	// flow at its source. Neither the fingerprint nor the location matches, so
@@ -2145,5 +2155,45 @@ func policyConfigFrom(cfg *ScanConfig) policy.Config {
 		Budget:              policyBudget(cfg.Policy.Budget),
 		Uncertainty:         policy.Uncertainty(cfg.Policy.Uncertainty),
 		RequireCapabilities: cfg.Policy.RequireCapabilities,
+	}
+}
+
+// recordFlowIdentity relates every candidate that describes a dataflow to the
+// flow itself.
+//
+// It runs before dedup, and that ordering is the point. Afterwards the
+// duplicates are gone and nothing is left to relate — the merge would be
+// invisible in exactly the way this whole programme exists to prevent, and
+// invisible in the direction that looks like progress, because the finding
+// count went down.
+//
+// A relation is an assertion and carries its own evidence, so the edge is not
+// asserted on nox's authority alone: the claim names the source variable, the
+// line its value came from, and the sink it reached, which is what a reader
+// needs to check the merge rather than take it.
+func recordFlowIdentity(store *reasoning.Store, fs *findings.FindingSet) {
+	if store == nil || fs == nil {
+		return
+	}
+	for _, f := range fs.Findings() {
+		id, ok := findings.FlowID(&f)
+		if !ok {
+			continue
+		}
+		candidate := SubjectForFinding(f)
+		flow := reasoning.Flow(id)
+
+		var ledger evidence.Ledger
+		ledger.Add(evidence.Claim{
+			Kind: evidence.KindStatic,
+			Statement: fmt.Sprintf("%s reports %s reaching a sink from line %s",
+				f.RuleID, f.Metadata["source_var"], f.Metadata["source_line"]),
+			Subject:    flow,
+			Provenance: evidence.Provenance{Source: "nox-scan", Tool: "taint"},
+		})
+
+		store.Relate(evidence.Relation{
+			From: candidate, Kind: evidence.RelConcerns, To: flow, Ledger: ledger,
+		})
 	}
 }


### PR DESCRIPTION
Track F of `docs/design/evidence-native-nox.md`, including its stated exit
criterion: **recreate TRIAGE-002 and solve it through the model.**

## What was already there, and what wasn't

Flow identity already existed — `flowKey`, which `DeduplicateFlows` merges on.
What did not exist was any way to **name** the flow. So the only thing the model
could do with *"these two findings describe one condition"* was delete one of
them. That is what dedup does, and the knowledge is discarded in the same
statement that acts on it.

`findings.FlowID` exports the identity, deliberately **without the rule ID**.

That asymmetry is the design. `flowKey` keeps the rule and must — it decides
whether to *delete* a finding, and deleting across rules would lose a genuinely
different report. `FlowID` names the **condition** rather than the report, and a
condition does not change identity because a second rule noticed it.

## Relations, recorded before the merge

The reasoning store now holds relations as well as claims, because they answer
what claims alone cannot: not *"what do we believe about this candidate?"* but
*"which candidates are about the same thing?"*.

Every candidate describing a flow is related to it **before dedup runs**. The
ordering is the point: afterwards the duplicates are gone and nothing is left to
relate, and the merge would be invisible in the direction that looks like
progress — because the finding count went down.

Relations carry their own evidence, so an edge is not asserted on nox's
authority alone: the claim names the source variable, the line its value came
from, and the sink it reached. On the precision suite that is **18 flows, and
the graph validates** — every edge justified.

## TRIAGE-002, recreated and resolved

It reported "missing input validation" on the **source** line of a flow whose
**sink** was already reported one line below. All 12 of its corpus findings were
that shape: 0 true positives, 12 false positives, precision 0.000. It was not
detecting anything — it was re-reporting, one line up, what the taint engine had
already found.

It was fixed by deleting the rule family. **That worked and taught nothing** —
the next detector to report a flow from the other end would reproduce it
exactly, because nothing in the model could say the two were one condition.

Now both ends resolve to one flow subject, so "two findings" and "one
vulnerability" are both representable and the relationship between them is
recorded rather than inferred from a count going down.

## The bench scorer is untouched

The plan asks for this explicitly, and it is the easiest corner to cut. The
corpus asserts complete ground truth; moving the measurement to make the exit
criterion pass would be the one way to fail it. `git diff` over `core/bench/` is
empty. Precision suite 37/0/0, refutation suite 10/0/0 — unchanged.

## Verification

- `go build ./...` clean, `golangci-lint run ./core/...` 0 issues
- `./core/... ./cli/... ./server/...` green; `core/reasoning` passes under `-race`
- `TestEndToEndEvidenceChain` passing
- **Both flow-identity tests falsified before being trusted** — putting the rule
  ID back into `FlowID` fails them, with the message explaining why it matters

## Still open

Dedup's *own* drop is still unrecorded — the relation now survives, but the fact
that a specific finding was the one discarded is not written down. That is a
smaller gap than it was (the condition is named, so nothing is lost about
*what* was merged) and it is worth doing next.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW