### PR TITLE
E and L: a vocabulary that outlives the solver, and the question that is open

### DIFF
--- a/cli/why_cmd.go
+++ b/cli/why_cmd.go
@@ -91,8 +91,8 @@ Flags:
 			Finding:  f,
 			Ledger:   res.Reasoning.About(subject),
 			Subject:  subject,
-			Coverage: res.Coverage,
-			Rule:     cat[f.RuleID],
+			Coverage: res.Coverage, Registry: res.Capabilities,
+			Rule: cat[f.RuleID],
 		}))
 	}
 

--- a/core/adjudicate/missing.go
+++ b/core/adjudicate/missing.go
@@ -1,0 +1,105 @@
+package adjudicate
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+// Gap is a question whose answer would change this verdict, and what it would
+// cost to answer it.
+//
+// This is the adjudicator's second job. Its first is to say what the evidence
+// supports; this one says what evidence is ABSENT, which is the more actionable
+// half for anyone deciding where to spend effort. A verdict of PLAUSIBLE with
+// the package confirmed, the symbol confirmed and the attacker path supported
+// is not a dead end — it is a question with one unknown, and naming that
+// unknown turns a report into a next step.
+type Gap struct {
+	// Capability is the analysis that would answer it.
+	Capability capability.AnalysisCapability `json:"capability"`
+	// Question is what would be established, in words.
+	Question string `json:"question"`
+	// Cost is the relative expense of answering it, cheapest first. It orders
+	// the gaps rather than pricing them: nox cannot know what a call-graph
+	// build costs on somebody else's monorepo, but it does know that reading a
+	// file is cheaper than executing an attack.
+	Cost int `json:"cost"`
+	// Available is whether anything on this installation could answer it. A gap
+	// nothing can fill is still worth naming — it tells a reader the silence is
+	// a limit rather than an oversight — but it is not a next step.
+	Available bool `json:"available"`
+}
+
+// costs orders the capabilities by what answering them takes, cheapest first.
+//
+// The ordering is the useful part and it is not arbitrary: reading a file is
+// cheaper than resolving symbols, which is cheaper than building a call graph,
+// which is far cheaper than executing anything against a live target. A
+// multi-stage architecture spends the cheap evidence first and only escalates
+// on what survives, and this is the order it escalates in.
+var costs = []struct {
+	capability.AnalysisCapability
+	question string
+	cost     int
+}{
+	// Each question stands alone, because each is shown on its own. An earlier
+	// version phrased them as a sequence — "is it reachable from one?" — which
+	// read as a fragment once a reader saw only the recommended one.
+	{capability.LexicalContext, "is this in real code, or in a comment or string?", 1},
+	{capability.ConstantEvaluation, "is this value a literal, or is it built from input?", 2},
+	{capability.SymbolResolution, "does the build actually reference the affected symbol?", 3},
+	{capability.Taint, "does untrusted input reach this location?", 4},
+	{capability.CallGraph, "is there any call path that reaches this code?", 5},
+	{capability.EntryPoint, "what are this application's entry points?", 6},
+	{capability.Reachability, "is this code reachable from an entry point?", 7},
+	{capability.AttackerReachability, "is it reachable from an entry point an attacker controls?", 8},
+	{capability.DynamicVerification, "does this actually happen when the code is exercised?", 9},
+}
+
+// MissingEvidence returns the questions that are open for a subject, cheapest
+// first, given what the scan established.
+//
+// A capability that already concluded is not a gap. One that ran and could not
+// tell IS — the question is open, and re-asking it may need a different
+// approach rather than the same one again, which is why the answer is the
+// capability and not an instruction.
+//
+// The cheapest available gap is the one worth taking first, and that is the
+// whole point: not every hypothesis travels to the bottom of the ladder, and
+// the ones that do should get there by having survived the cheap questions.
+func MissingEvidence(cov *capability.Coverage, reg *capability.Registry, s evidence.Subject) []Gap {
+	var out []Gap
+	for _, c := range costs {
+		switch cov.State(s, c.AnalysisCapability) {
+		case capability.Positive, capability.Negative:
+			// Answered. Not a gap, whichever way it went.
+			continue
+		}
+		out = append(out, Gap{
+			Capability: c.AnalysisCapability,
+			Question:   c.question,
+			Cost:       c.cost,
+			Available:  reg.Provided(c.AnalysisCapability),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Cost < out[j].Cost })
+	return out
+}
+
+// CheapestAvailable returns the least expensive open question something on this
+// installation could actually answer, and whether there is one.
+//
+// Availability is part of the answer rather than a filter applied to it. A gap
+// nothing can fill is real and belongs in MissingEvidence — it is why a verdict
+// stops where it does — but recommending it as a next step would send a reader
+// to do something they cannot.
+func CheapestAvailable(gaps []Gap) (Gap, bool) {
+	for _, g := range gaps {
+		if g.Available {
+			return g, true
+		}
+	}
+	return Gap{}, false
+}

--- a/core/adjudicate/missing_test.go
+++ b/core/adjudicate/missing_test.go
@@ -1,0 +1,125 @@
+package adjudicate_test
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/adjudicate"
+	"github.com/nox-hq/nox/core/capability"
+)
+
+func subj() evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectCandidate, ID: "SEC-003@a.go:1"}
+}
+
+// TestTheCheapestOpenQuestionComesFirst is Milestone L's point.
+//
+// A verdict that stops somewhere is not a dead end; it is a question with an
+// unknown, and naming the unknown turns a report into a next step. The ordering
+// is the useful part: reading a file is cheaper than resolving symbols, which
+// is cheaper than building a call graph, which is far cheaper than executing
+// anything. Not every hypothesis should travel to the bottom of that ladder,
+// and the ones that do should arrive having survived the cheap questions.
+func TestTheCheapestOpenQuestionComesFirst(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+
+	gaps := adjudicate.MissingEvidence(cov, reg, subj())
+	if len(gaps) == 0 {
+		t.Fatal("a subject nothing concluded about has no open questions")
+	}
+	for i := 1; i < len(gaps); i++ {
+		if gaps[i].Cost < gaps[i-1].Cost {
+			t.Errorf("gap %d (%s, cost %d) is cheaper than the one before it (%s, cost %d)",
+				i, gaps[i].Capability, gaps[i].Cost, gaps[i-1].Capability, gaps[i-1].Cost)
+		}
+	}
+
+	// Answering one removes it, whichever way it went. A question that was put
+	// and came back negative is answered, not open.
+	cov.Record(subj(), capability.LexicalContext, capability.Positive)
+	cov.Record(subj(), capability.Taint, capability.Negative)
+	after := adjudicate.MissingEvidence(cov, reg, subj())
+	for _, g := range after {
+		if g.Capability == capability.LexicalContext || g.Capability == capability.Taint {
+			t.Errorf("%s was answered and is still reported as an open question", g.Capability)
+		}
+	}
+	if len(after) != len(gaps)-2 {
+		t.Errorf("answering two questions closed %d gaps", len(gaps)-len(after))
+	}
+}
+
+// TestAnInconclusiveAnswerLeavesTheQuestionOpen. "The analysis ran and could
+// not tell" is not an answer, and treating it as one is how a scan reports a
+// question as settled because somebody asked it once.
+func TestAnInconclusiveAnswerLeavesTheQuestionOpen(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+	cov.Record(subj(), capability.Taint, capability.Unknown)
+	cov.Record(subj(), capability.SymbolResolution, capability.TimedOut)
+
+	var sawTaint, sawSymbol bool
+	for _, g := range adjudicate.MissingEvidence(cov, reg, subj()) {
+		switch g.Capability {
+		case capability.Taint:
+			sawTaint = true
+		case capability.SymbolResolution:
+			sawSymbol = true
+		}
+	}
+	if !sawTaint {
+		t.Error("a capability that ran and could not determine anything is reported " +
+			"as answered")
+	}
+	if !sawSymbol {
+		t.Error("a capability that timed out is reported as answered")
+	}
+}
+
+// TestTheRecommendationIsSomethingTheReaderCanDo. A gap nothing on this
+// installation can fill is real and belongs in the list — it is why the verdict
+// stops where it does — but recommending it would send a reader to do something
+// they cannot.
+func TestTheRecommendationIsSomethingTheReaderCanDo(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+
+	gaps := adjudicate.MissingEvidence(cov, reg, subj())
+	var unavailable int
+	for _, g := range gaps {
+		if !g.Available {
+			unavailable++
+		}
+	}
+	if unavailable == 0 {
+		t.Fatal("every capability is available on this installation, so the " +
+			"distinction this test is about cannot be exercised")
+	}
+
+	next, ok := adjudicate.CheapestAvailable(gaps)
+	if !ok {
+		t.Fatal("no open question can be answered on an installation that provides " +
+			"lexical context, taint and symbol resolution")
+	}
+	if !next.Available {
+		t.Errorf("recommended %s, which nothing here provides", next.Capability)
+	}
+	for _, g := range gaps {
+		if g.Available && g.Cost < next.Cost {
+			t.Errorf("recommended %s (cost %d) when %s (cost %d) is available and cheaper",
+				next.Capability, next.Cost, g.Capability, g.Cost)
+		}
+	}
+}
+
+// TestGapsAreNamedAsQuestions. "call_graph: not evaluated" tells a reader what
+// is missing; "is there a call path to it?" tells them what they would learn.
+func TestGapsAreNamedAsQuestions(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	for _, g := range adjudicate.MissingEvidence(capability.NewCoverage(reg), reg, subj()) {
+		if g.Question == "" {
+			t.Errorf("%s is an open question with no question", g.Capability)
+		}
+	}
+}

--- a/core/explain/explain.go
+++ b/core/explain/explain.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/adjudicate"
 	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/catalog"
 	"github.com/nox-hq/nox/core/findings"
@@ -76,6 +77,9 @@ type Inputs struct {
 	Ledger   evidence.Ledger
 	Subject  evidence.Subject
 	Coverage *capability.Coverage
+	// Registry is what this installation provides, needed to tell an open
+	// question something could answer from one nothing can.
+	Registry *capability.Registry
 	Rule     catalog.RuleMeta
 }
 
@@ -93,7 +97,7 @@ func Explain(in Inputs) Explanation {
 	e.NotEvaluated = append(limitationLines(f), notEvaluated(in.Coverage, in.Subject)...)
 	e.PotentialImpact = potentialImpact(f, in.Rule)
 	e.AffectsThisApplication = affectsThisApplication(f)
-	e.WhatToDo = whatToDo(in.Rule)
+	e.WhatToDo = whatToDo(in.Rule) + nextEvidence(in)
 	return e
 }
 
@@ -338,6 +342,26 @@ func affectsThisApplication(f findings.Finding) string {
 	default:
 		return fmt.Sprintf("Applicability reached %s.", reached)
 	}
+}
+
+// nextEvidence names the cheapest open question something on this installation
+// could answer, appended to the remediation.
+//
+// It is the actionable half of "what was not evaluated". That field says which
+// questions are open; this says which one to take first, and only ever
+// recommends something the reader can actually do — a gap nothing can fill is
+// worth naming as a limit but is not a next step.
+func nextEvidence(in Inputs) string {
+	if in.Coverage == nil || in.Registry == nil {
+		return ""
+	}
+	gaps := adjudicate.MissingEvidence(in.Coverage, in.Registry, in.Subject)
+	next, ok := adjudicate.CheapestAvailable(gaps)
+	if !ok {
+		return ""
+	}
+	return " The cheapest thing that would move this conclusion is " +
+		string(next.Capability) + ": " + next.Question
 }
 
 func whatToDo(rule catalog.RuleMeta) string {

--- a/core/verify/verify.go
+++ b/core/verify/verify.go
@@ -1,0 +1,170 @@
+// Package verify is the vocabulary a verification producer speaks, chosen so
+// the domain model outlives the technology that produced it.
+//
+// A constraint solver is one evidence producer. So is a fuzzer, a symbolic
+// executor, a runtime attack adapter, a unit-level harness, a proof-of-concept
+// runner and a property checker. Coupling nox's verdicts to any one of their
+// vocabularies — SAT and UNSAT most obviously — would make the domain model a
+// hostage to a tool choice that has not been made yet, and would have to be
+// unpicked the first time a second producer disagreed about what its own words
+// meant.
+//
+// # This is a separate axis, not a widening of Exploitability
+//
+// evidence.Exploitability is a lifecycle: how far dynamic validation of a
+// finding has got. A verification result is a different question — what one
+// producer established about one proposition, under one model. Track C3
+// rejected folding conflict into Exploitability for exactly this reason, and
+// the reasoning carries: INCONCLUSIVE already means "execution occurred and
+// could not decide", and a state meaning two things leaves a reader unable to
+// tell which applies. Conflict got its own field; so does this.
+//
+// # What a result may never say
+//
+// A solver returning UNSAT has refuted a PATH under a model, an abstraction and
+// a set of bounds. It has not refuted the finding. Nothing in this package can
+// express "refutes the finding", because the only refuting outcome is named
+// InfeasibleWithinScope and it carries the scope that bounds it — the same
+// asymmetry core/reach enforces, for the same reason: a universal claim is only
+// as good as the search behind it.
+package verify
+
+import (
+	"fmt"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// Outcome is what one producer established about one proposition.
+type Outcome string
+
+const (
+	// Feasible — the condition can be satisfied, under the stated model. It
+	// SUPPORTS the proposition; it does not confirm anything above it.
+	Feasible Outcome = "FEASIBLE"
+	// InfeasibleWithinScope — the condition could not be satisfied under the
+	// stated model, abstraction and bounds. Named at length on purpose: there
+	// is no way to say "infeasible" without saying within what.
+	InfeasibleWithinScope Outcome = "INFEASIBLE_WITHIN_SCOPE"
+	// Observed — something happened and was recorded. Not yet a judgement about
+	// whether it matters.
+	Observed Outcome = "OBSERVED"
+	// Violated — a stated security invariant was broken. Stronger than
+	// Observed, weaker than Reproduced.
+	Violated Outcome = "VIOLATED"
+	// Reproduced — it recurred under a determinism gate.
+	Reproduced Outcome = "REPRODUCED"
+	// Unknown — the producer could not tell. The honest default, and the only
+	// outcome an incomplete model may reach for a negative.
+	Unknown Outcome = "UNKNOWN"
+)
+
+// Valid reports whether o is a defined outcome.
+func (o Outcome) Valid() bool {
+	switch o {
+	case Feasible, InfeasibleWithinScope, Observed, Violated, Reproduced, Unknown:
+		return true
+	}
+	return false
+}
+
+// Refutes reports whether this outcome argues against its proposition. Only one
+// outcome does, and it is the one carrying its scope in its name.
+func (o Outcome) Refutes() bool { return o == InfeasibleWithinScope }
+
+// Result is one producer's finding about one proposition.
+//
+// Subject is required and is the whole point: a result is about a path, a flow,
+// a trigger condition — never about "the finding". Attaching a solver's answer
+// to a finding is how UNSAT on one path becomes "not vulnerable".
+type Result struct {
+	// Producer names what established this — "z3", "afl", "nox-attack" — so a
+	// reader can weigh it and a second producer can disagree attributably.
+	Producer string `json:"producer"`
+	// Subject is the proposition, typed.
+	Subject evidence.Subject `json:"subject"`
+	// Outcome is what was established.
+	Outcome Outcome `json:"outcome"`
+	// Scope is the model, abstraction and bounds it holds under, reusing the
+	// same object reachability results carry. A verification answer and a
+	// reachability answer are bounded the same way and by the same kinds of
+	// thing; two scope types would drift.
+	Scope reach.Scope `json:"scope"`
+	// Detail is the producer's own words.
+	Detail string `json:"detail"`
+}
+
+// Verify records an outcome, refusing the ones that cannot be stated.
+//
+// A negative — InfeasibleWithinScope — requires a scope with no limitations,
+// exactly as reach.Refute does. A model that could not resolve a dispatch has
+// not shown the condition unsatisfiable; it has shown its own search came up
+// empty, which is Unknown. The second return is false when the outcome was
+// downgraded, so a caller cannot get the stronger claim by not looking.
+func Verify(producer string, subject evidence.Subject, outcome Outcome, scope reach.Scope, detail string) (Result, bool) {
+	r := Result{Producer: producer, Subject: subject, Outcome: outcome, Scope: scope, Detail: detail}
+	if !outcome.Valid() || subject.Zero() {
+		// An unattributed result aggregates with every other unattributed one,
+		// which is how a solver's answer about a path reaches a finding.
+		r.Outcome = Unknown
+		return r, false
+	}
+	if outcome.Refutes() && !scope.Complete() {
+		r.Outcome = Unknown
+		r.Detail = detail + " (downgraded: " + scope.Describe() + ")"
+		return r, false
+	}
+	return r, true
+}
+
+// Claim converts a result into evidence, at a kind that reflects what the
+// producer actually did.
+//
+// A solver's answer is KindStatic: it is a machine-checkable statement about a
+// model, which is more than a heuristic and less than an execution. Only
+// something that actually ran and recurred earns KindControlledReproduction,
+// and only the Reproduced outcome maps to it — which is why a solver cannot
+// reach CONFIRMED however confident it is.
+func (r Result) Claim(observedAt string) (evidence.Claim, bool) {
+	var kind evidence.Kind
+	polarity := evidence.PolaritySupports
+	switch r.Outcome {
+	case Reproduced:
+		kind = evidence.KindControlledReproduction
+	case Violated, Observed:
+		kind = evidence.KindStatic
+	case Feasible:
+		kind = evidence.KindStatic
+	case InfeasibleWithinScope:
+		kind, polarity = evidence.KindStatic, evidence.PolarityRefutes
+	default:
+		// Unknown produces no claim. A producer that could not tell has not
+		// contributed evidence, and filing an empty one would make the ledger
+		// look busier than the enquiry was.
+		return evidence.Claim{}, false
+	}
+	return evidence.Claim{
+		Kind:      kind,
+		Subject:   r.Subject,
+		Polarity:  polarity,
+		Statement: r.Statement(),
+		Provenance: evidence.Provenance{
+			Source: r.Producer, SourceID: r.Producer, ObservedAt: observedAt,
+		},
+	}, true
+}
+
+// Statement is the sentence a person reads. It never drops the scope from a
+// negative, because the scope is what makes the negative true.
+func (r Result) Statement() string {
+	switch r.Outcome {
+	case InfeasibleWithinScope:
+		return fmt.Sprintf("%s found no satisfying assignment within its model (%s)",
+			r.Producer, r.Scope.Describe())
+	case Unknown:
+		return fmt.Sprintf("%s could not determine this (%s)", r.Producer, r.Scope.Describe())
+	default:
+		return fmt.Sprintf("%s established %s (%s)", r.Producer, r.Outcome, r.Scope.Describe())
+	}
+}

--- a/core/verify/verify_test.go
+++ b/core/verify/verify_test.go
@@ -1,0 +1,130 @@
+package verify_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/reach"
+	"github.com/nox-hq/nox/core/verify"
+)
+
+func path() evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectCallPath, ID: "main→handler→exec"}
+}
+
+func model() reach.Scope {
+	return reach.Scope{Analysis: "z3", Capability: capability.Taint, BuildID: "m1"}
+}
+
+// TestUNSATRefutesAPathAndNeverAFinding is Milestone E's central rule.
+//
+// A solver returning UNSAT has refuted a PATH under a model, an abstraction and
+// a set of bounds. It has not refuted the finding, and there must be no way to
+// say that it has. The subject is required, so a result cannot be filed against
+// nothing and reach everything by sharing the zero subject.
+func TestUNSATRefutesAPathAndNeverAFinding(t *testing.T) {
+	r, ok := verify.Verify("z3", path(), verify.InfeasibleWithinScope, model(),
+		"no satisfying assignment")
+	if !ok {
+		t.Fatalf("a complete model could not state a negative: %+v", r)
+	}
+	c, made := r.Claim("2026-08-31T00:00:00Z")
+	if !made {
+		t.Fatal("a refuting result produced no claim")
+	}
+	if !c.Refutes() {
+		t.Error("an infeasibility result does not refute")
+	}
+	if c.Subject != path() {
+		t.Errorf("the claim is filed against %v, not the path it is about", c.Subject)
+	}
+	if c.Kind == evidence.KindControlledReproduction {
+		t.Error("a solver's answer was recorded at reproduction strength; nothing ran")
+	}
+
+	// An unattributed result is refused: it would aggregate with every other
+	// unattributed claim, which is how a solver's answer about a path reaches a
+	// finding.
+	if _, ok := verify.Verify("z3", evidence.Subject{}, verify.InfeasibleWithinScope, model(), "x"); ok {
+		t.Error("a result with no subject was accepted; it aggregates with everything")
+	}
+}
+
+// TestANegativeNeedsACompleteModel. Same asymmetry as core/reach, for the same
+// reason: UNSAT on the paths a bounded model explored is not "no path exists".
+func TestANegativeNeedsACompleteModel(t *testing.T) {
+	bounded := model()
+	bounded.Limitations = []reach.Limitation{reach.BoundedLoops}
+
+	r, ok := verify.Verify("z3", path(), verify.InfeasibleWithinScope, bounded, "unsat")
+	if ok {
+		t.Error("a bounded model stated an unqualified negative")
+	}
+	if r.Outcome != verify.Unknown {
+		t.Errorf("the downgraded outcome is %q, want UNKNOWN", r.Outcome)
+	}
+	if !strings.Contains(r.Detail, "downgraded") {
+		t.Errorf("the downgrade is silent: %q", r.Detail)
+	}
+
+	// The positive direction is unaffected: finding a satisfying assignment is
+	// existential, and a bounded search that found one still found one.
+	if _, ok := verify.Verify("z3", path(), verify.Feasible, bounded, "sat"); !ok {
+		t.Error("a bounded model was blocked from reporting a path it did find")
+	}
+}
+
+// TestOnlyExecutionEarnsReproductionStrength. A solver is confident about a
+// model, not about the world, so no outcome it can produce may reach the kind
+// that carries CONFIRMED.
+func TestOnlyExecutionEarnsReproductionStrength(t *testing.T) {
+	for _, o := range []verify.Outcome{
+		verify.Feasible, verify.InfeasibleWithinScope, verify.Observed, verify.Violated,
+	} {
+		r, _ := verify.Verify("z3", path(), o, model(), "d")
+		c, made := r.Claim("t")
+		if made && c.Kind == evidence.KindControlledReproduction {
+			t.Errorf("outcome %s reached reproduction strength without anything running", o)
+		}
+	}
+	repro, _ := verify.Verify("nox-attack", path(), verify.Reproduced, model(), "d")
+	c, _ := repro.Claim("t")
+	if c.Kind != evidence.KindControlledReproduction {
+		t.Errorf("a reproduction was recorded at %q", c.Kind)
+	}
+}
+
+// TestUnknownFilesNoClaim. A producer that could not tell has not contributed
+// evidence, and an empty claim makes a ledger look busier than the enquiry was.
+func TestUnknownFilesNoClaim(t *testing.T) {
+	r, _ := verify.Verify("z3", path(), verify.Unknown, model(), "timeout")
+	if _, made := r.Claim("t"); made {
+		t.Error("an UNKNOWN outcome filed a claim")
+	}
+	if !strings.Contains(r.Statement(), "could not determine") {
+		t.Errorf("statement %q does not say the producer could not tell", r.Statement())
+	}
+}
+
+// TestNoStatementAssertsSafety, and no negative drops its scope — the scope is
+// what makes a negative true.
+func TestNoStatementAssertsSafety(t *testing.T) {
+	banned := []string{"safe", "secure", "no risk", "not vulnerable", "prevented", "clean"}
+	for _, o := range []verify.Outcome{
+		verify.Feasible, verify.InfeasibleWithinScope, verify.Observed,
+		verify.Violated, verify.Reproduced, verify.Unknown,
+	} {
+		r := verify.Result{Producer: "p", Subject: path(), Outcome: o, Scope: model()}
+		got := strings.ToLower(r.Statement())
+		for _, w := range banned {
+			if strings.Contains(got, w) {
+				t.Errorf("%s says %q, which contains %q", o, got, w)
+			}
+		}
+		if o.Refutes() && !strings.Contains(got, "z3") {
+			t.Errorf("a negative dropped its scope: %q", got)
+		}
+	}
+}

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -367,6 +367,58 @@ convention, because a convention is what a refactor does not consult.
 The entry points are enumerated from the source rather than listed by hand, and
 the count is asserted, so a fifth arrives as a failure rather than as silence.
 
+## Milestones E and L — landed
+
+### E, the verification vocabulary
+
+`core/verify` is what a verification producer speaks: `FEASIBLE`,
+`INFEASIBLE_WITHIN_SCOPE`, `OBSERVED`, `VIOLATED`, `REPRODUCED`, `UNKNOWN`. A
+constraint solver is one producer; so is a fuzzer, a symbolic executor, an
+attack adapter, a harness, a PoC runner, a property checker. Coupling the domain
+model to SAT/UNSAT would make it a hostage to a tool choice that has not been
+made.
+
+**It is a separate axis, following C3's precedent.** `Exploitability` is a
+lifecycle; a verification result is what one producer established about one
+proposition under one model. Folding them would give `INCONCLUSIVE` a second
+meaning, which is the mistake C3 declined.
+
+The rules E states are structural rather than documented. The only refuting
+outcome is named `INFEASIBLE_WITHIN_SCOPE` — there is no way to spell
+"infeasible" without saying within what — and it refuses to be stated from a
+scope with limitations, the same asymmetry `core/reach` enforces. A `Subject` is
+required, so a result cannot be filed against nothing and reach everything by
+sharing the zero subject, which is how a solver's answer about a path would
+otherwise become a statement about a finding. And no outcome a solver can
+produce maps to `KindControlledReproduction`: only something that ran and
+recurred earns the kind that carries CONFIRMED.
+
+It reuses `reach.Scope` rather than defining its own. A verification answer and
+a reachability answer are bounded by the same kinds of thing, and two scope
+types would drift. If Milestone M needs this in the kernel, that is the moment
+to promote both — with a real second consumer, rather than guessing now.
+
+### L, the verification-aware adjudicator
+
+`adjudicate.MissingEvidence` answers the other half of the adjudicator's job:
+not what the evidence supports, but what is absent. A verdict that stops
+somewhere is not a dead end; it is a question with an unknown, and naming the
+unknown turns a report into a next step.
+
+The ordering is the substance — lexical context, constants, symbols, taint, call
+graph, entry points, reachability, attacker reachability, dynamic verification —
+cheapest first, because a multi-stage architecture spends cheap evidence first
+and escalates only on what survives. Not every hypothesis should reach the
+bottom.
+
+Two distinctions it keeps. A capability that ran and could not tell leaves its
+question **open**, because "somebody asked once" is not an answer. And
+availability is part of the answer rather than a filter: a gap nothing on this
+installation can fill is real and belongs in the list — it is why the verdict
+stops where it does — but recommending it would send a reader to do something
+they cannot. `nox why` now closes with the cheapest question something here
+could actually answer.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:

--- a/server/evidence.go
+++ b/server/evidence.go
@@ -128,7 +128,7 @@ func (s *Server) handleWhy(_ context.Context, input whyInput) (mcp.StructuredRes
 		}
 		out.Explanations = append(out.Explanations, explain.Explain(explain.Inputs{
 			Finding: f, Ledger: ledger, Subject: subject,
-			Coverage: pc.result.Coverage, Rule: cat[f.RuleID],
+			Coverage: pc.result.Coverage, Registry: pc.result.Capabilities, Rule: cat[f.RuleID],
 		}))
 	}
 	if len(out.Explanations) == 0 {


### PR DESCRIPTION
## E — verification semantics before verification technology

`core/verify` is what a verification producer speaks:

```
FEASIBLE · INFEASIBLE_WITHIN_SCOPE · OBSERVED · VIOLATED · REPRODUCED · UNKNOWN
```

A constraint solver is **one** evidence producer. So is a fuzzer, a symbolic executor, a runtime attack adapter, a harness, a PoC runner, a property checker. Coupling the domain model to SAT/UNSAT would make it a hostage to a tool choice nobody has made yet.

**A separate axis, following C3's precedent.** `Exploitability` is a lifecycle; a verification result is what one producer established about one proposition under one model. Folding them would give `INCONCLUSIVE` a second meaning — exactly what C3 declined.

### The rules are structural, not documented

- The only refuting outcome is named **`INFEASIBLE_WITHIN_SCOPE`** — there is no way to spell "infeasible" without saying *within what*
- It **refuses to be stated** from a scope carrying limitations, the same asymmetry `core/reach` enforces: UNSAT on the paths a bounded model explored is not "no path exists"
- A `Subject` is **required**, so a result cannot be filed against nothing and reach everything by sharing the zero subject — which is how a solver's answer about a *path* becomes a claim about a *finding*
- **No outcome a solver can produce maps to `KindControlledReproduction`.** Only something that ran and recurred earns the kind that carries CONFIRMED

It reuses `reach.Scope` rather than defining its own — a verification answer and a reachability answer are bounded by the same kinds of thing, and two scope types would drift. If Milestone M needs this in the kernel, that's the moment to promote both, with a real second consumer rather than a guess.

## L — the adjudicator's second job

`adjudicate.MissingEvidence` says what is **absent**. A verdict that stops somewhere isn't a dead end; it's a question with an unknown, and naming it turns a report into a next step.

```
The cheapest thing that would move this conclusion is reachability:
is this code reachable from an entry point?
```

The **ordering** is the substance — lexical context → constants → symbols → taint → call graph → entry points → reachability → attacker reachability → dynamic verification. Cheapest first, because a multi-stage architecture spends cheap evidence first and escalates only on what survives. Not every hypothesis should reach the bottom.

Two distinctions it keeps:

- A capability that **ran and could not tell** leaves its question **open**. "Somebody asked once" is not an answer.
- **Availability is part of the answer, not a filter.** A gap nothing here can fill is real and belongs in the list — it's *why* the verdict stops — but recommending it would send a reader to do something they cannot.

## Falsification

| what was broken | what failed |
|---|---|
| a bounded model may state an unqualified negative | `a bounded model stated an unqualified negative` |
| an inconclusive answer closes the question | `a capability that ran and could not determine anything is reported as answered` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues across core, cli, server.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW