### PR TITLE
G: the applicability ladder — does this affect my code?

### DIFF
--- a/core/analyzers/deps/applicability_test.go
+++ b/core/analyzers/deps/applicability_test.go
@@ -1,0 +1,171 @@
+package deps
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/applicability"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// goAdvisory builds an OSV record scoping to the given import paths of module.
+func goAdvisory(module string, imports ...string) *osvVuln {
+	aff := osvAffected{Package: osvPackage{Name: module}}
+	for _, im := range imports {
+		aff.EcosystemSpecific.Imports = append(aff.EcosystemSpecific.Imports, osvImport{Path: im})
+	}
+	return &osvVuln{Affected: []osvAffected{aff}}
+}
+
+// TestApplicabilityClimbsAsFarAsTheEvidenceGoes covers every branch a
+// dependency finding can take, and asserts the reason as well as the outcome.
+//
+// The reason is half the value. "Stopped at call_reachable" is not actionable;
+// "stopped because no call-graph analysis is available" tells an operator what
+// to install — and it distinguishes a limit of this installation from a limit
+// of the evidence, which look identical in a finding that says neither.
+func TestApplicabilityClimbsAsFarAsTheEvidenceGoes(t *testing.T) {
+	const module = "golang.org/x/crypto"
+	linked := map[string]struct{}{"golang.org/x/crypto/openpgp": {}}
+
+	for _, tc := range []struct {
+		name        string
+		pkg         Package
+		adv         *osvVuln
+		linked      map[string]struct{}
+		linkedKnown bool
+		wantOutcome applicability.Outcome
+		wantReached applicability.Rung
+		wantStopped applicability.Rung
+		wantBecause capability.State
+	}{
+		{
+			name:   "affected package is linked — climbs to symbol_used, then hits a wall nox has not built",
+			pkg:    Package{Name: module, Ecosystem: "go"},
+			adv:    goAdvisory(module, "golang.org/x/crypto/openpgp"),
+			linked: linked, linkedKnown: true,
+			wantOutcome: applicability.Undetermined,
+			wantReached: applicability.SymbolUsed,
+			wantStopped: applicability.CallReachable,
+			wantBecause: capability.Unsupported,
+		},
+		{
+			name:   "affected package is not linked — the only NotImpacting case",
+			pkg:    Package{Name: module, Ecosystem: "go"},
+			adv:    goAdvisory(module, "golang.org/x/crypto/ssh"),
+			linked: linked, linkedKnown: true,
+			wantOutcome: applicability.NotImpacting,
+			wantReached: applicability.AffectedVersion,
+			wantStopped: applicability.SymbolUsed,
+			wantBecause: capability.Negative,
+		},
+		{
+			name:   "advisory names no import paths — nothing established",
+			pkg:    Package{Name: module, Ecosystem: "go"},
+			adv:    goAdvisory(module),
+			linked: linked, linkedKnown: true,
+			wantOutcome: applicability.Undetermined,
+			wantReached: applicability.AffectedVersion,
+			wantStopped: applicability.SymbolUsed,
+			wantBecause: capability.Unknown,
+		},
+		{
+			name:   "linked set unknown — an unavailable answer, not an empty one",
+			pkg:    Package{Name: module, Ecosystem: "go"},
+			adv:    goAdvisory(module, "golang.org/x/crypto/ssh"),
+			linked: nil, linkedKnown: false,
+			wantOutcome: applicability.Undetermined,
+			wantReached: applicability.AffectedVersion,
+			wantStopped: applicability.SymbolUsed,
+			wantBecause: capability.Unknown,
+		},
+		{
+			name:   "npm — unexamined, not unreachable",
+			pkg:    Package{Name: "left-pad", Ecosystem: "npm"},
+			adv:    goAdvisory("left-pad"),
+			linked: nil, linkedKnown: false,
+			wantOutcome: applicability.Undetermined,
+			wantReached: applicability.AffectedVersion,
+			wantStopped: applicability.SymbolUsed,
+			wantBecause: capability.Unsupported,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := applicabilityFor(tc.pkg, tc.adv, tc.linked, tc.linkedKnown)
+			if v.Outcome != tc.wantOutcome {
+				t.Errorf("outcome = %q, want %q", v.Outcome, tc.wantOutcome)
+			}
+			if v.Reached != tc.wantReached {
+				t.Errorf("reached = %q, want %q", v.Reached, tc.wantReached)
+			}
+			if v.StoppedAt != tc.wantStopped {
+				t.Errorf("stoppedAt = %q, want %q", v.StoppedAt, tc.wantStopped)
+			}
+			if v.Because != tc.wantBecause {
+				t.Errorf("because = %q, want %q — an unsupported analysis and an "+
+					"undetermined one are different answers", v.Because, tc.wantBecause)
+			}
+			if d := v.Describe(); d == "" {
+				t.Error("the verdict describes itself as nothing")
+			}
+		})
+	}
+}
+
+// TestOnlyTheUnlinkedCaseIsNotImpacting is Gate B at the analyzer level. Four of
+// the five branches above are absences of knowledge; exactly one is a finding.
+func TestOnlyTheUnlinkedCaseIsNotImpacting(t *testing.T) {
+	const module = "golang.org/x/crypto"
+	linked := map[string]struct{}{"golang.org/x/crypto/openpgp": {}}
+
+	notImpacting := 0
+	for _, tc := range []struct {
+		adv         *osvVuln
+		linked      map[string]struct{}
+		linkedKnown bool
+		eco         string
+	}{
+		{goAdvisory(module, "golang.org/x/crypto/openpgp"), linked, true, "go"},
+		{goAdvisory(module, "golang.org/x/crypto/ssh"), linked, true, "go"},
+		{goAdvisory(module), linked, true, "go"},
+		{goAdvisory(module, "golang.org/x/crypto/ssh"), nil, false, "go"},
+		{goAdvisory("left-pad"), nil, false, "npm"},
+	} {
+		v := applicabilityFor(Package{Name: module, Ecosystem: tc.eco}, tc.adv, tc.linked, tc.linkedKnown)
+		if v.Outcome == applicability.NotImpacting {
+			notImpacting++
+		}
+	}
+	if notImpacting != 1 {
+		t.Errorf("%d branches produced NotImpacting, want exactly 1 — every other "+
+			"branch is an absence of knowledge, and an absence that de-emphasises a "+
+			"finding is a blind spot reported as an all-clear", notImpacting)
+	}
+}
+
+// TestTheMessageSaysWhatWasEstablished. The old message said only "not
+// reachable", which invites the reader to supply the more comfortable reading.
+func TestTheMessageSaysWhatWasEstablished(t *testing.T) {
+	const module = "golang.org/x/crypto"
+	linked := map[string]struct{}{"golang.org/x/crypto/openpgp": {}}
+
+	unlinked := applicabilityFor(Package{Name: module, Ecosystem: "go"},
+		goAdvisory(module, "golang.org/x/crypto/ssh"), linked, true)
+	got := unlinked.Describe()
+	if !strings.Contains(got, "not currently impacting") {
+		t.Errorf("%q does not state the conclusion in a developer's terms", got)
+	}
+	if !strings.Contains(got, "not linked by this build") {
+		t.Errorf("%q does not give the reason", got)
+	}
+
+	stalled := applicabilityFor(Package{Name: module, Ecosystem: "go"},
+		goAdvisory(module, "golang.org/x/crypto/openpgp"), linked, true)
+	got = stalled.Describe()
+	if strings.Contains(got, "not currently impacting") {
+		t.Errorf("%q claims non-impact for a linked package", got)
+	}
+	if !strings.Contains(got, "not established") {
+		t.Errorf("%q does not say that the climb stopped short", got)
+	}
+}

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -22,6 +22,8 @@ import (
 	"github.com/nox-hq/nox-core/degrade"
 	"github.com/nox-hq/nox-core/vulnsource"
 	osvsource "github.com/nox-hq/nox-core/vulnsource/osv"
+	"github.com/nox-hq/nox/core/applicability"
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/rules"
@@ -715,6 +717,20 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 							meta["theoretical"] = "true"
 						}
 					}
+					// Applicability: how far the argument from "this advisory
+					// exists" to "an attacker can use it here" actually got, and
+					// why it stopped. Recorded on every dependency finding,
+					// including — especially — the ones where it got nowhere,
+					// because "we could not tell" and "we did not look" are the
+					// answers a reader most needs and least often gets.
+					verdict := applicabilityFor(pkg, &ov, linkedGoPkgs, linkedGoKnown)
+					meta["applicability"] = string(verdict.Outcome)
+					meta["applicability_reached"] = string(verdict.Reached)
+					if verdict.StoppedAt != "" {
+						meta["applicability_stopped_at"] = string(verdict.StoppedAt)
+						meta["applicability_because"] = string(verdict.Because)
+					}
+
 					if pkg.Ecosystem == "go" {
 						affected := goAffectedImports(&ov, pkg.Name)
 						if reachable, determined := goVulnReachable(affected, linkedGoPkgs, linkedGoKnown); determined {
@@ -724,10 +740,15 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 							} else {
 								meta["reachable"] = "false"
 								sev = findings.SeverityInfo
-								message += " (not reachable: the affected package is not linked by this build)"
 							}
 						}
 					}
+
+					// The message says what was established rather than only
+					// what was not. "not reachable" alone invites the reader to
+					// supply the more comfortable reading; the ladder says how
+					// far nox got and where it stopped.
+					message += " — " + verdict.Describe()
 
 					fs.Add(findings.Finding{
 						RuleID:     "VULN-001",
@@ -748,4 +769,41 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	}
 
 	return inventory, fs, nil
+}
+
+// applicabilityFor climbs the applicability ladder as far as the evidence
+// actually supports, and records where it stopped.
+//
+// Every rung above SymbolUsed is currently out of reach: nox has no call-graph
+// analysis, so CallReachable cannot be established for anything. Saying so is
+// the point. A scanner that stops climbing and stays silent leaves the reader
+// to assume it stopped because there was nothing above; this says it stopped
+// because nobody has built the thing that would look.
+func applicabilityFor(pkg Package, ov *osvVuln, linked map[string]struct{}, linkedKnown bool) applicability.Verdict {
+	// Present and AffectedVersion are established by the fact of the finding:
+	// the package is in the lockfile, and OSV matched its version.
+	const reached = applicability.AffectedVersion
+
+	if pkg.Ecosystem != "go" {
+		// Dependency reachability is implemented for Go only. An npm package is
+		// not unreachable; it is unexamined, and nothing here could examine it.
+		return applicability.Undeterminable(reached, applicability.SymbolUsed, capability.Unsupported)
+	}
+
+	affected := goAffectedImports(ov, pkg.Name)
+	reachable, determined := goVulnReachable(affected, linked, linkedKnown)
+	if !determined {
+		// The advisory named no import paths, or the linked set is unknown.
+		// Either way nothing was established, and the rung stays unclimbed.
+		return applicability.Undeterminable(reached, applicability.SymbolUsed, capability.Unknown)
+	}
+	if !reachable {
+		return applicability.Refuted(reached, applicability.SymbolUsed, capability.Negative,
+			[]string{"the build links no package under " + strings.Join(affected, ", ")})
+	}
+
+	// The affected package IS linked. That is SymbolUsed established — and the
+	// next rung, whether anything calls it, is one nox cannot climb at all.
+	return applicability.Undeterminable(applicability.SymbolUsed,
+		applicability.CallReachable, capability.Unsupported)
 }

--- a/core/applicability/applicability.go
+++ b/core/applicability/applicability.go
@@ -1,0 +1,201 @@
+// Package applicability answers the question a developer actually asks about a
+// dependency vulnerability: does this affect my code?
+//
+// It is a separate axis from exploitability, and keeping them separate is the
+// first decision this package makes.
+//
+// The roadmap asks for "PREVENTED as a normal scan result" — show the
+// vulnerability, and say it is not currently impacting this application.
+// Implemented literally that would corrupt the evidence kernel, whose PREVENTED
+// means "not exploited under the strategies tested; a defense was observed".
+// That state requires EXECUTION. A scan executes nothing and derives POTENTIAL,
+// correctly. Reusing PREVENTED for a static unreachability result would claim a
+// defense was observed when nothing ran — a false statement at exactly the
+// point a reader is deciding whether to act.
+//
+// So the honest answer is a second axis. A vulnerability can be POTENTIAL on
+// the exploitability ladder (nobody tried to exploit it) and NOT IMPACTING on
+// this one (the affected code is not in the build). Both are true, neither
+// implies the other, and collapsing them loses the distinction that makes the
+// second one worth reporting.
+package applicability
+
+import (
+	"fmt"
+
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// Rung is one step in the argument from "this advisory exists" to "an attacker
+// can use it against this application".
+//
+// The ladder is the point. A scanner that reports only the bottom rung floods
+// its user; one that claims the top rung it cannot establish misleads them.
+// Naming every step lets nox say exactly how far it got, which is a more useful
+// and more honest answer than either.
+type Rung string
+
+// The rungs, weakest first.
+const (
+	// Present — the dependency is in the build. Every dependency finding
+	// establishes this and nothing more, which is why a scanner that stops here
+	// produces a list nobody triages.
+	Present Rung = "present"
+	// AffectedVersion — and the resolved version falls in the advisory's range.
+	AffectedVersion Rung = "affected_version"
+	// SymbolUsed — and the specific package the advisory names is linked by
+	// this build. Linked is not called: the code is present, not proven to run.
+	SymbolUsed Rung = "symbol_used"
+	// CallReachable — and a call path reaches it from somewhere that executes.
+	CallReachable Rung = "call_reachable"
+	// AttackerReachable — and an attacker can cause that path to be taken.
+	// Strictly stronger than CallReachable, and separate because conflating
+	// them turns "the code runs" into "the code is exploitable".
+	AttackerReachable Rung = "attacker_reachable"
+)
+
+// ladder is the ordered set. Order is meaning here, not presentation: a rung is
+// established only if every rung below it is.
+var ladder = []Rung{Present, AffectedVersion, SymbolUsed, CallReachable, AttackerReachable}
+
+// Ladder returns the rungs, weakest first.
+func Ladder() []Rung {
+	out := make([]Rung, len(ladder))
+	copy(out, ladder)
+	return out
+}
+
+// index returns a rung's position, or -1 if it is not a defined rung.
+func (r Rung) index() int {
+	for i, v := range ladder {
+		if v == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// Valid reports whether r is a defined rung.
+func (r Rung) Valid() bool { return r.index() >= 0 }
+
+// Above reports whether r is a stronger claim than other.
+func (r Rung) Above(other Rung) bool {
+	ri, oi := r.index(), other.index()
+	return ri >= 0 && oi >= 0 && ri > oi
+}
+
+// Next returns the rung above r, and whether one exists.
+func (r Rung) Next() (Rung, bool) {
+	i := r.index()
+	if i < 0 || i+1 >= len(ladder) {
+		return "", false
+	}
+	return ladder[i+1], true
+}
+
+// Outcome is what the climb concluded.
+type Outcome string
+
+// Outcomes.
+const (
+	// Undetermined — the climb stopped because something could not be
+	// established, not because anything was refuted. The default, and by far
+	// the most common: nox has no call-graph analysis, so almost every
+	// dependency finding stops below CallReachable.
+	Undetermined Outcome = "undetermined"
+	// NotImpacting — a rung was DETERMINISTICALLY refuted, so the argument
+	// cannot continue. This is the only outcome that may justify de-emphasising
+	// a finding, and it requires the same evidence Gate B requires: an analysis
+	// that ran and established the negative.
+	NotImpacting Outcome = "not_impacting"
+)
+
+// Verdict is how far the applicability argument got, and why it stopped.
+//
+// It deliberately carries the reason alongside the result. "Stopped at
+// CallReachable" is not actionable; "stopped at CallReachable because no
+// call-graph analysis is available on this installation" tells an operator
+// what to install. And it keeps the two ways of not advancing distinguishable:
+// a refuted rung and an unevaluated one both stop the climb and mean opposite
+// things.
+type Verdict struct {
+	// Reached is the highest rung positively established.
+	Reached Rung `json:"reached"`
+	// Outcome says whether the climb stopped on a refutation or on an absence.
+	Outcome Outcome `json:"outcome"`
+	// StoppedAt is the rung that could not be established.
+	StoppedAt Rung `json:"stopped_at,omitempty"`
+	// Because is the evaluation state of the analysis that would have
+	// established StoppedAt — the capability vocabulary, so "unknown",
+	// "unsupported" and "not evaluated" stay distinguishable here too.
+	Because capability.State `json:"because,omitempty"`
+	// Path is the evidence trail, when there is one. It is what keeps a
+	// reachability conclusion auditable rather than a boolean a reader has to
+	// take on trust.
+	Path []string `json:"path,omitempty"`
+}
+
+// Describe renders the verdict as the sentence a developer should read.
+//
+// It never says "safe" and never says "prevented". The strongest thing it will
+// say is that a vulnerability does not currently impact this application, with
+// the reason attached — and it says that only when something was actually
+// established, never merely because nothing was found.
+func (v Verdict) Describe() string {
+	switch v.Outcome {
+	case NotImpacting:
+		return fmt.Sprintf("present, but not currently impacting this application: %s",
+			refutedAt(v.StoppedAt))
+	default:
+		if v.StoppedAt == "" {
+			return fmt.Sprintf("established as far as %q", v.Reached)
+		}
+		return fmt.Sprintf("established as far as %q; %s was not established (%s)",
+			v.Reached, v.StoppedAt, v.Because.Describe())
+	}
+}
+
+// refutedAt explains what a refuted rung means in a developer's terms.
+func refutedAt(r Rung) string {
+	switch r {
+	case SymbolUsed:
+		return "the affected package is not linked by this build"
+	case CallReachable:
+		return "no call path reaches the affected code"
+	case AttackerReachable:
+		return "the affected code is not reachable from attacker-controlled input"
+	case AffectedVersion:
+		return "the resolved version is outside the advisory's affected range"
+	default:
+		return "an applicability requirement was established not to hold"
+	}
+}
+
+// Undeterminable builds a verdict for a climb that stopped on an absence.
+//
+// The reason is required rather than optional. A verdict that stopped for an
+// unrecorded reason is the "reachability unavailable reads as unreachable"
+// failure with an extra field, and a caller that had no reason to give
+// probably has no business claiming the climb stopped at all.
+func Undeterminable(reached, stoppedAt Rung, because capability.State) Verdict {
+	return Verdict{Reached: reached, Outcome: Undetermined, StoppedAt: stoppedAt, Because: because}
+}
+
+// Refuted builds a verdict for a rung deterministically established not to hold.
+//
+// capability.Negative is the only state that may produce this, which is Gate B
+// expressed where the verdict is constructed rather than checked afterwards:
+// an undetermined result cannot be turned into a NotImpacting verdict by a
+// caller that would rather it were one.
+func Refuted(reached, refutedRung Rung, state capability.State, path []string) Verdict {
+	if !state.SuppressesFinding() {
+		return Undeterminable(reached, refutedRung, state)
+	}
+	return Verdict{
+		Reached:   reached,
+		Outcome:   NotImpacting,
+		StoppedAt: refutedRung,
+		Because:   state,
+		Path:      path,
+	}
+}

--- a/core/applicability/applicability_test.go
+++ b/core/applicability/applicability_test.go
@@ -1,0 +1,108 @@
+package applicability_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/applicability"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// TestOnlyADeterministicNegativeProducesNotImpacting is Gate B, enforced where
+// the verdict is CONSTRUCTED rather than checked afterwards.
+//
+// A caller who would rather an undetermined result were a clean one cannot get
+// it: Refuted downgrades to Undetermined for any state that is not a conclusive
+// negative. Checking this after the fact would leave a window in which the
+// wrong verdict exists and something could read it.
+func TestOnlyADeterministicNegativeProducesNotImpacting(t *testing.T) {
+	for _, s := range []capability.State{
+		capability.NotEvaluated, capability.Unsupported, capability.TimedOut,
+		capability.Unknown, capability.Positive, capability.State("from-a-newer-build"),
+	} {
+		v := applicability.Refuted(applicability.AffectedVersion, applicability.SymbolUsed, s, nil)
+		if v.Outcome == applicability.NotImpacting {
+			t.Errorf("state %q produced NotImpacting; only a conclusive negative may, "+
+				"or a scan reports its own blind spot as an all-clear", s)
+		}
+	}
+
+	v := applicability.Refuted(applicability.AffectedVersion, applicability.SymbolUsed,
+		capability.Negative, []string{"the build links no package under crypto/md5"})
+	if v.Outcome != applicability.NotImpacting {
+		t.Errorf("a conclusive negative produced %q, want NotImpacting", v.Outcome)
+	}
+	if len(v.Path) == 0 {
+		t.Error("a NotImpacting verdict carries no evidence path; that is the " +
+			"unauditable boolean this model exists to replace")
+	}
+}
+
+// TestDescribeNeverAssertsSafetyOrPrevention checks the wording a developer
+// reads, in both directions the wording could overstate.
+//
+// The second half matters as much as the first. PREVENTED is the kernel's word
+// for "a defense was observed after execution", and a static scan executes
+// nothing. Borrowing it here would claim a defense was seen where nothing ran.
+func TestDescribeNeverAssertsSafetyOrPrevention(t *testing.T) {
+	verdicts := []applicability.Verdict{
+		{},
+		applicability.Undeterminable(applicability.Present, applicability.SymbolUsed, capability.Unknown),
+		applicability.Undeterminable(applicability.SymbolUsed, applicability.CallReachable, capability.Unsupported),
+		applicability.Refuted(applicability.AffectedVersion, applicability.SymbolUsed, capability.Negative, nil),
+	}
+	banned := []string{"safe", "secure", "no risk", "not vulnerable", "prevented", "clean"}
+	for i, v := range verdicts {
+		got := strings.ToLower(v.Describe())
+		if got == "" {
+			t.Errorf("verdict %d describes itself as nothing", i)
+		}
+		for _, w := range banned {
+			if strings.Contains(got, w) {
+				t.Errorf("verdict %d says %q, which contains %q", i, got, w)
+			}
+		}
+	}
+}
+
+// TestUndeterminedSaysWhy. "Stopped at call_reachable" is not actionable;
+// "stopped because no call-graph analysis is available" tells an operator what
+// to install.
+func TestUndeterminedSaysWhy(t *testing.T) {
+	v := applicability.Undeterminable(applicability.SymbolUsed,
+		applicability.CallReachable, capability.Unsupported)
+	got := v.Describe()
+	if !strings.Contains(got, string(applicability.SymbolUsed)) {
+		t.Errorf("%q does not say how far the climb got", got)
+	}
+	if !strings.Contains(got, string(applicability.CallReachable)) {
+		t.Errorf("%q does not say where it stopped", got)
+	}
+	if !strings.Contains(got, "cannot apply") && !strings.Contains(got, "unsupported") {
+		t.Errorf("%q does not say why it stopped", got)
+	}
+}
+
+// TestTheLadderIsOrdered. Order is meaning here: a rung is established only if
+// every rung below it is, so a mis-ordered ladder would let a weaker claim
+// outrank a stronger one.
+func TestTheLadderIsOrdered(t *testing.T) {
+	rungs := applicability.Ladder()
+	for i := 1; i < len(rungs); i++ {
+		if !rungs[i].Above(rungs[i-1]) {
+			t.Errorf("%q is not above %q", rungs[i], rungs[i-1])
+		}
+	}
+	if applicability.Present.Above(applicability.AttackerReachable) {
+		t.Error("the weakest rung outranks the strongest")
+	}
+	if (applicability.Rung("invented")).Valid() {
+		t.Error("an undefined rung validated")
+	}
+	if _, ok := applicability.AttackerReachable.Next(); ok {
+		t.Error("the top rung reports one above it")
+	}
+	if next, ok := applicability.SymbolUsed.Next(); !ok || next != applicability.CallReachable {
+		t.Errorf("SymbolUsed.Next() = %q, %v; want call_reachable, true", next, ok)
+	}
+}


### PR DESCRIPTION
Track G's product question. It starts by **not** doing what the roadmap asks
for literally.

## Milestone 7.4, as written, would corrupt the kernel

It says *"PREVENTED becomes a normal scan result"* — show the vulnerability, say
it is not impacting.

But `PREVENTED` means *"not exploited under the strategies tested; **a defense
was observed**"*. It requires **execution**. A scan executes nothing and derives
`POTENTIAL`, correctly — I verified both against the kernel rather than
recalling them:

```
scan outcome        -> POTENTIAL
executed + defense  -> PREVENTED
```

Reusing `PREVENTED` for a static unreachability result would claim a defense was
observed where nothing ran, at exactly the point a reader is deciding whether to
act.

**So applicability is a second axis.** A vulnerability can be `POTENTIAL` on the
exploitability ladder (nobody tried to exploit it) and `NOT_IMPACTING` on this
one (the affected code is not in the build). Both true; neither implies the
other; collapsing them loses the distinction that makes the second worth
reporting.

## The ladder

Five rungs — `present` → `affected_version` → `symbol_used` → `call_reachable` →
`attacker_reachable` — and a verdict recording how far the climb got, where it
stopped, and **why**.

The why is half the value. *"Stopped at call_reachable"* is not actionable;
*"stopped because no call-graph analysis is available"* tells an operator what to
install — and it keeps a limit of **this installation** distinguishable from a
limit of **the evidence**.

## What a developer now reads

```
present, but not currently impacting this application: the affected package
is not linked by this build

established as far as "symbol_used"; call_reachable was not established
(unsupported — this analysis cannot apply here)
```

The second is the honest sentence nox could not say before. It stops climbing at
`symbol_used` because there is no call graph, and **says so** — rather than
staying silent and letting the reader assume it stopped because there was
nothing above.

## Gate B, enforced at construction

`Refuted()` downgrades to `Undetermined` for any state that is not a conclusive
negative. A caller who would rather an undetermined result were a clean one
cannot get it, and there is no window in which the wrong verdict exists for
something to read.

Of the five branches a dependency finding can take, **exactly one** produces
`NotImpacting`, and a test asserts that count rather than the individual cases.

The message also no longer says only *"not reachable"* — that phrasing invited
the reader to supply the more comfortable reading.

## Verification

- `go build ./...` clean, `golangci-lint` 0 issues, full suite green
- precision suite 37/0/0, refutation suite 10/0/0 — unchanged
- `TestGateB` (the corpus from #517) still passing
- All five analyzer branches covered, asserting the **reason** as well as the
  outcome

## What is still out of reach, and says so

`call_reachable` and `attacker_reachable` cannot be established by anything nox
ships — `nox analysis-capabilities` already reports the call-graph gap. Every
dependency finding now stops at `symbol_used` at best and names that as the
reason, which is the honest position rather than a silent one.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW