### PR TITLE
A: a reachability level, the scope it holds under, and the asymmetry

### DIFF
--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reach"
 	"github.com/nox-hq/nox/core/rules"
 )
 
@@ -733,12 +734,24 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 					if pkg.Ecosystem == "go" {
 						affected := goAffectedImports(&ov, pkg.Name)
-						if reachable, determined := goVulnReachable(affected, linkedGoPkgs, linkedGoKnown); determined {
+						if r, ok := goSymbolReferenced(affected, linkedGoPkgs, linkedGoKnown); ok {
 							meta["affected_imports"] = strings.Join(affected, ",")
-							if reachable {
-								meta["reachable"] = "true"
-							} else {
-								meta["reachable"] = "false"
+							// The LEVEL, named. `go list -deps` establishes that
+							// the affected import is in the linked set, which is
+							// symbol_referenced and nothing above it. This used to
+							// be written as meta["reachable"], a name that reads as
+							// call_reachable, and the capability matrix then counted
+							// it as the reachability capability — evidence for one
+							// proposition establishing a later one, which is the
+							// invariant this vocabulary exists to hold.
+							meta["reach_level"] = string(r.Level)
+							meta["reach_outcome"] = string(r.Outcome)
+							meta["reach_scope"] = r.Scope.Describe()
+							if r.Outcome == reach.Refuted {
+								// Refuted at symbol_referenced only: the build links
+								// no affected package. Severity drops because there
+								// is nothing here to call, not because the
+								// application was shown to be unaffected.
 								sev = findings.SeverityInfo
 							}
 						}

--- a/core/analyzers/deps/reachability.go
+++ b/core/analyzers/deps/reachability.go
@@ -9,6 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/reach"
 )
 
 // goListTimeout bounds the toolchain call used to enumerate imported packages.
@@ -130,4 +134,52 @@ func goVulnReachable(affectedImports []string, linked map[string]struct{}, linke
 		}
 	}
 	return false, true
+}
+
+// goSymbolReferenced answers whether the advisory's affected import is in the
+// build's linked package set, and says so at the level it actually establishes.
+//
+// That level is reach.SymbolReferenced. `go list -deps` is a linker-level
+// answer: it knows what the build links, not what calls what, so it cannot
+// speak to CallPathExists or anything above it. The previous form of this
+// answer was a bare `reachable` boolean, which read as the stronger claim and
+// was counted as the reachability capability.
+//
+// The scope carries the asymmetry. When the linked set is unknown — no go.mod,
+// a toolchain failure — the scope is incomplete and reach.Refute refuses to
+// build a negative from it, returning Undetermined instead. When the set IS
+// known, the search over it is exhaustive by construction: `go list -deps`
+// enumerates the whole closure, so "no affected import is linked" is a
+// universal claim this analysis can actually make.
+func goSymbolReferenced(affectedImports []string, linked map[string]struct{}, linkedKnown bool) (reach.Result, bool) {
+	subject := evidence.Subject{Kind: evidence.SubjectPackage, ID: strings.Join(affectedImports, ",")}
+	scope := reach.Scope{
+		Analysis:   "go list -deps",
+		Capability: capability.SymbolResolution,
+		BuildID:    "go build closure",
+	}
+	if len(affectedImports) == 0 {
+		// The advisory named no import paths, so there is nothing to look for.
+		scope.Limitations = append(scope.Limitations, reach.UnsupportedFramework)
+		return reach.Undeterminable(subject, reach.SymbolReferenced, scope), false
+	}
+	if !linkedKnown {
+		scope.Limitations = append(scope.Limitations, reach.BudgetExhausted)
+		return reach.Undeterminable(subject, reach.SymbolReferenced, scope), false
+	}
+
+	for _, imp := range affectedImports {
+		if _, ok := linked[imp]; ok {
+			r, _ := reach.Establish(subject, reach.SymbolReferenced, scope, []string{imp})
+			return r, true
+		}
+		for pkg := range linked {
+			if strings.HasPrefix(pkg, imp+"/") {
+				r, _ := reach.Establish(subject, reach.SymbolReferenced, scope, []string{pkg})
+				return r, true
+			}
+		}
+	}
+	r, ok := reach.Refute(subject, reach.SymbolReferenced, scope)
+	return r, ok
 }

--- a/core/explain/explain.go
+++ b/core/explain/explain.go
@@ -274,6 +274,27 @@ func affectsThisApplication(f findings.Finding) string {
 	stopped := f.Metadata["applicability_stopped_at"]
 	because := f.Metadata["applicability_because"]
 
+	// The reachability chain, when the dependency analyzer answered at some
+	// level of it. Reported as the LEVEL it established, never as "reachable":
+	// linker evidence establishes that an affected import is linked, which is
+	// several propositions short of an attacker being able to reach it.
+	if lvl, out := f.Metadata["reach_level"], f.Metadata["reach_outcome"]; lvl != "" && out != "" {
+		scope := f.Metadata["reach_scope"]
+		switch out {
+		case "established":
+			return fmt.Sprintf("%s holds: %s. That is one step on the chain from an "+
+				"advisory to an exploit, not the whole of it — whether anything calls "+
+				"it, and whether an attacker can reach that, were not established.",
+				lvl, scope)
+		case "refuted":
+			return fmt.Sprintf("%s does not hold within the scope searched (%s). "+
+				"Nothing here rules out another build or another path.", lvl, scope)
+		default:
+			return fmt.Sprintf("%s could not be determined (%s). Unknown, which is not "+
+				"the same as no.", lvl, scope)
+		}
+	}
+
 	switch outcome {
 	case "":
 		// Most findings are in this repository's own code, where the question

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -677,6 +677,15 @@ var confidencePriorityRank = map[Confidence]int{
 // for reachability (no metadata) rank in the neutral middle, so enabling the
 // reachability plugin only ever demotes likely-FPs — it never buries a normal
 // finding beneath one.
+//
+// The plugin is now the ONLY producer of this key. The dependency analyzer used
+// to write it too, from `go list -deps`, which establishes that an affected
+// import is in the linked set — reach.SymbolReferenced, a strictly weaker
+// proposition than the call-graph reachability this ranking is about. Two
+// producers writing one key with different meanings put a linker answer and a
+// call-graph answer in the same sort bucket. Dependency findings now carry
+// `reach_level` and rank neutral here, which is the honest position for a
+// question nothing in core answers.
 func reachabilityRank(f *Finding) int {
 	switch f.Metadata["reachable"] {
 	case "true":

--- a/core/reach/reach.go
+++ b/core/reach/reach.go
@@ -1,0 +1,286 @@
+// Package reach is the vocabulary for reachability propositions and the scope
+// each one was established under.
+//
+// It exists because "reachable" is not one question. The chain from an advisory
+// to an exploit passes through several propositions, and evidence for an
+// earlier one must never establish a later one:
+//
+//	package in closure → symbol referenced → a call path exists →
+//	a path from an attacker-controlled entry point exists →
+//	attacker-controlled data reaches the condition → a runtime path was observed
+//
+// That invariant was already violated when this package was written. The deps
+// analyzer establishes that an advisory's affected import is in the build's
+// linked package set — `symbol_referenced` — and recorded it as
+// `meta["reachable"]`, which the capability matrix then read as the
+// `reachability` capability. A project asking "was reachability answered for my
+// code?" was told yes on the strength of a weaker question, and the same
+// boolean set the finding's severity.
+//
+// # The asymmetry, which is the point of the package
+//
+// Reachable is existential: one witnessed path settles it. Unreachable is
+// universal: it claims no path exists, which is only true within some scope,
+// and is false the moment the analysis could not see everything.
+//
+// So the two are not symmetric constructors over a boolean. Established needs a
+// witness. NotEstablished needs a scope with no limitations, and refuses to
+// build otherwise — an analysis that admits it could not resolve a dispatch
+// cannot conclude that nothing reaches the sink. That is "UNSAT on path P ≠ all
+// paths impossible", enforced where the claim is constructed rather than
+// checked afterwards, because a value that briefly exists in the wrong state is
+// a value something can read.
+package reach
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// Level is one proposition in the reachability chain.
+type Level string
+
+// The chain, weakest first. Each is a strictly stronger claim than the one
+// before it, and evidence for one establishes only that one.
+const (
+	// PackageInClosure — the package is in the dependency closure. It says
+	// nothing about whether any code in it is referenced.
+	PackageInClosure Level = "package_in_closure"
+	// SymbolReferenced — the affected symbol or import is referenced by the
+	// build. This is as far as a linker-level answer goes.
+	SymbolReferenced Level = "symbol_referenced"
+	// CallPathExists — a call path reaches the symbol from somewhere. Needs a
+	// call graph.
+	CallPathExists Level = "call_path_exists"
+	// AttackerEntryPathExists — a call path reaches it from an entry point an
+	// attacker can reach. Needs an entry-point set.
+	AttackerEntryPathExists Level = "attacker_entry_path_exists"
+	// AttackerControlledFlowExists — attacker-controlled data reaches the
+	// vulnerable condition. Needs dataflow, not just a call graph.
+	AttackerControlledFlowExists Level = "attacker_controlled_flow_exists"
+	// RuntimePathObserved — the path was observed executing. Only an active
+	// run can establish this, never a scan.
+	RuntimePathObserved Level = "runtime_path_observed"
+)
+
+// Chain returns the levels in order, weakest first.
+func Chain() []Level {
+	return []Level{
+		PackageInClosure, SymbolReferenced, CallPathExists,
+		AttackerEntryPathExists, AttackerControlledFlowExists, RuntimePathObserved,
+	}
+}
+
+// Above reports whether l is a strictly stronger proposition than other.
+func (l Level) Above(other Level) bool {
+	return l.rank() > other.rank()
+}
+
+func (l Level) rank() int {
+	for i, c := range Chain() {
+		if c == l {
+			return i
+		}
+	}
+	return -1
+}
+
+// Valid reports whether l is a defined level.
+func (l Level) Valid() bool { return l.rank() >= 0 }
+
+// Limitation is a named reason an analysis could not be complete.
+//
+// This is Milestone C folded in, and it belongs here rather than in a separate
+// model: scope and incompleteness are one question — what did this analysis
+// cover, and what defeated it — and splitting them means touching every
+// analysis result twice. A capability state of "unknown" collapses every entry
+// below into one word, which tells an operator nothing they can act on.
+type Limitation string
+
+// The reasons an analysis stops being able to speak for a whole program.
+const (
+	UnresolvedDispatch   Limitation = "unresolved_dispatch"
+	Reflection           Limitation = "reflection"
+	ForeignFunctions     Limitation = "ffi"
+	DynamicLoading       Limitation = "dynamic_loading"
+	BoundedLoops         Limitation = "bounded_loops"
+	UnsupportedLanguage  Limitation = "unsupported_language"
+	UnsupportedFramework Limitation = "unsupported_framework"
+	SolverIncomplete     Limitation = "solver_incomplete"
+	BudgetExhausted      Limitation = "budget_exhausted"
+	NoEntryPointSet      Limitation = "no_entry_point_set"
+)
+
+// Describe returns the limitation in words an operator can act on.
+func (l Limitation) Describe() string {
+	switch l {
+	case UnresolvedDispatch:
+		return "a call target could not be resolved, so some paths were not followed"
+	case Reflection:
+		return "reflection was used, and the targets are not visible statically"
+	case ForeignFunctions:
+		return "control left the language through a foreign function"
+	case DynamicLoading:
+		return "code is loaded at runtime and was not available to analyse"
+	case BoundedLoops:
+		return "loops were unrolled to a bound rather than analysed to a fixpoint"
+	case UnsupportedLanguage:
+		return "this language is not analysed at this depth"
+	case UnsupportedFramework:
+		return "a framework's control flow is not modelled"
+	case SolverIncomplete:
+		return "the solver returned no answer within its limits"
+	case BudgetExhausted:
+		return "the analysis stopped on a budget rather than on a conclusion"
+	case NoEntryPointSet:
+		return "no entry points were identified, so nothing could be traced from one"
+	default:
+		return string(l)
+	}
+}
+
+// Scope is what an analysis actually covered, and what it could not.
+//
+// A reachability result without this is unusable in the direction that matters.
+// "Not reachable" is a claim about everything the analysis did not find, so it
+// is only as good as the search behind it, and a reader who cannot see the
+// search cannot weigh the claim.
+type Scope struct {
+	// Analysis names what produced the result — "go list -deps", "taint
+	// engine" — so a reader can judge it.
+	Analysis string `json:"analysis"`
+	// Capability is the analysis capability this result speaks for. It must
+	// match the LEVEL being claimed: linker evidence speaks for
+	// SymbolReferenced, not for Reachability.
+	Capability capability.AnalysisCapability `json:"capability"`
+	// EntryPoints is the set considered. Empty means none were, which makes
+	// any claim above CallPathExists impossible rather than merely weak.
+	EntryPoints []string `json:"entry_points,omitempty"`
+	// BuildID identifies the build or configuration the result is about. A
+	// reachability answer is about one build; another build links differently.
+	BuildID string `json:"build_id,omitempty"`
+	// Limitations are the reasons this analysis could not be exhaustive. A
+	// scope carrying any of them cannot support a universal claim.
+	Limitations []Limitation `json:"limitations,omitempty"`
+}
+
+// Complete reports whether the analysis could see everything it needed to.
+// Only a complete scope can support "no path exists".
+func (s Scope) Complete() bool { return len(s.Limitations) == 0 }
+
+// Describe states what was searched and what defeated it.
+func (s Scope) Describe() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s", s.Analysis)
+	if len(s.EntryPoints) > 0 {
+		fmt.Fprintf(&b, ", from %d entry point(s)", len(s.EntryPoints))
+	}
+	if s.BuildID != "" {
+		fmt.Fprintf(&b, ", build %s", s.BuildID)
+	}
+	if len(s.Limitations) == 0 {
+		return b.String()
+	}
+	reasons := make([]string, 0, len(s.Limitations))
+	for _, l := range s.Limitations {
+		reasons = append(reasons, l.Describe())
+	}
+	sort.Strings(reasons)
+	fmt.Fprintf(&b, "; incomplete because %s", strings.Join(reasons, "; and "))
+	return b.String()
+}
+
+// Outcome is what a result concluded about its level.
+type Outcome string
+
+const (
+	// Established — the proposition holds. Existential: a witness settles it.
+	Established Outcome = "established"
+	// Refuted — the proposition does not hold, within a complete scope.
+	// Universal, and only constructible from a scope with no limitations.
+	Refuted Outcome = "refuted"
+	// Undetermined — the analysis could not tell. This is the honest default
+	// and the only outcome an incomplete scope can reach.
+	Undetermined Outcome = "undetermined"
+)
+
+// Result is one reachability proposition, its outcome, and the scope it was
+// decided under.
+type Result struct {
+	Subject evidence.Subject `json:"subject"`
+	Level   Level            `json:"level"`
+	Outcome Outcome          `json:"outcome"`
+	Scope   Scope            `json:"scope"`
+	// Witness is the path that establishes an existential claim. Required for
+	// Established: a claim that something is reachable with nothing to point at
+	// is an assertion, not evidence.
+	Witness []string `json:"witness,omitempty"`
+	// Because states, in words, why the outcome is what it is.
+	Because string `json:"because"`
+}
+
+// Establish records that a level holds, evidenced by a witness path.
+//
+// Existential, so one path is enough and the scope's limitations do not matter:
+// an analysis that missed some paths can still have found this one.
+func Establish(subject evidence.Subject, level Level, scope Scope, witness []string) (Result, bool) {
+	if !level.Valid() || len(witness) == 0 {
+		// A reachability claim with nothing to point at is an assertion.
+		return Result{}, false
+	}
+	return Result{
+		Subject: subject, Level: level, Outcome: Established, Scope: scope,
+		Witness: append([]string(nil), witness...),
+		Because: fmt.Sprintf("a path was found (%s)", scope.Describe()),
+	}, true
+}
+
+// Refute records that a level does NOT hold, and refuses unless the scope
+// could see everything.
+//
+// This is the asymmetry, and it is enforced here rather than checked later
+// because a Result in the wrong state is a value something can read. An
+// analysis that could not resolve a dispatch has not established that nothing
+// reaches the sink; it has established that it did not find one, which is
+// Undetermined and says so.
+//
+// The second return is false when the scope is incomplete. Callers get an
+// Undetermined result carrying the same limitations, so refusing costs them
+// nothing and silently downgrading is not possible.
+func Refute(subject evidence.Subject, level Level, scope Scope) (Result, bool) {
+	if !level.Valid() {
+		return Result{}, false
+	}
+	if !scope.Complete() {
+		return Undeterminable(subject, level, scope), false
+	}
+	return Result{
+		Subject: subject, Level: level, Outcome: Refuted, Scope: scope,
+		Because: fmt.Sprintf("an exhaustive search found no path (%s)", scope.Describe()),
+	}, true
+}
+
+// Undeterminable records that the analysis could not tell, and why.
+func Undeterminable(subject evidence.Subject, level Level, scope Scope) Result {
+	return Result{
+		Subject: subject, Level: level, Outcome: Undetermined, Scope: scope,
+		Because: fmt.Sprintf("could not be determined (%s)", scope.Describe()),
+	}
+}
+
+// Describe is the sentence a person reads. It never asserts safety: a refuted
+// level is refuted within a scope, and the scope is named.
+func (r Result) Describe() string {
+	switch r.Outcome {
+	case Established:
+		return fmt.Sprintf("%s: yes — %s", r.Level, r.Because)
+	case Refuted:
+		return fmt.Sprintf("%s: no, within the scope searched — %s", r.Level, r.Because)
+	default:
+		return fmt.Sprintf("%s: unknown, which is not the same as no — %s", r.Level, r.Because)
+	}
+}

--- a/core/reach/reach_test.go
+++ b/core/reach/reach_test.go
@@ -1,0 +1,161 @@
+package reach_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+func subject() evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectPackage, ID: "golang.org/x/crypto/ssh"}
+}
+
+func completeScope() reach.Scope {
+	return reach.Scope{
+		Analysis: "go list -deps", Capability: capability.SymbolResolution,
+		BuildID: "go build closure",
+	}
+}
+
+// TestUnreachableIsUniversalAndRefusesAnIncompleteScope is the asymmetry, and
+// the reason this package exists as constructors rather than a struct.
+//
+// Reachable is existential: one witnessed path settles it, and an analysis that
+// missed other paths can still have found this one. Unreachable is universal:
+// it claims no path exists, which is only true within the scope searched and is
+// false the moment the analysis could not see everything.
+//
+// So an analysis that hit unresolved dispatch, reflection, FFI or a budget has
+// not established that nothing reaches the sink. It has established that it did
+// not find one, which is Undetermined. Enforced at construction because a
+// Result in the wrong state is a value something can read.
+func TestUnreachableIsUniversalAndRefusesAnIncompleteScope(t *testing.T) {
+	for _, lim := range []reach.Limitation{
+		reach.UnresolvedDispatch, reach.Reflection, reach.ForeignFunctions,
+		reach.DynamicLoading, reach.BoundedLoops, reach.UnsupportedLanguage,
+		reach.UnsupportedFramework, reach.SolverIncomplete, reach.BudgetExhausted,
+		reach.NoEntryPointSet,
+	} {
+		scope := completeScope()
+		scope.Limitations = []reach.Limitation{lim}
+
+		got, ok := reach.Refute(subject(), reach.CallPathExists, scope)
+		if ok {
+			t.Errorf("%s: a negative was built from an analysis that admits it could "+
+				"not see everything. That is UNSAT on one path read as no path "+
+				"existing", lim)
+		}
+		if got.Outcome != reach.Undetermined {
+			t.Errorf("%s: refused refutation produced %q, want undetermined — the "+
+				"caller must get the honest answer, not nothing", lim, got.Outcome)
+		}
+		if !strings.Contains(got.Because, lim.Describe()) {
+			t.Errorf("%s: the result does not say why it could not tell: %q", lim, got.Because)
+		}
+	}
+
+	// A complete scope CAN support the universal claim: `go list -deps`
+	// enumerates the whole closure, so "no affected import is linked" is a
+	// statement this analysis is entitled to make.
+	if _, ok := reach.Refute(subject(), reach.SymbolReferenced, completeScope()); !ok {
+		t.Error("an exhaustive analysis could not state a negative, which leaves nox " +
+			"unable to ever say a dependency does not apply")
+	}
+}
+
+// TestReachableNeedsAWitness. The existential claim is cheap to make and must
+// still point at something: "reachable" with nothing to show is an assertion,
+// and it is the direction that costs a developer their afternoon.
+func TestReachableNeedsAWitness(t *testing.T) {
+	if _, ok := reach.Establish(subject(), reach.CallPathExists, completeScope(), nil); ok {
+		t.Error("a reachability claim was accepted with no path to point at")
+	}
+	r, ok := reach.Establish(subject(), reach.CallPathExists, completeScope(),
+		[]string{"main → handler → ssh.Marshal"})
+	if !ok || len(r.Witness) == 0 {
+		t.Fatal("a witnessed path did not establish reachability")
+	}
+
+	// An incomplete scope does NOT block the existential claim. Finding a path
+	// is still finding a path.
+	scope := completeScope()
+	scope.Limitations = []reach.Limitation{reach.Reflection}
+	if _, ok := reach.Establish(subject(), reach.CallPathExists, scope, []string{"p"}); !ok {
+		t.Error("an incomplete analysis was blocked from reporting a path it found; " +
+			"reachable is existential and one witness settles it")
+	}
+}
+
+// TestTheChainIsOrdered. Order is meaning: each level is a strictly stronger
+// claim, and evidence for one must not establish a later one.
+func TestTheChainIsOrdered(t *testing.T) {
+	chain := reach.Chain()
+	for i := 1; i < len(chain); i++ {
+		if !chain[i].Above(chain[i-1]) {
+			t.Errorf("%q is not above %q", chain[i], chain[i-1])
+		}
+	}
+	if reach.PackageInClosure.Above(reach.RuntimePathObserved) {
+		t.Error("the weakest proposition outranks the strongest")
+	}
+	if reach.SymbolReferenced.Above(reach.CallPathExists) {
+		t.Error("symbol_referenced outranks call_path_exists — the exact confusion " +
+			"this vocabulary was written to end, where linker evidence was recorded " +
+			"as the reachability capability")
+	}
+	if (reach.Level("invented")).Valid() {
+		t.Error("an undefined level validated")
+	}
+}
+
+// TestNoOutcomeAssertsSafety. A refuted level is refuted WITHIN A SCOPE, and
+// the wording has to carry that or a reader takes it for a clearance.
+func TestNoOutcomeAssertsSafety(t *testing.T) {
+	scope := completeScope()
+	incomplete := completeScope()
+	incomplete.Limitations = []reach.Limitation{reach.UnresolvedDispatch}
+
+	refuted, _ := reach.Refute(subject(), reach.SymbolReferenced, scope)
+	established, _ := reach.Establish(subject(), reach.SymbolReferenced, scope, []string{"x"})
+	undetermined := reach.Undeterminable(subject(), reach.CallPathExists, incomplete)
+
+	banned := []string{"safe", "secure", "no risk", "not vulnerable", "prevented", "clean"}
+	for _, r := range []reach.Result{refuted, established, undetermined, {}} {
+		got := strings.ToLower(r.Describe())
+		for _, w := range banned {
+			if strings.Contains(got, w) {
+				t.Errorf("%q contains %q", got, w)
+			}
+		}
+	}
+	if !strings.Contains(refuted.Describe(), "within the scope searched") {
+		t.Errorf("a refutation reads as absolute: %q", refuted.Describe())
+	}
+	if !strings.Contains(undetermined.Describe(), "not the same as no") {
+		t.Errorf("an undetermined result can be read as a negative: %q", undetermined.Describe())
+	}
+}
+
+// TestAScopeSaysWhatItSearchedAndWhatDefeatedIt is Milestone C folded in. A
+// capability state of "unknown" collapses unresolved dispatch, reflection, FFI
+// and a budget into one word, which tells an operator nothing they can act on.
+func TestAScopeSaysWhatItSearchedAndWhatDefeatedIt(t *testing.T) {
+	s := reach.Scope{
+		Analysis: "taint engine", Capability: capability.Taint,
+		EntryPoints: []string{"http.HandleFunc"}, BuildID: "abc123",
+		Limitations: []reach.Limitation{reach.UnresolvedDispatch},
+	}
+	got := s.Describe()
+	for _, want := range []string{"taint engine", "1 entry point", "abc123", "could not be resolved"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("scope description %q omits %q", got, want)
+		}
+	}
+	if s.Complete() {
+		t.Error("a scope with a limitation reported itself complete, which would let " +
+			"it support a universal claim")
+	}
+}

--- a/core/reach_invariant_test.go
+++ b/core/reach_invariant_test.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// Milestone A's invariant: evidence about an earlier proposition must never
+// establish a later one.
+//
+// It was violated on main when this was written, and not subtly. The deps
+// analyzer establishes that an advisory's affected import is in the build's
+// linked package set — reach.SymbolReferenced — wrote it as
+// meta["reachable"], and recordCapabilityCoverage recorded that as
+// capability.Reachability. So a project declaring
+// require_capabilities: [reachability] was told the question had been answered
+// on the strength of a weaker one, and the same boolean set the severity.
+
+func vulnerableModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module reachtest\n\ngo 1.21\n")
+	write("main.go", "package main\n\nfunc main() {}\n")
+	return dir
+}
+
+// TestLinkerEvidenceDoesNotEstablishReachability drives the coverage mapping
+// directly rather than through a scan.
+//
+// The first version of this test scanned a fixture module and asserted that no
+// finding claimed the reachability capability. It passed — and it passed with
+// the defect restored, because the fixture had no dependencies, so no VULN
+// finding existed and the mapping never ran. A test that cannot reach the code
+// it is about is not a test. Feeding recordCapabilityCoverage a finding that
+// carries a reach outcome is what makes the assertion mean something.
+func TestLinkerEvidenceDoesNotEstablishReachability(t *testing.T) {
+	for _, outcome := range []reach.Outcome{reach.Established, reach.Refuted, reach.Undetermined} {
+		fs := findings.NewFindingSet()
+		fs.Add(findings.Finding{
+			RuleID: "VULN-001", Severity: findings.SeverityHigh,
+			Location: findings.Location{FilePath: "go.mod", StartLine: 1},
+			Message:  "vulnerable dependency",
+			Metadata: map[string]string{
+				"reach_level":   string(reach.SymbolReferenced),
+				"reach_outcome": string(outcome),
+				"reach_scope":   "go list -deps, build go build closure",
+			},
+		})
+		cov := capability.NewCoverage(capability.DefaultRegistry())
+		recordCapabilityCoverage(cov, fs)
+
+		subject := SubjectForFinding(fs.Findings()[0])
+
+		// The capability that must NOT be claimed. `go list -deps` is a linker
+		// answer; nothing in nox builds a call graph, so call-graph
+		// reachability is unevaluated for every finding and must read that way.
+		switch got := cov.State(subject, capability.Reachability); got {
+		case capability.Positive, capability.Negative:
+			t.Errorf("outcome %q recorded reachability=%q. Evidence for "+
+				"symbol_referenced is establishing a strictly later proposition, "+
+				"and a project declaring require_capabilities: [reachability] would "+
+				"be told the question was answered", outcome, got)
+		}
+		if answered, _ := cov.Answered(capability.Reachability); answered != 0 {
+			t.Errorf("outcome %q leaves reachability with %d answered result(s)",
+				outcome, answered)
+		}
+
+		// And the capability that SHOULD be: the level actually established.
+		if got := cov.State(subject, capability.SymbolResolution); got == capability.NotEvaluated {
+			t.Errorf("outcome %q recorded nothing for symbol resolution, so the level "+
+				"the analysis DID establish is invisible", outcome)
+		}
+	}
+}
+
+// TestTheUnscopedReachableBooleanIsGone is Milestone A's acceptance criterion:
+// nox cannot represent a generic reachability negative without the scope and
+// assumptions under which it holds.
+//
+// The old representation was meta["reachable"] = "false" — a bare boolean, no
+// entry-point set, no build identity, no statement of what defeated the search.
+// Track G added a scoped representation beside it and left this one in place,
+// and on live data the two disagreed: one finding carried reachable=true and
+// applicability=undetermined at the same time.
+func TestTheUnscopedReachableBooleanIsGone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := RunScanWithOptions(vulnerableModule(t), ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range res.Findings.Findings() {
+		if f.RuleID != "VULN-001" {
+			continue
+		}
+		if _, ok := f.Metadata["reachable"]; ok {
+			t.Errorf("%s still carries an unscoped `reachable` boolean. A negative "+
+				"reachability claim is universal and is only true within the scope "+
+				"searched; a bare boolean cannot say which", f.Fingerprint)
+		}
+		if out := f.Metadata["reach_outcome"]; out != "" && f.Metadata["reach_scope"] == "" {
+			t.Errorf("%s reports outcome %q with no scope", f.Fingerprint, out)
+		}
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -45,6 +45,7 @@ import (
 	"github.com/nox-hq/nox/core/intel"
 	"github.com/nox-hq/nox/core/lexctx"
 	"github.com/nox-hq/nox/core/policy"
+	"github.com/nox-hq/nox/core/reach"
 	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/replay"
 	"github.com/nox-hq/nox/core/rules"
@@ -2141,14 +2142,28 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 			cov.Record(subject, capability.SymbolResolution, capability.Positive)
 		}
 
-		// Dependency reachability answers only where it was determined, and the
-		// deps analyzer already refuses to answer otherwise: goVulnReachable
-		// returns false only on positive evidence.
-		switch f.Metadata["reachable"] {
-		case "true":
-			cov.Record(subject, capability.Reachability, capability.Positive)
-		case "false":
-			cov.Record(subject, capability.Reachability, capability.Negative)
+		// The dependency analyzer answers at the level it can, and coverage is
+		// recorded against THAT level's capability rather than a stronger one.
+		//
+		// This used to read meta["reachable"] and record capability.Reachability.
+		// What `go list -deps` establishes is that an affected import is in the
+		// linked set — reach.SymbolReferenced — so a project asking whether
+		// REACHABILITY had been answered was told yes on the strength of a
+		// weaker question. Evidence for an earlier proposition establishing a
+		// later one is the invariant core/reach exists to hold, and this was
+		// the place it was broken.
+		//
+		// Reachability stays unrecorded here on purpose. Nothing in nox builds
+		// a call graph, so call_path_exists is unevaluated for every finding,
+		// and saying nothing is what makes `nox why` and the capability gate
+		// report it as unevaluated rather than as answered.
+		switch reach.Outcome(f.Metadata["reach_outcome"]) {
+		case reach.Established:
+			cov.Record(subject, capability.SymbolResolution, capability.Positive)
+		case reach.Refuted:
+			cov.Record(subject, capability.SymbolResolution, capability.Negative)
+		case reach.Undetermined:
+			cov.Record(subject, capability.SymbolResolution, capability.Unknown)
 		}
 	}
 }

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -185,6 +185,43 @@ A's scope object. Building them first would mean four places inventing their own
 notion of scope, which is the cross-adapter duplication problem in a new
 costume.
 
+## Milestone A — landed
+
+`core/reach` is the vocabulary: six levels from `package_in_closure` to
+`runtime_path_observed`, a `Scope` carrying the analysis, capability,
+entry-point set, build identity and limitations, and three outcomes.
+
+**The asymmetry is enforced at construction, not checked after.** `Establish`
+requires a witness — a reachability claim with nothing to point at is an
+assertion. `Refute` requires a scope with no limitations and *refuses* otherwise,
+returning `Undetermined` carrying the same limitations. An analysis that hit
+unresolved dispatch, reflection, FFI or a budget has not shown that nothing
+reaches the sink; it has shown it did not find one. That is "UNSAT on path P ≠
+all paths impossible", held where the value is built, because a `Result` in the
+wrong state is a value something can read.
+
+**Milestone C is folded in**, as planned. `Limitation` names ten reasons an
+analysis stops being able to speak for a whole program, each with a sentence an
+operator can act on. A capability state of `unknown` collapsed all ten into one
+word.
+
+**The violation is closed.** `meta["reachable"]` is gone. The deps analyzer
+emits `reach_level` / `reach_outcome` / `reach_scope`, and coverage is recorded
+against `symbol_resolution` — the level `go list -deps` can speak for — rather
+than `reachability`. Nothing in nox builds a call graph, so `call_path_exists`
+is now unevaluated for every finding and reads that way in `nox why` and in the
+capability gate.
+
+Measured against the live intelligence service afterwards: of 54 dependency
+findings, 29 carry `symbol_referenced` (18 established, 11 refuted) with the
+scope travelling alongside, and none carries an unscoped boolean.
+
+**Two tests were vacuous and the falsifications found them.** The first version
+of the invariant test scanned a fixture module with no dependencies, so no
+VULN finding existed, the mapping never ran, and it passed with the defect
+restored. It now drives `recordCapabilityCoverage` directly. A third test
+asserted nothing at all and was deleted rather than shipped.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
Milestone A, with **Milestone C folded in** as planned — scope and incompleteness are one question ("what did this cover, and what defeated it"), and splitting them means touching every result twice.

## The vocabulary

`core/reach` names six propositions:

```
package_in_closure → symbol_referenced → call_path_exists →
attacker_entry_path_exists → attacker_controlled_flow_exists →
runtime_path_observed
```

Each result carries a `Scope`: the analysis, the capability, the entry-point set, the build identity, and the limitations.

## The asymmetry is enforced at construction

**Reachable is existential.** `Establish` needs a witness — a claim that something is reachable with nothing to point at is an assertion.

**Unreachable is universal.** `Refute` needs a scope with **no limitations** and *refuses* otherwise, handing back `Undetermined` carrying the same limitations. An analysis that hit unresolved dispatch, reflection, FFI or a budget has not shown that nothing reaches the sink — it has shown it did not find one.

That's *"UNSAT on path P ≠ all paths impossible"*, held where the value is built rather than checked after, because a `Result` in the wrong state is a value something can read.

## Milestone C arrives as `Limitation`

Ten named reasons an analysis stops being able to speak for a whole program — unresolved dispatch, reflection, FFI, dynamic loading, bounded loops, unsupported language/framework, solver limits, budget, no entry points — each with a sentence an operator can act on. A capability state of `unknown` collapsed all ten into one word.

## The violation is closed

`meta["reachable"]` is gone. `go list -deps` establishes that an advisory's affected import is in the linked set — **`symbol_referenced`** — and that is now what's emitted and what coverage records.

It used to record `capability.Reachability`, so a project declaring `require_capabilities: [reachability]` was told the question had been answered by an analysis that cannot answer it, and the same boolean set severity.

**Reachability is now recorded by nobody, deliberately.** Nothing in nox builds a call graph, so `call_path_exists` is unevaluated for every finding — and saying nothing is what makes `nox why` and the capability gate report it as unevaluated rather than answered.

`findings.reachabilityRank` still reads `meta["reachable"]`, now written **only** by the reachability plugin — the producer actually doing call-graph analysis. Two producers were writing one key with different meanings, putting a linker answer and a call-graph answer in the same sort bucket.

## Measured against the live service

Of 54 dependency findings: **29 carry `symbol_referenced`** (18 established, 11 refuted), scope alongside, and **none carries an unscoped boolean**.

## Two tests were vacuous, and falsifying found both

The invariant test scanned a fixture module with **no dependencies** — so no VULN finding existed, the mapping never ran, and it **passed with the defect restored**. It now drives `recordCapabilityCoverage` directly:

```
outcome "established" recorded reachability="positive". Evidence for
symbol_referenced is establishing a strictly later proposition…
```

A third test asserted nothing at all and was deleted rather than shipped.

`go build ./...` clean · `go test ./...` green · `golangci-lint run ./core/...` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW