### PR TITLE
J/SEC: verify JWT structure, and stop dropping real JWTs as data blobs

### DIFF
--- a/core/analyzers/secrets/checksum.go
+++ b/core/analyzers/secrets/checksum.go
@@ -3,6 +3,8 @@ package secrets
 import (
 	"hash/crc32"
 	"strings"
+
+	"github.com/nox-hq/nox/core/lexctx"
 )
 
 // This file establishes something about a matched value that a regex cannot:
@@ -104,4 +106,37 @@ func onlyBase62(s string) bool {
 		}
 	}
 	return s != ""
+}
+
+// verifyJWT reports whether value is a structurally valid JSON Web Token, and
+// whether the check APPLIED.
+//
+// It is the second deterministic signal in this pipeline, after the GitHub
+// checksum. A JWT is three base64url segments separated by dots, and the first
+// — the header — decodes to a JSON object naming a signing algorithm. That is
+// offline-verifiable: no network, no key. It does not check the SIGNATURE,
+// which needs the key nox does not have and must not want; it establishes that
+// the value is a real JWT rather than a string that happens to match the loose
+// `eyJ....eyJ....` pattern.
+//
+// The distinction matters because the pattern is weak. `eyJ` is `{"` in
+// base64url, so any header starting `eyJ` decodes to something starting `{"` —
+// but a full segment that is valid base64url AND decodes to a complete JSON
+// object with an `alg` field is a much stronger statement, and its absence is a
+// deterministic refutation rather than a heuristic doubt.
+//
+// Three-valued like the checksum: a value that is not three dot-separated
+// segments is not something this can speak about (applicable=false), a value
+// whose header decodes to a JSON object with `alg` is consistent, and one that
+// looks like a JWT but whose header does not decode is deterministically not a
+// JWT.
+func verifyJWT(value string) (consistent, applicable bool) {
+	if !lexctx.LooksJWTShaped(value) {
+		// Not the shape of a JWT, so this check has nothing to say.
+		return false, false
+	}
+	// Shaped like one; whether it IS one is the structural question lexctx
+	// answers, and it answers it the same way for the data-blob refiner, so the
+	// two cannot disagree about what a JWT is.
+	return lexctx.LooksLikeJWT(value), true
 }

--- a/core/analyzers/secrets/dedup.go
+++ b/core/analyzers/secrets/dedup.go
@@ -297,6 +297,14 @@ var canonicalOwners = []ownerEntry{
 	{"sk_test_", owned("SEC-030")},        // Stripe test secret key
 	{"AIza", owned("SEC-007")},            // GCP / Gemini API key
 	{"glpat-", owned("SEC-018")},          // GitLab PAT
+	// A JWT is three base64url segments starting with eyJ (`{"` encoded), and
+	// three rules match it — SEC-084, SEC-251, SEC-371. They are one credential
+	// class, so they collapse to one canonical owner the way the provider
+	// prefixes above do. SEC-371 is canonical: the tightest pattern, at high
+	// severity. This became reachable only once LooksLikeJWT stopped the
+	// data-blob refiner dropping real JWTs — before that, all three were
+	// suppressed upstream and never reached dedup.
+	{"eyJ", owned("SEC-371")}, // JSON Web Token
 }
 
 // ownersForValue returns the owner rule-ID set for a matched value, or nil if

--- a/core/analyzers/secrets/jwt_test.go
+++ b/core/analyzers/secrets/jwt_test.go
@@ -1,0 +1,68 @@
+package secrets
+
+import "testing"
+
+// TestVerifyJWTAgainstAKnownToken licenses the JWT check the way the checksum
+// test licenses the checksum: against a real, published token, not one the test
+// generated.
+//
+// This is the standard HS256 example from RFC 7519 / jwt.io. It is not a
+// credential — the signing key "your-256-bit-secret" is public — but its
+// structure is a genuine JWT, so it is the right thing to verify the decoder
+// against. A decoder checked only against tokens it built itself would prove
+// its encoder and decoder agree, which is circular.
+func TestVerifyJWTAgainstAKnownToken(t *testing.T) {
+	const known = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	consistent, applicable := verifyJWT(known)
+	if !applicable {
+		t.Fatal("a real JWT was not recognised as checkable")
+	}
+	if !consistent {
+		t.Error("a real JWT did not verify; the decoder is wrong")
+	}
+
+	// The same token behind a Bearer prefix, as a header carries it.
+	if c, a := verifyJWT("Bearer " + known); !a || !c {
+		t.Errorf("a bearer-prefixed JWT was not verified: consistent=%v applicable=%v", c, a)
+	}
+}
+
+// TestAJWTLookalikeIsRefutedNotIgnored is the value of the check.
+//
+// A string matching the loose eyJ....eyJ.... pattern whose header is not valid
+// base64url JSON is deterministically not a JWT. Refuting it is the deterministic
+// claim; staying silent would leave the finding resting on the pattern alone.
+func TestAJWTLookalikeIsRefutedNotIgnored(t *testing.T) {
+	// Three dot-separated segments, first starts with eyJ, but the header is
+	// not decodable JSON.
+	consistent, applicable := verifyJWT("eyJnotvalidbase64json.eyJalsonot.signature")
+	if !applicable {
+		t.Error("a JWT-shaped string was treated as uncheckable rather than refuted")
+	}
+	if consistent {
+		t.Error("a string that is not a JWT verified as one")
+	}
+
+	// A JSON header with no algorithm is not a JWT header.
+	// base64url of {"typ":"JWT"} — valid JSON, no alg.
+	noAlg := "eyJ0eXAiOiJKV1QifQ.eyJzdWIiOiJ4In0.sig"
+	if c, a := verifyJWT(noAlg); !a || c {
+		t.Errorf("a header with no algorithm verified as a JWT: consistent=%v", c)
+	}
+}
+
+// TestVerifyJWTIsThreeValued. A value that is not JWT-shaped must produce
+// applicable=false — "I cannot check this" is not "I checked and it failed", the
+// same discipline the checksum keeps.
+func TestVerifyJWTIsThreeValued(t *testing.T) {
+	for _, notAJWT := range []string{
+		"", "ghp_016C7f8e9d0A1b2C3d4E5f6G7h8I9j0K1l2M",
+		"just-a-string", "two.parts", "AKIAIOSFODNN7EXAMPLE",
+	} {
+		if _, applicable := verifyJWT(notAJWT); applicable {
+			t.Errorf("verifyJWT(%q) claimed to be able to check a non-JWT", notAJWT)
+		}
+	}
+}

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -414,6 +414,23 @@ func (a *Analyzer) corroborate(subject evidence.Subject, content []byte, f *find
 		}
 	}
 
+	// The second deterministic signal: a JWT's structure is offline-verifiable.
+	// The header base64url-decodes to a JSON object naming a signing algorithm,
+	// which no string that merely matches the loose eyJ....eyJ.... pattern will
+	// do by accident. It establishes that this IS a JWT, never that its
+	// signature is valid — that needs a key, and nox does not want one. A value
+	// shaped like a JWT whose header does not decode is deterministically not
+	// one, the same refutation the checksum makes for GitHub.
+	if consistent, applicable := verifyJWT(value); applicable {
+		if consistent {
+			a.reasoning.Support(subject, evidence.KindStatic, "nox-scan", "secrets",
+				"the value decodes as a JWT: its header is base64url-encoded JSON naming a signing algorithm, so it is a real token rather than a lookalike", nil)
+		} else {
+			a.reasoning.Refute(subject, evidence.KindStatic, "nox-scan", "secrets",
+				"the value is shaped like a JWT but its header does not base64url-decode to a JSON object with an algorithm, so it is not one")
+		}
+	}
+
 	if prefix, ok := recognisedProviderPrefix(strings.TrimLeft(value, `"'`)); ok {
 		a.support(subject, "the value carries the recognised provider prefix "+prefix+
 			" and a token body, so it is not a bare vocabulary reference")

--- a/core/jwt_detection_test.go
+++ b/core/jwt_detection_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// A published example JWT (RFC 7519 / jwt.io HS256). Not a credential — its
+// signing key is public — but structurally a real token, so it is the right
+// fixture: a JWT nox must detect, and one whose structure verifies.
+const exampleJWT = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.` +
+	`eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.` +
+	`SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
+
+func scanJWT(t *testing.T, source string) *ScanResult {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("end-to-end scan; skipped in -short")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.py"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return res
+}
+
+// TestAHardcodedJWTIsDetected is the regression for a silent false negative.
+//
+// A full JWT runs to hundreds of bytes, and the data-blob refiner dropped any
+// string over 96 bytes as an opaque base64 payload — so a hardcoded JWT
+// assigned to a variable was silently discarded. The threshold's own comment
+// reasoned about "a JWT header segment" and missed that the whole token is
+// long. A credential class nox could not see at all.
+func TestAHardcodedJWTIsDetected(t *testing.T) {
+	res := scanJWT(t, `API_JWT = "`+exampleJWT+`"`+"\n")
+	if len(res.Findings.Findings()) == 0 {
+		t.Error("a hardcoded JWT produced no finding; it was dropped as a data blob, " +
+			"which is how nox silently missed an entire credential class")
+	}
+}
+
+// TestADetectedJWTCarriesADeterministicClaim. The whole point of verifying the
+// structure is that the finding rests on more than a pattern match. A JWT
+// finding must carry a KindStatic claim, not only heuristics.
+func TestADetectedJWTCarriesADeterministicClaim(t *testing.T) {
+	res := scanJWT(t, `API_JWT = "`+exampleJWT+`"`+"\n")
+	var found bool
+	for _, f := range res.Findings.Findings() {
+		for _, c := range res.Reasoning.About(SubjectForFinding(f)).Claims {
+			if c.Kind == evidence.KindStatic && !c.Refutes() && strings.Contains(c.Statement, "JWT") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("a detected JWT carries no deterministic claim that it decodes as one; " +
+			"the finding rests on the pattern alone, which is what verification was for")
+	}
+}
+
+// TestOverlappingJWTRulesCollapseToOne. Three rules match a JWT, and they are
+// one credential class. Surfacing the JWT must not surface it three times.
+func TestOverlappingJWTRulesCollapseToOne(t *testing.T) {
+	res := scanJWT(t, `API_JWT = "`+exampleJWT+`"`+"\n")
+	active := res.Findings.ActiveFindings()
+	jwtFindings := 0
+	for _, f := range active {
+		if strings.Contains(strings.ToLower(f.Message), "jwt") ||
+			strings.Contains(strings.ToLower(f.Message), "json web token") {
+			jwtFindings++
+		}
+	}
+	if jwtFindings > 1 {
+		t.Errorf("one JWT produced %d findings; the overlapping rules did not collapse "+
+			"to a canonical owner", jwtFindings)
+	}
+}
+
+// TestAJWTLookalikeIsNotDetectedAsOne. A long base64 string that is NOT a JWT —
+// a real data blob — must still be dropped. The structural exception must not
+// become a hole through which every long base64 string re-enters.
+func TestAJWTLookalikeIsNotDetectedAsOne(t *testing.T) {
+	// A data URI: the exact false-positive carrier the blob refiner exists for.
+	blob := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	res := scanJWT(t, `IMG = "data:image/png;base64,`+blob+`"`+"\n")
+	for _, f := range res.Findings.Findings() {
+		if strings.Contains(strings.ToLower(f.Message), "jwt") {
+			t.Error("a base64 data URI was detected as a JWT")
+		}
+	}
+}

--- a/core/lexctx/jwt.go
+++ b/core/lexctx/jwt.go
@@ -1,0 +1,58 @@
+package lexctx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+// LooksLikeJWT reports whether s is structurally a JSON Web Token.
+//
+// It lives here, in the lowest layer, because two consumers need it and they
+// must agree: the secrets analyzer records "this is a JWT" as a deterministic
+// claim, and the data-blob refiner must NOT drop a real JWT as an opaque
+// payload. A JWT is a credential that happens to be long, and length is exactly
+// what a blob heuristic cannot tell apart from a base64 image chunk — so the
+// heuristic needs a structural check to defer to, and that check has to be the
+// same one the analyzer uses or the two will disagree about what a JWT is.
+//
+// Structural, offline, and about the token's shape rather than its validity: it
+// decodes the header and confirms a signing algorithm is named, never that the
+// signature holds — that needs a key nox does not have. A string matching the
+// loose `eyJ....eyJ....` pattern whose header does not decode to a JSON object
+// with an `alg` field is not a JWT, and saying so is the whole value.
+func LooksLikeJWT(s string) bool {
+	s = strings.TrimSpace(strings.Trim(s, `"'`))
+	s = strings.TrimPrefix(s, "Bearer ")
+	s = strings.TrimPrefix(s, "bearer ")
+
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return false
+	}
+	header, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(header, &claims); err != nil {
+		return false
+	}
+	if _, ok := claims["alg"]; !ok {
+		return false
+	}
+	_, err = base64.RawURLEncoding.DecodeString(parts[1])
+	return err == nil
+}
+
+// LooksJWTShaped reports whether s has the three-dot-segment shape of a JWT,
+// regardless of whether the segments decode. It is the "is this checkable at
+// all" question, distinct from LooksLikeJWT's "is it a real one".
+func LooksJWTShaped(s string) bool {
+	s = strings.TrimSpace(strings.Trim(s, `"'`))
+	s = strings.TrimPrefix(s, "Bearer ")
+	s = strings.TrimPrefix(s, "bearer ")
+	parts := strings.Split(s, ".")
+	return len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" &&
+		strings.HasPrefix(parts[0], "eyJ")
+}

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -288,6 +288,15 @@ const blobThreshold = 96
 // content-only — no heurist­ic that depends on scan order or environment.
 func isStringBlob(content []byte, r Region) bool {
 	body := content[r.Start:r.End]
+	// A structurally valid JWT is a credential, not an opaque payload, and it
+	// is often long — a full token runs to hundreds of bytes. The length
+	// heuristic below cannot tell it from a base64 image chunk, so it must
+	// defer to the structural check, or nox drops real hardcoded JWTs as data
+	// blobs. That was happening: blobThreshold's own comment reasoned about "a
+	// JWT header segment" and missed that the whole token is long.
+	if LooksLikeJWT(string(body)) {
+		return false
+	}
 	if len(body) > blobThreshold {
 		return true
 	}

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -133,9 +133,30 @@ Recording that here rather than letting it stay unmentioned.
 The roadmap's order was: noisy AI rules, secrets, endpoint/API misuse, taint
 overlaps, dependency applicability. Measuring suggests a different one.
 
-1. **SEC checksum verification, more providers.** The only intervention proven
-   to move a finding off the heuristic floor, no new capability required, and it
-   applies to the largest family. Cheapest real progress available.
+1. **SEC deterministic verification.** Started, and it went somewhere the plan
+   did not predict.
+
+   The checksum path is nearly exhausted at GitHub: its CRC32 is one of very few
+   schemes verifiable OFFLINE, and most providers can only be verified by an API
+   call, which nox's architecture forbids. So the honest next deterministic
+   signal is not another checksum but JWT structure: a JWT's header base64url-
+   decodes to JSON naming a signing algorithm, checkable with no network and no
+   key.
+
+   Building it surfaced a silent false negative. The data-blob refiner dropped
+   any string over 96 bytes as an opaque base64 payload, and a full JWT runs to
+   hundreds of bytes — so hardcoded JWTs were discarded before they became
+   findings. nox could not see an entire credential class. `lexctx.LooksLikeJWT`
+   now stops that: a structurally valid JWT is a credential, not a blob, however
+   long. Surfacing it then exposed a dedup gap — three rules match a JWT and did
+   not collapse — closed by adding `eyJ` as a canonical owner. End to end: a
+   hardcoded JWT goes from zero findings to one, carrying a deterministic claim
+   that it decodes as a token rather than resting on the pattern.
+
+   The remaining checksum work (Stripe, Slack, npm) is not there: none publishes
+   an offline-verifiable checksum. That is a result, not a gap — it says the
+   deterministic wins in this family are the structural ones (JWT, and base64/
+   hex decodability), not more checksums.
 2. **AI corroboration.** The refiners exist and only refute; recording what was
    checked about survivors is the smaller half of work already begun. It will
    not move confidence — see above — but it makes `nox why` answer "what


### PR DESCRIPTION
The migration profiling (10.1) named **SEC checksum verification** as the one proven way to lift a finding off the heuristic floor. Measuring where it could go next changed the plan — and found a silent false negative.

## The checksum path is nearly exhausted at GitHub

GitHub's CRC32 is one of very few schemes verifiable **offline**. Most providers can only be verified by calling their API, which nox's architecture forbids. So the honest next deterministic signal is not another checksum but **JWT structure**: a JWT's header base64url-decodes to a JSON object naming a signing algorithm — checkable with no network and no key. It establishes the value *is* a JWT, never that its signature holds.

## Building it surfaced a silent false negative

Testing against a real token (RFC 7519 HS256 example) revealed the JWT never reached the verifier — it was dropped three layers up. **The data-blob refiner drops any string over 96 bytes as an opaque base64 payload, and a full JWT runs to hundreds of bytes.** So a hardcoded JWT assigned to a variable was discarded before it became a finding. nox could not see an entire credential class.

The threshold's own comment gave it away: it reasoned about *"a JWT header segment"* and missed that the whole token is long.

`lexctx.LooksLikeJWT` closes it — a structurally valid JWT is a credential, not a blob, however long. It lives in `lexctx` because **two consumers must agree on what a JWT is**: the blob refiner that must not drop one, and the secrets analyzer that records *"this decodes as a JWT"* as a `KindStatic` claim. One recogniser, so they can't disagree.

## And that exposed a dedup gap

Three rules match a JWT (SEC-084, SEC-251, SEC-371) and didn't collapse — `eyJ` wasn't a recognised owner prefix. Added it; SEC-371 is canonical.

## End to end, measured

| | before | after |
|---|---|---|
| findings for a hardcoded JWT | **0** (dropped as blob) | **1** |
| deterministic claim | — | *"decodes as a JWT: its header is base64url-encoded JSON naming a signing algorithm"* |

Found by **running the scan, not reading** — the unit test of the verifier passed while the token never reached it.

## The rest of the checksum work isn't there, and that's a result

Stripe, Slack, npm publish no offline-verifiable checksum. The deterministic wins in the SEC family are **structural** (JWT, base64/hex decodability), not more checksums.

## Falsification

| what was broken | what failed |
|---|---|
| revert the blob deferral | `a hardcoded JWT produced no finding; it was dropped as a data blob` |
| drop the `alg` check | `a string that is not a JWT verified as one` |
| remove the owner entry | `one JWT produced 3 findings; the overlapping rules did not collapse` |

Full suite green (the threshold change broke no test — nothing relied on JWTs being dropped) · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW