### PR TITLE
Skip tool-state directories at any depth, not only at the root

### DIFF
--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -25,10 +25,38 @@ import (
 // wholesale. It matches each glob in generatedFileIgnorePatterns against both
 // the full (slash-normalised) path and its basename, mirroring the per-rule
 // matching in core/rules/engine.go.
+//
+// # Directory patterns match at any depth
+//
+// A pattern of the form "dir/*" names a tool-state DIRECTORY, and the intent is
+// that nothing inside it is scanned. filepath.Match cannot express that: its
+// "*" does not cross a separator and the pattern is anchored at the start, so
+// ".claude/*" matched .claude/settings.json and missed
+// .claude/worktrees/agent-x/.nox/baseline.json entirely.
+//
+// That was not theoretical. Scanning a repository with git worktrees under
+// .claude/ produced 107 high-severity "Cloudflare API Token" findings, every
+// one of them a SHA-256 fingerprint inside nox's OWN baseline files — the tool
+// reporting its own output as credentials, in the one directory the list
+// already claimed to exclude. Every directory entry had the same hole:
+// .nox, .claude, .roady, .cursor, .continue, .vex, testdata.
+//
+// So directory patterns are matched by path SEGMENT. Anything under a named
+// directory is skipped wherever that directory sits.
 func isGeneratedSecretsPath(path string) bool {
 	norm := filepath.ToSlash(path)
 	base := filepath.Base(norm)
+	segments := strings.Split(norm, "/")
+
 	for _, pattern := range generatedFileIgnorePatterns {
+		if dir, ok := strings.CutSuffix(pattern, "/*"); ok {
+			for _, seg := range segments[:max(0, len(segments)-1)] {
+				if seg == dir {
+					return true
+				}
+			}
+			continue
+		}
 		if matched, _ := filepath.Match(pattern, norm); matched {
 			return true
 		}

--- a/core/analyzers/secrets/secrets_paths_test.go
+++ b/core/analyzers/secrets/secrets_paths_test.go
@@ -1,0 +1,53 @@
+package secrets
+
+import "testing"
+
+// TestToolStateDirectoriesAreSkippedAtAnyDepth is the regression for a
+// self-inflicted false positive found by scanning real repositories.
+//
+// generatedFileIgnorePatterns names tool-state directories — .nox, .claude,
+// .roady and the rest — and the intent is that nothing inside them is scanned.
+// filepath.Match cannot express that: its "*" does not cross a separator and
+// the pattern is anchored at the start, so ".claude/*" excluded
+// .claude/settings.json and missed .claude/worktrees/agent-x/.nox/baseline.json
+// completely.
+//
+// Measured on a repository with git worktrees under .claude/: 107
+// high-severity "Cloudflare API Token" findings, every one a SHA-256
+// fingerprint inside nox's OWN baseline files. The tool reported its own
+// output as credentials, in a directory the exclusion list already named.
+// Removing it took that repository from 311 active findings to 195.
+func TestToolStateDirectoriesAreSkippedAtAnyDepth(t *testing.T) {
+	skipped := []string{
+		".nox/baseline.json",
+		"sub/.nox/baseline.json",
+		".claude/worktrees/agent-x/.nox/baseline.json",
+		"packages/api/.roady/spec.yaml",
+		"a/b/c/.cursor/state.json",
+		"vendor/thing/testdata/fixture.json",
+	}
+	for _, p := range skipped {
+		if !isGeneratedSecretsPath(p) {
+			t.Errorf("%s is scanned; it sits inside a tool-state directory the "+
+				"exclusion list already names, so nox reports its own artifacts "+
+				"as findings", p)
+		}
+	}
+
+	// The exclusion must stay about directories. A file that merely shares a
+	// name with something in a tool-state directory is ordinary source, and
+	// skipping it would hide real credentials.
+	scanned := []string{
+		"baseline.json",
+		"sub/baseline.json",
+		"app/config.py",
+		"noxious/main.go",       // not .nox
+		"claudette/settings.go", // not .claude
+	}
+	for _, p := range scanned {
+		if isGeneratedSecretsPath(p) {
+			t.Errorf("%s is skipped; it is not inside a tool-state directory, and "+
+				"excluding ordinary source is how a scanner misses a real secret", p)
+		}
+	}
+}


### PR DESCRIPTION
Found by the end-to-end campaign — scanning real repositories rather than the corpus.

## The bug

`generatedFileIgnorePatterns` names tool-state directories — `.nox`, `.claude`, `.roady`, `.cursor`, `.continue`, `.vex`, `testdata` — and the intent is that nothing inside them is scanned.

`filepath.Match` cannot express that. Its `*` does not cross a separator and the pattern is anchored at the start, so `.claude/*` excluded `.claude/settings.json` and **missed `.claude/worktrees/agent-x/.nox/baseline.json` entirely**. Every directory entry in the list had the same hole.

## The consequence: nox reporting its own output as credentials

On a repository with git worktrees under `.claude/`, **SEC-542 fired 107 times at high severity** as "Cloudflare API Token" — and every single one was a SHA-256 fingerprint inside **nox's own baseline files**, in a directory the exclusion list already named.

| | before | after |
|---|---|---|
| keyward active findings | 311 | **195** |
| SEC-542 | 107 | **0** |

Reproduced minimally first — the placement matrix is what pinned the rule:

| placement | before | after |
|---|---|---|
| `.nox/baseline.json` | skipped | skipped |
| `sub/.nox/baseline.json` | **scanned** | skipped |
| `.claude/w/.nox/baseline.json` | **scanned** | skipped |
| `sub/baseline.json` | scanned | scanned ✓ |

That last row matters: the exclusion stays about **directories**. A file that merely shares a name with something in a tool-state directory is ordinary source, and skipping it is how a scanner misses a real secret.

## Verified across four languages

Python, Rust, Go, TypeScript — evidence artifact written and replayed on each. **Every verdict reproduced exactly, before and after the fix.**

| repo | lang | findings | replay |
|---|---|---|---|
| mnemos | py | 136 | 136 reproduced |
| scout | ts | 5 | 5 reproduced |
| keyward | rust | 220 | 220 reproduced |
| bolt | go | 10 | 10 reproduced |
| coverctl | py+ts | 5 | 5 reproduced |

Full suite green — precision-suite scoring unaffected.

## The falsification needed a second attempt

Deleting the segment loop left an unused variable and import, so the package failed to **build** and the test printed nothing useful. A build error is not evidence about a test — the same trap this session hit earlier. Neutralising the loop while keeping it compiling produces the real failure, naming both the root and the nested path.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW