### PR TITLE
D: the scan hands over what it established, instead of the attack guessing

### DIFF
--- a/cli/attack_cmd.go
+++ b/cli/attack_cmd.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nox-hq/nox/core/replay"
+
 	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/analyzers/ai"
 	"github.com/nox-hq/nox/core/attack"
@@ -84,6 +86,8 @@ const attackPlanUsage = `Usage: nox attack plan [path] [flags]
 Flags:
   --findings <path>   findings.json from a prior scan (default findings.json)
   --inventory <path>  ai.inventory.json from a prior scan (default ai.inventory.json)
+  --evidence <path>   the evidence artifact a scan was asked to keep; carries
+                      what that scan established onto each hypothesis
   --output <path>     write the plan here (default attack.plan.json)
   --json              print the plan as JSON instead of a summary
                       (the plan is written to --output either way)
@@ -96,11 +100,13 @@ func runAttackPlan(args []string) int {
 	var (
 		findingsIn  string
 		inventoryIn string
+		evidenceIn  string
 		output      string
 		asJSON      bool
 	)
 	fs.StringVar(&findingsIn, "findings", "findings.json", "findings.json from a prior nox scan")
 	fs.StringVar(&inventoryIn, "inventory", "ai.inventory.json", "ai.inventory.json from a prior nox scan")
+	fs.StringVar(&evidenceIn, "evidence", "", "the evidence artifact a scan was asked to keep; carries what that scan established onto each hypothesis")
 	fs.StringVar(&output, "output", defaultPlanPath, "write the plan here")
 	fs.BoolVar(&asJSON, "json", false, "print the plan as JSON instead of a summary")
 	fs.Usage = func() { fmt.Fprint(os.Stderr, attackPlanUsage) }
@@ -131,12 +137,31 @@ func runAttackPlan(args []string) int {
 		fmt.Fprintf(os.Stderr, "warning: %v — tool-abuse and exfiltration scenarios will be skipped\n", invErr)
 	}
 
-	plan, err := attack.BuildPlan(attack.PlanInput{
+	// Milestone D's handoff. The evidence a scan gathers lives out-of-band and
+	// is discarded when the scan ends, so a plan built from findings.json alone
+	// cannot see why nox believed anything. `nox scan --evidence-out` keeps it,
+	// and this reads it — the artifact built for replay turns out to be exactly
+	// the scan-to-attack handoff.
+	//
+	// Optional throughout: without it every hypothesis carries an empty ledger,
+	// which is the behaviour before this existed and keeps `attack plan` usable
+	// from a findings file alone.
+	in := attack.PlanInput{
 		Root:      root,
 		Findings:  found,
 		Inventory: inv,
 		Now:       time.Now().UTC().Format(time.RFC3339),
-	})
+	}
+	if evidenceIn != "" {
+		art, aerr := replay.Load(evidenceIn)
+		if aerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: %v — hypotheses will carry no evidence\n", aerr)
+		} else {
+			in.Evidence = evidenceFromArtifact(art)
+			in.Unknowns = unknownsFromArtifact(art)
+		}
+	}
+	plan, err := attack.BuildPlan(in)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: building plan: %v\n", err)
 		return 2
@@ -857,4 +882,56 @@ func plural(n int, one, many string) string {
 		return one
 	}
 	return many
+}
+
+// evidenceFromArtifact adapts a Track I evidence artifact into the lookup
+// BuildPlan wants: given a finding, the subject its claims were filed against
+// and the ledger of those claims.
+//
+// The artifact records verdicts by fingerprint and claims by subject, so the
+// join is fingerprint → subject → ledger. A finding the artifact does not know
+// yields the zero subject and an empty ledger, which is honest: this scan
+// established nothing about it.
+func evidenceFromArtifact(a *replay.Artifact) func(findings.Finding) (evidence.Subject, evidence.Ledger) {
+	bySubject := make(map[string]evidence.Subject, len(a.Findings))
+	for _, v := range a.Findings {
+		bySubject[v.Fingerprint] = v.Subject
+	}
+	return func(f findings.Finding) (evidence.Subject, evidence.Ledger) {
+		s, ok := bySubject[f.Fingerprint]
+		if !ok {
+			return evidence.Subject{}, evidence.Ledger{}
+		}
+		l, _ := a.LedgerFor(s)
+		return s, l
+	}
+}
+
+// unknownsFromArtifact reports the questions the scan left open, cheapest
+// first, from the capability state it recorded.
+//
+// A capability that answered nothing is an open question whether or not
+// anything provides it, and both are worth carrying: one tells the reader what
+// to install, the other tells them what to run. The order is the artifact's,
+// which is capability.All()'s — the same cheapest-first ordering
+// adjudicate.MissingEvidence uses.
+func unknownsFromArtifact(a *replay.Artifact) func(evidence.Subject) []string {
+	var open []string
+	for _, c := range a.Capabilities {
+		if c.Answered > 0 {
+			continue
+		}
+		switch {
+		case !c.Provided:
+			open = append(open, c.Capability+": nothing on that installation could establish it")
+		case c.Inconclusive > 0:
+			open = append(open, c.Capability+": ran and could not determine anything")
+		default:
+			open = append(open, c.Capability+": nothing in that scan put the question")
+		}
+	}
+	// Scan-wide rather than per-subject: the artifact records capability counts
+	// across the scan, not per finding. Saying so beats inventing a per-subject
+	// breakdown the artifact cannot support.
+	return func(evidence.Subject) []string { return open }
 }

--- a/cli/flag_efficacy_test.go
+++ b/cli/flag_efficacy_test.go
@@ -314,6 +314,7 @@ var subcommandFlags = []struct {
 		flags: []flagSpec{
 			{"findings", "--findings=testdata/nox-flag-efficacy-absent.json", "names the scan artifact the plan is grounded in; a missing file is a hard error"},
 			{"inventory", "--inventory=testdata/nox-flag-efficacy-absent.json", "supplies the tool matrix that grounds tool and exfiltration hypotheses"},
+			{"evidence", "--evidence=testdata/nox-flag-efficacy-absent.json", "carries what the scan established onto each hypothesis; a missing file warns and plans without it"},
 			{"output", "--output=testdata/nox-flag-efficacy-absent.json", "chooses where the plan is written"},
 			{"json", "--json=true", "prints the plan instead of a summary"},
 		},

--- a/core/attack/hypothesis_handoff_test.go
+++ b/core/attack/hypothesis_handoff_test.go
@@ -1,0 +1,139 @@
+package attack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// Milestone D: the scan produces the hypothesis; the attack fills in the
+// observation. Given a scan result, `nox attack` must be able to consume a
+// hypothesis without rediscovering why nox considered it worth testing.
+//
+// Before this, it rediscovered it badly. The runner seeded its ledger with a
+// single heuristic claim restating the rationale, while the scan had already
+// gathered better evidence and thrown it away — the evidence is out-of-band and
+// dies with the scan. `nox scan --evidence-out` keeps it, and the artifact
+// built for replay turns out to be exactly this handoff.
+
+func planFinding() findings.Finding {
+	return findings.Finding{
+		RuleID: "AI-PI-001", Severity: findings.SeverityHigh,
+		Fingerprint: "abc123def456",
+		Location:    findings.Location{FilePath: "app/agent.py", StartLine: 50},
+		Message:     "untrusted input reaches the system prompt",
+		Metadata: map[string]string{
+			"source_var":           "user_input",
+			"analysis_limitations": "reflection",
+		},
+	}
+}
+
+// TestAHypothesisCarriesWhatTheScanEstablished checks the fields the handoff
+// exists to carry.
+func TestAHypothesisCarriesWhatTheScanEstablished(t *testing.T) {
+	f := planFinding()
+	subject := evidence.Subject{Kind: evidence.SubjectCandidate, ID: "AI-PI-001@app/agent.py:50"}
+	ledger := evidence.Ledger{Claims: []evidence.Claim{{
+		Kind: evidence.KindStatic, Subject: subject,
+		Statement: "the value is not a literal",
+	}}}
+
+	in := PlanInput{
+		Root: ".", Findings: []findings.Finding{f}, Now: "2026-08-31T00:00:00Z",
+		Evidence: func(findings.Finding) (evidence.Subject, evidence.Ledger) {
+			return subject, ledger
+		},
+		Unknowns: func(evidence.Subject) []string {
+			return []string{"call_graph: nothing could establish it"}
+		},
+	}
+	var h Hypothesis
+	attachEvidence(&h, f, in)
+
+	if h.Subject != subject {
+		t.Errorf("the hypothesis is not attributed: %v", h.Subject)
+	}
+	if len(h.Evidence.Claims) != 1 {
+		t.Errorf("the scan's evidence was not carried: %d claims", len(h.Evidence.Claims))
+	}
+	if len(h.Unknowns) != 1 {
+		t.Errorf("the open questions were not carried: %v", h.Unknowns)
+	}
+}
+
+// TestAHypothesisWithoutEvidenceIsStillUsable. `attack plan` reads a findings
+// file and works offline, so a caller with no artifact must get the behaviour
+// it had before this existed rather than an error or an empty plan.
+func TestAHypothesisWithoutEvidenceIsStillUsable(t *testing.T) {
+	f := planFinding()
+	var h Hypothesis
+	attachEvidence(&h, f, PlanInput{Root: ".", Findings: []findings.Finding{f}})
+
+	if !h.Subject.Zero() {
+		t.Errorf("a hypothesis built without evidence invented a subject: %v", h.Subject)
+	}
+	if len(h.Evidence.Claims) != 0 || len(h.Unknowns) != 0 {
+		t.Error("a hypothesis built without evidence carries claims or unknowns from nowhere")
+	}
+}
+
+// TestAssumptionsNameWhatWasNotEstablished. Stating them is what lets a reader
+// disagree with the hypothesis rather than only with its result, and every
+// entry must be something nox did NOT establish.
+func TestAssumptionsNameWhatWasNotEstablished(t *testing.T) {
+	got := assumptionsOf(planFinding(), "POST /chat")
+	joined := strings.Join(got, " | ")
+
+	for _, want := range []string{
+		"reachable by an attacker", // the entry point is assumed reachable
+		"is the one that executes", // the static path is assumed to be the real one
+		"reachable at runtime",     // no reach level was recorded on this finding
+		"incomplete",               // the file carries an analysis limitation
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the assumptions do not mention %q:\n%s", want, joined)
+		}
+	}
+
+	// A finding whose reachability WAS established should not carry the
+	// assumption that it was not.
+	established := planFinding()
+	established.Metadata["reach_level"] = "symbol_referenced"
+	if strings.Contains(strings.Join(assumptionsOf(established, "e"), " "), "reachable at runtime") {
+		t.Error("a finding with a recorded reach level still assumes nothing established it")
+	}
+}
+
+// TestTheRunnerUsesTheCarriedEvidence is the acceptance criterion at the
+// consumer. A run that rebuilt its own thin ledger would pass every test above
+// and still discard what it was handed.
+func TestTheRunnerUsesTheCarriedEvidence(t *testing.T) {
+	subject := evidence.Subject{Kind: evidence.SubjectFlow, ID: "flow-9"}
+	h := Hypothesis{
+		ID: "hyp-x", Rationale: "grounding",
+		Evidence: evidence.Ledger{Claims: []evidence.Claim{{
+			Kind: evidence.KindStatic, Subject: subject,
+			Statement: "the scan established this",
+		}}},
+	}
+	l := groundingLedger(h, "2026-08-31T00:00:00Z")
+
+	var carried bool
+	for _, c := range l.Claims {
+		if c.Statement == "the scan established this" {
+			carried = true
+			if c.Subject != subject {
+				t.Errorf("a carried claim was re-attributed from %v to %v. It is "+
+					"evidence about that proposition, not about this hypothesis's "+
+					"invariant, and re-attributing it is the promotion the "+
+					"reproduction hierarchy exists to prevent", subject, c.Subject)
+			}
+		}
+	}
+	if !carried {
+		t.Error("the runner rebuilt its ledger and discarded what the scan established")
+	}
+}

--- a/core/attack/model.go
+++ b/core/attack/model.go
@@ -3,6 +3,7 @@ package attack
 import (
 	"sort"
 
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/catalog"
 )
 
@@ -105,6 +106,41 @@ type Hypothesis struct {
 	Path []PathStep `json:"path"`
 	// InvariantIDs are the invariants a successful attack would violate.
 	InvariantIDs []string `json:"invariant_ids"`
+
+	// Everything below is the deterministic handoff between passive analysis
+	// and active verification. The scan produces the hypothesis; the attack
+	// fills in the observation. Without these, `nox attack` rediscovers why nox
+	// considered this worth testing — badly, because it cannot see the evidence
+	// the scan gathered and discarded.
+
+	// Subject is the proposition this hypothesis is about, typed. A run's
+	// claims are filed against it, so a reproduction confirms this and nothing
+	// above it — see the reproduction hierarchy in nox-core.
+	Subject evidence.Subject `json:"subject,omitzero"`
+	// Evidence is what the SCAN established, carried rather than rebuilt. The
+	// runner previously seeded a ledger with one heuristic claim restating the
+	// rationale, which is a thinner record than the scan already held.
+	Evidence evidence.Ledger `json:"evidence,omitzero"`
+	// AttackerInput names the input an attacker would control — the field,
+	// parameter or header the payload enters through.
+	AttackerInput string `json:"attacker_input,omitempty"`
+	// TriggerCondition states, in words, what would have to hold for the
+	// objective to be reached. It is a suspicion, not a constraint: nox records
+	// no path constraints (see docs/research/smt-spike), so this is what a
+	// person or a producer believes rather than something solved.
+	TriggerCondition string `json:"trigger_condition,omitempty"`
+	// ExpectedOracle names what would settle this if the attack ran — chosen
+	// when the hypothesis is built rather than at fire time, so a reader of the
+	// plan knows what success would look like before anything executes.
+	ExpectedOracle string `json:"expected_oracle,omitempty"`
+	// Assumptions are the things taken as true without evidence. Stating them
+	// is what lets a reader disagree with the hypothesis rather than only with
+	// its result.
+	Assumptions []string `json:"assumptions,omitempty"`
+	// Unknowns are the questions still open about this subject, cheapest first
+	// — adjudicate.MissingEvidence, carried across the boundary. They are why
+	// this is a hypothesis rather than a conclusion.
+	Unknowns []string `json:"unknowns,omitempty"`
 }
 
 // Scenario is a reusable attack template in the V1 library: a class of exploit,

--- a/core/attack/plan.go
+++ b/core/attack/plan.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/analyzers/ai"
 	"github.com/nox-hq/nox/core/findings"
 )
@@ -54,6 +55,22 @@ type PlanInput struct {
 	Inventory *ai.Inventory
 	// Now is an RFC3339 timestamp stamped onto the plan.
 	Now string
+
+	// Evidence returns what the scan established about a finding, and the
+	// subject its claims were filed against. Optional: a caller that has no
+	// reasoning store passes nil and every hypothesis carries an empty ledger,
+	// which is the old behaviour.
+	//
+	// It is a function rather than a map because the caller owns the subject
+	// derivation. Duplicating that here would put two implementations of
+	// "which subject is this finding about" in the tree, and they would
+	// disagree the first time one changed.
+	Evidence func(findings.Finding) (evidence.Subject, evidence.Ledger)
+
+	// Unknowns returns the open questions about a subject, cheapest first —
+	// adjudicate.MissingEvidence, supplied by the caller so this package does
+	// not depend on the capability registry. Optional.
+	Unknowns func(evidence.Subject) []string
 }
 
 // Plan is the attack blueprint: the assets and boundaries derived from the scan,
@@ -139,7 +156,9 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 		fpShort := shortID(f.Fingerprint)
 		for _, sid := range []string{ScenarioPIDirect, ScenarioPIIndirect} {
 			usedScenarios[sid] = true
-			hyps = append(hyps, injectionHypothesis(sid, f, entry, fpShort))
+			h := injectionHypothesis(sid, f, entry, fpShort)
+			attachEvidence(&h, f, in)
+			hyps = append(hyps, h)
 		}
 	}
 
@@ -235,7 +254,78 @@ func injectionHypothesis(scenarioID string, f findings.Finding, entry, fpShort s
 		EntryPoint:          entry,
 		Path:                path,
 		InvariantIDs:        invIDs,
+		AttackerInput:       attackerInputOf(f),
+		TriggerCondition:    triggerConditionOf(f, scen),
+		ExpectedOracle:      scen.Category,
+		Assumptions:         assumptionsOf(f, entry),
 	}
+}
+
+// attachEvidence carries what the scan established onto the hypothesis.
+//
+// This is the acceptance criterion for Milestone D: given a scan result, `nox
+// attack` must be able to consume a hypothesis without rediscovering why nox
+// considered it worth testing. The runner previously seeded its ledger with a
+// single heuristic claim restating the rationale — a thinner record than the
+// scan already held and then threw away.
+//
+// A caller that supplies neither function gets exactly the old behaviour: an
+// empty ledger, no subject, no unknowns. That keeps `nox attack plan` usable
+// from a findings file alone, which is how it is used offline.
+func attachEvidence(h *Hypothesis, f findings.Finding, in PlanInput) {
+	if in.Evidence != nil {
+		subject, ledger := in.Evidence(f)
+		h.Subject = subject
+		h.Evidence = ledger
+	}
+	if in.Unknowns != nil && !h.Subject.Zero() {
+		h.Unknowns = in.Unknowns(h.Subject)
+	}
+}
+
+// attackerInputOf names the input an attacker would control, from what the
+// finding recorded. Empty when the finding does not say — an invented field
+// name would read as knowledge.
+func attackerInputOf(f findings.Finding) string {
+	for _, k := range []string{"source_var", "field", "parameter", "source"} {
+		if v := f.Metadata[k]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// triggerConditionOf states what would have to hold, in words.
+//
+// A suspicion, not a constraint. nox records no path constraints at all (see
+// docs/research/smt-spike/RESULT.md), so this is what the scenario believes
+// rather than something derived, and it says so rather than implying a
+// precision it does not have.
+func triggerConditionOf(f findings.Finding, scen Scenario) string {
+	input := attackerInputOf(f)
+	if input == "" {
+		input = "the attacker-controlled input"
+	}
+	return "suspected: " + input + " reaches the " + scen.Category +
+		" sink without being neutralised for that context"
+}
+
+// assumptionsOf states what the hypothesis takes as true without evidence.
+//
+// Naming them is what lets a reader disagree with the hypothesis rather than
+// only with its result. Every entry here is something nox did NOT establish.
+func assumptionsOf(f findings.Finding, entry string) []string {
+	out := []string{
+		"the entry point " + entry + " is reachable by an attacker",
+		"the code path observed statically is the one that executes",
+	}
+	if f.Metadata["reach_level"] == "" {
+		out = append(out, "nothing established that this code is reachable at runtime")
+	}
+	if lim := f.Metadata["analysis_limitations"]; lim != "" {
+		out = append(out, "the analysis of this file was incomplete ("+lim+")")
+	}
+	return out
 }
 
 // toolCapabilities classifies one tool by name and capability tags into whether

--- a/core/attack/run.go
+++ b/core/attack/run.go
@@ -357,6 +357,18 @@ func InvariantSubject(h Hypothesis) evidence.Subject {
 // deterministic oracle can add that.
 func groundingLedger(h Hypothesis, now string) *evidence.Ledger {
 	l := &evidence.Ledger{}
+	// What the SCAN established, carried on the hypothesis rather than
+	// rediscovered. Milestone D: the scan produces the hypothesis, the attack
+	// fills in the observation, and a run that rebuilt a one-claim ledger from
+	// the rationale was discarding the better record it had been handed.
+	//
+	// Claims arrive with their own subjects — a candidate, a flow — and keep
+	// them. They are evidence about those propositions and not about this
+	// hypothesis's invariant, so re-attributing them would be exactly the
+	// promotion the reproduction hierarchy exists to prevent.
+	for _, c := range h.Evidence.Claims {
+		l.Add(c)
+	}
 	l.Add(evidence.Claim{
 		Kind:      evidence.KindHeuristic,
 		Subject:   InvariantSubject(h),

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -453,6 +453,43 @@ with nothing to consume it. Measuring first cost an afternoon.
 The measurement is committed and re-runnable, so if the flow count rises by an
 order of magnitude the question can be re-asked rather than re-argued.
 
+## Milestone D — landed
+
+The scan produces the hypothesis; the attack fills in the observation. Before
+this, the attack rediscovered it, and badly: the runner seeded its ledger with a
+single heuristic claim restating the rationale, while the scan had already
+gathered better evidence and thrown it away — the ledger is out-of-band and dies
+with the scan.
+
+`Hypothesis` now carries the subject, the scan's ledger, the attacker-controlled
+input, a suspected trigger condition, the expected oracle, the assumptions, and
+the open questions. `groundingLedger` uses what it was handed instead of
+rebuilding a thinner version, and carried claims keep their own subjects — they
+are evidence about a candidate or a flow, not about this hypothesis's invariant,
+and re-attributing them would be exactly the promotion G exists to prevent.
+
+**The handoff is the Track I artifact.** `nox attack plan --evidence
+evidence.json` reads what `nox scan --evidence-out` kept. That was not planned:
+the artifact was built for replay, and it turns out to hold precisely what D
+asks to cross the boundary — input identity, claims with provenance, subjects,
+capability state. Measured on the `core/confirm` fixtures: without it a
+hypothesis carries no subject, no claims and no unknowns; with it, a typed
+subject, the scan's claims, six open questions and three assumptions.
+
+**Assumptions are the part worth arguing with.** They name what nox did NOT
+establish — that the entry point is attacker-reachable, that the static path is
+the one that executes, that nothing showed the code reachable at runtime, that
+the file carried an analysis limitation. Stating them is what lets a reader
+disagree with the hypothesis rather than only with its result.
+
+Everything is optional. A caller with no artifact gets what it had before, which
+keeps `attack plan` usable from a findings file alone — its offline case.
+
+The `trigger_condition` says "suspected" in the string, deliberately. nox
+records no path constraints at all (see the SMT spike), so this is what the
+scenario believes rather than something derived, and it should not read as a
+precision nox does not have.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
> Scan produces the hypothesis; attack fills in the observation.

Before this the attack **rediscovered** it, badly: the runner seeded its ledger with a single heuristic claim restating the rationale, while the scan had already gathered better evidence and thrown it away. The ledger is out-of-band and dies with the scan.

## What a hypothesis now carries

`subject` · `evidence` (the scan's ledger) · `attacker_input` · `trigger_condition` · `expected_oracle` · `assumptions` · `unknowns`

`groundingLedger` uses what it was handed instead of rebuilding a thinner version. **Carried claims keep their own subjects** — they're evidence about a candidate or a flow, not about this hypothesis's invariant, and re-attributing them would be exactly the promotion G exists to prevent.

## The handoff turned out to already exist

```sh
nox scan . --evidence-out evidence.json
nox attack plan --evidence evidence.json
```

That wasn't planned. The artifact was built for **replay** in Milestone I, and it holds precisely what D asks to cross the boundary: input identity, claims with provenance, typed subjects, capability state.

Measured on the `core/confirm` fixtures:

| | without `--evidence` | with |
|---|---|---|
| subject | `None` | `candidate:AGENTFLOW-001@vulnerable_app.py:50` |
| claims carried | 0 | 1 |
| unknowns | 0 | 6 |
| assumptions | 3 | 3 |

## Assumptions are the part worth arguing with

They name what nox did **not** establish — that the entry point is attacker-reachable, that the static path is the one that executes, that nothing showed the code reachable at runtime, that the file carried an analysis limitation.

Stating them is what lets a reader disagree with the *hypothesis* rather than only with its result.

`trigger_condition` says **"suspected"** in the string, deliberately. nox records no path constraints at all — the SMT spike measured that — so this is what the scenario believes, not something derived, and it must not read as a precision nox doesn't have.

Everything is optional: a caller with no artifact gets what it had before, keeping `attack plan` usable from a findings file alone.

## The flag guard fired twice

It caught that `--evidence` needed an inventory entry, **and** that my help text mentioned `--evidence-out` — a flag this command doesn't have — which reads as advertising it. Third time that guard has fired this session.

## Falsification

| what was broken | what failed |
|---|---|
| runner discards carried evidence | `the runner rebuilt its ledger and discarded what the scan established` |
| plan drops subject and evidence | `the hypothesis is not attributed` + `the scan's evidence was not carried: 0 claims` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

**Eleven of thirteen milestones.** Remaining: J (directed active verification) and M (Intel verification knowledge).

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW