### PR TITLE
J/AI: record what a surviving AI finding was checked against

### DIFF
--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -104,6 +104,27 @@ func (a *Analyzer) refute(subject evidence.Subject, kind evidence.Kind, statemen
 	a.reasoning.Refute(subject, kind, "nox-scan", "ai", statement)
 }
 
+// corroborate records what the analyzer VERIFIED about a candidate it is about
+// to report, the positive counterpart of the refiners above.
+//
+// It exists because of the same gap the secrets analyzer had before E3: every
+// drop recorded why it dropped, and every SURVIVOR recorded nothing — so a
+// reported AI finding's ledger said only "the rule fired", never what nox
+// checked before believing it. A survivor of these refiners has been checked:
+// it is in real code, not a comment or blob; an AI-002 interpolation has prompt
+// context near it; an AI-006 logging call logs a real value. Recording that is
+// what lets `nox why` answer "what supports it" with an inspection rather than
+// a tautology.
+//
+// Every claim here is a heuristic and deliberately so — a proximity check is
+// not a proof, and E3 measured that recording these does not move confidence,
+// only explanation. Aggregation takes the strongest supporting claim, and three
+// heuristics are still a heuristic. What it buys is a ledger that says what was
+// examined, not one that would have said only what would have stopped it.
+func (a *Analyzer) corroborate(subject evidence.Subject, statement string) {
+	a.reasoning.Support(subject, evidence.KindHeuristic, "nox-scan", "ai", statement, nil)
+}
+
 // Option configures an Analyzer.
 type Option func(*Analyzer)
 
@@ -238,6 +259,18 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				a.refute(candidate, evidence.KindHeuristic,
 					"the call executes a SQL statement, so the AI token the rule gated on is a column name inside the query text")
 				continue
+			}
+			// Survived every refiner above. Record what that means: the match
+			// was inspected and is in real code, and for the rules with a
+			// context requirement, that the context nox required was present.
+			a.corroborate(candidate, "the match was inspected and lies in code, not in a comment, string literal or embedded blob")
+			switch results[i].RuleID {
+			case "AI-002":
+				a.corroborate(candidate, "a prompt or LLM context was found near the interpolation, so it is a prompt rather than an unrelated formatted string")
+			case "AI-006":
+				a.corroborate(candidate, "the logging call carries a non-constant argument, so it logs a value that could be a prompt or response")
+			case "AI-049":
+				a.corroborate(candidate, "the call is a code-execution sink rather than a SQL statement whose AI token is a column name")
 			}
 			fs.Add(results[i])
 		}

--- a/core/analyzers/ai/corroboration_test.go
+++ b/core/analyzers/ai/corroboration_test.go
@@ -1,0 +1,115 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// TestASurvivingAIFindingCarriesWhatWasChecked is the AI half of E3.
+//
+// Before this, every AI refiner recorded why it DROPPED a candidate and nothing
+// about the ones that survived — so a reported AI finding's ledger said only
+// "the rule fired", never what nox inspected before believing it. A survivor
+// has been checked: it is in real code, and for a rule with a context
+// requirement, the context was present. Recording that is what lets `nox why`
+// answer "what supports it" with an inspection rather than a tautology.
+func scanWithReasoning(t *testing.T, src string) (*reasoning.Store, *findings.FindingSet) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.py")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := reasoning.New()
+	a := NewAnalyzer()
+	a.RecordReasoningTo(store)
+	// ScanArtifacts runs the refiner+corroborate loop; ScanFile alone does not.
+	fs, _, err := a.ScanArtifacts(context.Background(), []discovery.Artifact{
+		{Path: "agent.py", AbsPath: path, Type: discovery.Source},
+	})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return store, fs
+}
+
+const promptInjectionSrc = "import openai\n" +
+	"def chat(user_input):\n" +
+	"    prompt = f\"You are helpful. User: {user_input}\"\n" +
+	"    return openai.ChatCompletion.create(model=\"gpt-4\", messages=[{\"role\":\"system\",\"content\":prompt}])\n"
+
+// TestASurvivingAIFindingCarriesWhatWasChecked is the AI half of E3.
+//
+// Before this, every AI refiner recorded why it DROPPED a candidate and nothing
+// about the ones that survived — so a reported AI finding's ledger said only
+// "the rule fired", never what nox inspected before believing it. A survivor
+// has been checked: it is in real code, and for a rule with a context
+// requirement, the context was present. Recording that is what lets `nox why`
+// answer "what supports it" with an inspection rather than a tautology.
+func TestASurvivingAIFindingCarriesWhatWasChecked(t *testing.T) {
+	store, fs := scanWithReasoning(t, promptInjectionSrc)
+
+	// Key off the FINDING, not off a subject in the store. A survivor's subject
+	// only appears in the store because corroboration files a claim against it,
+	// so keying off the subject would make this SKIP when corroboration is
+	// removed rather than FAIL — the vacuous-under-mutation trap. The finding
+	// exists whether or not it was corroborated, so it is the honest anchor.
+	var ai002 *findings.Finding
+	for i := range fs.Findings() {
+		f := fs.Findings()[i]
+		if f.RuleID == "AI-002" {
+			ai002 = &f
+			break
+		}
+	}
+	if ai002 == nil {
+		t.Skip("this build does not report AI-002 on the fixture; the corroboration " +
+			"path is unreachable and this test cannot exercise it")
+	}
+
+	subject := reasoning.Candidate("AI-002", "agent.py",
+		ai002.Location.StartLine, ai002.Location.StartColumn)
+	var supports []string
+	for _, c := range store.About(subject).Claims {
+		if c.Supports() {
+			supports = append(supports, c.Statement)
+		}
+	}
+	joined := strings.Join(supports, " | ")
+	if !strings.Contains(joined, "lies in code") {
+		t.Errorf("a surviving AI finding does not record that it was inspected and is "+
+			"in code: %q", joined)
+	}
+	if !strings.Contains(joined, "prompt or LLM context") {
+		t.Errorf("an AI-002 survivor does not record that the context its rule requires "+
+			"was actually found: %q", joined)
+	}
+	if len(supports) < 2 {
+		t.Errorf("AI-002 carries %d supporting claims; a reported survivor recorded "+
+			"nothing beyond the rule firing", len(supports))
+	}
+}
+
+// TestCorroborationIsHeuristicNotStatic. E3 measured that recording these does
+// not move confidence, only explanation — because they are proximity checks, not
+// proofs. A corroborating claim recorded at static strength would be claiming
+// the analysis established something it only estimated.
+func TestCorroborationIsHeuristicNotStatic(t *testing.T) {
+	store, _ := scanWithReasoning(t, promptInjectionSrc)
+	for _, s := range store.Subjects() {
+		for _, c := range store.About(s).Claims {
+			if c.Supports() && c.Kind.Deterministic() {
+				t.Errorf("a corroborating AI claim is recorded at %q, a deterministic "+
+					"kind; a proximity check is not a proof and must not read as one: %q",
+					c.Kind, c.Statement)
+			}
+		}
+	}
+}

--- a/core/migration_report_test.go
+++ b/core/migration_report_test.go
@@ -95,12 +95,41 @@ func TestEarnedEvidenceIsNotTheSameAsAGenerousClassification(t *testing.T) {
 // without anything having been migrated. A metric that silently flatters the
 // work is worse than no metric.
 func TestBareObservationIsRecognised(t *testing.T) {
-	r := measureOn(t, "../testdata/precision-suite")
-	for _, f := range r.Families {
-		if f.Corroborated == f.Findings && f.Earned == 0 && f.Family != "TAINT" {
-			t.Errorf("family %s reports every finding corroborated with nothing earned, "+
-				"which is what the metric looks like when it has stopped recognising "+
-				"the bare observation claim", f.Family)
+	// Test the recogniser directly, not through a proxy. An earlier version
+	// asserted that no family is "corroborated everywhere with nothing earned",
+	// on the theory that only a broken recogniser produces that shape. That
+	// theory expired: once the AI analyzer records what it checked about
+	// survivors (heuristic corroboration, nothing earned), a fully-corroborated
+	// heuristic family is the NORMAL state, indistinguishable from a broken
+	// recogniser under the proxy. So this checks the actual property — a
+	// finding whose only claim is the bare observation is not counted as
+	// corroborated — which is what the proxy was standing in for.
+	obs := func(ruleID string) evidence.Claim {
+		return evidence.Claim{
+			Kind: evidence.KindHeuristic, Statement: "rule " + ruleID + " matched at this location",
 		}
+	}
+	bare := findings.Finding{RuleID: "SEC-003", Fingerprint: "a"}
+	extra := findings.Finding{RuleID: "SEC-003", Fingerprint: "b"}
+
+	rep := migration.Measure([]findings.Finding{bare, extra}, func(f findings.Finding) evidence.Ledger {
+		if f.Fingerprint == "a" {
+			return evidence.Ledger{Claims: []evidence.Claim{obs("SEC-003")}}
+		}
+		return evidence.Ledger{Claims: []evidence.Claim{
+			obs("SEC-003"),
+			{Kind: evidence.KindHeuristic, Statement: "the value carries a recognised provider prefix"},
+		}}
+	})
+	if len(rep.Families) != 1 {
+		t.Fatalf("expected one family, got %d", len(rep.Families))
+	}
+	// Of the two findings, only the one with a claim BEYOND the observation is
+	// corroborated. A recogniser that stopped matching the observation string
+	// would count both.
+	if rep.Families[0].Corroborated != 1 {
+		t.Errorf("corroborated = %d, want 1; the bare-observation finding was counted "+
+			"as corroborated, so isBareObservation has stopped matching the statement "+
+			"the scan writes", rep.Families[0].Corroborated)
 	}
 }

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -157,10 +157,16 @@ overlaps, dependency applicability. Measuring suggests a different one.
    an offline-verifiable checksum. That is a result, not a gap — it says the
    deterministic wins in this family are the structural ones (JWT, and base64/
    hex decodability), not more checksums.
-2. **AI corroboration.** The refiners exist and only refute; recording what was
-   checked about survivors is the smaller half of work already begun. It will
-   not move confidence — see above — but it makes `nox why` answer "what
-   supports it" with something other than the rule firing.
+2. **AI corroboration.** *Done.* The refiners recorded why they dropped a
+   candidate and nothing about the ones that survived, so a reported AI
+   finding's ledger said only "the rule fired". A survivor now records what was
+   checked: that it is in real code, and — for a rule with a context
+   requirement — that the context its rule needs was actually present. Measured:
+   AI-002 goes from one supporting claim to three. Heuristic, so it moves
+   explanation not confidence (E3 measured that), which is the honest ceiling
+   for a proximity check. The remaining AI work is constant evaluation — knowing
+   a prompt is a literal rather than assembled from input — which needs a
+   capability nothing implements yet.
 3. **IAC structural parsing.** Largest single piece of work, largest family, and
    the only way 490 rules ever exceed heuristic. Should be scoped as a feature.
 4. **Endpoint/API misuse** is a plugin (`nox-plugin-api-abuse`) and cannot be


### PR DESCRIPTION
The migration profiling (10.1) named this: the AI refiners recorded why they **dropped** a candidate and nothing about the ones that survived — so a reported AI finding's ledger said only *"the rule fired"*. Secrets got its corroboration in E3; AI didn't.

## The change

A survivor of the refiners has been checked: it's in real code, and for a rule with a context requirement, that context was found. `corroborate` records each, so `nox why` can answer *"what supports it"* with an inspection rather than a tautology.

| | AI-002 supporting claims |
|---|---|
| before | 1 (the bare observation) |
| after | 3 |

Every claim is a **heuristic**, deliberately — a proximity check is not a proof, and E3 measured that recording these moves *explanation, not confidence*. What it buys is a ledger that says what was examined rather than one that would have said only what would have stopped it.

## Two tests needed reworking, and both reasons matter

**The corroboration test skipped instead of failing.** It first keyed off the AI-002 subject appearing in the reasoning store — but a survivor's subject only appears *because* corroboration files a claim against it. So removing corroboration made the test **skip**, not fail — the vacuous-under-mutation trap this session keeps hitting. It now anchors on the **finding**, which exists regardless.

**This invalidated a proxy in the J 10.1 migration metric.** `TestBareObservationIsRecognised` asserted no family is "corroborated everywhere with nothing earned", on the theory that only a broken recogniser produces that shape. **That theory expired** the moment AI began corroborating survivors with heuristics — a fully-corroborated heuristic family is now normal. The test now checks the actual property directly: a finding whose only claim is the bare observation is not counted as corroborated.

## Falsification

| what was broken | what failed |
|---|---|
| remove the corroboration block | survivor test fails by name (no longer skips) |
| record corroboration at static strength | `a corroborating AI claim is recorded at "static", a deterministic kind` |
| drift the observation statement | `isBareObservation has stopped matching the statement the scan writes` |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW