### PR TITLE
One selector, and the evidence surface reaches MCP

### DIFF
--- a/cli/why_cmd.go
+++ b/cli/why_cmd.go
@@ -123,9 +123,10 @@ func matches(f findings.Finding, selector string) bool {
 	if selector == "" {
 		return true
 	}
-	return strings.EqualFold(f.RuleID, selector) ||
-		strings.HasPrefix(f.Fingerprint, strings.ToLower(selector)) ||
-		f.MatchesRuleID(selector)
+	// findings.Addresses, not a local copy. The MCP server and this command
+	// each had their own prefix match and they already disagreed about case,
+	// so the same prefix resolved on one surface and not the other.
+	return f.Addresses(selector)
 }
 
 func printExplanation(e explain.Explanation) {

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -235,6 +235,50 @@ func (f *Finding) MatchesRuleID(id string) bool {
 	return false
 }
 
+// MatchesFingerprint reports whether fp addresses this finding, by full
+// fingerprint or by an unambiguous prefix.
+//
+// Prefix matching exists because a full SHA-256 is 64 characters and nobody
+// retypes one; every surface that lets a person name a finding accepts a
+// prefix. It lives here rather than in each adapter because it had already
+// drifted: the MCP server and the CLI each grew their own copy, differing on
+// whether the input was lowercased, so the same prefix could resolve in one
+// and not the other. That is the cross-adapter duplication this codebase has
+// fixed five times before.
+//
+// An empty prefix matches nothing. Treating it as "matches everything" would
+// turn a missing argument into a silent select-all, which is the wrong default
+// on any surface that acts on what it selects.
+func (f *Finding) MatchesFingerprint(fp string) bool {
+	fp = strings.TrimSpace(fp)
+	if fp == "" || f.Fingerprint == "" {
+		return false
+	}
+	if strings.EqualFold(f.Fingerprint, fp) {
+		return true
+	}
+	if strings.HasPrefix(strings.ToLower(f.Fingerprint), strings.ToLower(fp)) {
+		return true
+	}
+	// A waiver written before a rule retirement names the fingerprint the
+	// retired rule would have produced; the same courtesy applies to a person
+	// naming one at a prompt.
+	for _, alias := range f.AliasFingerprints {
+		if strings.EqualFold(alias, fp) ||
+			strings.HasPrefix(strings.ToLower(alias), strings.ToLower(fp)) {
+			return true
+		}
+	}
+	return false
+}
+
+// Addresses reports whether selector names this finding, by rule ID (current or
+// retired) or by fingerprint (full or prefix). It is what every adapter should
+// call when a person names a finding.
+func (f *Finding) Addresses(selector string) bool {
+	return f.MatchesRuleID(selector) || f.MatchesFingerprint(selector)
+}
+
 // NewFinding constructs a Finding with a normalized location. It is the
 // preferred way to create findings: the location range is made valid and the
 // caller's severity/confidence are used as-is (validate with Validate). Fields

--- a/core/findings/selector_test.go
+++ b/core/findings/selector_test.go
@@ -1,0 +1,50 @@
+package findings
+
+import "testing"
+
+// TestAddressesIsTheOneSelector guards the cross-adapter duplication this
+// codebase has fixed five times.
+//
+// Every surface that lets a person name a finding — the CLI, the MCP server,
+// the LSP — accepts a fingerprint prefix, because a full SHA-256 is 64
+// characters and nobody retypes one. Each grew its own copy, and they had
+// already drifted: the MCP server compared case-sensitively and the CLI
+// lowercased the input, so the same prefix resolved on one surface and not the
+// other. A person cannot debug that; it looks like the finding is gone.
+func TestAddressesIsTheOneSelector(t *testing.T) {
+	f := Finding{
+		RuleID:            "SEC-003",
+		Fingerprint:       "65f66b3f2c177f2795e5db6ebff43f41",
+		RetiredRuleIDs:    []string{"SEC-903"},
+		AliasFingerprints: []string{"deadbeefdeadbeef"},
+	}
+
+	for _, sel := range []string{
+		"SEC-003", "sec-003", // current rule ID, either case
+		"SEC-903",                          // a retired ID a waiver may still name
+		"65f66b3f2c177f2795e5db6ebff43f41", // the whole fingerprint
+		"65f66b3f", "65F66B3F",             // a prefix, either case
+		"deadbeef", // the fingerprint a retired rule would have produced
+	} {
+		if !f.Addresses(sel) {
+			t.Errorf("Addresses(%q) = false; a selector a person would reasonably "+
+				"type does not resolve", sel)
+		}
+	}
+
+	for _, sel := range []string{
+		"", "   ", // an omitted argument must not select everything
+		"SEC-004", "ffffffff", "65f66b3f2c177f2795e5db6ebff43f41x",
+	} {
+		if f.Addresses(sel) {
+			t.Errorf("Addresses(%q) = true; it names a different finding, or nothing", sel)
+		}
+	}
+
+	// A finding with no fingerprint cannot be addressed by one, and must not
+	// match every prefix by accident.
+	blank := Finding{RuleID: "SEC-003"}
+	if blank.MatchesFingerprint("65f66b3f") {
+		t.Error("a finding with no fingerprint matched a fingerprint prefix")
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1053,6 +1053,25 @@ policy:
   baseline_mode: strict
 ```
 
+#### Via MCP
+
+The evidence surface is on the MCP server too, because an agent triaging a scan
+needs it more than a person does — a person can read the terminal and notice
+what is missing.
+
+| tool | what it answers |
+|---|---|
+| `analysis_capabilities` | what this installation can establish, and what **this scan** actually established |
+| `why` | the eight questions for a finding (fingerprint, prefix, or rule ID) |
+
+`analysis_capabilities` is the one worth calling before summarising a scan. The
+MCP surface already carried degradations, which say a check *broke*; nothing
+said a question was never *asked*. A capability that is provided but answered
+nothing was available and unused — not a clean result.
+
+MCP scans record reasoning so `why` has evidence to answer from. Both tools are
+read-only, like the rest of the MCP surface.
+
 #### `nox why` — the eight questions
 
 ```sh

--- a/server/evidence.go
+++ b/server/evidence.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"context"
+	"sort"
+
+	"github.com/nox-hq/nox-core/evidence"
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/catalog"
+	"github.com/nox-hq/nox/core/explain"
+	mcp "go.klarlabs.de/mcp"
+)
+
+// capabilityOutput reports what this installation can establish and what this
+// scan actually established.
+//
+// This is the tool that closes a gap an agent could not otherwise see. The MCP
+// surface already carries degradations, which say that a check BROKE. Nothing
+// said that a question was never ASKED, and those are different: an agent
+// reading a clean finding list has no way to learn that reachability was never
+// evaluated, and "no findings" then reads as "nothing is wrong". Track D exists
+// for exactly that distinction, and until now it stopped at the CLI.
+type capabilityOutput struct {
+	Capabilities []capabilityRow `json:"capabilities"`
+	// Note is addressed to the agent reading this, because the failure mode
+	// here is a confident summary written from an incomplete scan.
+	Note string `json:"note"`
+}
+
+type capabilityRow struct {
+	Capability string `json:"capability"`
+	// Provided says whether anything on this installation can establish it at
+	// all — a fact about the binary, not about this scan.
+	Provided bool `json:"provided"`
+	// ProvidedBy names the implementations, so "install a plugin" is
+	// actionable rather than a guess.
+	ProvidedBy []string `json:"provided_by,omitempty"`
+	// Answered and Inconclusive are what happened in THIS scan. Provided with
+	// zero answered means the capability exists and nothing used it here.
+	Answered     int `json:"answered"`
+	Inconclusive int `json:"inconclusive"`
+	// Meaning states, in words, what the row implies for a reader.
+	Meaning string `json:"meaning"`
+}
+
+func (s *Server) handleAnalysisCapabilities(_ context.Context, _ emptyInput) (mcp.StructuredResult, error) {
+	pc := s.getCache("")
+	if pc == nil {
+		return toolError("no scan results available — run the scan tool first"), nil
+	}
+
+	out := capabilityOutput{Note: "A capability that is provided but answered nothing was " +
+		"available and never used here. That is not a clean result; it means the question " +
+		"was not asked about this code."}
+
+	for _, c := range capability.All() {
+		answered, inconclusive := pc.result.Coverage.Answered(c)
+		provided := pc.result.Capabilities.Provided(c)
+		row := capabilityRow{
+			Capability: string(c), Provided: provided,
+			ProvidedBy: pc.result.Capabilities.ProvidedBy(c),
+			Answered:   answered, Inconclusive: inconclusive,
+		}
+		switch {
+		case !provided:
+			row.Meaning = "Nothing on this installation can establish it. Findings that " +
+				"depend on it are unevaluated, not cleared."
+		case answered > 0:
+			row.Meaning = "Established for some findings in this scan."
+		case inconclusive > 0:
+			row.Meaning = "The analysis ran and could not determine anything."
+		default:
+			row.Meaning = "Available, but nothing in this scan put the question."
+		}
+		out.Capabilities = append(out.Capabilities, row)
+	}
+	sort.Slice(out.Capabilities, func(i, j int) bool {
+		return out.Capabilities[i].Capability < out.Capabilities[j].Capability
+	})
+	return structured(out)
+}
+
+// whyInput selects the finding to explain.
+type whyInput struct {
+	// Fingerprint is a full fingerprint or an unambiguous prefix, or a rule ID.
+	// Resolved by findings.Addresses, the same selector the CLI uses.
+	Fingerprint string `json:"fingerprint" jsonschema:"Fingerprint (full or prefix) or rule ID of the finding to explain"`
+}
+
+type whyOutput struct {
+	Explanations []explain.Explanation `json:"explanations"`
+	// Note tells the agent what this is and, more usefully, what it is not.
+	Note string `json:"note"`
+}
+
+// handleWhy answers the eight questions for a finding.
+//
+// Deterministic: it reads only what the scan established, so an agent gets the
+// same answer twice and can quote it. The two questions worth the round trip
+// are "what was not evaluated" and "does it affect this application" — the ones
+// a scanner normally leaves out, and the ones an agent most needs before
+// writing a confident summary.
+func (s *Server) handleWhy(_ context.Context, input whyInput) (mcp.StructuredResult, error) {
+	pc := s.getCache("")
+	if pc == nil {
+		return toolError("no scan results available — run the scan tool first"), nil
+	}
+	if pc.result.Reasoning == nil {
+		return toolError("this scan recorded no reasoning, so there is nothing to explain " +
+			"from; the evidence a finding rests on is collected during the scan and cannot " +
+			"be reconstructed afterwards"), nil
+	}
+
+	cat := catalog.Catalog()
+	out := whyOutput{Note: "Answers derive from what the scan established, not from a " +
+		"language model. An empty 'supports' or a populated 'not_evaluated' is information, " +
+		"not an omission."}
+
+	for _, f := range pc.result.Findings.ActiveFindings() {
+		if input.Fingerprint != "" && !f.Addresses(input.Fingerprint) {
+			continue
+		}
+		subject := nox.SubjectForFinding(f)
+		var ledger evidence.Ledger
+		if pc.result.Reasoning != nil {
+			ledger = pc.result.Reasoning.About(subject)
+		}
+		out.Explanations = append(out.Explanations, explain.Explain(explain.Inputs{
+			Finding: f, Ledger: ledger, Subject: subject,
+			Coverage: pc.result.Coverage, Rule: cat[f.RuleID],
+		}))
+	}
+	if len(out.Explanations) == 0 {
+		return toolError("no active finding matches that selector"), nil
+	}
+	return structured(out)
+}

--- a/server/evidence_test.go
+++ b/server/evidence_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	nox "github.com/nox-hq/nox/core"
+)
+
+// scanned puts a real scan of the precision suite into the server's cache, the
+// way the scan tool would.
+func scanned(t *testing.T) *Server {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := nox.RunScanWithOptions("../testdata/precision-suite",
+		nox.ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	s := New("test", nil)
+	s.setCache("", res)
+	return s
+}
+
+func payload(t *testing.T, r any) string {
+	t.Helper()
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestAnAgentCanLearnWhatWasNotEvaluated is the gap this tool closes.
+//
+// The MCP surface already carried degradations, which say that a check BROKE.
+// Nothing said a question was never ASKED, and an agent reading a clean finding
+// list had no way to tell the two apart — so "no findings" read as "nothing is
+// wrong". Track D exists for that distinction and it stopped at the CLI.
+func TestAnAgentCanLearnWhatWasNotEvaluated(t *testing.T) {
+	s := scanned(t)
+	res, err := s.handleAnalysisCapabilities(context.Background(), emptyInput{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	out := payload(t, res)
+
+	var report capabilityOutput
+	decode(t, res, &report)
+	if len(report.Capabilities) == 0 {
+		t.Fatal("the capability report is empty")
+	}
+
+	// Assert on the ROW, not on the covering note. An earlier version of this
+	// test matched a phrase that only ever appeared in the note, so a row could
+	// describe an unasked question as "no issues found" and the test still
+	// passed — a guard reading the reassurance instead of the claim. Found by
+	// falsifying it and watching nothing fail.
+	var sawUnprovided, sawUnasked bool
+	for _, row := range report.Capabilities {
+		switch {
+		case !row.Provided:
+			sawUnprovided = true
+			if !strings.Contains(row.Meaning, "Nothing on this installation can establish it") {
+				t.Errorf("%s is unprovided but its meaning reads %q", row.Capability, row.Meaning)
+			}
+		case row.Answered == 0 && row.Inconclusive == 0:
+			sawUnasked = true
+			if !strings.Contains(row.Meaning, "nothing in this scan put the question") {
+				t.Errorf("%s was never asked but its meaning reads %q — an agent "+
+					"summarising this would report it as checked", row.Capability, row.Meaning)
+			}
+		}
+	}
+	if !sawUnprovided || !sawUnasked {
+		t.Errorf("the corpus exercised unprovided=%v unasked=%v; both must appear or "+
+			"the assertions above are vacuous", sawUnprovided, sawUnasked)
+	}
+	// Never a clearance. An agent summarising this must not be handed a word
+	// that lets it write "no issues".
+	for _, banned := range []string{"\"safe\"", "no risk", "not vulnerable"} {
+		if strings.Contains(strings.ToLower(out), banned) {
+			t.Errorf("the capability report contains %q", banned)
+		}
+	}
+}
+
+// TestAnAgentCanAskWhy. The two questions worth the round trip are the ones a
+// scanner normally omits, so they are the ones checked here.
+func TestAnAgentCanAskWhy(t *testing.T) {
+	s := scanned(t)
+	res, err := s.handleWhy(context.Background(), whyInput{Fingerprint: "SEC-003"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	out := payload(t, res)
+
+	for _, want := range []string{
+		"not_evaluated", "affects_this_application", "supports", "what_to_do",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the explanation omits %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "no active finding matches") {
+		t.Fatalf("selecting by rule ID matched nothing; the shared selector is not "+
+			"being used:\n%s", out)
+	}
+}
+
+// TestWhyResolvesTheSameSelectorAsTheCLI. A person who gets a fingerprint
+// prefix from `nox scan` and hands it to an agent must have it resolve. The two
+// surfaces each grew their own prefix match once and drifted on case; this
+// pins that they now share one.
+func TestWhyResolvesTheSameSelectorAsTheCLI(t *testing.T) {
+	s := scanned(t)
+	pc := s.getCache("")
+	if pc == nil {
+		t.Fatal("no cache")
+	}
+	all := pc.result.Findings.ActiveFindings()
+	if len(all) == 0 {
+		t.Fatal("no findings to select")
+	}
+	full := all[0].Fingerprint
+
+	for _, sel := range []string{full, full[:12], strings.ToUpper(full[:12])} {
+		res, err := s.handleWhy(context.Background(), whyInput{Fingerprint: sel})
+		if err != nil {
+			t.Fatalf("handler(%q): %v", sel, err)
+		}
+		if strings.Contains(payload(t, res), "no active finding matches") {
+			t.Errorf("selector %q resolved nothing; the CLI accepts it", sel)
+		}
+	}
+}
+
+// TestWhySaysSoWhenThereIsNoEvidence. A scan that recorded no reasoning must
+// report that, not return an explanation with empty support that reads as
+// "nothing backs this finding".
+func TestWhySaysSoWhenThereIsNoEvidence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := nox.RunScanWithOptions("../testdata/precision-suite", nox.ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	s := New("test", nil)
+	s.setCache("", res)
+
+	got, err := s.handleWhy(context.Background(), whyInput{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !strings.Contains(payload(t, got), "recorded no reasoning") {
+		t.Errorf("a scan with no evidence did not say so:\n%s", payload(t, got))
+	}
+}
+
+// TestFingerprintLookupAcceptsWhatTheCLIAccepts covers the second surface that
+// shares the selector.
+//
+// It exists because falsifying the first selector test proved nothing:
+// reverting get_finding_by_fingerprint to its own case-sensitive prefix match
+// failed no test, because `why` had coverage and this tool had none. A shared
+// helper with one caller tested is still two implementations as far as the
+// evidence goes.
+func TestFingerprintLookupAcceptsWhatTheCLIAccepts(t *testing.T) {
+	s := scanned(t)
+	all := s.getCache("").result.Findings.ActiveFindings()
+	if len(all) == 0 {
+		t.Fatal("no findings to select")
+	}
+	full := all[0].Fingerprint
+
+	for _, sel := range []string{full, full[:12], strings.ToUpper(full[:12])} {
+		res, err := s.handleFindingByFingerprint(context.Background(),
+			findingByFingerprintInput{Fingerprint: sel})
+		if err != nil {
+			t.Fatalf("handler(%q): %v", sel, err)
+		}
+		if !strings.Contains(payload(t, res), `"found":true`) {
+			t.Errorf("get_finding_by_fingerprint(%q) found nothing; the CLI accepts it, "+
+				"so a person moving between the two surfaces sees the finding vanish", sel)
+		}
+	}
+}
+
+func decode(t *testing.T, r, into any) {
+	t.Helper()
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(b, &envelope); err == nil {
+		for _, key := range []string{"structuredContent", "structured_content", "content"} {
+			if raw, ok := envelope[key]; ok {
+				if err := json.Unmarshal(raw, into); err == nil {
+					return
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(b, into); err != nil {
+		t.Fatalf("could not decode structured result: %v\n%s", err, b)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -242,6 +242,21 @@ func (s *Server) registerTools(srv *mcp.Server) {
 		OutputSchema(detail.FindingDetail{}).
 		Handler(s.handleGetFindingDetail)
 
+	// Track D and Milestone 9.3 reach the agent surface here. Both are
+	// read-only and both answer a question the existing tools cannot: what was
+	// never evaluated, and why a finding was reported.
+	srv.Tool("analysis_capabilities").
+		Description("What this installation can establish and what THIS scan actually established, per analysis capability. Call it before summarising a scan: a capability that is provided but answered nothing was available and never used, which is not a clean result — it means the question was not asked. Degradations tell you a check broke; this tells you a question was never put.").
+		ReadOnly().
+		OutputSchema(capabilityOutput{}).
+		Handler(s.handleAnalysisCapabilities)
+
+	srv.Tool("why").
+		Description("Answer eight questions about a finding: what was observed, why it matters, what supports it, what argues against it, what was NOT evaluated, the potential impact, whether it affects this application, and what to do. Deterministic — derived from what the scan established, not written by a model. Pass a fingerprint (full or prefix) or a rule ID; omit to explain every active finding.").
+		ReadOnly().
+		OutputSchema(whyOutput{}).
+		Handler(s.handleWhy)
+
 	srv.Tool("summary").
 		Description("Aggregate overview of the last scan: active/total/suppressed counts and breakdowns by severity, confidence, and rule family, plus dependency and AI-component totals. Call this first to size up a scan before paging through individual findings.").
 		ReadOnly().
@@ -511,7 +526,13 @@ func (s *Server) handleScan(_ context.Context, input scanInput) (string, error) 
 		return "Error: " + err.Error(), nil
 	}
 
-	result, err := nox.RunScan(input.Path)
+	// RecordReasoning, not RunScan's default. The `why` tool answers from the
+	// evidence a scan gathers, and that evidence cannot be reconstructed
+	// afterwards — a scan that did not record it can only report that it did
+	// not. An agent surface is precisely where being able to ask "why" is worth
+	// the cost, and the ledger is held out-of-band so a finding still carries
+	// no extra bytes.
+	result, err := nox.RunScanWithOptions(input.Path, nox.ScanOptions{RecordReasoning: true})
 	if err != nil {
 		return "Error: scan failed: " + err.Error(), nil
 	}
@@ -689,7 +710,7 @@ func (s *Server) handleFindingByFingerprint(_ context.Context, input findingByFi
 	all := pc.result.Findings.Findings()
 	for i := range all {
 		f := &all[i]
-		if f.Fingerprint == fp || strings.HasPrefix(f.Fingerprint, fp) {
+		if f.Addresses(fp) {
 			loc := f.Location
 			return structured(fingerprintLookupOutput{
 				Found:       true,


### PR DESCRIPTION
Two findings from auditing what this session actually built, rather than assuming it was fine.

## 1. The duplication I reintroduced

Fingerprint-prefix selection existed in `server/server.go`, and I added a second copy in `cli/why_cmd.go`. That's the cross-adapter duplication this codebase has already fixed **five times** — and the two copies had already drifted:

- MCP compared **case-sensitively**
- the CLI **lowercased** its input

So the same prefix resolved on one surface and not the other. A person moving between them sees the finding vanish and cannot debug it.

`findings.Addresses` is now the one selector — rule ID (current or retired), fingerprint (full or prefix), alias fingerprints, and an empty selector matches **nothing** rather than everything. Both adapters call it.

## 2. The evidence surface stopped at the CLI

nox is meant to be callable by humans, CI, **and agents**. Track D's capability coverage and 9.3's eight questions were CLI-only, and the first is a real gap.

The MCP surface already carried degradations — which say a check **broke**. Nothing said a question was never **asked**. An agent reading a clean finding list couldn't tell those apart, so *"no findings"* read as *"nothing is wrong"* — the false all-clear, at the interface where a model is about to write a confident summary. That's precisely the distinction Track D exists for.

Two read-only tools:

| tool | answers |
|---|---|
| `analysis_capabilities` | what this installation can establish, and what **this scan** established |
| `why` | the eight questions for a finding |

MCP scans now record reasoning, because a scan's evidence cannot be reconstructed afterwards and an agent surface is where asking "why" is worth the cost. The ledger stays out-of-band, so a finding carries no extra bytes.

**Absences that are not gaps**, for the record: `attack`, `confirm`, `fix`, `verify-secrets` are excluded because MCP is read-only by design; `lsp`, `serve`, `completion`, `uri` are process concerns; `show`, `fix`, `vex`, `baseline` are already there under other names.

## Both falsifications failed to fail, first time

Worth reporting because a falsification that quietly proves nothing is the same failure as a test that doesn't test.

- **Reverting MCP to its own prefix match broke no test** — `why` had coverage, `get_finding_by_fingerprint` had none. A shared helper with one caller tested is still two implementations as far as the evidence goes.
- **Rewording a never-asked capability to "No issues found" passed** — the assertion matched a phrase that only appeared in the covering *note*, not in the row that lied.

Both tests now assert on the thing that can be wrong. Re-falsified:

```
get_finding_by_fingerprint("4D74D1919732") found nothing; the CLI accepts it
attacker_reachability was never asked but its meaning reads "No issues found
for this capability." — an agent summarising this would report it as checked
```

## Architecture audit — the rest is sound

- Dependency direction clean: nothing in `core` imports `cli`/`server`/`ai-assist` (`go list -deps`).
- `core/explain`, `core/migration`, `core/adjudicate` are pure — no I/O, no clock, no network. `replay.Inputs.GeneratedAt` is passed in, keeping the kernel's no-clock rule.
- `core/replay` does file I/O, matching the `core/baseline` and `core/vex` convention. Consistent, not a violation.

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues across core, cli, server.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW