### PR TITLE
G: an attack confirms the invariant it tested, and nothing above it

### DIFF
--- a/core/attack/confirmed_contract_test.go
+++ b/core/attack/confirmed_contract_test.go
@@ -106,3 +106,62 @@ func TestNoRunnerReportsAReproductionItCutShort(t *testing.T) {
 		t.Errorf("a hypothesis that never ran is %s", tr.Exploitability)
 	}
 }
+
+// TestAnAttackConfirmsTheInvariantItTestedAndNothingAbove is Milestone G at the
+// producer.
+//
+// The kernel aggregates per subject, so the reproduction hierarchy is only real
+// if a producer attributes its claims. Until this landed, core/attack set no
+// Subject on any claim: every claim shared the zero subject and landed in one
+// bag, where the cheapest deterministic claim satisfied the precondition for
+// the most expensive.
+//
+// A run that saw a guardrail bypassed and reproduced it has established that
+// the guardrail was bypassed. What an attacker could then do is a later
+// proposition with its own evidence, and promoting across that gap is how a
+// scanner reports an RCE it never saw.
+func TestAnAttackConfirmsTheInvariantItTestedAndNothingAbove(t *testing.T) {
+	h := Hypothesis{ID: "hyp-1", Rationale: "a prompt boundary is splice-able"}
+	ledger := &evidence.Ledger{}
+	ledger.Add(evidence.Claim{
+		Kind:      evidence.KindDynamicExploit,
+		Subject:   InvariantSubject(h),
+		Statement: "a deterministic oracle observed the invariant violated and it reproduced",
+	})
+	outcome := evidence.RunOutcome{
+		Executed: true, Violated: true, Reproduced: true, ControlSound: true,
+	}
+
+	if got := evidence.DeriveExploitabilityAbout(outcome, ledger, InvariantSubject(h)); got != evidence.Confirmed {
+		t.Errorf("the invariant this run actually tested was not confirmed: %s", got)
+	}
+
+	// Everything above it on the hierarchy stays unconfirmed on this evidence.
+	for _, k := range []evidence.SubjectKind{
+		evidence.SubjectSecurityEffect, evidence.SubjectExploit,
+	} {
+		s := evidence.Subject{Kind: k, ID: h.ID}
+		if got := evidence.DeriveExploitabilityAbout(outcome, ledger, s); got == evidence.Confirmed {
+			t.Errorf("a reproduced invariant violation confirmed %s — a later "+
+				"proposition this run produced no evidence for", k)
+		}
+	}
+}
+
+// TestEveryAttackClaimIsAttributed. The subject is what makes the hierarchy
+// real, and a claim without one rejoins the undifferentiated bag. Checked on
+// the ledger a real run builds rather than on the constructor, because the
+// constructor is easy to get right and the call sites are what drift.
+func TestEveryAttackClaimIsAttributed(t *testing.T) {
+	h := Hypothesis{ID: "hyp-2", Rationale: "grounding"}
+	l := groundingLedger(h, "2026-08-31T00:00:00Z")
+	if len(l.Claims) == 0 {
+		t.Fatal("the grounding ledger is empty; this test checks nothing")
+	}
+	for i, c := range l.Claims {
+		if c.Subject.Zero() {
+			t.Errorf("claim %d (%q) carries no subject, so it aggregates with every "+
+				"other unattributed claim regardless of what it is about", i, c.Statement)
+		}
+	}
+}

--- a/core/attack/run.go
+++ b/core/attack/run.go
@@ -324,14 +324,26 @@ func notRunTrace(h Hypothesis, cfg RunConfig, note string) Trace {
 	})
 }
 
+// InvariantSubject is the proposition an attack run can establish: that this
+// hypothesis's security invariant was violated.
+//
+// It is invariant_violation rather than exploit on purpose. A run that saw a
+// guardrail bypassed has established that the guardrail was bypassed; what an
+// attacker could then do is a later proposition needing its own evidence, and
+// promoting across that gap is how a scanner reports an RCE it never saw.
+func InvariantSubject(h Hypothesis) evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectInvariantViolation, ID: h.ID}
+}
+
 // groundingLedger returns a ledger seeded with the hypothesis's grounding as a
-// heuristic claim. It is deliberately NON-deterministic in the evidence sense, so
-// it can never on its own carry a trace to CONFIRMED — only a reproduced
+// heuristic claim. It is deliberately NON-deterministic in the evidence sense,
+// so it can never on its own carry a trace to CONFIRMED — only a reproduced
 // deterministic oracle can add that.
 func groundingLedger(h Hypothesis, now string) *evidence.Ledger {
 	l := &evidence.Ledger{}
 	l.Add(evidence.Claim{
 		Kind:      evidence.KindHeuristic,
+		Subject:   InvariantSubject(h),
 		Statement: h.Rationale,
 		Provenance: evidence.Provenance{
 			Source:     "nox-attack",
@@ -487,11 +499,27 @@ attackLoop:
 // violation observed by a machine-checkable oracle in a sound environment — this
 // is the single gate that lets a trace reach CONFIRMED, and it is enforced here
 // rather than trusted to the caller.
+//
+// Every claim is attributed to a SUBJECT, and the subject says which
+// proposition the evidence is about. Until Milestone G this file set none, so
+// every claim shared the zero subject and landed in one bag where the cheapest
+// deterministic claim satisfied the precondition for the most expensive.
+// Reproducing an invariant violation is not reproducing an exploit, and the
+// subject is what keeps those apart — the kernel aggregates per subject, so the
+// distinction is only real if somebody makes it here.
 func (r *runner) finalize(trace Trace, outcome evidence.RunOutcome, h Hypothesis, winner *Attempt, verdict OracleVerdict, controlSound bool) Trace {
 	ledger := groundingLedger(h, r.cfg.Now)
+	// What a reproduced oracle hit actually establishes: the security invariant
+	// this scenario names was violated, and it recurred. That is
+	// invariant_violation on the reproduction hierarchy. It is deliberately NOT
+	// filed against the exploit — nothing here demonstrated an end-to-end
+	// exploit, and an oracle that saw a control bypassed has not thereby shown
+	// what an attacker could do with it.
+	violated := InvariantSubject(h)
 	if outcome.Violated && outcome.Reproduced && controlSound && winner != nil {
 		ledger.Add(evidence.Claim{
 			Kind:      oracleEvidenceKind(verdict.Kind),
+			Subject:   violated,
 			Statement: fmt.Sprintf("a %s oracle observed the invariant violated and it reproduced (%d/%d)", verdict.Kind, trace.ReproductionHits, trace.ReproductionSamples),
 			Provenance: evidence.Provenance{
 				Source:     "nox-attack",
@@ -504,7 +532,7 @@ func (r *runner) finalize(trace Trace, outcome evidence.RunOutcome, h Hypothesis
 	}
 	trace.Outcome = outcome
 	trace.Ledger = *ledger
-	trace.Exploitability = evidence.DeriveExploitability(outcome, ledger)
+	trace.Exploitability = evidence.DeriveExploitabilityAbout(outcome, ledger, violated)
 	trace.Confidence = ledger.Confidence()
 	return classified(trace)
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/nox-hq/nox-core v0.2.2
+	github.com/nox-hq/nox-core v0.2.3
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/nox-hq/nox-core v0.2.2 h1:nAqLR2AgXRv4OFWx+KfopdCxhR9kOaE9ztx1atvcqnk=
-github.com/nox-hq/nox-core v0.2.2/go.mod h1:MQ6xDjQeSts2TGYEqGu3nzshk1mDlj/cAGT1I1KI8Ao=
+github.com/nox-hq/nox-core v0.2.3 h1:RQYvAxWiC7kIm16yJijB4mJthrQNSy5qeUH5DwuSzvE=
+github.com/nox-hq/nox-core v0.2.3/go.mod h1:MQ6xDjQeSts2TGYEqGu3nzshk1mDlj/cAGT1I1KI8Ao=
 github.com/openai/openai-go/v3 v3.52.0 h1:VDSjIvI5Sr2/AzGJI6219sM2Il+zBWuopvluMy6KdjE=
 github.com/openai/openai-go/v3 v3.52.0/go.mod h1:Vy3y2/I2H/MbqvJGXEK8VbN5+avZV6zxux4I3eBdvaA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Bumps **nox-core to v0.2.3**, where reproduction gained subjects and CONFIRMED gained a scope.

## The hierarchy

```
trigger_condition → invariant_violation → crash → security_effect → exploit
```

Reproducing something is not reproducing everything. An integer overflow that fires establishes that the **trigger condition** holds — not that a security invariant was violated, not that the bug is exploitable.

## The kernel half

`HasDeterministic` is subject-blind, and **CONFIRMED was asking it**. So deterministic evidence *anywhere* in a ledger satisfied the precondition for *any* proposition in it.

`HasDeterministicAbout` scopes it; `DeriveExploitabilityAbout` scopes the derivation. `DeriveExploitability` keeps its signature and delegates with the zero subject — exactly the old behaviour for unattributed evidence, and the honest behaviour for typed evidence: an unattributed run confirms only on unattributed evidence and cannot reach into a typed proposition it says nothing about.

## The producer half — and why it mattered

The kernel aggregates per subject, so the hierarchy is only real if a producer attributes its claims. **`core/attack` attributed nothing.** Every claim it filed shared the zero subject and landed in one bag.

A run that saw a guardrail bypassed and reproduced it has established that **the guardrail was bypassed**. What an attacker could then do is a later proposition with its own evidence — and promoting across that gap is how a scanner reports an RCE it never saw.

So attack claims are now filed against `invariant_violation`, and the trace's verdict is derived *about that subject*. `security_effect` and `exploit` stay unconfirmed on the same evidence, which is the honest position: nothing in the run demonstrated either.

## Falsification

| what was broken | what failed |
|---|---|
| kernel: back to subject-blind determinism | `reproducing the trigger condition confirmed the EXPLOIT` |
| producer: grounding claim loses its subject | `claim 0 carries no subject, so it aggregates with every other unattributed claim` |
| producer: oracle claim loses its subject | the correlation tests fail too |

`TestEveryAttackClaimIsAttributed` checks the ledger a **real run builds** rather than the constructor — the constructor is easy to get right, and the call sites are what drift.

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW