### PR TITLE
M: intel supplies propositions, and local nox decides whether they apply

### DIFF
--- a/core/intel/propositions.go
+++ b/core/intel/propositions.go
@@ -1,0 +1,206 @@
+package intel
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// ResearchProposition is a structured claim an intelligence source makes about
+// a package, ahead of or alongside a published advisory.
+//
+// Milestone M's shape: intel should be able to say more than "CVE-X affects
+// package@version". It can carry the affected symbol, a trigger condition, an
+// affected configuration, known entry points, a proof-of-concept hypothesis, an
+// oracle, reproduction evidence, known refutations and maintainer evidence.
+//
+// # The invariant this type exists to hold
+//
+// Intel provides evidence. It does not decide what affects a repository.
+//
+// Every proposition here is about a PACKAGE — a thing that exists in the world,
+// independent of anyone's code. Whether it applies to a particular repository is
+// a different proposition, about a candidate or a flow in that repository, and
+// only local analysis can establish it. A researcher's confidence that a
+// symbol is dangerous says nothing about whether this build calls it.
+//
+// core/reasoning already refuses to record an advisory as evidence about a
+// candidate, for exactly this reason, and left the package side unbuilt. This
+// is that side. The claims it produces are filed against the package subject
+// and can never reach a candidate's ledger, because aggregation is per-subject
+// and the two subjects differ.
+type ResearchProposition struct {
+	// Ecosystem and Package identify what this is about.
+	Ecosystem string `json:"ecosystem"`
+	Package   string `json:"package"`
+	// Advisory is the identifier, when one exists. Empty for research that
+	// precedes publication — which is the case M is really for, since an
+	// unpublished finding is where intel could help before OSV can.
+	Advisory string `json:"advisory,omitempty"`
+
+	// AffectedSymbols are the import paths or symbols the research names.
+	// Local nox tests whether the build references them; intel does not know.
+	AffectedSymbols []string `json:"affected_symbols,omitempty"`
+	// TriggerCondition is what the researcher believes must hold. Words, not
+	// constraints: nox records no path constraints and neither does this.
+	TriggerCondition string `json:"trigger_condition,omitempty"`
+	// AffectedConfiguration narrows it to a configuration, when it applies only
+	// under one.
+	AffectedConfiguration string `json:"affected_configuration,omitempty"`
+	// KnownEntryPoints are entry points the research observed reaching it.
+	// Whether THIS application has them is a local question.
+	KnownEntryPoints []string `json:"known_entry_points,omitempty"`
+	// PoCHypothesis describes an attack the research believes would work.
+	PoCHypothesis string `json:"poc_hypothesis,omitempty"`
+	// Oracle names what would settle it.
+	Oracle string `json:"oracle,omitempty"`
+
+	// Maturity is how far the research got, and it is what stops a hypothesis
+	// being read as a fact.
+	Maturity Maturity `json:"maturity"`
+	// Refutations are what argues against it — a maintainer disputing it, a
+	// reproduction that did not hold. Carried because a source that only
+	// forwards supporting evidence is a source that cannot be checked.
+	Refutations []string `json:"refutations,omitempty"`
+	// ReporterCount is the number of DISTINCT reporters, never observations.
+	// One project scanning itself a thousand times is one source.
+	ReporterCount int `json:"reporter_count,omitempty"`
+	// Attested records whether any of it came from a source whose identity the
+	// service could check. Anonymous intake is deliberate; treating anonymous
+	// corroboration as attestation would not be.
+	Attested bool `json:"attested,omitempty"`
+}
+
+// Maturity is the research ladder, weakest first.
+//
+// It exists so a zero-day can begin benefiting users before publication without
+// pretending to a certainty it does not have. Each rung maps to an evidence
+// kind, and the mapping is the whole safety property: a hypothesis cannot enter
+// a local ledger at advisory strength however confident its author was.
+type Maturity string
+
+const (
+	// MaturityHypothesis — a researcher believes there is something here.
+	MaturityHypothesis Maturity = "research_hypothesis"
+	// MaturityIndependent — distinct reporters have seen it.
+	MaturityIndependent Maturity = "independent_observation"
+	// MaturityStatic — static analysis established it against the package.
+	MaturityStatic Maturity = "static_confirmation"
+	// MaturityReproduced — a controlled reproduction held.
+	MaturityReproduced Maturity = "controlled_reproduction"
+	// MaturityMaintainer — the maintainer confirmed it.
+	MaturityMaintainer Maturity = "maintainer_confirmed"
+	// MaturityAdvisory — it is published.
+	MaturityAdvisory Maturity = "public_advisory"
+)
+
+// kind maps a maturity rung to the evidence kind it may enter a ledger at.
+//
+// An unrecognised rung maps to KindHeuristic rather than to something in the
+// middle: a maturity this build does not understand is not evidence of
+// anything, and reading it generously is how a source's vocabulary becomes a
+// consumer's verdict.
+func (m Maturity) kind() evidence.Kind {
+	switch m {
+	case MaturityIndependent:
+		return evidence.KindIndependentObservation
+	case MaturityStatic:
+		return evidence.KindStatic
+	case MaturityReproduced:
+		return evidence.KindControlledReproduction
+	case MaturityMaintainer:
+		return evidence.KindMaintainerConfirmed
+	case MaturityAdvisory:
+		return evidence.KindPublicAdvisory
+	case MaturityHypothesis:
+		return evidence.KindResearchHypothesis
+	default:
+		return evidence.KindHeuristic
+	}
+}
+
+// PackageSubject is the subject a proposition about a package is filed against.
+//
+// Deliberately distinct from any candidate, flow or finding subject in the
+// scanned repository. Aggregation is per-subject, so this is the mechanism that
+// keeps a researcher's confidence about a library from becoming confidence
+// about somebody's code.
+func PackageSubject(ecosystem, pkg string) evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectPackage, ID: ecosystem + "/" + pkg}
+}
+
+// Claims converts a proposition into evidence about the package, and nothing
+// else.
+//
+// Refutations become refuting claims rather than being dropped. A source that
+// forwards only what supports its conclusion cannot be checked, and the
+// polarity model exists precisely so disagreement survives transport.
+func (p ResearchProposition) Claims(source, observedAt string) []evidence.Claim {
+	subject := PackageSubject(p.Ecosystem, p.Package)
+	var out []evidence.Claim
+
+	prov := func() evidence.Provenance {
+		return evidence.Provenance{
+			Source: source, SourceID: p.Advisory, ObservedAt: observedAt,
+			Reference: p.Advisory,
+		}
+	}
+
+	if s := p.statement(); s != "" {
+		out = append(out, evidence.Claim{
+			Kind: p.Maturity.kind(), Subject: subject,
+			Statement: s, Provenance: prov(),
+		})
+	}
+	for _, r := range p.Refutations {
+		out = append(out, evidence.Claim{
+			Kind: evidence.KindStatic, Subject: subject,
+			Polarity: evidence.PolarityRefutes, Statement: r, Provenance: prov(),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Statement < out[j].Statement })
+	return out
+}
+
+func (p ResearchProposition) statement() string {
+	switch {
+	case p.PoCHypothesis != "":
+		return p.PoCHypothesis
+	case p.TriggerCondition != "":
+		return p.TriggerCondition
+	case len(p.AffectedSymbols) > 0:
+		return "research names " + p.AffectedSymbols[0] + " as affected"
+	case p.Advisory != "":
+		return p.Advisory + " affects this package"
+	default:
+		return ""
+	}
+}
+
+// AppliesLocally reports what a local scan would still have to establish for
+// this proposition to matter here.
+//
+// It returns questions, not answers, and that is the point. Intel can say a
+// symbol is dangerous; only the local build can say whether it is referenced,
+// only local analysis can say whether anything reaches it, and only an
+// authorized run can say whether it fires. A source that answered these would
+// be deciding what affects a repository it has never seen.
+func (p ResearchProposition) AppliesLocally() []string {
+	var q []string
+	if len(p.AffectedSymbols) > 0 {
+		q = append(q, "does this build reference "+p.AffectedSymbols[0]+"?")
+	}
+	if p.AffectedConfiguration != "" {
+		q = append(q, "is this deployment configured as "+p.AffectedConfiguration+"?")
+	}
+	if len(p.KnownEntryPoints) > 0 {
+		q = append(q, "does this application expose "+p.KnownEntryPoints[0]+"?")
+	}
+	if p.TriggerCondition != "" {
+		q = append(q, "can the trigger condition be reached here?")
+	}
+	if len(q) == 0 {
+		q = append(q, "does this package appear in this build at all?")
+	}
+	return q
+}

--- a/core/intel/propositions_test.go
+++ b/core/intel/propositions_test.go
@@ -1,0 +1,124 @@
+package intel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/intel"
+)
+
+func proposition() intel.ResearchProposition {
+	return intel.ResearchProposition{
+		Ecosystem: "Go", Package: "golang.org/x/crypto", Advisory: "GO-2026-9999",
+		AffectedSymbols:  []string{"golang.org/x/crypto/ssh"},
+		TriggerCondition: "a client presents a crafted key exchange",
+		KnownEntryPoints: []string{"ssh.NewServerConn"},
+		PoCHypothesis:    "a malformed KEX packet bypasses the source-address check",
+		Maturity:         intel.MaturityReproduced,
+	}
+}
+
+// TestIntelEvidenceIsAboutThePackageAndNothingElse is Milestone M's invariant.
+//
+// Intel provides evidence; it does not decide what affects a repository. Every
+// proposition is about a PACKAGE — a thing in the world, independent of anyone's
+// code. Whether it applies here is a different proposition, about a candidate or
+// a flow in this repository, and only local analysis can establish it.
+//
+// core/reasoning already refuses to record an advisory as evidence about a
+// candidate and left the package side unbuilt. Aggregation is per-subject, so
+// filing against a distinct subject is the mechanism — not a convention — that
+// keeps a researcher's confidence about a library from becoming confidence
+// about somebody's code.
+func TestIntelEvidenceIsAboutThePackageAndNothingElse(t *testing.T) {
+	claims := proposition().Claims("nox-intel", "2026-08-31T00:00:00Z")
+	if len(claims) == 0 {
+		t.Fatal("a proposition produced no claims")
+	}
+	want := intel.PackageSubject("Go", "golang.org/x/crypto")
+	for _, c := range claims {
+		if c.Subject != want {
+			t.Errorf("a claim is filed against %v, not the package", c.Subject)
+		}
+		if c.Subject.Kind != evidence.SubjectPackage {
+			t.Errorf("claim subject kind is %q; anything but package lets intel's "+
+				"authority reach a local proposition", c.Subject.Kind)
+		}
+	}
+
+	// The decisive check: this evidence must not raise confidence about a
+	// candidate in the scanned repository, whatever its strength.
+	candidate := evidence.Subject{Kind: evidence.SubjectCandidate, ID: "VULN-001@go.mod:1"}
+	l := evidence.Ledger{Claims: claims}
+	if got := l.ConfidenceAbout(candidate); got != evidence.ConfidenceLow {
+		t.Errorf("a maintainer-grade intel claim about a package raised confidence "+
+			"about a local candidate to %s. Intel would then be deciding what "+
+			"affects a repository it has never seen", got)
+	}
+	// And it must raise confidence about the package, or it is carrying nothing.
+	if got := l.ConfidenceAbout(want); got == evidence.ConfidenceLow {
+		t.Error("a controlled-reproduction claim did not raise confidence even about " +
+			"the package it is explicitly about")
+	}
+}
+
+// TestMaturityCannotBeUpgradedByConfidence. The ladder exists so an unpublished
+// finding can help before OSV can, without pretending to certainty. A hypothesis
+// entering a ledger at advisory strength would defeat the whole point.
+func TestMaturityCannotBeUpgradedByConfidence(t *testing.T) {
+	p := proposition()
+	p.Maturity = intel.MaturityHypothesis
+	claims := p.Claims("nox-intel", "t")
+	if len(claims) == 0 {
+		t.Fatal("no claims")
+	}
+	if claims[0].Kind == evidence.KindPublicAdvisory ||
+		claims[0].Kind == evidence.KindMaintainerConfirmed {
+		t.Errorf("a research hypothesis entered the ledger at %q", claims[0].Kind)
+	}
+
+	// An unrecognised rung must not be read generously.
+	p.Maturity = intel.Maturity("very-confident-honestly")
+	claims = p.Claims("nox-intel", "t")
+	if claims[0].Kind != evidence.KindHeuristic {
+		t.Errorf("an unrecognised maturity entered at %q; a vocabulary this build "+
+			"does not understand is not evidence of anything", claims[0].Kind)
+	}
+}
+
+// TestRefutationsSurviveTransport. A source that forwards only what supports its
+// conclusion cannot be checked. The polarity model exists so disagreement
+// survives the wire.
+func TestRefutationsSurviveTransport(t *testing.T) {
+	p := proposition()
+	p.Refutations = []string{"the maintainer disputes that the check is reachable"}
+	var refuting int
+	for _, c := range p.Claims("nox-intel", "t") {
+		if c.Refutes() {
+			refuting++
+		}
+	}
+	if refuting != 1 {
+		t.Errorf("%d refuting claims; a disputed proposition arrived as though "+
+			"nobody had disputed it", refuting)
+	}
+}
+
+// TestAppliesLocallyReturnsQuestions. Intel can say a symbol is dangerous; only
+// the local build can say whether it is referenced. A source that answered
+// these would be deciding what affects a repository it has never seen.
+func TestAppliesLocallyReturnsQuestions(t *testing.T) {
+	for _, q := range proposition().AppliesLocally() {
+		if !strings.HasSuffix(q, "?") {
+			t.Errorf("%q is not a question. This method exists to hand work back "+
+				"to local analysis, not to answer it", q)
+		}
+	}
+	// Even a proposition with nothing specific still asks something local.
+	bare := intel.ResearchProposition{Ecosystem: "npm", Package: "left-pad"}
+	if len(bare.AppliesLocally()) == 0 {
+		t.Error("a bare proposition asks nothing locally, so it would be applied " +
+			"without any local test at all")
+	}
+}

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -490,6 +490,49 @@ records no path constraints at all (see the SMT spike), so this is what the
 scenario believes rather than something derived, and it should not read as a
 precision nox does not have.
 
+## Milestone M — the client half landed; the service half is a conversation
+
+M's shape: intel should say more than "CVE-X affects package@version". It can
+carry the affected symbol, a trigger condition, an affected configuration, known
+entry points, a PoC hypothesis, an oracle, reproduction evidence, known
+refutations and maintainer evidence — and **local nox then determines whether
+those propositions apply here**.
+
+That last clause is the whole milestone, and it was already half-built. The
+reasoning shim refuses to record an advisory as evidence about a candidate, with
+a comment saying why — an advisory is about a PACKAGE, and a finding is about a
+CANDIDATE — and it closes "the package subject and its advisory claim belong to
+Track G". That side was never built. `core/intel.ResearchProposition` is it.
+
+**Three properties, each enforced rather than documented:**
+
+Every claim is filed against `SubjectPackage`, and aggregation is per-subject,
+so a maintainer-grade intel claim about a library leaves confidence about a
+local candidate at LOW. That is the mechanism, not a convention: intel cannot
+decide what affects a repository it has never seen.
+
+The maturity ladder maps to evidence kinds, and an **unrecognised rung maps to
+`KindHeuristic`** rather than to something in the middle. A vocabulary this
+build does not understand is not evidence of anything, and reading it generously
+is how a source's words become a consumer's verdict.
+
+**Refutations survive transport.** A source that forwards only what supports its
+conclusion cannot be checked. `nox-intelligence` currently has no way to record
+a dispute — verified twice earlier in this programme — so this is the receiving
+end being ready before the sending end exists.
+
+`AppliesLocally` returns **questions, not answers**: does this build reference
+the symbol, is this deployment configured that way, does this application expose
+that entry point. Intel can say a symbol is dangerous; only the local build can
+say whether it is referenced.
+
+**Not built, deliberately:** the service side. Emitting these propositions means
+extending the query payload and the disclosure model in a private repository,
+and it is a design conversation before it is code — what a researcher may
+assert, what publication requires, how an unpublished hypothesis reaches a user
+without becoming a claim nox cannot support. The client is ready to receive
+them, which is the half that can be got right in the open.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
M's shape: intel should say more than *"CVE-X affects package@version"* — affected symbol, trigger condition, affected configuration, known entry points, PoC hypothesis, oracle, reproduction evidence, known refutations, maintainer evidence — and **local nox then determines whether any of it applies here.**

That last clause is the milestone, and it was **already half-built**. `core/reasoning` refuses to record an advisory as evidence about a candidate, with a comment saying why — an advisory is about a *package*, a finding is about a *candidate* — and closes:

> The package subject and its advisory claim belong to Track G.

That side was never built. `ResearchProposition` is it.

## Three properties, enforced rather than documented

**Every claim is filed against `SubjectPackage`.** Aggregation is per-subject, so a maintainer-grade intel claim about a library leaves confidence about a local candidate at `LOW`. That's the mechanism, not a convention — intel cannot decide what affects a repository it has never seen.

**An unrecognised maturity rung maps to `KindHeuristic`**, not to something in the middle. A vocabulary this build doesn't understand is not evidence of anything, and reading it generously is how a source's words become a consumer's verdict.

**Refutations survive transport.** A source that forwards only what supports its conclusion cannot be checked. `nox-intelligence` currently has *no way to record a dispute* — verified twice earlier in this programme — so this is the receiving end being ready before the sending end exists.

`AppliesLocally` returns **questions, not answers**:

```
does this build reference golang.org/x/crypto/ssh?
does this application expose ssh.NewServerConn?
can the trigger condition be reached here?
```

Intel can say a symbol is dangerous; only the local build can say whether it's referenced.

## Not built, deliberately

**The service side.** Emitting these propositions means extending the query payload and the disclosure model in a private repository, and that's a design conversation before it's code: what a researcher may assert, what publication requires, how an unpublished hypothesis reaches a user without becoming a claim nox can't support.

The client is ready to receive them — the half that can be got right in the open.

## Falsification

| what was broken | what failed |
|---|---|
| file against a candidate subject | `claim subject kind is "candidate"; anything but package lets intel's authority reach a local proposition` |
| read an unrecognised maturity generously | `an unrecognised maturity entered at "public_advisory"` |
| drop refutations in transport | `0 refuting claims; a disputed proposition arrived as though nobody had disputed it` |

The third needed a second attempt — my first mutation didn't compile, and a build error is not evidence about a test.

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

**Twelve of thirteen.** Only J remains.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW