### PR TITLE
C: say what defeated the analysis, instead of saying nothing

### DIFF
--- a/cli/why_cmd.go
+++ b/cli/why_cmd.go
@@ -45,13 +45,26 @@ Flags:
 `)
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
+	// Split flags from positionals before parsing. Go's flag package stops at
+	// the first non-flag argument, so `nox why . --offline` left --offline as a
+	// positional and it was then read as a finding selector — the tool told the
+	// user no finding matched "--offline". `nox show` splits first for the same
+	// reason; this now does too.
+	var flagArgs, positional []string
+	for i := 0; i < len(args); i++ {
+		if strings.HasPrefix(args[i], "-") {
+			flagArgs = append(flagArgs, args[i])
+			continue
+		}
+		positional = append(positional, args[i])
+	}
+	if err := fs.Parse(flagArgs); err != nil {
 		return 2
 	}
 
 	target := "."
 	selector := ""
-	for _, a := range fs.Args() {
+	for _, a := range positional {
 		if looksLikeSelector(a) {
 			selector = a
 			continue

--- a/core/explain/explain.go
+++ b/core/explain/explain.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/catalog"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reach"
 )
 
 // Explanation is the eight answers, in the order a person reads them.
@@ -89,7 +90,7 @@ func Explain(in Inputs) Explanation {
 	e.Observed = observed(f)
 	e.WhyItMatters = whyItMatters(f, in.Rule)
 	e.Supports, e.Against = argument(in.Ledger, in.Subject)
-	e.NotEvaluated = notEvaluated(in.Coverage, in.Subject)
+	e.NotEvaluated = append(limitationLines(f), notEvaluated(in.Coverage, in.Subject)...)
 	e.PotentialImpact = potentialImpact(f, in.Rule)
 	e.AffectsThisApplication = affectsThisApplication(f)
 	e.WhatToDo = whatToDo(in.Rule)
@@ -239,7 +240,29 @@ func notEvaluated(cov *capability.Coverage, s evidence.Subject) []string {
 	}
 	sort.Strings(out)
 	if len(out) == 0 {
-		return []string{"Every analysis nox has reached a conclusion about this finding."}
+		out = []string{"Every analysis nox has reached a conclusion about this finding."}
+	}
+	return out
+}
+
+// limitationLines reports the constructs in this file that defeat static
+// analysis, so silence about the rest of the file reads as what it is.
+//
+// It appears under "what was not evaluated" because that is the question it
+// answers. A capability state says an analysis reached no conclusion; this says
+// why one could not be reached here, which is the difference between a reader
+// installing a plugin and a reader understanding that the code is not
+// statically analysable at this point.
+func limitationLines(f findings.Finding) []string {
+	raw := f.Metadata["analysis_limitations"]
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, name := range strings.Split(raw, ",") {
+		l := reach.Limitation(strings.TrimSpace(name))
+		out = append(out, "this file defeats static analysis — "+l.Describe()+
+			" — so any analysis of it is incomplete, and nothing here was ruled out")
 	}
 	return out
 }

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -1016,3 +1016,19 @@ func matchRulePatterns(ruleID string, patterns []string) bool {
 	}
 	return false
 }
+
+// SetMetadata records a key on finding i, creating the map if needed.
+//
+// Used by scan-stage annotations that are derived rather than authored by an
+// analyzer — see recordAnalysisLimitations. Metadata is a non-ingredient field,
+// so nothing written here can move a fingerprint; that is held by
+// TestFingerprintIngredientsAreClosed.
+func (fs *FindingSet) SetMetadata(i int, key, value string) {
+	if i < 0 || i >= len(fs.items) || key == "" {
+		return
+	}
+	if fs.items[i].Metadata == nil {
+		fs.items[i].Metadata = map[string]string{}
+	}
+	fs.items[i].Metadata[key] = value
+}

--- a/core/reach/detect.go
+++ b/core/reach/detect.go
@@ -1,0 +1,76 @@
+package reach
+
+import (
+	"regexp"
+	"sort"
+)
+
+// marker ties a source construct to the limitation it imposes on any analysis
+// of the file containing it.
+type marker struct {
+	limitation Limitation
+	pattern    *regexp.Regexp
+}
+
+// markers are the constructs that defeat static analysis.
+//
+// # What is deliberately NOT here
+//
+// Dynamic dispatch. An interface value whose concrete type comes from data is a
+// real limitation and the second case in the hard corpus, and it cannot be
+// detected this way: `interface{}` and `any` appear in ordinary Go constantly,
+// so a marker for them fires on almost every file. A limitation reported on
+// every file carries no information and trains a reader to skip the field,
+// which is worse than not reporting it.
+//
+// That was measured rather than assumed. The first version of this list
+// included `interface{}` and a bare `import (`, and on the five-case hard
+// corpus it reported dynamic_loading for all five — including the three files
+// that contain no dynamic loading at all, because Go's own import block matched.
+// A detector that fires everywhere is not a detector.
+//
+// Lexical on purpose. Recognising these properly means resolving types, which
+// is the very analysis the construct defeats — so the detector cannot be
+// stronger than the thing it is reporting on. What saves it is the DIRECTION of
+// the error: a marker only ever ADDS a limitation, which only ever makes a
+// claim weaker. A false positive here means nox says "I may have missed
+// something" when it did not, and a scope carrying a spurious limitation can
+// still Establish; it just cannot Refute. Failing toward "I could not tell" is
+// the safe direction for a tool whose most dangerous output is a negative.
+var markers = []marker{
+	{Reflection, regexp.MustCompile(`\breflect\.(ValueOf|TypeOf)\b|\bMethodByName\b|\bgetattr\(|\b__import__\(|\beval\(`)},
+	{DynamicLoading, regexp.MustCompile(`\bplugin\.Open\b|\bdlopen\b|\bimportlib\b|\bLoadLibrary\b`)},
+	{ForeignFunctions, regexp.MustCompile(`import "C"|\bunsafe\.Pointer\b|\bsyscall\.Syscall\b|\bctypes\b|\bJNIEnv\b`)},
+}
+
+// Detect returns the limitations a file's contents impose on any analysis of
+// it, sorted and deduplicated.
+//
+// This is the honest half of what nox can say about its own incompleteness. It
+// cannot say WHICH flow a reflective call defeated — that needs the engine to
+// know it was defeated, and the engine does not. It can say that this file
+// contains a call whose target is a string at runtime, which is enough for a
+// reader to know that "no flow found here" is a statement about what was
+// visible.
+//
+// Measured on testdata/refutation-hard, where four of five cases produced
+// complete silence: nox formed no candidate, so it had nothing to attach an
+// explanation to and said nothing at all. A reader could not distinguish that
+// from a clean file.
+func Detect(content []byte) []Limitation {
+	seen := map[Limitation]bool{}
+	for _, m := range markers {
+		if m.pattern.Match(content) {
+			seen[m.limitation] = true
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]Limitation, 0, len(seen))
+	for l := range seen {
+		out = append(out, l)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/core/reach/detect_test.go
+++ b/core/reach/detect_test.go
@@ -1,0 +1,97 @@
+package reach_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// TestDetectFindsWhatItClaimsAndStaysQuietOtherwise checks both directions a
+// detector for incompleteness can fail in.
+//
+// A detector for incompleteness has an unusual failure mode: it fails SAFE in
+// one direction and useless in the other. A false positive only adds a
+// limitation, which only weakens a claim — nox says "I may have missed
+// something" when it did not. A limitation on every file, though, carries no
+// information and trains a reader to skip the field, which is worse than not
+// reporting it at all.
+//
+// So both halves are checked: it must fire on the constructs it names, and it
+// must stay quiet on ordinary source.
+func TestDetectFindsWhatItClaimsAndStaysQuietOtherwise(t *testing.T) {
+	cases := map[string]reach.Limitation{
+		`m := reflect.ValueOf(x).MethodByName("Run")`: reach.Reflection,
+		`v = getattr(obj, name)`:                      reach.Reflection,
+		`p, _ := plugin.Open(path)`:                   reach.DynamicLoading,
+		`mod = importlib.import_module(name)`:         reach.DynamicLoading,
+		`ptr := unsafe.Pointer(&b[0])`:                reach.ForeignFunctions,
+		`import "C"`:                                  reach.ForeignFunctions,
+	}
+	for src, want := range cases {
+		got := reach.Detect([]byte(src))
+		var found bool
+		for _, l := range got {
+			if l == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%q did not report %s (got %v)", src, want, got)
+		}
+	}
+
+	// Ordinary code, including the shapes an over-broad marker would catch.
+	for _, src := range []string{
+		"package main\n\nimport (\n\t\"fmt\"\n)\n\nfunc main() { fmt.Println() }",
+		"func f(v interface{}) {}",
+		"func g(v any) error { return nil }",
+		"require (\n\tgithub.com/x/y v1.0.0\n)",
+		"const s = \"we use reflection nowhere\"",
+	} {
+		if got := reach.Detect([]byte(src)); len(got) > 0 {
+			t.Errorf("ordinary source reported %v:\n%s", got, src)
+		}
+	}
+}
+
+// TestDetectIsQuietOnNoxItself is the noise measurement, kept executable.
+//
+// The first version of this detector matched Go's own `import (` block and
+// `interface{}`, and reported dynamic_loading on all five cases of a corpus
+// where only one has any — including three files containing no dynamic loading
+// at all. A detector that fires everywhere is not a detector, and the way that
+// was found was measuring it rather than reasoning about the patterns.
+func TestDetectIsQuietOnNoxItself(t *testing.T) {
+	var files, flagged int
+	root := filepath.Join("..", "..")
+	err := filepath.Walk(root, func(p string, i os.FileInfo, err error) error {
+		if err != nil || i.IsDir() || !strings.HasSuffix(p, ".go") || strings.Contains(p, "testdata") {
+			return nil
+		}
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		files++
+		if len(reach.Detect(b)) > 0 {
+			flagged++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if files < 100 {
+		t.Fatalf("only %d files walked; the measurement is not covering the tree", files)
+	}
+	rate := 100 * float64(flagged) / float64(files)
+	if rate > 15 {
+		t.Errorf("%.1f%% of nox's own source is flagged as defeating static analysis "+
+			"(%d of %d). A limitation reported on that many files carries no "+
+			"information and trains a reader to skip the field", rate, flagged, files)
+	}
+	t.Logf("nox's own source: %d of %d files flagged (%.1f%%)", flagged, files, rate)
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -836,6 +836,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// a larger change than this one and are left to the E track.
 	recordObservations(reasons, allFindings)
 	recordCapabilityCoverage(coverage, allFindings)
+	recordAnalysisLimitations(allFindings, target, reasons)
 	divergences, conflicts := adjudicateFindings(reasons, allFindings)
 
 	// Stage 4: Evaluate policy gates.
@@ -2164,6 +2165,69 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 			cov.Record(subject, capability.SymbolResolution, capability.Negative)
 		case reach.Undetermined:
 			cov.Record(subject, capability.SymbolResolution, capability.Unknown)
+		}
+	}
+}
+
+// recordAnalysisLimitations annotates findings whose file contains a construct
+// that defeats static analysis, so "nothing else was found here" reads as what
+// it is.
+//
+// This is Milestone C's second half. The first gave nox a vocabulary for
+// incompleteness; this is the first thing that speaks it. It does not know
+// WHICH flow a reflective call defeated — that needs the taint engine to know
+// it was defeated, and the engine has no such notion — but it can say the file
+// contains a call whose target is a string at runtime, which is enough for a
+// reader to know that silence about the rest of the file is a statement about
+// what was visible.
+//
+// Only findings are annotated, which is a real limit and worth naming: a file
+// with no finding at all gets no annotation, so the four-of-five silence on the
+// hard corpus is only partly addressed. Attaching limitations to files rather
+// than findings would need a per-file record the scan result does not have, and
+// that is a larger change than this one.
+func recordAnalysisLimitations(fs *findings.FindingSet, target string, store *reasoning.Store) {
+	if fs == nil {
+		return
+	}
+	byFile := map[string][]int{}
+	items := fs.Findings()
+	for i := range items {
+		if p := items[i].Location.FilePath; p != "" {
+			byFile[p] = append(byFile[p], i)
+		}
+	}
+
+	for filePath, idx := range byFile {
+		full := filePath
+		if !filepath.IsAbs(full) {
+			full = filepath.Join(ConfigRoot(target), full)
+		}
+		if fi, err := os.Stat(full); err != nil || fi.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		limits := reach.Detect(content)
+		if len(limits) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(limits))
+		for _, l := range limits {
+			names = append(names, string(l))
+		}
+		joined := strings.Join(names, ",")
+		for _, i := range idx {
+			fs.SetMetadata(i, "analysis_limitations", joined)
+		}
+		// Withheld, not refuting: a construct the analysis cannot follow is not
+		// an argument against any finding. It is a statement that the search
+		// behind any negative here was incomplete.
+		for _, i := range idx {
+			store.Withheld(SubjectForFinding(items[i]), "nox-scan", "scan",
+				"the analysis of this file is incomplete: "+limits[0].Describe())
 		}
 	}
 }

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -253,6 +253,50 @@ as the tainted value; nox produced zero subjects, so the acceptance criterion
 passed while testing nothing. Giving them a real source made the engine reach
 them, and one case firing is the proof that it does.
 
+## Milestone C — landed in two halves
+
+The first half shipped with A: `reach.Limitation` names ten reasons an analysis
+stops being able to speak for a whole program, each with a sentence an operator
+can act on.
+
+The second half is `reach.Detect`, which makes something actually speak it.
+Milestone B measured the gap precisely: four of five hard cases produced
+complete silence, so nox had nothing to attach an explanation to and a reader
+could not tell those files from clean ones.
+
+**It is lexical, and that is a considered limit rather than a shortcut.**
+Recognising these constructs properly means resolving types, which is the
+analysis the construct defeats — the detector cannot be stronger than the thing
+it reports on. What makes it safe is the direction of its error: a marker only
+ever ADDS a limitation, which only ever weakens a claim. A false positive means
+nox says "I may have missed something" when it did not, and a scope carrying a
+spurious limitation can still `Establish`; it just cannot `Refute`.
+
+**Dynamic dispatch is deliberately not detected.** `interface{}` and `any`
+appear in ordinary Go constantly, so a marker for them fires on nearly every
+file — and a limitation reported everywhere carries no information and trains a
+reader to skip the field. That was measured, not assumed: the first version of
+the marker list included `interface{}` and a bare `import (`, and reported
+`dynamic_loading` on all five hard cases including the three that contain none,
+because Go's own import block matched.
+
+Measured after the fix: reflection and dynamic loading detected on the two cases
+that have them, silence on the three that cannot be detected lexically, and
+**21 of 794** of nox's own Go files flagged — 2.6%, quiet enough to mean
+something. `TestDetectIsQuietOnNoxItself` keeps that executable with a ceiling
+of 15%.
+
+**The remaining limit, stated:** only findings are annotated. A file with no
+finding gets no annotation, so B's four-of-five silence is only partly
+addressed. Attaching limitations to files rather than findings needs a per-file
+record the scan result does not carry, which is a larger change than this one.
+
+**A usability bug surfaced while testing it.** `nox why . --offline` reported
+`no active finding matches "--offline"`: Go's flag package stops parsing at the
+first positional, so the flag became a selector. `nox show` splits flags from
+positionals first for exactly this reason; `nox why` now does too. Found by
+using the command, not by reading it.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
Milestone A gave nox a vocabulary for its own incompleteness. **Nothing spoke it.** Milestone B measured the gap exactly: four of five hard cases produced complete silence — no candidate, no claim, no capability state — so nox had nothing to attach an explanation to, and a reader could not tell those files from clean ones.

```
What was not evaluated
  this file defeats static analysis — reflection was used, and the targets
  are not visible statically — so any analysis of it is incomplete, and
  nothing here was ruled out
  call_graph: no analysis on this installation can establish it.
  …
```

## Lexical, and that's a considered limit

Recognising these constructs properly means resolving types — which is the analysis the construct defeats. The detector cannot be stronger than the thing it reports on.

What makes it safe is the **direction of its error**: a marker only ever *adds* a limitation, which only ever *weakens* a claim. A false positive means nox says "I may have missed something" when it didn't, and a scope carrying a spurious limitation can still `Establish` — it just cannot `Refute`. Failing toward "I could not tell" is the safe direction for a tool whose most dangerous output is a negative.

## Dynamic dispatch is deliberately not detected

`interface{}` and `any` appear in ordinary Go constantly, so a marker for them fires on nearly every file — and **a limitation reported everywhere carries no information** and trains a reader to skip the field.

Measured, not assumed. My first marker list included `interface{}` and a bare `import (`, and reported `dynamic_loading` on **all five** hard cases — including the three that contain none, because Go's own import block matched. A detector that fires everywhere is not a detector.

After the fix:

| | |
|---|---|
| hard corpus | reflection + dynamic loading detected; silence on the three that can't be detected lexically |
| nox's own source | **21 of 794 files (2.6%)** |

`TestDetectIsQuietOnNoxItself` keeps that executable with a 15% ceiling.

## The remaining limit, stated

**Only findings are annotated.** A file with no finding gets no annotation, so B's four-of-five silence is only partly addressed. Attaching limitations to files rather than findings needs a per-file record the scan result doesn't carry — a larger change than this one.

## A usability bug, found by using the command

`nox why . --offline` answered `no active finding matches "--offline"`. Go's flag package stops parsing at the first positional, so the flag became a selector. `nox show` splits flags from positionals first for exactly this reason; `nox why` now does too.

## Falsification

| what was broken | what failed |
|---|---|
| an over-broad marker (Go's `import (`) | `ordinary source reported [dynamic_loading]` + the noise ceiling |
| drop limitations from the explanation | the "defeats static analysis" line disappears from `nox why` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW