### PR TITLE
Recognise an open quantifier as anchorless, and retire two rules

### DIFF
--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -28,6 +28,11 @@ type secretRule struct {
 	// minEntropy overrides the default 3.0 minimum Shannon entropy when
 	// secretShape is enabled. Higher values reject more candidates.
 	minEntropy float64
+	// retires lists rule IDs this rule absorbed, with the pattern each used.
+	// See rules.RetiredRule: deleting a duplicate ID outright would un-waive
+	// every finding an operator accepted under it, because baselines hash the
+	// rule ID and VEX statements and nox:ignore comments name it directly.
+	retires []rules.RetiredRule
 }
 
 // builtinSecretRules returns all built-in secret detection rules.
@@ -777,6 +782,15 @@ func builtinSecretRules() []*rules.Rule {
 			pattern:     `(?i)cloudflare[_-]?api[_-]?token\s*[=:]\s*['"]?[A-Za-z0-9_-]{40}`,
 			description: "Cloudflare API Token detected",
 			cwe:         "CWE-798", keywords: []string{"cloudflare_api_token", "cloudflare-api-token"},
+			// SEC-542 claimed the same credential with the pattern
+			// `[a-zA-Z0-9]{32,}` and the file-level keyword "cloudflare",
+			// which means "this file mentions cloudflare somewhere and
+			// contains 32 alphanumeric characters somewhere". On a fixture
+			// with a SHA-256 digest five lines below a comment about
+			// Cloudflare, it fired; on a real token it fired a second time
+			// alongside this rule. Absorbed rather than deleted so waivers
+			// written against SEC-542 keep working.
+			retires:     []rules.RetiredRule{{ID: "SEC-542", Pattern: `[a-zA-Z0-9]{32,}`}},
 			remediation: "Rotate the exposed token immediately. Use environment variables or a secrets manager.",
 			references:  []string{"https://cwe.mitre.org/data/definitions/798.html"},
 		},
@@ -3270,7 +3284,19 @@ func builtinSecretRules() []*rules.Rule {
 		{id: "SEC-521", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `https://container.googleapis.com/v1/projects/`, description: "Detected GKE Cluster URL", cwe: "CWE-798", keywords: []string{"gcp_gke"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-522", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `https://storage.googleapis.com/`, description: "Detected GCS Bucket URL", cwe: "CWE-798", keywords: []string{"gcp_storage"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-523", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `/subscriptions/[a-z0-9-]+/resourceGroups/`, description: "Detected Azure Resource ID", cwe: "CWE-798", keywords: []string{"azure"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
-		{id: "SEC-524", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-zA-Z0-9]{32,}`, description: "Detected Azure Subscription ID", cwe: "CWE-798", keywords: []string{"azure_sub"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
+		// SEC-524 ("Azure Subscription ID") was removed rather than retired.
+		// A subscription ID is not a credential: it appears in ARM templates,
+		// az CLI output, portal URLs and Microsoft's own samples, and no
+		// survivor should inherit it, so there is nothing to retire it INTO.
+		// The rule was also incapable of detecting what it named — a
+		// subscription ID is a UUID, and `[a-zA-Z0-9]{32,}` does not match one
+		// because the hyphens break the class. Wrong target and wrong pattern,
+		// advising "rotate the exposed credential immediately" for an
+		// identifier that cannot be rotated.
+		//
+		// Deleting is safe here in the way retiring exists to protect against:
+		// the finding does not come back under another ID, so a waiver naming
+		// SEC-524 simply has nothing left to match.
 		{id: "SEC-525", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-z0-9]{32}`, description: "Detected DigitalOcean API Key (alternate)", cwe: "CWE-798", keywords: []string{"digitalocean"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-526", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `do_[a-z0-9]{32}`, description: "Detected DigitalOcean OAuth Token", cwe: "CWE-798", keywords: []string{"digitalocean_oauth"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-527", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[A-Za-z0-9_-]{64}`, description: "Detected Scaleway API Token", cwe: "CWE-798", keywords: []string{"scaleway"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
@@ -3288,7 +3314,6 @@ func builtinSecretRules() []*rules.Rule {
 		{id: "SEC-539", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-z0-9]{32}`, description: "Detected DNSimple API Token", cwe: "CWE-798", keywords: []string{"dnsimple"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-540", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-zA-Z0-9]{32}`, description: "Detected Namecheap API Key", cwe: "CWE-798", keywords: []string{"namecheap"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-541", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-zA-Z0-9@#$%^&*]{16,}`, description: "Detected GoDaddy API Key", cwe: "CWE-798", keywords: []string{"godaddy"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
-		{id: "SEC-542", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-zA-Z0-9]{32,}`, description: "Detected Cloudflare API Token (alternate)", cwe: "CWE-798", keywords: []string{"cloudflare"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-543", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-zA-Z0-9]{32}`, description: "Detected Datadog API Key (alternate)", cwe: "CWE-798", keywords: []string{"datadog"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-544", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `[a-f0-9]{32}`, description: "Detected New Relic License Key (alternate)", cwe: "CWE-798", keywords: []string{"newrelic"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}},
 		{id: "SEC-545", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium, pattern: `\b[a-zA-Z0-9]{20}\b`, description: "Detected PagerDuty API Key (alternate)", cwe: "CWE-798", keywords: []string{"pagerduty"}, remediation: "Rotate the exposed credential immediately", references: []string{"https://cwe.mitre.org/data/definitions/798.html"}, secretShape: true, minEntropy: 3.5},
@@ -3767,6 +3792,7 @@ func builtinSecretRules() []*rules.Rule {
 			MatcherType:            "regex",
 			Pattern:                d.pattern,
 			Keywords:               d.keywords,
+			Retires:                d.retires,
 			RequireContextKeywords: requireContext,
 			Tags:                   []string{"secrets"},
 			Metadata:               md,
@@ -3783,7 +3809,20 @@ func builtinSecretRules() []*rules.Rule {
 // `\b[a-f0-9]{40}\b`. Such a pattern contains no literal text tying it to the
 // credential format it claims to detect, so it needs the vendor name nearby to
 // mean anything.
-var anchorlessPattern = regexp.MustCompile(`^(\\b)?\[[^\]]+\]\{\d+(,\d+)?\}(\\b)?$`)
+//
+// The upper bound is optional — `(,\d*)?`, not `(,\d+)?` — and that single
+// character is the whole point. `{32,}` is the MOST anchorless form a pattern
+// can take: unbounded above, so it matches any run of characters at least that
+// long. Requiring a digit after the comma excluded exactly those, so the
+// protection applied to `{32}` and `{32,64}` and skipped `{32,}`, `{50,}` and
+// `{20,}` — the ones that needed it most.
+//
+// Measured when this was found: 36 vendor rules used an unbounded quantifier,
+// all at high severity, none of them receiving either the proximity
+// requirement or the secret-shape filter. SEC-542 ("Cloudflare API Token")
+// meant, in practice, "this file mentions cloudflare somewhere and contains 32
+// alphanumeric characters somewhere".
+var anchorlessPattern = regexp.MustCompile(`^(\\b)?\[[^\]]+\]\{\d+(,\d*)?\}(\\b)?$`)
 
 // isAnchorlessPattern reports whether a rule pattern relies entirely on shape
 // and length, with no literal anchor of its own.

--- a/core/analyzers/secrets/secrets_paths_test.go
+++ b/core/analyzers/secrets/secrets_paths_test.go
@@ -51,3 +51,63 @@ func TestToolStateDirectoriesAreSkippedAtAnyDepth(t *testing.T) {
 		}
 	}
 }
+
+// TestAnchorlessRecognisesAnOpenQuantifier is the regression for a guard that
+// missed the case it was written for.
+//
+// isAnchorlessPattern decides whether a vendor rule gets the proximity
+// requirement and the secret-shape filter. Its regex required a digit after the
+// comma — `(,\d+)?` — so `{32}` and `{32,64}` were recognised and `{32,}` was
+// not. The unbounded form is the MOST anchorless a pattern can be, and it was
+// the one form the protection skipped: 36 rules, all high severity, none of
+// them getting either control.
+func TestAnchorlessRecognisesAnOpenQuantifier(t *testing.T) {
+	for _, p := range []string{
+		`[a-zA-Z0-9]{32}`, `[a-zA-Z0-9]{32,64}`,
+		`[a-zA-Z0-9]{32,}`, `[a-zA-Z0-9_-]{50,}`, `[a-zA-Z0-9-]{20,}`,
+		`\b[a-f0-9]{40}\b`,
+	} {
+		if !isAnchorlessPattern(p) {
+			t.Errorf("%s is not recognised as anchorless, so it receives neither the "+
+				"proximity requirement nor the shape filter — the two controls that "+
+				"stop a bare character class matching every long string in a file", p)
+		}
+	}
+	// A pattern carrying real literal text ties itself to the credential
+	// format, and must not be treated as anchorless: adding a proximity
+	// requirement to it would cost recall for nothing.
+	for _, p := range []string{
+		`(?i)cloudflare[_-]?api[_-]?token\s*[=:]\s*['"]?[A-Za-z0-9_-]{40}`,
+		`ghp_[A-Za-z0-9]{36}`,
+		`AKIA[0-9A-Z]{16}`,
+	} {
+		if isAnchorlessPattern(p) {
+			t.Errorf("%s carries literal text and was treated as anchorless", p)
+		}
+	}
+}
+
+// TestEveryAnchorlessRuleGetsBothControls. The protection is applied by a
+// derivation rather than declared per rule, so a rule can silently miss it —
+// which is exactly what happened. This checks the outcome instead of the
+// derivation.
+func TestEveryAnchorlessRuleGetsBothControls(t *testing.T) {
+	var unprotected []string
+	for _, r := range builtinSecretRules() {
+		if r.MatcherType != "regex" || !isAnchorlessPattern(r.Pattern) {
+			continue
+		}
+		if len(r.RequireContextKeywords) == 0 && len(r.Keywords) > 0 {
+			unprotected = append(unprotected, r.ID)
+		}
+		if r.Metadata["secret_shape"] != "true" {
+			unprotected = append(unprotected, r.ID+" (no shape filter)")
+		}
+	}
+	if len(unprotected) > 0 {
+		t.Errorf("%d anchorless rule(s) carry no proximity requirement or shape "+
+			"filter: %v. Such a rule means \"this file mentions the vendor and "+
+			"contains a long string\", at whatever severity it declares",
+			len(unprotected), unprotected)
+	}
+}

--- a/core/analyzers/secrets/secrets_test.go
+++ b/core/analyzers/secrets/secrets_test.go
@@ -660,10 +660,18 @@ func TestAllRules_PositiveMatch(t *testing.T) {
 // (SEC-356..SEC-370 and SEC-430..SEC-433): they fired on password-less URLs like
 // `redis://localhost`, and the credential-aware DSN rules SEC-073/SEC-074/SEC-076
 // already cover connection strings that carry userinfo credentials.
+//
+// 913 -> 911 removed SEC-542 and SEC-524, both of which paired the pattern
+// `[a-zA-Z0-9]{32,}` with a file-level keyword and a HIGH severity. SEC-542
+// restated SEC-087, which detects a Cloudflare API token properly by requiring
+// the assignment; it is retired INTO SEC-087 so waivers keep working. SEC-524
+// was deleted outright: an Azure subscription ID is not a credential, and the
+// pattern could not have matched one anyway, since a subscription ID is a UUID
+// and the hyphens fall outside the class.
 func TestAllRules_Count(t *testing.T) {
 	rules := builtinSecretRules()
-	if len(rules) != 913 {
-		t.Fatalf("expected 913 built-in secret rules, got %d", len(rules))
+	if len(rules) != 911 {
+		t.Fatalf("expected 911 built-in secret rules, got %d", len(rules))
 	}
 }
 

--- a/core/catalog/catalog_test.go
+++ b/core/catalog/catalog_test.go
@@ -38,8 +38,13 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	// and TAINT-AI-001, CRYPTO-001/002, HARDEN-001/002, PERM-001/002 and
 	// MEMSAFE-001. Their findings appeared in scans while `nox rules` and the
 	// MCP rules tool denied the rules existed.
-	if got := len(cat); got != 1537 {
-		t.Errorf("Catalog() returned %d rules, want 1537", got)
+	//
+	// 1537 -> 1535 removed two secrets rules whose pattern was a bare
+	// character class plus a file-level keyword: SEC-542 (retired into
+	// SEC-087, which detects the same credential by requiring the assignment)
+	// and SEC-524 (an Azure subscription ID is not a credential).
+	if got := len(cat); got != 1535 {
+		t.Errorf("Catalog() returned %d rules, want 1535", got)
 	}
 }
 


### PR DESCRIPTION
The proximity control was already here and already right. It just never saw the patterns that needed it most.

## One character

`isAnchorlessPattern` decides whether a vendor rule gets the context requirement and the secret-shape filter. Its own regex required a digit after the comma:

```
^(\b)?\[[^\]]+\]\{\d+(,\d+)?\}(\b)?$
                       ^^^^^^
```

So `{32}` and `{32,64}` were recognised — and **`{32,}` was not**. The unbounded form is the most anchorless a pattern can be: it matches any run of characters at least that long, with no upper bound. That was the one form the protection skipped.

**36 rules used an unbounded quantifier, every one at high severity, none receiving either control.** In practice SEC-542 "Cloudflare API Token" meant: *this file mentions cloudflare somewhere, and contains 32 alphanumeric characters somewhere.*

| | before | after |
|---|---|---|
| rules with proximity requirement | 126 | **161** |
| fixture findings | 3 | **1** |

The fixture: a SHA-256 digest five lines below a comment about Cloudflare, plus a real `cloudflare_api_token = "..."`. Before, SEC-542 fired on the digest (false positive) *and* duplicated SEC-087 on the real token. After, only SEC-087. Full suite green — **no corpus recall lost**.

**Fourth defect of this shape in the programme**: a check written correctly against the wrong input, after D5's policy validation, C3's corpus guard, and H's capability gate. Its own doc comment described the exact problem it was missing.

## Two rules retired

**SEC-542** restated SEC-087, which requires the assignment and the real 40-character shape. Retired *into* SEC-087 via `rules.RetiredRule`, so a baseline entry, VEX statement or `nox:ignore` naming SEC-542 keeps matching — which is what that mechanism exists for.

**SEC-524 "Azure Subscription ID"** was **deleted**, not retired. A subscription ID is not a credential — it appears in ARM templates, `az` CLI output, portal URLs and Microsoft's own samples — so no survivor should inherit it and there is nothing to retire it into. The rule couldn't detect its own target anyway: a subscription ID is a UUID, and `[a-zA-Z0-9]{32,}` doesn't match one because the hyphens fall outside the class. Wrong target, wrong pattern, and advising *"rotate the exposed credential immediately"* for an identifier that cannot be rotated.

Deleting is safe here in the way retiring exists to protect against: the finding doesn't come back under another ID, so a waiver naming SEC-524 simply has nothing left to match.

Both count assertions updated with the reason rather than just the number.

## Testing the outcome, not the derivation

`TestEveryAnchorlessRuleGetsBothControls` checks that every anchorless rule *ends up with* both controls, rather than that the derivation looks right — because the protection is applied by a function reading a pattern, and a rule can silently miss it. Which is what happened.

Falsified: restoring `(,\d+)?` fails by naming each unprotected pattern.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW