### PR TITLE
B: the cases where refusing to refute is the whole job

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -14,6 +14,11 @@ scan:
     - "core/analyzers/deps/testdata/lockfiles/"
     - "testdata/precision-corpus/"
     - "testdata/precision-suite/"
+    # The hard refutation corpus: five real flows a static analysis cannot
+    # follow, so every file is deliberately vulnerable. They exist to test that
+    # nox REFUSES to refute what it cannot see (see the corpus README and
+    # core/refutation_hard_test.go), and the self-scan must not flag fixtures.
+    - "testdata/refutation-hard/"
     # Intentionally finding-bearing inputs for the metamorphic corpus oracle
     # (scripts/metamorphic/sweep.py). Same rationale as the precision corpora:
     # the sweep scans them explicitly in isolated temp dirs; the self-scan must

--- a/core/refutation_hard_test.go
+++ b/core/refutation_hard_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// Milestone B: the refutation corpus must contain intentionally difficult cases
+// — reflection, dynamic dispatch, FFI, unsupported semantics, bounded analysis
+// — and none of them may incorrectly reach a negative.
+//
+// testdata/refutation-suite answers the other question: does nox refute what it
+// SHOULD? This one answers the dangerous one: does nox refuse to refute what it
+// cannot see? Automated negative evidence is the most dangerous capability in
+// the tool, because a wrong positive costs an afternoon and a wrong negative
+// costs the finding.
+
+// TestTheHardCorpusIsActuallyAnalysed comes first, because the corpus is
+// worthless if nothing runs on it.
+//
+// The first version of these fixtures used a bare function parameter as the
+// tainted value. nox produced zero findings, zero subjects and zero claims, so
+// the acceptance criterion below passed while testing nothing at all — the
+// mechanism was never reached. Giving the fixtures a real source
+// (`r.URL.Query().Get`) is what makes the corpus exercise the taint engine, and
+// h3 firing is the proof that it does.
+func TestTheHardCorpusIsActuallyAnalysed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := RunScanWithOptions("../testdata/refutation-hard",
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res.Reasoning.Subjects()) == 0 {
+		t.Fatal("the hard corpus produced no subjects, so the analysis never ran on " +
+			"it and every assertion about refutation safety below is vacuous")
+	}
+	var taint bool
+	for _, f := range res.Findings.Findings() {
+		if strings.HasPrefix(f.RuleID, "TAINT-") {
+			taint = true
+		}
+	}
+	if !taint {
+		t.Error("no taint finding on the hard corpus: the engine whose refutations " +
+			"this corpus is about is not reaching it")
+	}
+}
+
+// TestNoUnearnedNegativeOnTheHardCorpus is the acceptance criterion.
+//
+// Every file here contains a real flow that a static analysis cannot follow.
+// The correct outcome for each is silence or an explicit unknown. What must
+// never appear is a NEGATIVE — a refuting claim, a capability conclusion of
+// `negative`, or a reach outcome of `refuted` — because each of those is a
+// universal statement, and no analysis that could not resolve the callee is
+// entitled to make one.
+func TestNoUnearnedNegativeOnTheHardCorpus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := RunScanWithOptions("../testdata/refutation-hard",
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	for _, s := range res.Reasoning.Subjects() {
+		for _, c := range res.Reasoning.About(s).Claims {
+			if c.Refutes() {
+				t.Errorf("%v carries a refutation on a flow the analysis cannot "+
+					"follow: %q. Not finding a path is an existential search coming "+
+					"up empty, not a universal claim that none exists", s, c.Statement)
+			}
+		}
+	}
+
+	for _, s := range res.Coverage.Subjects() {
+		for _, c := range capability.All() {
+			if res.Coverage.State(s, c) == capability.Negative {
+				t.Errorf("%v records a NEGATIVE conclusion for %s. capability.Negative "+
+					"is the one state that may suppress a finding, and it must never "+
+					"come from an analysis that was defeated", s, c)
+			}
+		}
+	}
+
+	for _, f := range res.Findings.Findings() {
+		if f.Metadata["reach_outcome"] == string(reach.Refuted) {
+			t.Errorf("%s reports a refuted reachability level on a construct the "+
+				"analysis cannot model", f.RuleID)
+		}
+	}
+}
+
+// TestSilenceHereIsNotYetRecognisedIncompleteness records what the corpus
+// measured, including the part that is not yet good.
+//
+// Four of the five cases produce nothing at all: no candidate, no claim, no
+// capability state. That is SAFE — nox states no negative it has not earned,
+// which is the criterion — but it is safe by silence rather than by design. nox
+// does not currently recognise that reflection or dynamic dispatch defeated it;
+// it simply never formed a candidate.
+//
+// The distinction matters for what comes next. Milestone A shipped the
+// Limitation vocabulary — unresolved_dispatch, reflection, dynamic_loading —
+// and nothing emits it yet, so `nox why` cannot say "the analysis stopped at an
+// unresolved dispatch" and says nothing instead. A more capable engine that
+// followed PART of one of these flows could conclude "no path" where it owes
+// the reader "could not resolve the callee", and this test would not catch it,
+// because the claim would be about a subject that exists.
+//
+// It is written as a measurement rather than an assertion of the counts, so it
+// keeps reporting as the engine improves instead of failing on progress.
+func TestSilenceHereIsNotYetRecognisedIncompleteness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	res, err := RunScanWithOptions("../testdata/refutation-hard",
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var withLimitation int
+	for _, f := range res.Findings.Findings() {
+		if f.Metadata["reach_scope"] != "" && strings.Contains(f.Metadata["reach_scope"], "incomplete") {
+			withLimitation++
+		}
+	}
+	t.Logf("hard corpus: %d finding(s) from 5 cases, %d recording a named limitation. "+
+		"The remainder are silent — safe, because silence states nothing, but not "+
+		"yet the engine saying what defeated it.",
+		len(res.Findings.Findings()), withLimitation)
+}

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -222,6 +222,37 @@ VULN finding existed, the mapping never ran, and it passed with the defect
 restored. It now drives `recordCapabilityCoverage` directly. A third test
 asserted nothing at all and was deleted rather than shipped.
 
+## Milestone B — landed, with the caveat stated
+
+`testdata/refutation-hard` holds five cases where a real flow exists and a
+static analysis cannot follow it: reflection through `MethodByName`, dynamic
+dispatch chosen from request data, a flow that only occurs after the eighth
+loop iteration, a closure fetched from a map, and `plugin.Open`.
+
+**The criterion is met.** Zero refutations, zero `capability.Negative`
+conclusions, zero refuted reach outcomes across the corpus. nox states no
+negative it has not earned.
+
+**It is met by silence, not by design, and that distinction is the finding.**
+One of the five produces a finding — the bounded loop, which the taint engine
+handles. The other four produce nothing at all: no candidate, no claim, no
+capability state. nox does not recognise that reflection defeated it; it never
+formed a candidate. Milestone A shipped the `Limitation` vocabulary and nothing
+emits it yet, so `nox why` cannot say "the analysis stopped at an unresolved
+dispatch" and says nothing instead.
+
+That matters for what a better engine would do. One that followed *part* of
+these flows could conclude "no path" where it owes the reader "could not resolve
+the callee", and the corpus would not catch it, because the claim would be about
+a subject that exists. Emitting limitations is the remaining half of C and the
+natural next step.
+
+**The corpus was vacuous on its first build**, and the guard against that is now
+the first test in the file. The initial fixtures used a bare function parameter
+as the tainted value; nox produced zero subjects, so the acceptance criterion
+passed while testing nothing. Giving them a real source made the engine reach
+them, and one case firing is the proof that it does.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:

--- a/testdata/refutation-hard/README.md
+++ b/testdata/refutation-hard/README.md
@@ -1,0 +1,31 @@
+# The hard refutation corpus
+
+Milestone B: *"the refutation corpus contains intentionally difficult cases
+involving reflection, dynamic dispatch, FFI, unsupported semantics and bounded
+analysis, and none can incorrectly reach PREVENTED."*
+
+`testdata/refutation-suite` holds cases where a refutation is CORRECT and nox
+must make it — a value in a comment, a documentation placeholder, a sanitizer
+on the dominating path. It answers "does nox refute what it should?".
+
+This corpus answers the opposite and more dangerous question: **does nox refuse
+to refute what it cannot see?**
+
+Every file here contains a real flow that a static analysis cannot follow. The
+correct result for each is *undetermined*, with the reason named. The failure
+this corpus exists to catch is an analyzer reporting "no flow found" as though
+it were "no flow exists" — the difference between an existential search that
+came up empty and a universal claim, which is the asymmetry `core/reach`
+enforces at construction.
+
+| case | what defeats the analysis |
+|---|---|
+| `h1_reflection.go` | `MethodByName` — the callee is a string at runtime |
+| `h2_dynamic_dispatch.go` | the concrete type behind the interface is chosen from data |
+| `h3_bounded_loop.go` | the flow only occurs after the eighth iteration |
+| `h4_ffi.go` | the value leaves through a pointer the analysis cannot model |
+| `h5_dynamic_loading.go` | `plugin.Open` — the callee does not exist at analysis time |
+
+These are not scored for precision. A finding here is neither a true nor a false
+positive; what is being measured is whether nox ever states a NEGATIVE it has
+not earned.

--- a/testdata/refutation-hard/h1_reflection.go
+++ b/testdata/refutation-hard/h1_reflection.go
@@ -1,0 +1,24 @@
+// Reflection. The same source and sink as a case nox detects, with the call
+// made through reflect so nothing static resolves the callee.
+//
+// The correct answer is UNDETERMINED. Dropping the finding here would state a
+// negative the analysis has not earned.
+package hard
+
+import (
+	"net/http"
+	"os/exec"
+	"reflect"
+)
+
+type runner struct{}
+
+func (runner) Run(cmd string) error {
+	return exec.Command("sh", "-c", cmd).Run()
+}
+
+func Reflection(r *http.Request) {
+	cmd := r.URL.Query().Get("cmd")
+	m := reflect.ValueOf(runner{}).MethodByName("Run")
+	m.Call([]reflect.Value{reflect.ValueOf(cmd)})
+}

--- a/testdata/refutation-hard/h2_dynamic_dispatch.go
+++ b/testdata/refutation-hard/h2_dynamic_dispatch.go
@@ -1,0 +1,28 @@
+// Dynamic dispatch. One implementation sanitizes, one does not, and the choice
+// comes from data. Following only the statically-visible implementation sees a
+// clean path that is not necessarily the one that runs.
+package hard
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+type handler interface{ handle(string) error }
+
+type quoted struct{}
+
+func (quoted) handle(s string) error { return exec.Command("echo", s).Run() }
+
+type raw struct{}
+
+func (raw) handle(s string) error { return exec.Command("sh", "-c", s).Run() }
+
+func Dispatch(r *http.Request) error {
+	cmd := r.URL.Query().Get("cmd")
+	var h handler = quoted{}
+	if r.URL.Query().Get("mode") == "legacy" {
+		h = raw{}
+	}
+	return h.handle(cmd)
+}

--- a/testdata/refutation-hard/h3_bounded_loop.go
+++ b/testdata/refutation-hard/h3_bounded_loop.go
@@ -1,0 +1,19 @@
+// Bounded analysis. The tainted value only reaches the sink after the eighth
+// iteration, so an analysis that unrolls to a small bound sees a clean pass.
+package hard
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func BoundedLoop(r *http.Request) error {
+	inputs := r.URL.Query()["arg"]
+	cmd := "echo hello"
+	for i := 0; i < len(inputs); i++ {
+		if i > 8 {
+			cmd = inputs[i]
+		}
+	}
+	return exec.Command("sh", "-c", cmd).Run()
+}

--- a/testdata/refutation-hard/h4_indirection.go
+++ b/testdata/refutation-hard/h4_indirection.go
@@ -1,0 +1,20 @@
+// Unsupported semantics. The value passes through a map and a closure stored in
+// it, so the callee is a value rather than a name.
+package hard
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+var table = map[string]func(string) error{
+	"run": func(s string) error { return exec.Command("sh", "-c", s).Run() },
+}
+
+func Indirection(r *http.Request) error {
+	cmd := r.URL.Query().Get("cmd")
+	if fn, ok := table[r.URL.Query().Get("op")]; ok {
+		return fn(cmd)
+	}
+	return nil
+}

--- a/testdata/refutation-hard/h5_dynamic_loading.go
+++ b/testdata/refutation-hard/h5_dynamic_loading.go
@@ -1,0 +1,24 @@
+// Dynamic loading. The callee does not exist at analysis time, so "no sink
+// found" is a statement about the code that was present.
+package hard
+
+import (
+	"net/http"
+	"plugin"
+)
+
+func DynamicLoad(r *http.Request, path string) error {
+	cmd := r.URL.Query().Get("cmd")
+	p, err := plugin.Open(path)
+	if err != nil {
+		return err
+	}
+	s, err := p.Lookup("Exec")
+	if err != nil {
+		return err
+	}
+	if fn, ok := s.(func(string) error); ok {
+		return fn(cmd)
+	}
+	return nil
+}


### PR DESCRIPTION
`testdata/refutation-suite` answers *"does nox refute what it should?"*. This corpus answers the dangerous one: **does nox refuse to refute what it cannot see?**

Automated negative evidence is the most dangerous capability in the tool. A wrong positive costs an afternoon; a wrong negative costs the finding.

## Five cases

| case | what defeats the analysis |
|---|---|
| `h1_reflection.go` | `MethodByName` — the callee is a string at runtime |
| `h2_dynamic_dispatch.go` | the concrete type is chosen from request data |
| `h3_bounded_loop.go` | the flow only occurs after the eighth iteration |
| `h4_indirection.go` | a closure fetched from a map |
| `h5_dynamic_loading.go` | `plugin.Open` — the callee doesn't exist at analysis time |

**The criterion is met**: zero refutations, zero `capability.Negative` conclusions, zero refuted reach outcomes across the corpus.

## Met by silence, not by design — and that's the finding

One of the five produces a finding (the bounded loop, which the taint engine handles). **The other four produce nothing at all** — no candidate, no claim, no capability state. nox doesn't recognise that reflection defeated it; it never formed a candidate.

That is safe, because silence states nothing. It is not the same as the engine saying what stopped it.

Milestone A shipped the `Limitation` vocabulary — `unresolved_dispatch`, `reflection`, `dynamic_loading` — and **nothing emits it yet**, so `nox why` can't say *"the analysis stopped at an unresolved dispatch"* and says nothing instead.

It matters for what comes next: an engine that followed *part* of one of these flows could conclude "no path" where it owes the reader "could not resolve the callee", and this corpus **would not catch it**, because the claim would be about a subject that exists. Emitting limitations is the remaining half of C.

`TestSilenceHereIsNotYetRecognisedIncompleteness` records that as a measurement rather than an assertion on the counts, so it keeps reporting as the engine improves instead of failing on progress.

## The corpus was vacuous on its first build

The initial fixtures used a bare function parameter as the tainted value. nox produced **zero findings, zero subjects, zero claims** — so the acceptance criterion passed while testing nothing. The mechanism was never reached.

Giving them a real source (`r.URL.Query().Get`) is what makes the engine reach them, and one case firing is the proof that it does. `TestTheHardCorpusIsActuallyAnalysed` is now the **first** test in the file, so a corpus that stops being analysed fails loudly rather than going quietly green.

Third vacuous test this programme has caught by falsifying rather than reading.

## Falsification

| what was broken | what failed |
|---|---|
| a taint conclusion recorded as `Negative` | `records a NEGATIVE conclusion for taint… must never come from an analysis that was defeated` |
| strip the taint source from a fixture | `the hard corpus produced no subjects… every assertion about refutation safety below is vacuous` |

`go build ./...` clean · `go test ./...` green · `golangci-lint run ./core/...` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW