### PR TITLE
H and K: promise the replay you can perform, and keep the boundary by test

### DIFF
--- a/core/attack/passive_active_boundary_test.go
+++ b/core/attack/passive_active_boundary_test.go
@@ -1,0 +1,176 @@
+package attack
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Milestone K: the passive/active boundary is a permanent invariant.
+//
+// `nox scan` is read-only — lexing, constant evaluation, SCA, taint, graph
+// analysis, reachability, hypothesis construction. `nox attack` is where
+// network requests, target interaction and dynamic reproduction live, and it is
+// explicitly authorized.
+//
+// That boundary matters more than shaving false positives off a scan. A
+// security scanner that can unknowingly attack its target becomes unsafe to run
+// in most of the environments where it should be ubiquitous — a CI runner
+// pointed at production, a developer laptop on a corporate VPN, a pipeline in
+// someone else's cloud.
+//
+// It is currently enforced by wiring rather than policy, which is the right
+// place. These tests are what stop the wiring being rearranged by accident.
+
+// TestEveryActiveEntryPointRequiresAuthorization enumerates the exported
+// functions that can touch a target and checks each refuses without it.
+//
+// Enumerated from the source rather than listed by hand: a fifth entry point
+// added later must appear here, and a hand-written list is exactly what would
+// not notice it.
+func TestEveryActiveEntryPointRequiresAuthorization(t *testing.T) {
+	active := activeEntryPoints(t)
+	// The four that exist when this was written. The count is asserted so a new
+	// one arrives as a failure rather than as silence.
+	for _, want := range []string{"Run", "Replay", "RunSuite", "RunMCP"} {
+		if !active[want] {
+			t.Errorf("%s is no longer an exported entry point taking a context and a "+
+				"config; if it was renamed, this guard has stopped covering it", want)
+		}
+	}
+	if len(active) > 4 {
+		var extra []string
+		for name := range active {
+			switch name {
+			case "Run", "Replay", "RunSuite", "RunMCP":
+			default:
+				extra = append(extra, name)
+			}
+		}
+		t.Errorf("new active entry point(s) %v. Each must refuse an unauthorized "+
+			"non-safe profile and refuse a network target under the safe profile; "+
+			"add them below and to this list", extra)
+	}
+
+	ctx := context.Background()
+	unauthorized := RunConfig{Profile: ProfileStaging}
+
+	if _, err := Run(ctx, &Plan{}, &SimTarget{}, unauthorized); err == nil {
+		t.Error("Run executed under an unauthorized active profile")
+	}
+	if _, err := RunSuite(ctx, &Suite{}, &SimTarget{}, unauthorized); err == nil {
+		t.Error("RunSuite executed under an unauthorized active profile")
+	}
+	res := &Result{Traces: []Trace{{ID: "t", Evidence: &ExploitEvidence{}}}}
+	if _, err := Replay(ctx, res, "t", &SimTarget{}, unauthorized); err == nil {
+		t.Error("Replay executed under an unauthorized active profile")
+	}
+}
+
+// TestTheSafeProfileCannotReachTheNetwork. The safe profile's guarantee is
+// structural: it selects an adapter with no network capability, so the promise
+// is kept by what is wired rather than by a check somebody might move.
+func TestTheSafeProfileCannotReachTheNetwork(t *testing.T) {
+	if ProfileSafe.AllowsNetwork() {
+		t.Fatal("the safe profile allows network traffic, which is the whole of what " +
+			"it promises not to do")
+	}
+	if ProfileSafe.RequiresAuthorization() {
+		t.Error("the safe profile demands authorization it does not need, which " +
+			"trains operators to pass --authorize by reflex")
+	}
+	for _, p := range []Profile{ProfileSandbox, ProfileStaging, ProfileAuthorizedLive} {
+		if !p.AllowsNetwork() || !p.RequiresAuthorization() {
+			t.Errorf("profile %q is active but does not require authorization or "+
+				"network permission", p)
+		}
+	}
+}
+
+// TestTheScanCannotReachTheAttackPackage is the boundary at its strongest.
+//
+// If core (the scan pipeline) imported core/attack, a scan could execute
+// something by accident — a refactor, a helper reused in the wrong place. It
+// does not, and the dependency graph is what guarantees that. Asserted by
+// reading the imports rather than by convention, because a convention is what
+// a refactor does not consult.
+func TestTheScanCannotReachTheAttackPackage(t *testing.T) {
+	root := filepath.Join("..", "..", "core")
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("reading core: %v", err)
+	}
+	fset := token.NewFileSet()
+	var checked int
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(root, e.Name()), nil, parser.ImportsOnly)
+		if err != nil {
+			continue
+		}
+		checked++
+		for _, imp := range f.Imports {
+			if strings.Contains(imp.Path.Value, "nox/core/attack") {
+				t.Errorf("%s imports core/attack. The scan pipeline must not be able "+
+					"to reach code that touches a target; a scanner that can "+
+					"unknowingly attack what it is pointed at is unsafe to run in most "+
+					"places nox should be ubiquitous", e.Name())
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no files in core were parsed; this guard is checking nothing")
+	}
+	t.Logf("%d files in core carry no import of core/attack", checked)
+}
+
+// activeEntryPoints returns the exported functions in this package that take a
+// context and a run configuration — the shape of something that can act.
+func activeEntryPoints(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	fset := token.NewFileSet()
+	ents, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package: %v", err)
+	}
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, e.Name(), nil, 0)
+		if err != nil {
+			continue
+		}
+		for _, d := range f.Decls {
+			fn, ok := d.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !fn.Name.IsExported() || fn.Type.Params == nil {
+				continue
+			}
+			var takesCtx, takesCfg bool
+			for _, p := range fn.Type.Params.List {
+				switch typ := p.Type.(type) {
+				case *ast.SelectorExpr:
+					if typ.Sel.Name == "Context" {
+						takesCtx = true
+					}
+				case *ast.Ident:
+					if strings.HasSuffix(typ.Name, "RunConfig") {
+						takesCfg = true
+					}
+				}
+			}
+			if takesCtx && takesCfg {
+				out[fn.Name.Name] = true
+			}
+		}
+	}
+	return out
+}

--- a/core/attack/replay_honesty_test.go
+++ b/core/attack/replay_honesty_test.go
@@ -1,0 +1,66 @@
+package attack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// Milestone H: nox must never claim execution reproducibility where it can only
+// guarantee adjudication reproducibility.
+//
+// Two commands are called replay and they answer different questions.
+// `nox replay` re-derives verdicts from a stored ledger and touches nothing —
+// deterministic, because the ledger is the whole input. `nox attack replay`
+// re-runs the winning probe against a live target — best-effort, because nox
+// does not control the target's state, so a failed replay may mean the bug was
+// fixed, the data changed, or the service moved.
+//
+// The artifact used to blur that. Every trace carried a ReplayCommand,
+// including hypotheses that never executed, and attack.Replay answers such a
+// trace with "carries no reproducible evidence". An artifact advertising a
+// reproduction it cannot perform is the criterion violated in its most literal
+// form.
+
+// TestOnlyAReplayableTraceAdvertisesAReplay checks that the artifact promises a
+// re-run only where one is possible.
+func TestOnlyAReplayableTraceAdvertisesAReplay(t *testing.T) {
+	notRun := notRunTrace(Hypothesis{ID: "h1"}, RunConfig{}, "scenario above profile")
+	if notRun.ReplayCommand != "" {
+		t.Errorf("a hypothesis that never executed advertises %q; attack.Replay "+
+			"refuses it, so the artifact promises something the tool declines",
+			notRun.ReplayCommand)
+	}
+	if notRun.ReplayNote == "" {
+		t.Error("a trace that cannot be re-run says nothing about why. Silence there " +
+			"reads as an oversight rather than as a limit")
+	}
+	if notRun.Evidence != nil {
+		t.Fatal("fixture: a not-run trace should carry no evidence")
+	}
+}
+
+// TestTheReplayNoteDistinguishesTheTwoKinds. A reader holding a trace with no
+// replay command should learn that the OTHER replay still applies — the verdict
+// can be re-derived from its evidence even though the probe cannot be re-fired.
+// Those are different guarantees and the note is where the difference is
+// visible to someone reading an artifact rather than the source.
+func TestTheReplayNoteDistinguishesTheTwoKinds(t *testing.T) {
+	notRun := notRunTrace(Hypothesis{ID: "h2"}, RunConfig{}, "nothing ran")
+	if strings.Contains(notRun.ReplayNote, "nox attack replay") {
+		t.Errorf("the note points back at the command that will refuse it: %q", notRun.ReplayNote)
+	}
+	// A trace whose run produced no reproduction is the common case, and it is
+	// the one where the distinction matters most: no probe to re-fire, but the
+	// verdict is still re-derivable.
+	r := &runner{cfg: RunConfig{}.withDefaults()}
+	tr := r.finalize(Trace{ID: "trace-h3"}, evidence.RunOutcome{HypothesisConstructed: true, ControlSound: true}, Hypothesis{ID: "h3"}, nil, OracleVerdict{}, true)
+	if tr.ReplayCommand != "" {
+		t.Errorf("a trace with no reproduced violation advertises %q", tr.ReplayCommand)
+	}
+	if !strings.Contains(tr.ReplayNote, "nox replay") {
+		t.Errorf("the note does not tell the reader that the verdict is still "+
+			"re-derivable from its evidence: %q", tr.ReplayNote)
+	}
+}

--- a/core/attack/run.go
+++ b/core/attack/run.go
@@ -143,8 +143,24 @@ type Trace struct {
 	ReproductionSamples int `json:"reproduction_samples"`
 	// Note is a human-readable explanation of the outcome.
 	Note string `json:"note,omitempty"`
-	// ReplayCommand is the literal command to reproduce this trace.
-	ReplayCommand string `json:"replay_command"`
+	// ReplayCommand is the literal command to re-run this trace against a
+	// target, and it is EMPTY when there is nothing to re-run.
+	//
+	// It used to be set on every trace, including hypotheses that never
+	// executed — so an artifact advertised a reproduction it could not perform,
+	// and attack.Replay answered "carries no reproducible evidence". That is
+	// nox claiming execution reproducibility it does not have, which is the one
+	// thing this artifact must not do.
+	//
+	// Note what KIND of reproducibility this is. Re-running against a target is
+	// best-effort: nox does not control the target's state, so a replay that
+	// fails may mean the bug was fixed, the data changed, or the service moved.
+	// That is a different guarantee from `nox replay`, which re-derives verdicts
+	// from a stored ledger and is deterministic. Two commands named replay,
+	// answering different questions — see ReplayNote.
+	ReplayCommand string `json:"replay_command,omitempty"`
+	// ReplayNote says why this trace cannot be re-run, when it cannot.
+	ReplayNote string `json:"replay_note,omitempty"`
 	// FindingFingerprints links the trace back to the static findings its
 	// hypothesis was grounded in. This is an additive field beyond the original
 	// contract; it lets Correlate merge static and dynamic claims without needing
@@ -319,7 +335,7 @@ func notRunTrace(h Hypothesis, cfg RunConfig, note string) Trace {
 		Ledger:              *ledger,
 		ReproductionSamples: cfg.Samples,
 		Note:                note,
-		ReplayCommand:       "nox attack replay trace-" + h.ID,
+		ReplayNote:          "nothing ran, so there is nothing to re-run",
 		FindingFingerprints: h.FindingFingerprints,
 	})
 }
@@ -365,7 +381,6 @@ func (r *runner) attackHypothesis(h Hypothesis) Trace {
 		Objective:           h.Objective,
 		Path:                h.Path,
 		ReproductionSamples: r.cfg.Samples,
-		ReplayCommand:       "nox attack replay trace-" + h.ID,
 		FindingFingerprints: h.FindingFingerprints,
 	}
 	outcome := evidence.RunOutcome{HypothesisConstructed: true, ControlSound: true}
@@ -529,6 +544,16 @@ func (r *runner) finalize(trace Trace, outcome evidence.RunOutcome, h Hypothesis
 			},
 			Attributes: map[string]string{"oracle": verdict.OracleName, "signal": verdict.Signal},
 		})
+	}
+	// Advertise a re-run only where there is something to re-run. Replay
+	// reconstructs the winning probe from trace.Evidence, so a trace without it
+	// cannot be replayed and must not say it can.
+	if trace.Evidence != nil {
+		trace.ReplayCommand = "nox attack replay " + trace.ID
+	} else {
+		trace.ReplayNote = "no reproduced violation was recorded, so there is no " +
+			"winning probe to re-run; `nox replay` still re-derives this verdict " +
+			"from its evidence"
 	}
 	trace.Outcome = outcome
 	trace.Ledger = *ledger

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -328,6 +328,45 @@ This is the second time the roadmap's literal text has been wrong against
 measurement, after C5. Both times the plan was right about the concern and
 wrong about the remedy.
 
+## Milestones H and K — landed
+
+### H, the artifact audit
+
+The attack artifact turned out to be in better shape than expected. Hypothesis
+identity, the action sequence with the exact payload sent, resolved
+nondeterministic values, target identity, oracle result, determinism-gate tally,
+termination status, profile and the evidence ledger are all persisted. What is
+thin: the oracle DEFINITION is recorded only on a reproduced violation, control
+attempts are not distinguishable from attack attempts within `Attempts`, and
+environment assumptions and target *state* are absent.
+
+**The acceptance criterion was violated, in its most literal form.** Every
+trace carried a `ReplayCommand` — including hypotheses that never executed —
+while `attack.Replay` refuses any trace without recorded evidence. The artifact
+advertised a reproduction the tool declines. It is now set only where a winning
+probe exists, and a `ReplayNote` says why not otherwise.
+
+**The two replays are now distinguished where a reader meets them.** `nox
+replay` re-derives verdicts from a stored ledger and touches nothing:
+deterministic, because the ledger is the whole input. `nox attack replay`
+re-fires the winning probe at a live target: best-effort, because nox does not
+control target state, so a failed replay may mean the bug was fixed, the data
+changed, or the service moved. A trace that cannot be re-fired now says the
+verdict is still re-derivable, which is the distinction stated in the place it
+matters.
+
+### K, the boundary
+
+Already enforced by wiring, and now by test. Three properties: every exported
+entry point that takes a context and a run config refuses an unauthorized
+non-safe profile; the safe profile allows no network and demands no
+authorization it does not need; and **`core` — the scan pipeline — carries no
+import of `core/attack`**, checked by parsing its imports rather than by
+convention, because a convention is what a refactor does not consult.
+
+The entry points are enumerated from the source rather than listed by hand, and
+the count is asserted, so a fifth arrives as a failure rather than as silence.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
Two milestones. H found a real violation; K turns a convention into a guard.

## H — the artifact audit

The attack artifact is in **better shape than the milestone assumed**. Persisted: hypothesis identity, the action sequence with the exact payload sent, resolved nondeterministic values, target identity, oracle result, the determinism-gate tally, termination status, profile, and the evidence ledger.

Thin: the oracle *definition* is recorded only on a reproduced violation, control attempts aren't distinguishable from attack attempts inside `Attempts`, and environment assumptions and target *state* are absent.

### The criterion was violated, literally

> NOX never claims execution reproducibility where it can only guarantee adjudication reproducibility.

**Every trace carried a `ReplayCommand`** — including hypotheses that never executed — while `attack.Replay` refuses any trace without recorded evidence:

```
attack: trace "trace-h1" carries no reproducible evidence
```

The artifact advertised a reproduction the tool declines. It's now set only where a winning probe exists, with a `ReplayNote` saying why not otherwise.

### The two replays, distinguished where a reader meets them

| | guarantee |
|---|---|
| `nox replay` | **deterministic** — re-derives verdicts from a stored ledger; the ledger is the whole input |
| `nox attack replay` | **best-effort** — re-fires the winning probe at a live target |

nox doesn't control target state, so a failed attack replay may mean the bug was fixed, the data changed, or the service moved. A trace that can't be re-fired now says the verdict is **still re-derivable** — the distinction stated where it matters.

## K — the boundary

Already enforced by wiring. Now also by test, which is what stops the wiring being rearranged by accident.

- Every exported entry point taking a context and a run config **refuses an unauthorized non-safe profile**
- The safe profile allows no network **and demands no authorization it doesn't need** — a profile that asks for `--authorize` when it cannot act trains operators to pass it by reflex
- **`core` carries no import of `core/attack`**, checked by parsing imports rather than by convention, because a convention is what a refactor doesn't consult

Entry points are enumerated **from the source**, and the count asserted — so a fifth arrives as a failure rather than as silence.

That last one matters most: a scanner that can unknowingly attack its target is unsafe to run in most of the environments where nox should be ubiquitous.

## Falsification

| what was broken | what failed |
|---|---|
| `core` imports `core/attack` | `analyzer.go imports core/attack. The scan pipeline must not be able to reach code that touches a target` |
| the safe profile allows network | `the safe profile allows network traffic, which is the whole of what it promises not to do` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW