### PR TITLE
M: consume a served record as research, not an opaque advisory

### DIFF
--- a/core/intel/from_record_test.go
+++ b/core/intel/from_record_test.go
@@ -1,0 +1,123 @@
+package intel_test
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox-core/vulnsource"
+	"github.com/nox-hq/nox/core/intel"
+)
+
+func servedRecord(claims ...evidence.Claim) vulnsource.Record {
+	return vulnsource.Record{
+		ID: "NOX-CAND-2026-0001",
+		Affected: []vulnsource.Affected{{
+			Package: vulnsource.Package{Name: "golang.org/x/crypto", Ecosystem: "Go"},
+			EcosystemSpecific: vulnsource.EcosystemSpecific{
+				Imports: []vulnsource.Import{{Path: "golang.org/x/crypto/ssh"}},
+			},
+		}},
+		Intelligence: &vulnsource.Intelligence{
+			Corroboration: 3,
+			Evidence:      &evidence.Ledger{Claims: claims},
+		},
+	}
+}
+
+// TestAServedRecordBecomesALocalQuestion is the receiving end of Milestone M.
+//
+// The service says a package is affected and how strongly its own evidence
+// supports that; local nox turns it into what THIS build still has to establish.
+// The adapter must carry the affected symbol across, because that is what the
+// local applicability test needs — "does this build reference it?" cannot be
+// asked without the "it".
+func TestAServedRecordBecomesALocalQuestion(t *testing.T) {
+	p := intel.FromRecord(servedRecord(evidence.Claim{
+		Kind: evidence.KindIndependentObservation, Statement: "a distinct installation reported it",
+		Provenance: evidence.Provenance{Source: "nox-intel"},
+	}))
+
+	if p.Package != "golang.org/x/crypto" || p.Ecosystem != "Go" {
+		t.Errorf("the package was not carried: %s/%s", p.Ecosystem, p.Package)
+	}
+	if len(p.AffectedSymbols) != 1 || p.AffectedSymbols[0] != "golang.org/x/crypto/ssh" {
+		t.Errorf("the affected symbol was not carried: %v", p.AffectedSymbols)
+	}
+	if p.ReporterCount != 3 {
+		t.Errorf("the corroboration count was not carried: %d", p.ReporterCount)
+	}
+
+	// And the questions it hands to local analysis reference that symbol.
+	var asksSymbol bool
+	for _, q := range p.AppliesLocally() {
+		if q == "does this build reference golang.org/x/crypto/ssh?" {
+			asksSymbol = true
+		}
+	}
+	if !asksSymbol {
+		t.Errorf("the local questions do not test the affected symbol: %v", p.AppliesLocally())
+	}
+}
+
+// TestMaturityComesFromTheStrongestLiveClaim. A ledger is as mature as its
+// best-supported evidence, and a retracted claim is not part of that — the same
+// rule the kernel applies to confidence.
+func TestMaturityComesFromTheStrongestLiveClaim(t *testing.T) {
+	p := intel.FromRecord(servedRecord(
+		evidence.Claim{Kind: evidence.KindIndependentObservation, Statement: "reported"},
+		evidence.Claim{Kind: evidence.KindStatic, Statement: "static analysis established it"},
+	))
+	if p.Maturity != intel.MaturityStatic {
+		t.Errorf("maturity = %q, want static (the strongest live claim)", p.Maturity)
+	}
+
+	// A retracted reproduction must not lift the maturity above what still
+	// stands. The kernel weighs a retracted claim at nothing; so does this.
+	retracted := intel.FromRecord(servedRecord(
+		evidence.Claim{Kind: evidence.KindIndependentObservation, Statement: "reported"},
+		evidence.Claim{
+			Kind: evidence.KindControlledReproduction, Statement: "reproduced, then withdrawn",
+			Status: evidence.StatusRetracted,
+		},
+	))
+	if retracted.Maturity == intel.MaturityReproduced {
+		t.Error("a retracted reproduction lifted the maturity to reproduced; a " +
+			"withdrawn claim must weigh nothing here as it does in the kernel")
+	}
+}
+
+// TestRefutationsCrossTheWire. A disputed proposition must arrive disputed. The
+// service records refuting claims in the ledger; the adapter must carry them,
+// or a source that forwarded only support would look uncontested.
+func TestRefutationsCrossTheWire(t *testing.T) {
+	p := intel.FromRecord(servedRecord(
+		evidence.Claim{Kind: evidence.KindStatic, Statement: "affected"},
+		evidence.Claim{
+			Kind: evidence.KindStatic, Polarity: evidence.PolarityRefutes,
+			Statement: "the maintainer says the sink is unreachable",
+		},
+	))
+	if len(p.Refutations) != 1 {
+		t.Errorf("a refuting claim did not cross the wire: %v", p.Refutations)
+	}
+}
+
+// TestARecordWithNoEvidenceIsAHypothesisNotNothing. The weakest a served record
+// can be is a hypothesis, never an absence — a package the service names at all
+// is at least a lead, and dropping it to no maturity would lose it.
+func TestARecordWithNoEvidenceIsAHypothesis(t *testing.T) {
+	p := intel.FromRecord(vulnsource.Record{
+		ID:       "NOX-CAND-2026-0002",
+		Affected: []vulnsource.Affected{{Package: vulnsource.Package{Name: "left-pad", Ecosystem: "npm"}}},
+	})
+	if p.Maturity != intel.MaturityHypothesis {
+		t.Errorf("a record with no evidence has maturity %q, want hypothesis", p.Maturity)
+	}
+	// And a proposition from it still produces its claims about the PACKAGE, not
+	// about any local candidate — the M invariant survives the adapter.
+	for _, c := range p.Claims("nox-intel", "t") {
+		if c.Subject.Kind != evidence.SubjectPackage {
+			t.Errorf("an adapted proposition filed a claim against %q", c.Subject.Kind)
+		}
+	}
+}

--- a/core/intel/propositions.go
+++ b/core/intel/propositions.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox-core/vulnsource"
 )
 
 // ResearchProposition is a structured claim an intelligence source makes about
@@ -203,4 +204,106 @@ func (p ResearchProposition) AppliesLocally() []string {
 		q = append(q, "does this package appear in this build at all?")
 	}
 	return q
+}
+
+// FromRecord adapts a served intelligence record into a research proposition
+// this repository can test for local applicability.
+//
+// This is the receiving end of Milestone M. The intelligence service serves
+// PUBLIC candidates carrying an evidence ledger, a corroboration count and the
+// affected import paths of the advisory they reconcile against — and the
+// milestone's shape is that local nox then determines whether any of that
+// applies here. This turns what the service sent into the questions the local
+// scan still has to answer.
+//
+// It reads only what a record carries. The richer proposition fields — a
+// trigger condition, a PoC hypothesis, known entry points — need a
+// researcher-intake path the service does not yet have, and building that is a
+// disclosure decision (what a researcher may assert, and how an unpublished
+// hypothesis reaches a user) rather than an adapter. What is here is everything
+// the wire currently carries, mapped honestly; what is not is named so.
+//
+// Maturity comes from the ledger's strongest LIVE claim, so a retracted or
+// disputed claim cannot inflate it — the same rule the kernel applies to
+// confidence. A record with no evidence maps to a hypothesis, the weakest rung,
+// rather than to nothing.
+func FromRecord(rec vulnsource.Record) ResearchProposition {
+	p := ResearchProposition{
+		Advisory: rec.ID,
+		Maturity: MaturityHypothesis,
+	}
+	if len(rec.Affected) > 0 {
+		p.Ecosystem = rec.Affected[0].Package.Ecosystem
+		p.Package = rec.Affected[0].Package.Name
+		for _, aff := range rec.Affected {
+			for _, imp := range aff.EcosystemSpecific.Imports {
+				if imp.Path != "" {
+					p.AffectedSymbols = append(p.AffectedSymbols, imp.Path)
+				}
+			}
+		}
+	}
+	if intel := rec.Intelligence; intel != nil {
+		p.ReporterCount = intel.Corroboration
+		if intel.Evidence != nil {
+			p.Maturity = maturityOf(intel.Evidence)
+			p.Attested = attested(intel.Evidence)
+			for _, c := range intel.Evidence.Claims {
+				if c.Live() && c.Refutes() {
+					p.Refutations = append(p.Refutations, c.Statement)
+				}
+			}
+		}
+	}
+	return p
+}
+
+// maturityOf reads the ledger's strongest live claim onto the research ladder.
+//
+// It is the inverse of Maturity.kind(), and it takes the STRONGEST live claim
+// because that is what the kernel's confidence aggregation does — a ledger is
+// as mature as its best-supported evidence, and a retracted claim is not part
+// of that. A ledger with only heuristics is a hypothesis; one with a controlled
+// reproduction is at that rung, and no higher unless a maintainer or advisory
+// claim outranks it.
+func maturityOf(l *evidence.Ledger) Maturity {
+	best := MaturityHypothesis
+	bestRank := -1
+	rank := map[evidence.Kind]int{
+		evidence.KindResearchHypothesis:     0,
+		evidence.KindIndependentObservation: 1,
+		evidence.KindStatic:                 2,
+		evidence.KindControlledReproduction: 3,
+		evidence.KindMaintainerConfirmed:    4,
+		evidence.KindPublicAdvisory:         5,
+	}
+	rungFor := map[evidence.Kind]Maturity{
+		evidence.KindResearchHypothesis:     MaturityHypothesis,
+		evidence.KindIndependentObservation: MaturityIndependent,
+		evidence.KindStatic:                 MaturityStatic,
+		evidence.KindControlledReproduction: MaturityReproduced,
+		evidence.KindMaintainerConfirmed:    MaturityMaintainer,
+		evidence.KindPublicAdvisory:         MaturityAdvisory,
+	}
+	for _, c := range l.Claims {
+		if !c.Live() || !c.Supports() {
+			continue
+		}
+		if r, ok := rank[c.Kind]; ok && r > bestRank {
+			bestRank = r
+			best = rungFor[c.Kind]
+		}
+	}
+	return best
+}
+
+// attested reports whether any live claim came from a source whose identity was
+// checkable — anything but the anonymous contribution source.
+func attested(l *evidence.Ledger) bool {
+	for _, c := range l.Claims {
+		if c.Live() && c.Provenance.Source != "" && c.Provenance.Source != "nox-intel" {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/design/verification-roadmap-evaluation.md
+++ b/docs/design/verification-roadmap-evaluation.md
@@ -526,7 +526,9 @@ the symbol, is this deployment configured that way, does this application expose
 that entry point. Intel can say a symbol is dangerous; only the local build can
 say whether it is referenced.
 
-**Not built, deliberately:** the service side. Emitting these propositions means
+**The receiving loop is now closed** (`intel.FromRecord`): a served intelligence record becomes a `ResearchProposition`, its maturity read from the ledger's strongest live claim, its refutations carried across, its affected imports mapped into the local applicability questions. So what the service already sends — the evidence ledger, the corroboration count, the advisory's affected imports — is consumed as research the local scan tests, not as an opaque advisory it can only trust or ignore.
+
+**Still not built, deliberately:** the researcher-intake side. Emitting the richer fields — a trigger condition, a PoC hypothesis, known entry points — means
 extending the query payload and the disclosure model in a private repository,
 and it is a design conversation before it is code — what a researcher may
 assert, what publication requires, how an unpublished hypothesis reaches a user


### PR DESCRIPTION
The client half of M named the `ResearchProposition` shape and held its invariant — intel evidence is about a **package**, and only local analysis decides whether it applies here. This closes the **receiving loop** against what the service actually sends.

## `intel.FromRecord`

A served intelligence record becomes a proposition:

- the affected package and its **import paths** become the symbols the local applicability test asks about (`does this build reference golang.org/x/crypto/ssh?`)
- the **corroboration count** and **refuting claims** cross the wire
- the **maturity** is read from the ledger's strongest *live* claim — a retracted or disputed claim weighs nothing, the same rule the kernel applies to confidence

So everything the service carries today — the evidence ledger, the distinct-reporter count, the affected imports of the advisory a candidate reconciles against — is now consumed as **research the local scan tests for applicability**, not as an opaque advisory the scan can only trust or ignore.

## Still not built, deliberately

The **researcher-intake side**. A record can't yet carry a trigger condition, a PoC hypothesis or known entry points, because a `Candidate` has no fields for them and no path for a researcher to assert them. Populating those is a **disclosure decision** — what a researcher may assert, and how an unpublished hypothesis reaches a user without becoming a claim nox can't support — rather than an adapter.

The adapter carries everything the wire holds and names what it doesn't, so the gap is visible rather than papered over.

## Falsification

| what was broken | what failed |
|---|---|
| let a retracted claim set the maturity | `a retracted reproduction lifted the maturity to reproduced` |
| drop the affected symbols | `the affected symbol was not carried` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW