### PR TITLE
J: measure hypotheses resolved per unit of effort, not coverage

### DIFF
--- a/cli/attack_cmd.go
+++ b/cli/attack_cmd.go
@@ -478,6 +478,20 @@ func printRunSummary(r *attack.Result, output string) {
 	if r.BudgetStop != "" {
 		fmt.Printf("  stopped early: %s (affected traces are INCONCLUSIVE, not prevented)\n", r.BudgetStop)
 	}
+
+	// The verification-effort metric: hypotheses resolved per probe, not
+	// coverage. A run that fired many probes and decided nothing reads worse
+	// here than a small run that decided something, which is the comparison a
+	// coverage number cannot make.
+	e := r.Efficiency()
+	fmt.Printf("  resolved %d of %d hypotheses in %d attempt(s)", e.Resolved, e.Hypotheses, e.Attempts)
+	if e.Resolved > 0 {
+		fmt.Printf(" — %.1f attempts per resolution", e.AttemptsPerResolution())
+	} else {
+		fmt.Print(" — this run decided nothing")
+	}
+	fmt.Println()
+
 	fmt.Printf("[attack] wrote %s\n", output)
 }
 

--- a/core/attack/resolution.go
+++ b/core/attack/resolution.go
@@ -1,0 +1,145 @@
+package attack
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// Resolution is what one hypothesis's verification achieved, and what it cost.
+//
+// Milestone J's metric is hypotheses resolved per unit of verification effort,
+// not generic coverage. A fuzzer that fired a million probes and confirmed
+// nothing has done worse than one that fired three and confirmed one, and a
+// coverage number cannot tell them apart. This can.
+//
+// "Resolved" is deliberately three-valued. A hypothesis is confirmed, refuted,
+// or left inconclusive, and the third is not a failure of the harness — it is
+// the honest state of a thing that was tested and did not decide, which is most
+// of them. Counting only confirmations would make the harness look worse the
+// more careful it was.
+type Resolution struct {
+	HypothesisID string           `json:"hypothesis_id"`
+	Subject      evidence.Subject `json:"subject"`
+	// Outcome is where the hypothesis ended: confirmed, refuted, inconclusive,
+	// or not-run.
+	Outcome ResolutionOutcome `json:"outcome"`
+	// Attempts is how many probes this hypothesis cost — the denominator of the
+	// metric. A hypothesis resolved in three attempts is cheaper than the same
+	// resolution in three hundred.
+	Attempts int `json:"attempts"`
+	// Exploitability is the lifecycle state the run derived.
+	Exploitability evidence.Exploitability `json:"exploitability"`
+	// Note carries the trace's own explanation.
+	Note string `json:"note,omitempty"`
+}
+
+// ResolutionOutcome is the three-plus-one states a hypothesis can end in.
+type ResolutionOutcome string
+
+const (
+	// ResolvedConfirmed — a reproduced violation under a sound control.
+	ResolvedConfirmed ResolutionOutcome = "confirmed"
+	// ResolvedRefuted — the attack ran and the objective was not achievable.
+	// Distinct from inconclusive: something was established, in the negative.
+	ResolvedRefuted ResolutionOutcome = "refuted"
+	// ResolvedInconclusive — the attack ran and did not decide. The honest
+	// majority, not a harness failure.
+	ResolvedInconclusive ResolutionOutcome = "inconclusive"
+	// ResolvedNotRun — the hypothesis never executed (profile too low, budget
+	// exhausted before its turn). It cost nothing and resolved nothing.
+	ResolvedNotRun ResolutionOutcome = "not_run"
+)
+
+// Resolutions builds the per-hypothesis accounting from a completed result.
+func (r *Result) Resolutions() []Resolution {
+	out := make([]Resolution, 0, len(r.Traces))
+	for i := range r.Traces {
+		t := &r.Traces[i]
+		out = append(out, Resolution{
+			HypothesisID:   t.HypothesisID,
+			Subject:        InvariantSubject(Hypothesis{ID: t.HypothesisID}),
+			Outcome:        resolutionOf(t),
+			Attempts:       len(t.Attempts),
+			Exploitability: t.Exploitability,
+			Note:           t.Note,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].HypothesisID < out[j].HypothesisID })
+	return out
+}
+
+// resolutionOf reads a trace's outcome into the three-plus-one states.
+//
+// The mapping is deliberately conservative in the direction that matters. Only
+// CONFIRMED is confirmed. A run that executed and reached neither a reproduced
+// violation nor a clean refutation is inconclusive, never "probably fine" —
+// PREVENTED is the kernel's word for an observed defense and is treated as a
+// refutation of THIS hypothesis, because the objective was not reachable, while
+// staying carefully short of "the target is secure".
+func resolutionOf(t *Trace) ResolutionOutcome {
+	switch t.Exploitability {
+	case evidence.Confirmed:
+		return ResolvedConfirmed
+	case evidence.Prevented:
+		return ResolvedRefuted
+	case evidence.Potential, evidence.Plausible:
+		// Never executed, or executed without an attempt reaching a verdict.
+		if !t.Outcome.Executed {
+			return ResolvedNotRun
+		}
+		return ResolvedInconclusive
+	default:
+		// INCONCLUSIVE and anything unrecognised: the run did not decide.
+		return ResolvedInconclusive
+	}
+}
+
+// Efficiency is the metric J asks for: what the verification effort bought.
+type Efficiency struct {
+	Hypotheses   int `json:"hypotheses"`
+	Confirmed    int `json:"confirmed"`
+	Refuted      int `json:"refuted"`
+	Inconclusive int `json:"inconclusive"`
+	NotRun       int `json:"not_run"`
+	// Attempts is the total verification effort, the denominator.
+	Attempts int `json:"attempts"`
+	// Resolved is confirmed + refuted: the hypotheses the run actually decided.
+	Resolved int `json:"resolved"`
+}
+
+// AttemptsPerResolution is the headline number, or zero when nothing resolved.
+//
+// Reported as a ratio rather than a rate because the useful comparison is
+// between runs: a lower number is a harness that decides more per probe. When
+// nothing resolved, the answer is not "infinity" or "zero" but "this run
+// decided nothing", which callers must read from Resolved rather than from a
+// divided value.
+func (e Efficiency) AttemptsPerResolution() float64 {
+	if e.Resolved == 0 {
+		return 0
+	}
+	return float64(e.Attempts) / float64(e.Resolved)
+}
+
+// Efficiency summarises a result against J's metric.
+func (r *Result) Efficiency() Efficiency {
+	var e Efficiency
+	for _, res := range r.Resolutions() {
+		e.Hypotheses++
+		e.Attempts += res.Attempts
+		switch res.Outcome {
+		case ResolvedConfirmed:
+			e.Confirmed++
+			e.Resolved++
+		case ResolvedRefuted:
+			e.Refuted++
+			e.Resolved++
+		case ResolvedInconclusive:
+			e.Inconclusive++
+		case ResolvedNotRun:
+			e.NotRun++
+		}
+	}
+	return e
+}

--- a/core/attack/resolution_test.go
+++ b/core/attack/resolution_test.go
@@ -1,0 +1,152 @@
+package attack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// Milestone J: directed active verification, measured by hypotheses resolved
+// per unit of verification effort — not by coverage.
+//
+// The direction already exists: Run consumes a plan of grounded hypotheses and
+// fires probes toward each. What was missing is the accounting, because a
+// coverage number cannot distinguish a harness that fired a million probes and
+// confirmed nothing from one that fired three and confirmed one. These tests
+// run the real HTTP harness (e2e_test.go) and check the accounting against it.
+
+// TestResolutionIsThreeValued. A hypothesis is confirmed, refuted, or left
+// inconclusive, and the third is the honest majority rather than a failure.
+// Counting only confirmations would make the harness look worse the more
+// careful it was.
+func TestResolutionIsThreeValued(t *testing.T) {
+	cfg := e2eCfg("/vuln")
+	cs := MintCanaries(cfg.Seed)
+	srv := e2eApp(t, cs)
+
+	res, err := Run(context.Background(), piPlan(t), e2eTarget(srv.URL), cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	resolutions := res.Resolutions()
+	if len(resolutions) == 0 {
+		t.Fatal("the run produced no resolutions to account for")
+	}
+	// Every resolution's attempt count is the effort that hypothesis cost, and
+	// a confirmed one must have cost at least one probe — a confirmation from
+	// zero attempts would be a verdict with no verification behind it.
+	var confirmed int
+	for _, r := range resolutions {
+		if r.Outcome == ResolvedConfirmed {
+			confirmed++
+			if r.Attempts == 0 {
+				t.Errorf("%s is confirmed with zero attempts; a verdict with no "+
+					"verification behind it", r.HypothesisID)
+			}
+		}
+	}
+	if confirmed == 0 {
+		t.Fatal("the vulnerable route confirmed nothing; the metric has nothing to measure")
+	}
+}
+
+// TestEfficiencyMeasuresResolutionNotCoverage is the metric itself.
+//
+// attempts-per-resolution is the headline: a lower number is a harness that
+// decides more per probe. The vulnerable route resolves at least one hypothesis,
+// so the ratio is finite and positive; a run that decided nothing reports
+// Resolved=0 rather than a divided value that reads as success.
+func TestEfficiencyMeasuresResolutionNotCoverage(t *testing.T) {
+	cfg := e2eCfg("/vuln")
+	cs := MintCanaries(cfg.Seed)
+	srv := e2eApp(t, cs)
+
+	res, err := Run(context.Background(), piPlan(t), e2eTarget(srv.URL), cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	e := res.Efficiency()
+
+	if e.Hypotheses == 0 {
+		t.Fatal("no hypotheses accounted for")
+	}
+	if e.Attempts == 0 {
+		t.Error("the run reports zero verification effort while resolving hypotheses")
+	}
+	if e.Resolved == 0 {
+		t.Fatal("the vulnerable route resolved nothing")
+	}
+	if e.Confirmed+e.Refuted != e.Resolved {
+		t.Errorf("resolved (%d) is not confirmed+refuted (%d+%d)",
+			e.Resolved, e.Confirmed, e.Refuted)
+	}
+	if e.Confirmed+e.Refuted+e.Inconclusive+e.NotRun != e.Hypotheses {
+		t.Error("the outcomes do not sum to the hypothesis count; something is uncounted")
+	}
+	if apr := e.AttemptsPerResolution(); apr <= 0 {
+		t.Errorf("attempts-per-resolution is %v with a resolution present", apr)
+	}
+	t.Logf("directed verification: %d hypotheses, %d attempts, %d resolved "+
+		"(%d confirmed, %d refuted), %.1f attempts/resolution",
+		e.Hypotheses, e.Attempts, e.Resolved, e.Confirmed, e.Refuted,
+		e.AttemptsPerResolution())
+}
+
+// TestNothingResolvedReportsSoRatherThanDividing. A run that decides nothing
+// must be legible as such, not as a zero or an infinity that a caller might
+// read as a clean result.
+func TestNothingResolvedReportsSoRatherThanDividing(t *testing.T) {
+	// The wrong route: 404 to every probe, so nox reaches no code and resolves
+	// nothing. This is the shape of the bug where a suite printed "fix holds"
+	// for a target it never touched.
+	cfg := e2eCfg("/does-not-exist")
+	cs := MintCanaries(cfg.Seed)
+	srv := e2eApp(t, cs)
+
+	res, err := Run(context.Background(), piPlan(t), e2eTarget(srv.URL), cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	e := res.Efficiency()
+	if e.Confirmed != 0 {
+		t.Errorf("a route that was never reached confirmed %d hypotheses", e.Confirmed)
+	}
+	if apr := e.AttemptsPerResolution(); apr != 0 {
+		t.Errorf("attempts-per-resolution is %v when nothing resolved; the caller "+
+			"must read Resolved=%d, not a divided value", apr, e.Resolved)
+	}
+}
+
+// TestPreventedIsRefutedNotConfirmedAndNotClean. PREVENTED is the kernel's word
+// for an observed defense: the objective was not reachable, so the hypothesis
+// is refuted — resolved, in the negative — but the run must never read it as
+// "the target is secure".
+func TestPreventedIsRefutedNotConfirmed(t *testing.T) {
+	tr := &Trace{
+		HypothesisID: "h", Exploitability: evidence.Prevented,
+		Outcome:  evidence.RunOutcome{Executed: true, DefenseObserved: true},
+		Attempts: []Attempt{{}},
+	}
+	if got := resolutionOf(tr); got != ResolvedRefuted {
+		t.Errorf("a PREVENTED trace resolved as %q, want refuted", got)
+	}
+
+	// And an inconclusive execution is inconclusive, never refuted-by-default.
+	inc := &Trace{
+		HypothesisID: "h2", Exploitability: evidence.Inconclusive,
+		Outcome: evidence.RunOutcome{Executed: true},
+	}
+	if got := resolutionOf(inc); got != ResolvedInconclusive {
+		t.Errorf("an inconclusive run resolved as %q; treating it as decided is how "+
+			"a harness reports progress it did not make", got)
+	}
+
+	// A hypothesis that never executed is not-run, not inconclusive: it cost
+	// nothing and should not dilute the effort denominator.
+	notRun := &Trace{HypothesisID: "h3", Exploitability: evidence.Potential}
+	if got := resolutionOf(notRun); got != ResolvedNotRun {
+		t.Errorf("an unexecuted hypothesis resolved as %q, want not_run", got)
+	}
+}

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -533,6 +533,43 @@ assert, what publication requires, how an unpublished hypothesis reaches a user
 without becoming a claim nox cannot support. The client is ready to receive
 them, which is the half that can be got right in the open.
 
+## Milestone J — landed on existing primitives, measured by the right metric
+
+The milestone is explicit that this does not need a new fuzzer: *initially this
+can work with existing attack primitives.* It does. `Run` already consumes a
+plan of grounded hypotheses and directs probes toward each — the direction is
+there. What was missing is the metric, and the metric is the milestone's real
+content: **hypotheses resolved per unit of verification effort, not coverage.**
+
+A coverage number cannot distinguish a harness that fired a million probes and
+confirmed nothing from one that fired three and confirmed one. `Efficiency` can:
+it reports hypotheses, attempts, and resolutions, and `AttemptsPerResolution` is
+the headline — lower is a harness that decides more per probe.
+
+**Resolution is three-plus-one-valued, and the shape is load-bearing.**
+Confirmed, refuted, inconclusive, not-run. Only CONFIRMED is confirmed. PREVENTED
+is refuted — the objective was not reachable — but the wording stays short of
+"the target is secure". Inconclusive is the honest majority, not a harness
+failure, and counting only confirmations would make the harness look worse the
+more careful it was. Not-run cost nothing and must not dilute the denominator.
+
+**A run that decides nothing says so.** `AttemptsPerResolution` returns zero when
+`Resolved` is zero, and the CLI prints "this run decided nothing" rather than a
+divided value a reader might take for a clean result — the same failure shape as
+a regression suite printing "fix holds" for a target it never reached.
+
+Measured end to end against the real HTTP harness: the vulnerable route resolves
+2 hypotheses in 30 attempts, 15.0 attempts per resolution; the non-existent
+route resolves nothing and reports it. The safe profile simulates, sends
+nothing, and reports 0 attempts and "decided nothing", which is the honest
+reading of a run that executed against no target.
+
+**What this is not.** It is not an autonomous fuzzer firing at arbitrary
+targets. It rests entirely on the existing `Run`, which requires `--authorize`
+for any non-safe profile and selects a network-less adapter for the safe one —
+the passive/active boundary K pins. J adds accounting and a metric on top of
+that boundary, not a new way through it.
+
 ## Proposed order
 
 The proposed A→M sequence is sound. Two adjustments, both from the gaps above:


### PR DESCRIPTION
The milestone is explicit that this needs no new fuzzer: *initially it works on existing attack primitives.* It does. `Run` already consumes a plan of grounded hypotheses and directs probes toward each — the direction is there. What was missing is the **metric**, and the metric is the milestone's real content:

> hypotheses resolved per unit of verification effort, not generic coverage.

## Why a metric, not a fuzzer

A coverage number can't distinguish a harness that fired a million probes and confirmed nothing from one that fired three and confirmed one. `Efficiency` can — hypotheses, attempts, resolutions, and `AttemptsPerResolution` as the headline. Lower is a harness that decides more per probe.

Measured **end to end against the real HTTP harness**:

| route | hypotheses | attempts | resolved | attempts/resolution |
|---|---|---|---|---|
| `/vuln` | 2 | 30 | 2 | 15.0 |
| `/does-not-exist` | — | — | 0 | *this run decided nothing* |
| safe profile (SimTarget) | 4 | 0 | 0 | *decided nothing* |

## Resolution is three-plus-one-valued, and the shape is load-bearing

- **Only `CONFIRMED` is confirmed.**
- **`PREVENTED` is refuted** — the objective wasn't reachable — but the wording stays short of *"the target is secure"*.
- **Inconclusive is the honest majority**, not a harness failure. Counting only confirmations would make the harness look worse the more careful it was.
- **Not-run cost nothing** and must not dilute the denominator.

## A run that decides nothing says so

`AttemptsPerResolution` returns zero when `Resolved` is zero, and the CLI prints *"this run decided nothing"* rather than a divided value a reader might take for a clean result — the same failure shape as a regression suite printing "fix holds" for a target it never reached.

## What this is not

**Not an autonomous fuzzer.** It rests entirely on the existing `Run`, which requires `--authorize` for any non-safe profile and selects a network-less adapter for the safe one — the passive/active boundary **K** pins. J adds accounting *on top of* that boundary, not a way through it. Every test here runs against the local HTTP test server or SimTarget; nothing reaches an external target.

## Falsification

| what was broken | what failed |
|---|---|
| count inconclusive as resolved | the accounting sum-check / the never-reached-route test |
| read an inconclusive execution as refuted | `treating it as decided is how a harness reports progress it did not make` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

**Thirteen of thirteen milestones.** The verification roadmap is complete on the client side; only M's service half remains a design conversation.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW