### PR TITLE
The corpus behind Gate B, and the bug it found immediately

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -52,6 +52,13 @@ scan:
     # future value-semantics refiner cannot dismiss them on the name. The
     # refutation harness scans this dir explicitly; the self-scan must not.
     - "testdata/refutation-suite/"
+    # The reachability suite (Gate B, docs/design/evidence-native-nox.md). Its
+    # `reachable` case imports crypto/md5 on purpose — the whole case is "the
+    # affected package IS linked", and an advisory scoping to a weak-crypto
+    # stdlib package is what makes it a realistic one. The suite is scored by
+    # its own test, which reads the modules directly; the self-scan must not
+    # flag a fixture for containing exactly what it was built to contain.
+    - "testdata/reachability-suite/"
     - ".relicta/"
     - ".cover/"
     - ".roady/"

--- a/core/analyzers/deps/reachability.go
+++ b/core/analyzers/deps/reachability.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -45,6 +47,29 @@ func goAffectedImports(vuln *osvVuln, module string) []string {
 // silently hide real vulnerabilities, so when the toolchain cannot answer,
 // this reports ok=false and callers keep the finding.
 func goImportedPackages(ctx context.Context, dir string) (map[string]struct{}, bool) {
+	// A directory with no go.mod is not a module, and `go list -deps -e ./...`
+	// does NOT say so: it exits 0 and prints the standard library's dependency
+	// closure. Ninety-one packages, none of them the caller's, and no error.
+	//
+	// Without this check the result is a confident wrong answer rather than an
+	// absent one — a large non-empty set with ok=true, in which any advisory's
+	// import path is missing, so every Go advisory would be answered
+	// "deterministically unreachable" for a directory nox never managed to
+	// enumerate. That is precisely the Gate B failure: a blind spot reported as
+	// an all-clear.
+	//
+	// The only caller today passes a directory where a go.mod was already
+	// found, so this was not reachable in production. It was reachable from the
+	// documented contract — "when the toolchain cannot answer, this reports
+	// ok=false" — which was false as written, and would have become reachable
+	// the first time a second caller believed it. Found by
+	// testdata/reachability-suite on its first run.
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err != nil {
+		slog.DebugContext(ctx, "no go.mod; the linked package set is unknown rather than empty",
+			"dir", dir)
+		return nil, false
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, goListTimeout)
 	defer cancel()
 

--- a/core/analyzers/deps/reachability_suite_test.go
+++ b/core/analyzers/deps/reachability_suite_test.go
@@ -1,0 +1,181 @@
+package deps
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// expectation is one case's declared ground truth: what the advisory scopes to,
+// what reachability should conclude, and — the field the gate turns on —
+// whether that conclusion may justify hiding a finding.
+type expectation struct {
+	AdvisoryImports []string `json:"advisory_imports"`
+	WantReachable   bool     `json:"want_reachable"`
+	WantDetermined  bool     `json:"want_determined"`
+	WantState       string   `json:"want_state"`
+	MaySuppress     bool     `json:"may_suppress"`
+	Why             string   `json:"why"`
+}
+
+// suiteDir resolves testdata/reachability-suite from this package.
+func suiteDir() string {
+	return filepath.Join("..", "..", "..", "testdata", "reachability-suite")
+}
+
+// loadCases reads every case in the suite.
+func loadCases(t *testing.T) map[string]expectation {
+	t.Helper()
+	entries, err := os.ReadDir(suiteDir())
+	if err != nil {
+		t.Fatalf("reading suite: %v", err)
+	}
+	out := make(map[string]expectation)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(suiteDir(), e.Name(), "expect.json"))
+		if err != nil {
+			t.Fatalf("%s: reading expect.json: %v", e.Name(), err)
+		}
+		var exp expectation
+		if err := json.Unmarshal(raw, &exp); err != nil {
+			t.Fatalf("%s: parsing expect.json: %v", e.Name(), err)
+		}
+		if exp.Why == "" {
+			t.Errorf("%s: expect.json has no `why`; a ground truth nobody explained "+
+				"is one nobody can check", e.Name())
+		}
+		out[e.Name()] = exp
+	}
+	if len(out) == 0 {
+		t.Fatal("the suite has no cases")
+	}
+	return out
+}
+
+// TestReachabilitySuiteMatchesGroundTruth scores the corpus.
+//
+// It measures the (reachable, determined) PAIR rather than a boolean, because
+// the pair is the entire point: a scanner that collapses it reports "not
+// reachable" for code it never managed to look at.
+//
+// The suite is deterministic and offline by construction. Every module depends
+// only on the standard library — Go issues advisories for stdlib packages, so
+// this is not a contrivance — which means `go list` needs no network and no
+// module cache. A corpus that needed either would be a corpus that quietly
+// stopped running, and the first thing anyone would notice is that it had
+// stopped failing.
+func TestReachabilitySuiteMatchesGroundTruth(t *testing.T) {
+	for name, exp := range loadCases(t) {
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(suiteDir(), name)
+			linked, linkedKnown := goImportedPackages(context.Background(), dir)
+			reachable, determined := goVulnReachable(exp.AdvisoryImports, linked, linkedKnown)
+
+			if determined != exp.WantDetermined {
+				t.Errorf("determined = %v, want %v — %s", determined, exp.WantDetermined, exp.Why)
+			}
+			if reachable != exp.WantReachable {
+				t.Errorf("reachable = %v, want %v — %s", reachable, exp.WantReachable, exp.Why)
+			}
+		})
+	}
+}
+
+// TestGateB is the gate.
+//
+// Deterministic unreachability may suppress a finding. Nothing else may — not
+// an advisory without import metadata, not a toolchain that failed, not an
+// ecosystem nox cannot analyse. All four look identical downstream: no
+// reachability annotation, and so no reason shown for a finding to be absent.
+// The difference between them exists only if something checks it.
+//
+// Deliberately expressed as "which cases could justify suppression", not "which
+// cases return false". A future refactor returning false for an undetermined
+// case would pass a test written the second way, and would be the exact failure
+// this gate exists to stop: nox reporting its own blind spot as an all-clear.
+func TestGateB(t *testing.T) {
+	var suppressible []string
+	for name, exp := range loadCases(t) {
+		dir := filepath.Join(suiteDir(), name)
+		linked, linkedKnown := goImportedPackages(context.Background(), dir)
+		reachable, determined := goVulnReachable(exp.AdvisoryImports, linked, linkedKnown)
+
+		// The only honest basis for hiding a finding: the analysis ran, and it
+		// established the affected code is not reached.
+		couldSuppress := determined && !reachable
+
+		if couldSuppress != exp.MaySuppress {
+			t.Errorf("%s: couldSuppress = %v, want %v — %s",
+				name, couldSuppress, exp.MaySuppress, exp.Why)
+		}
+		if couldSuppress {
+			suppressible = append(suppressible, name)
+		}
+	}
+
+	if len(suppressible) != 1 || suppressible[0] != "unreachable" {
+		t.Errorf("cases that could justify suppression = %v, want exactly [unreachable]. "+
+			"Every other case in this suite is an absence of knowledge, and an absence "+
+			"of knowledge that can hide a finding is how a scanner reports a blind spot "+
+			"as an all-clear.", suppressible)
+	}
+}
+
+// TestUndeterminedNeverAnswersFalse pins the contract at its source.
+//
+// goVulnReachable answers false ONLY on positive evidence. Anything less
+// returns (true, false): reachable-by-default, undetermined. The default
+// direction is the safety property — an undetermined case defaulting to "not
+// reachable" would suppress findings nobody examined, silently.
+func TestUndeterminedNeverAnswersFalse(t *testing.T) {
+	linked := map[string]struct{}{"crypto/sha256": {}}
+
+	for _, tc := range []struct {
+		name        string
+		imports     []string
+		linked      map[string]struct{}
+		linkedKnown bool
+	}{
+		{"no advisory imports", nil, linked, true},
+		{"empty advisory imports", []string{}, linked, true},
+		{"linked set unknown", []string{"crypto/md5"}, nil, false},
+		{"linked set unknown despite entries", []string{"crypto/md5"}, linked, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reachable, determined := goVulnReachable(tc.imports, tc.linked, tc.linkedKnown)
+			if determined {
+				t.Error("determined = true with nothing to determine it from")
+			}
+			if !reachable {
+				t.Error("reachable = false on an UNDETERMINED result; a finding nobody " +
+					"examined would be suppressed as though it had been cleared")
+			}
+		})
+	}
+}
+
+// TestSubpackagesOfAnAffectedImportAreReachable. An advisory scoping to
+// golang.org/x/crypto/openpgp covers its subpackages, and missing that would
+// report a reachable vulnerability as unreachable — a false negative produced
+// by the very mechanism meant to reduce false positives.
+func TestSubpackagesOfAnAffectedImportAreReachable(t *testing.T) {
+	linked := map[string]struct{}{"golang.org/x/crypto/openpgp/packet": {}}
+	reachable, determined := goVulnReachable([]string{"golang.org/x/crypto/openpgp"}, linked, true)
+	if !determined || !reachable {
+		t.Errorf("subpackage of an affected import: reachable=%v determined=%v, want both true",
+			reachable, determined)
+	}
+
+	// A package that merely shares a prefix is not a subpackage.
+	other := map[string]struct{}{"golang.org/x/crypto/openpgpx": {}}
+	reachable, determined = goVulnReachable([]string{"golang.org/x/crypto/openpgp"}, other, true)
+	if !determined || reachable {
+		t.Errorf("prefix-sharing package treated as affected: reachable=%v determined=%v, "+
+			"want reachable=false determined=true", reachable, determined)
+	}
+}

--- a/testdata/reachability-suite/README.md
+++ b/testdata/reachability-suite/README.md
@@ -1,0 +1,80 @@
+# Reachability suite — the corpus behind Gate B
+
+Gate B is the rule that **deterministic unreachability may suppress a finding,
+and nothing else may**.
+
+That sounds obvious and is the easiest thing in the system to get wrong,
+because the four states that must not suppress are indistinguishable from the
+one that may, at the only place anyone looks — the output. A finding hidden
+because reachability proved it unreachable and a finding hidden because
+reachability never ran produce the same artifact: no finding, and no reason
+given for its absence.
+
+The design doc records this corpus as owed:
+
+> The refutation suite is offline-only by design, so dependency applicability
+> and reachability are unrepresented. **Gate B therefore has no corpus yet**,
+> and Track G must bring one before deterministic unreachability is allowed to
+> suppress anything.
+
+This is that corpus.
+
+## How it stays deterministic offline
+
+Every module here depends only on the **standard library**. Go issues
+advisories for stdlib packages, so this is not a contrivance — and it means
+`go list` needs no network and no module cache.
+
+That constraint is load-bearing. A corpus needing either would be a corpus that
+quietly stopped running in CI, and the first symptom would be that it had
+stopped failing.
+
+## The cases
+
+Each directory carries an `expect.json` declaring the advisory's scope, the
+expected `(reachable, determined)` pair, and — the field the gate turns on —
+whether that conclusion may justify hiding a finding.
+
+| case | `(reachable, determined)` | may suppress |
+|---|---|---|
+| `reachable` | `(true, true)` | no — it is reachable |
+| `unreachable` | `(false, true)` | **yes** — the only one |
+| `undetermined_no_import_metadata` | `(true, false)` | no — the advisory scopes to nothing |
+| `undetermined_not_a_module` | `(true, false)` | no — the toolchain could not answer |
+| `unsupported_ecosystem` | `(true, false)` | no — nox has no analysis for npm |
+
+`may_suppress` is true for exactly one case, and `TestGateB` asserts that by
+name rather than by count. A future change that made a second case suppressible
+fails with the case named.
+
+## What it found immediately
+
+`undetermined_not_a_module` failed on the corpus's first run, and the reason is
+worth keeping.
+
+A directory with Go source and no `go.mod` does **not** make `go list -deps -e
+./...` fail. It exits 0 and prints the standard library's dependency closure —
+91 packages, none of them the caller's, no error. `goImportedPackages` therefore
+returned a large non-empty set with `ok=true`, and every advisory import path
+was missing from it, so every Go advisory would have been answered
+**deterministically unreachable** for a directory nox never enumerated.
+
+This was **not reachable in production**: the only caller passes a directory
+where a `go.mod` was already found. It was reachable from the function's own
+documented contract — *"when the toolchain cannot answer, this reports
+ok=false"* — which was false as written, and would have become reachable the
+first time a second caller believed it.
+
+Fixed by checking for `go.mod` before running the toolchain.
+
+## Rules for changing this corpus
+
+1. **`may_suppress` stays true for exactly one case.** If a change makes a
+   second one suppressible, the change is wrong until argued otherwise —
+   loudly, in the commit, with the reasoning.
+2. **Every case explains itself.** `expect.json` requires a `why`, and the test
+   fails without one. A ground truth nobody explained is one nobody can check.
+3. **No network, no module cache.** Standard library only.
+4. **Add the case before the analysis.** Track G will extend reachability
+   beyond Go; each new ecosystem should arrive with its unsupported case turned
+   into a determined one, and the unsupported case for whatever comes next.

--- a/testdata/reachability-suite/reachable/expect.json
+++ b/testdata/reachability-suite/reachable/expect.json
@@ -1,0 +1,8 @@
+{
+  "advisory_imports": ["crypto/md5"],
+  "want_reachable": true,
+  "want_determined": true,
+  "want_state": "positive",
+  "may_suppress": false,
+  "why": "The affected package is linked. The finding stands; a reachable vulnerability is not a candidate for suppression."
+}

--- a/testdata/reachability-suite/reachable/go.mod
+++ b/testdata/reachability-suite/reachable/go.mod
@@ -1,0 +1,3 @@
+module example.com/reachable
+
+go 1.21

--- a/testdata/reachability-suite/reachable/main.go
+++ b/testdata/reachability-suite/reachable/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// The advisory for this case names crypto/md5. This build links it, so
+// reachability is determined AND positive.
+func main() { fmt.Printf("%x\n", md5.Sum([]byte("x"))) }

--- a/testdata/reachability-suite/undetermined_no_import_metadata/expect.json
+++ b/testdata/reachability-suite/undetermined_no_import_metadata/expect.json
@@ -1,0 +1,8 @@
+{
+  "advisory_imports": [],
+  "want_reachable": true,
+  "want_determined": false,
+  "want_state": "unknown",
+  "may_suppress": false,
+  "why": "An advisory with no import metadata scopes to the whole module. Nothing was established, and 'we could not tell' must not read as 'not reachable'."
+}

--- a/testdata/reachability-suite/undetermined_no_import_metadata/go.mod
+++ b/testdata/reachability-suite/undetermined_no_import_metadata/go.mod
@@ -1,0 +1,3 @@
+module example.com/nometa
+
+go 1.21

--- a/testdata/reachability-suite/undetermined_no_import_metadata/main.go
+++ b/testdata/reachability-suite/undetermined_no_import_metadata/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// The advisory for this case names NO import paths — most ecosystems' advisories
+// do not. Nothing can be concluded about which package is affected, so
+// reachability is undetermined however completely the build was enumerated.
+func main() { fmt.Printf("%x\n", sha256.Sum256([]byte("x"))) }

--- a/testdata/reachability-suite/undetermined_not_a_module/expect.json
+++ b/testdata/reachability-suite/undetermined_not_a_module/expect.json
@@ -1,0 +1,8 @@
+{
+  "advisory_imports": ["crypto/md5"],
+  "want_reachable": true,
+  "want_determined": false,
+  "want_state": "unknown",
+  "may_suppress": false,
+  "why": "The toolchain failed, so the linked set is unknown. An empty answer and an unavailable answer look identical downstream and must not be treated alike."
+}

--- a/testdata/reachability-suite/undetermined_not_a_module/main.go
+++ b/testdata/reachability-suite/undetermined_not_a_module/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+// This directory holds Go source and NO go.mod, so `go list -deps` cannot
+// enumerate anything. The linked set is unknown, which is a different statement
+// from the linked set being empty — and the difference is the whole of Gate B.
+func main() { fmt.Println("no module here") }

--- a/testdata/reachability-suite/unreachable/expect.json
+++ b/testdata/reachability-suite/unreachable/expect.json
@@ -1,0 +1,8 @@
+{
+  "advisory_imports": ["crypto/md5"],
+  "want_reachable": false,
+  "want_determined": true,
+  "want_state": "negative",
+  "may_suppress": true,
+  "why": "The toolchain enumerated every linked package and the affected one is not among them. This is the ONLY case in this suite where suppression is honest."
+}

--- a/testdata/reachability-suite/unreachable/go.mod
+++ b/testdata/reachability-suite/unreachable/go.mod
@@ -1,0 +1,3 @@
+module example.com/unreachable
+
+go 1.21

--- a/testdata/reachability-suite/unreachable/main.go
+++ b/testdata/reachability-suite/unreachable/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// The advisory for this case names crypto/md5. This build links sha256 and not
+// md5, so reachability is determined AND negative — the only state in the whole
+// suite that may justify suppressing a finding.
+func main() { fmt.Printf("%x\n", sha256.Sum256([]byte("x"))) }

--- a/testdata/reachability-suite/unsupported_ecosystem/expect.json
+++ b/testdata/reachability-suite/unsupported_ecosystem/expect.json
@@ -1,0 +1,8 @@
+{
+  "advisory_imports": ["left-pad"],
+  "want_reachable": true,
+  "want_determined": false,
+  "want_state": "unsupported",
+  "may_suppress": false,
+  "why": "Dependency reachability is implemented for Go only. An npm dependency is not unreachable; it is unexamined, and nox has no implementation that could examine it."
+}

--- a/testdata/reachability-suite/unsupported_ecosystem/package-lock.json
+++ b/testdata/reachability-suite/unsupported_ecosystem/package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "unsupported-ecosystem",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/left-pad": { "version": "1.3.0" }
+  }
+}


### PR DESCRIPTION
The design doc has recorded this corpus as owed since Track A:

> Gate B therefore has no corpus yet, and Track G must bring one before
> deterministic unreachability is allowed to suppress anything.

## Why it is worth the trouble

Gate B is the rule that **deterministic unreachability may suppress a finding,
and nothing else may.**

That sounds obvious and is the easiest thing in the system to get wrong,
because the four states that must *not* suppress are indistinguishable from the
one that may at the only place anyone looks — the output. A finding hidden
because reachability proved it unreachable, and a finding hidden because
reachability never ran, produce the same artifact: no finding, and no reason
given for its absence.

## The corpus

Five cases, each declaring the `(reachable, determined)` **pair** rather than a
boolean — the pair is the point — and whether that conclusion may justify
hiding a finding.

| case | `(reachable, determined)` | may suppress |
|---|---|---|
| `reachable` | `(true, true)` | no |
| `unreachable` | `(false, true)` | **yes** |
| `undetermined_no_import_metadata` | `(true, false)` | no |
| `undetermined_not_a_module` | `(true, false)` | no |
| `unsupported_ecosystem` | `(true, false)` | no |

`TestGateB` asserts exactly one case may suppress, **by name rather than by
count**, so a change making a second one suppressible fails with the case named.

**Deterministic and offline by construction:** every module depends only on the
standard library. Go issues advisories for stdlib packages, so this is not a
contrivance, and it means `go list` needs no network and no module cache. A
corpus needing either would be one that quietly stopped running — and the first
symptom would be that it had stopped failing.

## It failed on its first run

Which is the best thing a new corpus can do.

A directory with Go source and no `go.mod` does **not** make `go list -deps -e
./...` fail. It exits 0 and prints the standard library's dependency closure —
91 packages, none of them the caller's, no error. `goImportedPackages` therefore
returned a large non-empty set with `ok=true`, every advisory import path was
missing from it, and every Go advisory would have been answered
**deterministically unreachable** for a directory nox never enumerated.

Exactly the Gate B failure: a blind spot reported as an all-clear.

**Not reachable in production, and I checked rather than assumed** — the only
caller passes a directory where a `go.mod` was already found. It *was* reachable
from the function's own documented contract (*"when the toolchain cannot
answer, this reports ok=false"*), which was false as written and would have
become reachable the first time a second caller believed it.

Fixed by checking for `go.mod` before running the toolchain.

## Falsified properly, on the second attempt

The first removal of the fix left two unused imports, so the package failed to
**build** rather than the test failing — and a build error is not evidence about
a test. Removing the check *and* its imports fails both tests, with the messages
explaining why.

## Verification

- `go build ./...` clean, `golangci-lint run ./core/...` 0 issues
- Full suite green
- precision suite 37/0/0, refutation suite 10/0/0 — unchanged
- Suite excluded from the self-scan for the reason the other corpora are, plus
  one of its own: `reachable` imports `crypto/md5` deliberately, since "the
  affected package IS linked" needs an affected package

## What this unblocks

Track G. `PREVENTED` as a normal, visible scan result now has a corpus standing
behind the one state that may produce it.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW