### PR TITLE
IAC: brace-enclosing absence rules now reach CloudFormation-in-YAML

### DIFF
--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -360,7 +360,20 @@ func absenceSpan(content []byte, loc []int, mode string) []byte {
 	case "brace-block":
 		return braceBlockFollowing(content, loc[1])
 	case "brace-enclosing":
-		return braceBlockEnclosing(content, loc[0])
+		// JSON bounds a resource by its enclosing { }. A CloudFormation
+		// template written in YAML has no braces, so braceBlockEnclosing returns
+		// nil and every brace-enclosing absence rule silently fails to fire —
+		// measured: IAC-051 flags an unencrypted S3 bucket in a JSON template
+		// and misses the identical bucket in YAML, an entire format left
+		// unscanned by the CloudFormation absence rules. Fall back to the
+		// indentation-bounded span, which is the YAML equivalent of "the block
+		// this anchor introduces". The rules already list *.yaml and *.yml in
+		// their file patterns, so YAML was always in scope; only the span could
+		// not reach it.
+		if span := braceBlockEnclosing(content, loc[0]); span != nil {
+			return span
+		}
+		return yamlEnclosingSpan(content, loc[0])
 	case "yaml-block":
 		return yamlBlockSpan(content, loc[0])
 	case "yaml-doc":
@@ -587,6 +600,50 @@ func yamlBlockSpan(content []byte, pos int) []byte {
 // when there are no separators) that contains pos. Used for K8s resources whose
 // companion property may sit anywhere within the same document — e.g. a
 // Deployment and a `securityContext:` nested several levels below its `kind:`.
+// yamlEnclosingSpan returns the YAML mapping block that ENCLOSES the anchor,
+// which is the indentation analogue of braceBlockEnclosing.
+//
+// The distinction from yamlBlockSpan is the whole point, and it was found by a
+// false positive. yamlBlockSpan bounds the block an anchor INTRODUCES — for an
+// anchor on a `Type: AWS::S3::Bucket` line, that is just the scalar, and a
+// sibling `BucketEncryption:` falls outside it, so an encrypted bucket looked
+// unencrypted. brace-enclosing walks OUT to the object containing the anchor;
+// this is its YAML equivalent: from the anchor, up to the nearest less-indented
+// line (the resource key), then that key's whole block.
+func yamlEnclosingSpan(content []byte, pos int) []byte {
+	// The anchor's own line start and indent.
+	lineStart := pos
+	for lineStart > 0 && content[lineStart-1] != '\n' {
+		lineStart--
+	}
+	anchorIndent := lineIndent(content, lineStart)
+
+	// Walk up to the nearest preceding non-blank line with a smaller indent:
+	// the mapping key that owns the block the anchor sits in.
+	parentStart := lineStart
+	for parentStart > 0 {
+		// Move to the previous line.
+		prevEnd := parentStart - 1
+		ps := prevEnd
+		for ps > 0 && content[ps-1] != '\n' {
+			ps--
+		}
+		if trimmed := bytes.TrimSpace(content[ps:prevEnd]); len(trimmed) > 0 {
+			if lineIndent(content, ps) < anchorIndent {
+				parentStart = ps
+				break
+			}
+		}
+		parentStart = ps
+		if ps == 0 {
+			break
+		}
+	}
+	// yamlBlockSpan from the parent key captures the parent and all of its more-
+	// indented children — the enclosing resource block.
+	return yamlBlockSpan(content, parentStart)
+}
+
 func yamlDocSpan(content []byte, pos int) []byte {
 	lines := bytes.SplitAfter(content, []byte("\n"))
 	starts := make([]int, len(lines))

--- a/core/rules/yaml_absence_span_test.go
+++ b/core/rules/yaml_absence_span_test.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBraceEnclosingFallsBackToYAML is the regression for a measured
+// false-negative class: every brace-enclosing absence rule silently missed
+// CloudFormation written in YAML, because YAML has no braces to bound the
+// resource block.
+//
+// The rules already list *.yaml and *.yml in their file patterns, so YAML was
+// always in scope — only the span could not reach it. The fix makes
+// brace-enclosing fall back to the indentation-bounded enclosing block.
+func TestBraceEnclosingFallsBackToYAML(t *testing.T) {
+	// Anchor at "AWS::S3::Bucket" inside a YAML resource with NO encryption
+	// property. The enclosing span must cover the whole resource so the absence
+	// of the property is real.
+	yaml := "Resources:\n" +
+		"  LogBucket:\n" +
+		"    Type: AWS::S3::Bucket\n" +
+		"    Properties:\n" +
+		"      BucketName: my-logs\n"
+	anchor := strings.Index(yaml, "AWS::S3::Bucket")
+	span := absenceSpan([]byte(yaml), []int{anchor, anchor + len("AWS::S3::Bucket")}, "brace-enclosing")
+	if span == nil {
+		t.Fatal("brace-enclosing returned no span for a YAML resource; the whole " +
+			"CloudFormation-in-YAML class stays unscanned")
+	}
+	if !strings.Contains(string(span), "BucketName") {
+		t.Errorf("the enclosing span does not cover the resource's properties: %q", span)
+	}
+}
+
+// TestTheEnclosingSpanCoversSiblingsNotJustChildren is the distinction a false
+// positive taught.
+//
+// yamlBlockSpan bounds the block an anchor INTRODUCES; on a `Type:` line that is
+// just the scalar, so a sibling property falls outside it and a configured
+// resource looks unconfigured. The enclosing span must reach the sibling.
+func TestTheEnclosingSpanCoversSiblingsNotJustChildren(t *testing.T) {
+	yaml := "Resources:\n" +
+		"  DataBucket:\n" +
+		"    Type: AWS::S3::Bucket\n" +
+		"    Properties:\n" +
+		"      BucketName: my-data\n" +
+		"      BucketEncryption:\n" +
+		"        ServerSideEncryptionConfiguration: []\n"
+	anchor := strings.Index(yaml, "AWS::S3::Bucket")
+	span := string(absenceSpan([]byte(yaml), []int{anchor, anchor + len("AWS::S3::Bucket")}, "brace-enclosing"))
+	if !strings.Contains(span, "BucketEncryption") {
+		t.Errorf("the enclosing span of the Type anchor does not reach the sibling "+
+			"BucketEncryption property, so an encrypted bucket would be reported as "+
+			"missing encryption: %q", span)
+	}
+}
+
+// TestJSONBraceSpanIsUnchanged. The fallback must only trigger when there is no
+// brace — a JSON template must still be bounded by its braces exactly as before.
+func TestJSONBraceSpanIsUnchanged(t *testing.T) {
+	json := `{"Resources":{"LogBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"x"}}}}`
+	anchor := strings.Index(json, "AWS::S3::Bucket")
+	span := string(absenceSpan([]byte(json), []int{anchor, anchor + len("AWS::S3::Bucket")}, "brace-enclosing"))
+	if !strings.HasPrefix(strings.TrimSpace(span), "{") {
+		t.Errorf("a JSON resource is no longer bounded by its braces: %q", span)
+	}
+	if !strings.Contains(span, "BucketName") {
+		t.Errorf("the JSON brace span lost the resource properties: %q", span)
+	}
+}

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -162,7 +162,23 @@ overlaps, dependency applicability. Measuring suggests a different one.
    not move confidence — see above — but it makes `nox why` answer "what
    supports it" with something other than the rule firing.
 3. **IAC structural parsing.** Largest single piece of work, largest family, and
-   the only way 490 rules ever exceed heuristic. Should be scoped as a feature.
+   the only way 490 rules ever exceed heuristic. Should be scoped as a feature —
+   but measuring it first found a bounded, high-value bug that did not need the
+   feature.
+
+   Every brace-enclosing absence rule (IAC-051 and its family) silently missed
+   CloudFormation written in YAML. The span that bounds a resource block was
+   `brace-enclosing`, which walks out to the enclosing `{ }` — and YAML has
+   none, so the span came back empty and the rule never fired. Measured: IAC-051
+   flags an unencrypted S3 bucket in a JSON template and misses the identical
+   bucket in YAML. The rules already listed *.yaml in their file patterns, so
+   the format was always in scope; only the span could not reach it. Fixed with
+   an indentation-bounded ENCLOSING span — distinct from the block span, a
+   distinction a false positive taught: the block span of a `Type:` anchor is
+   the scalar alone, so a sibling encryption property fell outside it and an
+   encrypted bucket looked unencrypted. This is not the structural rewrite; it
+   is one bounded fix the rewrite would have subsumed, delivered now because it
+   is a real false negative with a reproduction.
 4. **Endpoint/API misuse** is a plugin (`nox-plugin-api-abuse`) and cannot be
    fixed from this repository. Its API-ABUSE-001 sits at precision 0.000 — never
    a true positive on the corpus — which under Milestone 10.2 makes it a


### PR DESCRIPTION
Measuring the IAC family for the migration found a **bounded false-negative class** that didn't need the structural rewrite.

## The bug

Every `brace-enclosing` absence rule — IAC-051 (S3 bucket missing encryption) and its family — **silently missed CloudFormation written in YAML**. The span that bounds a resource block was `brace-enclosing`, which walks out to the enclosing `{ }`. YAML has none, so `braceBlockEnclosing` returned `nil`, the absence matcher had no span to search, and the rule never fired.

The rules already listed `*.yaml`/`*.yml` in their file patterns — the format was always in scope; only the span couldn't reach it.

| | JSON template | YAML template |
|---|---|---|
| IAC-051 on an unencrypted S3 bucket | fires ✓ | **misses ✗** |

## The fix, and the false positive that shaped it

Fall back to an indentation-bounded span when there's no brace. But it must be the **enclosing** span, not the block the anchor introduces — and a false positive taught that:

`yamlBlockSpan` of a `Type: AWS::S3::Bucket` anchor is the scalar alone, so a sibling `BucketEncryption` property falls outside it — and an **encrypted** bucket got reported as missing encryption. `yamlEnclosingSpan` walks up to the resource key and takes its whole block, the YAML analogue of walking out to the enclosing brace.

Measured after, on a template with one encrypted and one unencrypted bucket:

```
IAC-051 fires once, on the unencrypted one (line 11); the encrypted DataBucket (line 3) is not flagged
```

The JSON path is untouched — the fallback triggers only when there's no brace — and the full suite is green, so no existing IAC test relied on the empty YAML span.

## Scope

This is **not** the structural rewrite the family needs — it's one bounded fix the rewrite would have subsumed, worth doing now because it's a real false negative with a reproduction. Found by running the scan; the false positive that shaped the fix was found the same way.

## Falsification

| what was broken | what failed |
|---|---|
| remove the fallback | `brace-enclosing returned no span for a YAML resource; the whole CloudFormation-in-YAML class stays unscanned` |
| use the block span instead of enclosing | `does not reach the sibling BucketEncryption property` — with the offending span `Type: AWS::S3::Bucket` in the message |

`go build ./...` clean · `go test ./...` green · `golangci-lint` 0 issues.

https://claude.ai/code/session_01WfjQxdozB9WJpydUnGQLUW