### PR TITLE
IAC: absence rules resolve the companion, instead of counting its name

### DIFF
--- a/core/analyzers/iac/absence_test.go
+++ b/core/analyzers/iac/absence_test.go
@@ -68,7 +68,11 @@ func TestAbsenceRules_HardenedCleanInsecureFlagged(t *testing.T) {
 		},
 		{
 			id: "IAC-059", path: "vpc.json",
-			hardened: `{"Resources":{"V":{"Type":"AWS::EC2::VPC","Properties":{}},"F":{"Type":"AWS::EC2::FlowLog","Properties":{}}}}`,
+			// The flow log must REFERENCE the VPC. It used to be enough for one
+			// to exist with empty properties, which is what the text path could
+			// see; a flow log that targets nothing monitors nothing, and
+			// TestCompanionRefusesAnUnboundFlowLog holds that it is flagged.
+			hardened: `{"Resources":{"V":{"Type":"AWS::EC2::VPC","Properties":{}},"F":{"Type":"AWS::EC2::FlowLog","Properties":{"ResourceId":{"Ref":"V"},"TrafficType":"ALL"}}}}`,
 			insecure: `{"Resources":{"V":{"Type":"AWS::EC2::VPC","Properties":{}}}}`,
 		},
 		{

--- a/core/analyzers/iac/companion_absence_test.go
+++ b/core/analyzers/iac/companion_absence_test.go
@@ -1,0 +1,276 @@
+package iac
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// manifest is the case that motivates cross-resource resolution: three
+// workloads and one PodDisruptionBudget that selects exactly one of them.
+//
+// The text form of IAC-132 searches the whole file for "PodDisruptionBudget",
+// finds it, and reports nothing — so two workloads with no availability
+// guarantee at all read as protected.
+const manifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: api:1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+        - name: worker
+          image: worker:1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+spec:
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - name: db
+          image: db:1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: api
+`
+
+// The headline: a budget that selects one workload protects one workload.
+func TestCompanionResolutionSeesWhoIsActuallyProtected(t *testing.T) {
+	got := iacFindings(t, "manifest.yaml", manifest, "IAC-132")
+	if len(got) != 2 {
+		for _, f := range got {
+			t.Logf("  line %d", f.Location.StartLine)
+		}
+		t.Fatalf("IAC-132 fired %d times, want 2 (worker and db); "+
+			"the text path reports 0 because the word is in the file", len(got))
+	}
+
+	// Both findings must land on the unprotected workloads, never on api.
+	for _, f := range got {
+		claim := f.Metadata[rules.StructuralClaimKey]
+		if strings.Contains(claim, `"api"`) {
+			t.Errorf("reported the protected workload: %q", claim)
+		}
+		if !strings.Contains(claim, "binds to a different resource") {
+			t.Errorf("claim does not say the budget binds elsewhere: %q", claim)
+		}
+	}
+}
+
+// A workload the budget does select must be refuted, not reported. This is the
+// direction that matters most: the structural path may only ever remove a
+// finding it can prove wrong.
+func TestCompanionResolutionRefutesTheProtectedWorkload(t *testing.T) {
+	single := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: api:1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-pdb
+spec:
+  selector:
+    matchLabels:
+      app: api
+`
+	if got := iacFindings(t, "manifest.yaml", single, "IAC-132"); len(got) != 0 {
+		t.Errorf("IAC-132 fired on a workload its budget selects: %+v", got)
+	}
+}
+
+// A flow log that references nothing monitors nothing.
+//
+// This was the previous hardened fixture for IAC-059, and it passed only
+// because the text path counted the word "FlowLog" as the protection existing.
+func TestCompanionRefusesAnUnboundFlowLog(t *testing.T) {
+	tmpl := `{"Resources":{
+	  "V":{"Type":"AWS::EC2::VPC","Properties":{}},
+	  "F":{"Type":"AWS::EC2::FlowLog","Properties":{}}
+	}}`
+	got := iacFindings(t, "vpc.json", tmpl, "IAC-059")
+	if len(got) != 1 {
+		t.Fatalf("IAC-059 fired %d times, want 1: a flow log with no ResourceId "+
+			"targets no VPC, so this VPC is unmonitored", len(got))
+	}
+	if claim := got[0].Metadata[rules.StructuralClaimKey]; !strings.Contains(claim, "binds to a different resource") {
+		t.Errorf("claim = %q, want it to say the flow log binds elsewhere", claim)
+	}
+}
+
+// A tag whose KEY contains the companion's name is not the companion. The text
+// property regex for IAC-059 is `(?i)FlowLog`, which `FlowLogsEnabled: false`
+// satisfies — so a VPC with logging explicitly turned OFF read as configured.
+func TestCompanionIsNotSatisfiedByMatchingText(t *testing.T) {
+	tmpl := `{"Resources":{"V":{"Type":"AWS::EC2::VPC","Properties":{
+	  "CidrBlock":"10.0.0.0/16",
+	  "Tags":[{"Key":"FlowLogsEnabled","Value":"false"}]
+	}}}}`
+	if got := iacFindings(t, "vpc.json", tmpl, "IAC-059"); len(got) != 1 {
+		t.Errorf("IAC-059 fired %d times, want 1: a tag naming flow logs is not a flow log", len(got))
+	}
+}
+
+// A quota bounds the namespace it is scoped to and no other.
+func TestCompanionResolutionScopesQuotaToItsNamespace(t *testing.T) {
+	elsewhere := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: limits
+  namespace: team-b
+spec:
+  hard:
+    cpu: "4"
+`
+	if got := iacFindings(t, "ns.yaml", elsewhere, "IAC-133"); len(got) != 1 {
+		t.Errorf("IAC-133 fired %d times, want 1: the quota bounds team-b, not team-a", len(got))
+	}
+
+	same := strings.Replace(elsewhere, "namespace: team-b", "namespace: team-a", 1)
+	if got := iacFindings(t, "ns.yaml", same, "IAC-133"); len(got) != 0 {
+		t.Errorf("IAC-133 fired on a namespace its quota bounds: %+v", got)
+	}
+}
+
+// An ARM child resource binds to its parent by nesting, whatever either of them
+// is named — which matters because ARM names are usually expressions.
+func TestCompanionResolutionFollowsARMNesting(t *testing.T) {
+	nested := `{
+	  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+	  "resources": [{
+	    "type": "Microsoft.Sql/servers",
+	    "apiVersion": "2021-11-01",
+	    "name": "[parameters('serverName')]",
+	    "resources": [{
+	      "type": "auditingSettings",
+	      "apiVersion": "2021-11-01",
+	      "name": "default",
+	      "properties": {"state": "Enabled"}
+	    }]
+	  }]
+	}`
+	if got := iacFindings(t, "azuredeploy.json", nested, "IAC-084"); len(got) != 0 {
+		t.Errorf("IAC-084 fired on a server with a nested auditingSettings child: %+v", got)
+	}
+
+	bare := `{
+	  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+	  "resources": [{
+	    "type": "Microsoft.Sql/servers",
+	    "apiVersion": "2021-11-01",
+	    "name": "sqlserver1"
+	  }]
+	}`
+	if got := iacFindings(t, "azuredeploy.json", bare, "IAC-084"); len(got) != 1 {
+		t.Errorf("IAC-084 fired %d times on an unaudited server, want 1", len(got))
+	}
+}
+
+// A cross-resource finding carries evidence naming what was enumerated, so a
+// reader can check the claim against the file rather than take it.
+func TestCompanionFindingCarriesAStaticClaim(t *testing.T) {
+	a := NewAnalyzer()
+	store := reasoning.New()
+	a.RecordReasoningTo(store)
+
+	got, err := a.ScanFile("manifest.yaml", []byte(manifest))
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+	var target *findings.Finding
+	for i := range got {
+		if got[i].RuleID == "IAC-132" {
+			target = &got[i]
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("IAC-132 did not fire")
+	}
+
+	subject := reasoning.Candidate(target.RuleID, "manifest.yaml",
+		target.Location.StartLine, target.Location.StartColumn)
+
+	var found bool
+	for _, c := range store.About(subject).Claims {
+		if c.Kind == evidence.KindStatic && strings.Contains(c.Statement, "PodDisruptionBudget") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no static claim naming the companion; the finding rests on the pattern alone")
+	}
+}
+
+// Content the parser cannot read must keep the text path, in both directions:
+// a Helm template is not valid YAML until it is rendered, and a chart with no
+// budget must still be reported.
+func TestCompanionUnparseableKeepsTheTextPath(t *testing.T) {
+	tmpl := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicas }}
+  template:
+    spec:
+      containers:
+        - name: app
+          image: {{ .Values.image }}
+`
+	if got := iacFindings(t, "deployment.yaml", tmpl, "IAC-132"); len(got) != 1 {
+		t.Errorf("IAC-132 fired %d times on an unrenderable template, want 1 "+
+			"from the text path: a document nox cannot read is not a document with nothing in it", len(got))
+	}
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -55,6 +55,13 @@ type iacRule struct {
 	// path. A pod is hardened only when every container is; "any" would call a
 	// pod with one hardened container safe.
 	absenceRequireAll bool
+	// absenceCompanion* make the rule CROSS-RESOURCE: what the subject needs is
+	// a different object bound to it, not a property on itself. See
+	// rules.Rule.AbsenceCompanionTypes and structural.Companion for the link
+	// kinds and why the mechanism is stated per rule.
+	absenceCompanionTypes []string
+	absenceCompanionLink  string
+	absenceCompanionPath  string
 }
 
 // builtinBaseIaCRules returns the original set of IaC security rules (IAC-001 to IAC-185).
@@ -730,8 +737,17 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceAnchor:   `(?i)AWS::EC2::VPC\b`,
 			absenceProperty: `(?i)FlowLog`,
 			absenceSpan:     "file",
-			description:     "CloudFormation VPC without flow logs",
-			cwe:             "CWE-778", keywords: []string{"AWS::EC2::VPC", "FlowLog", "TrafficType"},
+			// A flow log is a separate resource that names its VPC in
+			// Properties.ResourceId. The text form is satisfied by any
+			// occurrence of "FlowLog" — including a `FlowLogsEnabled: false`
+			// tag, and including a flow log for a VPC this template does not
+			// create.
+			absenceResourceTypes:  []string{"AWS::EC2::VPC"},
+			absenceCompanionTypes: []string{"AWS::EC2::FlowLog"},
+			absenceCompanionLink:  "ref",
+			absenceCompanionPath:  "Properties.ResourceId",
+			description:           "CloudFormation VPC without flow logs",
+			cwe:                   "CWE-778", keywords: []string{"AWS::EC2::VPC", "FlowLog", "TrafficType"},
 			filePatterns: []string{"*.template", "*.json", "*.yaml", "*.yml"},
 			tags:         []string{"iac", "cloudformation", "aws", "logging"},
 			remediation:  "Add an AWS::EC2::FlowLog resource for every VPC to capture network traffic metadata. Flow logs are essential for security monitoring and incident response.",
@@ -952,8 +968,15 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceAnchor:   `(?i)AWS::SecretsManager::Secret\b`,
 			absenceProperty: `(?i)RotationRules|RotationSchedule`,
 			absenceSpan:     "file",
-			description:     "CloudFormation Secrets Manager secret without rotation rules",
-			cwe:             "CWE-324", keywords: []string{"AWS::SecretsManager::Secret", "RotationRules"},
+			// RotationRules live on an AWS::SecretsManager::RotationSchedule,
+			// never on the secret, so no lookup within the secret can find
+			// them. The schedule names its secret in Properties.SecretId.
+			absenceResourceTypes:  []string{"AWS::SecretsManager::Secret"},
+			absenceCompanionTypes: []string{"AWS::SecretsManager::RotationSchedule"},
+			absenceCompanionLink:  "ref",
+			absenceCompanionPath:  "Properties.SecretId",
+			description:           "CloudFormation Secrets Manager secret without rotation rules",
+			cwe:                   "CWE-324", keywords: []string{"AWS::SecretsManager::Secret", "RotationRules"},
 			filePatterns: []string{"*.template", "*.json", "*.yaml", "*.yml"},
 			tags:         []string{"iac", "cloudformation", "aws", "secrets"},
 			remediation:  "Add RotationRules with AutomaticallyAfterDays to Secrets Manager secrets. Automatic rotation limits the lifetime of compromised credentials.",
@@ -1016,8 +1039,14 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceAnchor:   `(?i)Microsoft\.Sql/servers`,
 			absenceProperty: `(?i)auditingSettings`,
 			absenceSpan:     "file",
-			description:     "Azure SQL Server without auditing settings",
-			cwe:             "CWE-778", keywords: []string{"Microsoft.Sql/servers", "auditingSettings"},
+			// auditingSettings is a CHILD resource of the server, declared
+			// either nested in its `resources` array or at the top level under
+			// a "<server>/<name>" name.
+			absenceResourceTypes:  []string{"Microsoft.Sql/servers"},
+			absenceCompanionTypes: []string{"Microsoft.Sql/servers/auditingSettings"},
+			absenceCompanionLink:  "child",
+			description:           "Azure SQL Server without auditing settings",
+			cwe:                   "CWE-778", keywords: []string{"Microsoft.Sql/servers", "auditingSettings"},
 			filePatterns: []string{"*.json", "azuredeploy.json", "*.bicep"},
 			tags:         []string{"iac", "arm", "azure", "database", "logging"},
 			remediation:  "Enable auditing on Azure SQL Server with a retention period of at least 90 days. Send audit logs to a storage account or Log Analytics workspace.",
@@ -1035,11 +1064,14 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-086", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?i)Microsoft\.Sql/servers`,
-			absenceProperty: `(?i)firewallRules`,
-			absenceSpan:     "file",
-			description:     "Azure SQL Server without firewall rules",
-			cwe:             "CWE-284", keywords: []string{"Microsoft.Sql/servers", "firewallRules"},
+			absenceAnchor:         `(?i)Microsoft\.Sql/servers`,
+			absenceProperty:       `(?i)firewallRules`,
+			absenceSpan:           "file",
+			absenceResourceTypes:  []string{"Microsoft.Sql/servers"},
+			absenceCompanionTypes: []string{"Microsoft.Sql/servers/firewallRules"},
+			absenceCompanionLink:  "child",
+			description:           "Azure SQL Server without firewall rules",
+			cwe:                   "CWE-284", keywords: []string{"Microsoft.Sql/servers", "firewallRules"},
 			filePatterns: []string{"*.json", "azuredeploy.json", "*.bicep"},
 			tags:         []string{"iac", "arm", "azure", "database", "network"},
 			remediation:  "Configure firewall rules to restrict SQL Server access to specific IP ranges. Avoid using 0.0.0.0 as start IP which allows all Azure services.",
@@ -1586,8 +1618,14 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceAnchor:   `(?i)kind\s*:\s*(Deployment|StatefulSet)`,
 			absenceProperty: `(?i)PodDisruptionBudget`,
 			absenceSpan:     "file",
-			description:     "Kubernetes workload without PodDisruptionBudget",
-			cwe:             "CWE-693", keywords: []string{"PodDisruptionBudget"},
+			// A budget binds to a workload through its label selector, which
+			// the text form cannot see: one PodDisruptionBudget anywhere in the
+			// file silences the rule for every workload in it, selected or not.
+			absenceResourceTypes:  []string{"Deployment", "StatefulSet"},
+			absenceCompanionTypes: []string{"PodDisruptionBudget"},
+			absenceCompanionLink:  "selector",
+			description:           "Kubernetes workload without PodDisruptionBudget",
+			cwe:                   "CWE-693", keywords: []string{"PodDisruptionBudget"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "availability"},
 			remediation:  "Create a PodDisruptionBudget for each Deployment and StatefulSet to ensure minimum availability during voluntary disruptions like node drains.",
@@ -1598,8 +1636,13 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceAnchor:   `(?i)kind\s*:\s*Namespace`,
 			absenceProperty: `(?i)ResourceQuota`,
 			absenceSpan:     "file",
-			description:     "Kubernetes namespace without ResourceQuota",
-			cwe:             "CWE-770", keywords: []string{"Namespace", "ResourceQuota"},
+			// A quota is scoped to a namespace by metadata.namespace, so a
+			// quota for team-b does not bound team-a however near it sits.
+			absenceResourceTypes:  []string{"Namespace"},
+			absenceCompanionTypes: []string{"ResourceQuota"},
+			absenceCompanionLink:  "namespace",
+			description:           "Kubernetes namespace without ResourceQuota",
+			cwe:                   "CWE-770", keywords: []string{"Namespace", "ResourceQuota"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "resources"},
 			remediation:  "Create ResourceQuota objects for each namespace to prevent any single namespace from consuming excessive cluster resources.",
@@ -1607,11 +1650,14 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-134", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?i)kind\s*:\s*Namespace`,
-			absenceProperty: `(?i)LimitRange`,
-			absenceSpan:     "file",
-			description:     "Kubernetes namespace without LimitRange",
-			cwe:             "CWE-770", keywords: []string{"Namespace", "LimitRange"},
+			absenceAnchor:         `(?i)kind\s*:\s*Namespace`,
+			absenceProperty:       `(?i)LimitRange`,
+			absenceSpan:           "file",
+			absenceResourceTypes:  []string{"Namespace"},
+			absenceCompanionTypes: []string{"LimitRange"},
+			absenceCompanionLink:  "namespace",
+			description:           "Kubernetes namespace without LimitRange",
+			cwe:                   "CWE-770", keywords: []string{"Namespace", "LimitRange"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "resources"},
 			remediation:  "Create LimitRange objects for namespaces to set default resource requests and limits for containers that do not specify their own.",
@@ -2248,6 +2294,9 @@ func convertIaCRules(defs []iacRule) []rules.Rule {
 			r.AbsenceResourceTypes = defs[i].absenceResourceTypes
 			r.AbsencePropertyPath = defs[i].absencePropertyPath
 			r.AbsenceRequireAll = defs[i].absenceRequireAll
+			r.AbsenceCompanionTypes = defs[i].absenceCompanionTypes
+			r.AbsenceCompanionLink = defs[i].absenceCompanionLink
+			r.AbsenceCompanionPath = defs[i].absenceCompanionPath
 			// Absence rules must NOT be keyword-gated. The engine skips a rule
 			// when none of its keywords appear in the file, but these rules'
 			// keywords name the hardening property — which is precisely what is

--- a/core/analyzers/iac/structural_absence_test.go
+++ b/core/analyzers/iac/structural_absence_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
+	"github.com/nox-hq/nox/core/rules/structural"
 )
 
 // aliasTemplate is the case that motivated the structural path: two encrypted
@@ -195,8 +196,32 @@ func TestMigratedRulesKeepTheirTextPath(t *testing.T) {
 		if r.AbsenceProperty == "" {
 			t.Errorf("%s: structural descriptor but no absence property to fall back to", r.ID)
 		}
-		if len(r.AbsencePropertyPath) == 0 {
-			t.Errorf("%s: resource types but no property path", r.ID)
+		// A descriptor addresses the requirement either as a property on the
+		// resource or as a companion bound to it. One or the other must be
+		// there, or the structural path has nothing to evaluate and silently
+		// falls back on every file.
+		hasProperty := len(r.AbsencePropertyPath) > 0
+		hasCompanion := len(r.AbsenceCompanionTypes) > 0
+		if !hasProperty && !hasCompanion {
+			t.Errorf("%s: resource types but neither a property path nor a companion", r.ID)
+		}
+		if !hasCompanion {
+			continue
+		}
+		// The link mechanism is never inferred: resolving with the wrong one
+		// answers "not bound" for every subject, which invents a finding on
+		// each of them.
+		switch structural.Link(r.AbsenceCompanionLink) {
+		case structural.LinkRef:
+			if r.AbsenceCompanionPath == "" {
+				t.Errorf("%s: a ref companion needs the path holding the reference", r.ID)
+			}
+		case structural.LinkSelector, structural.LinkNamespace, structural.LinkChild:
+			if r.AbsenceCompanionPath != "" {
+				t.Errorf("%s: %s linkage takes no path", r.ID, r.AbsenceCompanionLink)
+			}
+		default:
+			t.Errorf("%s: unknown companion link %q", r.ID, r.AbsenceCompanionLink)
 		}
 	}
 	if migrated == 0 {

--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -386,15 +386,32 @@ func (m *AbsenceMatcher) Match(content []byte, rule *Rule) []MatchResult {
 // structuralAbsence evaluates a rule's structural descriptor, returning the
 // results and whether the verdict decided the question.
 //
-// ok=false means fall back to text matching. It covers three distinct cases
+// ok=false means fall back to text matching. It covers four distinct cases
 // that must all degrade the same way: the rule has no descriptor, the content
-// did not parse, or it parsed into a schema this build does not understand.
+// did not parse, it parsed into a schema this build does not understand, or —
+// for a cross-resource rule — a companion's binding could not be resolved.
 func structuralAbsence(content []byte, rule *Rule) ([]MatchResult, bool) {
-	if len(rule.AbsenceResourceTypes) == 0 || len(rule.AbsencePropertyPath) == 0 {
+	if len(rule.AbsenceResourceTypes) == 0 {
 		return nil, false
 	}
-	v := structural.Evaluate(content, rule.AbsenceResourceTypes,
-		rule.AbsencePropertyPath, rule.AbsenceRequireAll)
+
+	var v structural.Verdict
+	switch {
+	case len(rule.AbsenceCompanionTypes) > 0:
+		// Cross-resource: the requirement is another object bound to the
+		// subject, not a property on it.
+		v = structural.EvaluateCompanion(content, rule.AbsenceResourceTypes,
+			structural.Companion{
+				Types: rule.AbsenceCompanionTypes,
+				Link:  structural.Link(rule.AbsenceCompanionLink),
+				Path:  rule.AbsenceCompanionPath,
+			})
+	case len(rule.AbsencePropertyPath) > 0:
+		v = structural.Evaluate(content, rule.AbsenceResourceTypes,
+			rule.AbsencePropertyPath, rule.AbsenceRequireAll)
+	default:
+		return nil, false
+	}
 	if !v.Decided {
 		return nil, false
 	}

--- a/core/rules/rules.go
+++ b/core/rules/rules.go
@@ -166,6 +166,28 @@ type Rule struct {
 	// because getting it wrong in this direction HIDES findings, and a default
 	// that hides is worse than one that is explicit at every site that needs it.
 	AbsenceRequireAll bool `yaml:"absence_require_all"`
+	// AbsenceCompanion* make the rule CROSS-RESOURCE: what the subject needs is
+	// not a property on it but a different object bound to it — a flow log for
+	// a VPC, a PodDisruptionBudget for a workload, a ResourceQuota for a
+	// Namespace, an auditingSettings child for a SQL server.
+	//
+	// These rules cannot be expressed by the property path above, because the
+	// property is on another resource; and the text form they replace searches
+	// the whole file for the companion's NAME, which cannot see whether the
+	// companion binds to THIS subject, cannot report more than one subject, and
+	// is satisfied by any text that contains the word.
+	//
+	// AbsenceCompanionLink names the binding mechanism ("ref", "selector",
+	// "namespace", "child") — see structural.Link. It is stated per rule and
+	// never inferred, because resolving with the wrong mechanism answers "not
+	// bound" for every subject, which for an absence rule invents a finding on
+	// each of them.
+	//
+	// AbsenceCompanionPath applies to "ref" only: where inside the companion
+	// the reference to the subject is written.
+	AbsenceCompanionTypes []string `yaml:"absence_companion_types"`
+	AbsenceCompanionLink  string   `yaml:"absence_companion_link"`
+	AbsenceCompanionPath  string   `yaml:"absence_companion_path"`
 }
 
 // RuleSet is an ordered collection of rules with fast lookup by ID and tag.

--- a/core/rules/structural/cloudformation.go
+++ b/core/rules/structural/cloudformation.go
@@ -119,8 +119,8 @@ func armElements(res *yaml.Node) []*yaml.Node {
 // same reasoning as maxAliasDepth: the document is attacker-controllable.
 func armResources(r *yaml.Node) []Resource {
 	var out []Resource
-	var walk func(n *yaml.Node, depth int)
-	walk = func(n *yaml.Node, depth int) {
+	var walk func(n *yaml.Node, parent *yaml.Node, parentType string, depth int)
+	walk = func(n *yaml.Node, parent *yaml.Node, parentType string, depth int) {
 		if depth > maxAliasDepth {
 			return
 		}
@@ -129,16 +129,19 @@ func armResources(r *yaml.Node) []Resource {
 			if typ == "" {
 				continue
 			}
-			out = append(out, Resource{
-				Family: FamilyARM,
-				Type:   typ,
-				Name:   scalarAt(el, "name"),
-				Props:  el,
-				Line:   el.Line,
-			})
-			walk(el, depth+1)
+			child := Resource{
+				Family:     FamilyARM,
+				Type:       typ,
+				Name:       scalarAt(el, "name"),
+				Props:      el,
+				Line:       el.Line,
+				Parent:     parent,
+				ParentType: parentType,
+			}
+			out = append(out, child)
+			walk(el, el, child.QualifiedType(), depth+1)
 		}
 	}
-	walk(r, 0)
+	walk(r, nil, "", 0)
 	return out
 }

--- a/core/rules/structural/companion.go
+++ b/core/rules/structural/companion.go
@@ -1,0 +1,503 @@
+package structural
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Companion resolution answers a question the single-resource model cannot:
+// whether a resource is protected by a DIFFERENT object declared elsewhere in
+// the document set.
+//
+// Eight absence rules ask it. A VPC is unmonitored unless a flow log targets
+// it; a Deployment is unprotected unless a PodDisruptionBudget selects it; a
+// Namespace is unbounded unless a ResourceQuota names it; a SQL server is
+// unaudited unless an auditingSettings child hangs off it. None of these
+// properties is on the resource the rule is about, so no lookup within it can
+// find them.
+//
+// What the text path does instead is search the whole file for the companion's
+// NAME. That is wrong in both directions, and measurably so:
+//
+//   - It cannot see linkage. A PodDisruptionBudget selecting `app: api`
+//     silences the rule for every workload in the file, including the three
+//     that it does not select. The word appearing is treated as the protection
+//     existing.
+//   - It cannot see quantity. `absenceSpan: "file"` reports one finding at the
+//     first anchor, so a manifest with four unprotected Deployments reports one.
+//   - It matches text that is not a resource. `FlowLogsEnabled: false` in a tag
+//     contains "FlowLog", so a VPC with logging explicitly turned OFF reads as
+//     a VPC with logging configured.
+//
+// Resolving the companion structurally answers all three, and yields a claim a
+// regex cannot make: the document set was parsed, its resources enumerated, and
+// none of them is a flow log bound to this VPC.
+//
+// # The boundary this deliberately does not cross
+//
+// A document set is what one file contains. A PodDisruptionBudget living in a
+// second file is not visible here, and "no companion in this file" is not "no
+// companion anywhere". That limit is inherited, not introduced — the text rule
+// it replaces is scoped to one file too — but it is the reason a companion
+// verdict claims what was PARSED rather than what is DEPLOYED, and the reason
+// Statement says "the document set" rather than "the cluster".
+
+// Link is how a companion binds to the subject it protects.
+//
+// Each kind is a different question, and asking the wrong one silently answers
+// "not bound" for every resource — which for an absence rule means inventing a
+// finding on every one of them. The kind is therefore named per rule and never
+// inferred from the types involved.
+type Link string
+
+const (
+	// LinkRef — the companion references the subject's logical name through a
+	// template intrinsic. CloudFormation's binding mechanism: a flow log names
+	// its VPC in `Properties.ResourceId`, a rotation schedule names its secret
+	// in `Properties.SecretId`.
+	LinkRef Link = "ref"
+	// LinkSelector — the companion's label selector matches the subject's pod
+	// template labels. How a PodDisruptionBudget binds to a workload.
+	LinkSelector Link = "selector"
+	// LinkNamespace — the companion is scoped to the namespace the subject
+	// declares. How a ResourceQuota or LimitRange binds to a Namespace.
+	LinkNamespace Link = "namespace"
+	// LinkChild — the companion is an ARM child resource of the subject,
+	// declared either nested inside it or at the top level under a name the
+	// parent's prefixes.
+	LinkChild Link = "child"
+)
+
+// Companion describes the resource whose existence AND linkage satisfies a
+// requirement the subject cannot express on itself.
+type Companion struct {
+	// Types are the companion's type, in the document's own spelling.
+	Types []string
+	// Link is how it binds to the subject.
+	Link Link
+	// Path, for LinkRef only, is where inside the companion the reference to
+	// the subject is written.
+	Path string
+}
+
+// linkage is the outcome of asking whether one companion binds to one subject.
+//
+// The third value is the point. "I cannot tell" is not "not bound": a selector
+// written with matchExpressions, an ARM name that is an expression, or a
+// reference to a template parameter are all cases where the answer needs
+// information the file does not carry. Reading any of them as "not bound"
+// would report a resource that is very likely protected, so an undecidable
+// pair takes the whole file back to the text path instead.
+type linkage int
+
+const (
+	unlinked linkage = iota
+	linked
+	undecidable
+)
+
+// EvaluateCompanion decides a cross-resource absence rule structurally.
+//
+// A subject is Absent when the document set contains no companion of the given
+// type bound to it, and Present when one is found. The two absent cases are
+// distinguished on the Hit — no companion at all, against a companion that
+// binds elsewhere — because they are different findings to read and the second
+// is the one the text path could never produce.
+func EvaluateCompanion(content []byte, subjectTypes []string, c Companion) Verdict {
+	if len(subjectTypes) == 0 || len(c.Types) == 0 || c.Link == "" {
+		return Verdict{Reason: "rule carries no companion descriptor"}
+	}
+	if c.Link == LinkRef && c.Path == "" {
+		return Verdict{Reason: "a ref companion needs the path holding the reference"}
+	}
+
+	docs, err := Parse(content)
+	if err != nil {
+		return Verdict{Reason: fmt.Sprintf("not parseable as YAML or JSON: %v", err)}
+	}
+	all := Resources(docs)
+	if len(all) == 0 {
+		return Verdict{Reason: "no CloudFormation, Kubernetes or ARM resources in the document"}
+	}
+
+	subjects := OfTypes(all, subjectTypes)
+	companions := OfTypes(all, c.Types)
+	companionType := c.Types[0]
+
+	v := Verdict{Decided: true}
+	for _, s := range subjects {
+		hit := Hit{
+			Type: s.Type, Name: s.Name, Line: s.Line, Family: s.Family,
+			Companion: companionType,
+		}
+
+		bound := false
+		for _, comp := range companions {
+			switch c.resolve(s, comp, all) {
+			case linked:
+				bound = true
+				hit.CompanionName = comp.Name
+			case undecidable:
+				// One pair nobody can decide makes the whole file undecided.
+				// Reporting the other subjects while silently dropping this one
+				// would be a verdict that looks complete and is not.
+				return Verdict{Reason: fmt.Sprintf(
+					"cannot resolve whether the %s at line %d binds to %s at line %d",
+					comp.Type, comp.Line, s.Type, s.Line)}
+			}
+			if bound {
+				break
+			}
+		}
+
+		if bound {
+			v.Present = append(v.Present, hit)
+			continue
+		}
+		// A companion of the right type exists somewhere in the document set,
+		// but none of them binds here. That is the finding the text path is
+		// structurally incapable of reporting, so it is worth distinguishing.
+		hit.Unlinked = len(companions) > 0
+		v.Absent = append(v.Absent, hit)
+	}
+	return v
+}
+
+// resolve asks the linkage question this companion is defined by.
+func (c Companion) resolve(subject, comp Resource, all []Resource) linkage {
+	// A resource cannot be its own companion. Types can legitimately overlap
+	// (a rule may name the subject's own type among the companions), and
+	// without this a resource would satisfy its own requirement.
+	if subject.Props == comp.Props {
+		return unlinked
+	}
+	switch c.Link {
+	case LinkRef:
+		return linkByRef(subject, comp, c.Path, all)
+	case LinkSelector:
+		return linkBySelector(subject, comp)
+	case LinkNamespace:
+		return linkByNamespace(subject, comp)
+	case LinkChild:
+		return linkByChild(subject, comp)
+	default:
+		return undecidable
+	}
+}
+
+// linkByRef resolves a CloudFormation intrinsic reference.
+//
+// Referencing a resource declared in the same template REQUIRES an intrinsic —
+// `!Ref`, `Fn::GetAtt`, `Fn::Sub` — so a literal string in the reference slot
+// names something outside the template and binds to nothing here. That is a
+// decidable "no", not an unknown, and it is exactly the case the text path gets
+// wrong: a flow log for a pre-existing VPC silences the rule for the VPC this
+// template creates.
+//
+// A reference to a name that is not a resource in the template — a parameter,
+// a pseudo-parameter — is undecidable rather than unlinked, because the
+// parameter may well carry the subject at deployment time and the file cannot
+// say.
+func linkByRef(subject, comp Resource, path string, all []Resource) linkage {
+	if subject.Family != FamilyCloudFormation || comp.Family != FamilyCloudFormation {
+		return undecidable
+	}
+	if subject.Name == "" {
+		return undecidable
+	}
+	target := nodeAt(comp.Props, path)
+	if target == nil {
+		// The companion does not set the property that would bind it. It binds
+		// to nothing, which is a fact about this companion, not an unknown.
+		return unlinked
+	}
+
+	names := templateRefs(target, 0)
+	if len(names) == 0 {
+		return unlinked
+	}
+	declared := make(map[string]bool, len(all))
+	for _, r := range all {
+		if r.Family == FamilyCloudFormation && r.Name != "" {
+			declared[r.Name] = true
+		}
+	}
+	external := false
+	for _, n := range names {
+		if n == subject.Name {
+			return linked
+		}
+		if !declared[n] {
+			external = true
+		}
+	}
+	if external {
+		return undecidable
+	}
+	return unlinked
+}
+
+// templateRefs collects the logical names a node references.
+//
+// It reads the intrinsic forms syntactically and never evaluates them, in
+// keeping with the rest of the package: `!Ref Vpc` references "Vpc" whatever
+// "Vpc" turns out to be at deployment time. Both notations are handled because
+// one template may use either — the YAML short form (`!Ref`, `!GetAtt`,
+// `!Sub`) and the JSON long form (`Ref`, `Fn::GetAtt`, `Fn::Sub`) are the same
+// document to CloudFormation and must be the same document here.
+func templateRefs(n *yaml.Node, depth int) []string {
+	n = resolve(n)
+	if n == nil || depth > maxAliasDepth {
+		return nil
+	}
+	var out []string
+	switch n.Kind {
+	case yaml.ScalarNode:
+		switch n.Tag {
+		case "!Ref":
+			out = append(out, n.Value)
+		case "!GetAtt":
+			out = append(out, logicalNameOf(n.Value))
+		case "!Sub":
+			out = append(out, subRefs(n.Value)...)
+		}
+	case yaml.SequenceNode:
+		for _, el := range n.Content {
+			out = append(out, templateRefs(el, depth+1)...)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key, val := n.Content[i].Value, resolve(n.Content[i+1])
+			switch key {
+			case "Ref":
+				if val != nil && val.Kind == yaml.ScalarNode {
+					out = append(out, val.Value)
+				}
+			case "Fn::GetAtt":
+				// Either ["Logical", "Attr"] or the "Logical.Attr" string.
+				if val == nil {
+					continue
+				}
+				if val.Kind == yaml.SequenceNode && len(val.Content) > 0 {
+					out = append(out, val.Content[0].Value)
+				} else if val.Kind == yaml.ScalarNode {
+					out = append(out, logicalNameOf(val.Value))
+				}
+			case "Fn::Sub":
+				// Either "text ${Logical}" or ["text ${Logical}", {vars}].
+				if val == nil {
+					continue
+				}
+				if val.Kind == yaml.SequenceNode && len(val.Content) > 0 {
+					out = append(out, subRefs(val.Content[0].Value)...)
+				} else if val.Kind == yaml.ScalarNode {
+					out = append(out, subRefs(val.Value)...)
+				}
+			default:
+				out = append(out, templateRefs(val, depth+1)...)
+			}
+		}
+	}
+	return out
+}
+
+// logicalNameOf takes the resource half of a "Logical.Attribute" GetAtt.
+func logicalNameOf(v string) string {
+	name, _, _ := strings.Cut(v, ".")
+	return name
+}
+
+// subRefs extracts the ${Name} placeholders of an Fn::Sub string.
+//
+// `${!Literal}` is CloudFormation's escape for a literal `${…}` and references
+// nothing, so it is skipped rather than read as a resource called "!Literal".
+func subRefs(s string) []string {
+	var out []string
+	for {
+		start := strings.Index(s, "${")
+		if start < 0 {
+			return out
+		}
+		s = s[start+2:]
+		end := strings.Index(s, "}")
+		if end < 0 {
+			return out
+		}
+		ref := s[:end]
+		s = s[end+1:]
+		if strings.HasPrefix(ref, "!") {
+			continue
+		}
+		if name := logicalNameOf(ref); name != "" {
+			out = append(out, name)
+		}
+	}
+}
+
+// linkBySelector resolves a Kubernetes label selector against a workload's pod
+// template labels.
+//
+// The quantifier is the one Kubernetes uses: a selector binds when EVERY label
+// it requires is present on the pod with the same value. A selector requiring
+// two labels of which the pod carries one does not select that pod, and reading
+// it as a match would silence the rule for a workload nothing protects.
+func linkBySelector(subject, comp Resource) linkage {
+	if subject.Family != FamilyKubernetes || comp.Family != FamilyKubernetes {
+		return undecidable
+	}
+	if !namespacesCompatible(subject, comp) {
+		return unlinked
+	}
+
+	sel := mapValue(mapValue(comp.Props, "spec"), "selector")
+	if sel == nil {
+		// A budget with no selector applies to everything in its namespace.
+		return linked
+	}
+	if mapValue(sel, "matchExpressions") != nil {
+		// Set-based requirements are a small language of their own (In, NotIn,
+		// Exists, DoesNotExist). Nothing here evaluates it, and guessing would
+		// decide a resource's fate on a selector this package cannot read.
+		return undecidable
+	}
+	match := mapValue(sel, "matchLabels")
+	if match == nil || len(match.Content) == 0 {
+		// An empty selector selects every pod in the namespace. That is
+		// Kubernetes' rule, and it is the opposite of HasAll's empty case:
+		// there, nothing satisfied the requirement; here, the requirement asks
+		// for nothing.
+		return linked
+	}
+
+	labels := podLabels(subject.Props)
+	if labels == nil {
+		// A workload whose pod template carries no labels cannot be matched by
+		// any selector, but a manifest that omits them is more likely relying
+		// on generation than declaring an unselectable pod.
+		return undecidable
+	}
+	for i := 0; i+1 < len(match.Content); i += 2 {
+		key, want := match.Content[i].Value, resolve(match.Content[i+1])
+		if want == nil || want.Kind != yaml.ScalarNode {
+			return undecidable
+		}
+		got := mapValue(labels, key)
+		if got == nil || got.Kind != yaml.ScalarNode {
+			return unlinked
+		}
+		if got.Value != want.Value {
+			return unlinked
+		}
+	}
+	return linked
+}
+
+// podLabels returns a workload's pod template labels.
+//
+// `spec.template.metadata.labels` for a Deployment, StatefulSet, DaemonSet or
+// Job; `metadata.labels` for a bare Pod, which has no template. A selector
+// matches the POD's labels, never the workload's own, and the two routinely
+// differ — which is why this does not simply read `metadata.labels`.
+func podLabels(props *yaml.Node) *yaml.Node {
+	spec := mapValue(props, "spec")
+	if tmpl := mapValue(spec, "template"); tmpl != nil {
+		if l := mapValue(mapValue(tmpl, "metadata"), "labels"); l != nil {
+			return l
+		}
+		return nil
+	}
+	if kind := scalarAt(props, "kind"); kind == "Pod" {
+		return mapValue(mapValue(props, "metadata"), "labels")
+	}
+	return nil
+}
+
+// namespacesCompatible reports whether two objects could be in the same
+// namespace.
+//
+// An omitted namespace is not "the default namespace": it is a namespace
+// supplied at apply time, by `kubectl -n` or by the kustomization or chart that
+// renders the manifest. Treating omission as a mismatch would report every
+// workload in every namespace-agnostic manifest — which is most of them — so
+// only two namespaces that are both stated and different are incompatible.
+func namespacesCompatible(a, b Resource) bool {
+	na := scalarAt(mapValue(a.Props, "metadata"), "namespace")
+	nb := scalarAt(mapValue(b.Props, "metadata"), "namespace")
+	if na == "" || nb == "" {
+		return true
+	}
+	return na == nb
+}
+
+// linkByNamespace resolves a namespaced object against the Namespace it is
+// scoped to.
+func linkByNamespace(subject, comp Resource) linkage {
+	if subject.Family != FamilyKubernetes || comp.Family != FamilyKubernetes {
+		return undecidable
+	}
+	name := scalarAt(mapValue(subject.Props, "metadata"), "name")
+	if name == "" {
+		return undecidable
+	}
+	ns := scalarAt(mapValue(comp.Props, "metadata"), "namespace")
+	if ns == "" {
+		// Same reasoning as namespacesCompatible: a quota with no namespace is
+		// scoped when it is applied, and this file cannot say to where.
+		return undecidable
+	}
+	if ns == name {
+		return linked
+	}
+	return unlinked
+}
+
+// linkByChild resolves an ARM child resource against its parent.
+//
+// ARM allows the same child two spellings, and both are handled because both
+// appear in real templates:
+//
+//   - nested inside the parent's `resources` array, where the nesting IS the
+//     binding and no name has to be read;
+//   - at the top level, where the child's name carries the parent's as its
+//     first segment ("sqlserver1/DefaultAuditing").
+//
+// The second form is frequently written as an expression — `[concat(
+// parameters('serverName'), '/audit')]` — and this package does not evaluate
+// expressions, so those pairs are undecidable and take the file back to the
+// text path rather than guessing.
+func linkByChild(subject, comp Resource) linkage {
+	if subject.Family != FamilyARM || comp.Family != FamilyARM {
+		return undecidable
+	}
+	if comp.Parent != nil {
+		// Nested. Pointer identity, so an expression name decides nothing.
+		if comp.Parent == subject.Props {
+			return linked
+		}
+		return unlinked
+	}
+	if subject.Name == "" || comp.Name == "" {
+		return undecidable
+	}
+	if isARMExpression(subject.Name) || isARMExpression(comp.Name) {
+		return undecidable
+	}
+	parent, _, ok := strings.Cut(comp.Name, "/")
+	if !ok {
+		// A top-level child whose name carries no parent segment is malformed
+		// for this schema; nothing can be concluded from it.
+		return undecidable
+	}
+	if parent == subject.Name {
+		return linked
+	}
+	return unlinked
+}
+
+// isARMExpression reports whether a value is an ARM template expression rather
+// than a literal.
+func isARMExpression(v string) bool {
+	return strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]")
+}

--- a/core/rules/structural/companion_test.go
+++ b/core/rules/structural/companion_test.go
@@ -1,0 +1,670 @@
+package structural
+
+import (
+	"strings"
+	"testing"
+)
+
+// pdb is the companion descriptor IAC-132 carries.
+var pdb = Companion{Types: []string{"PodDisruptionBudget"}, Link: LinkSelector}
+
+// quota is IAC-133's.
+var quota = Companion{Types: []string{"ResourceQuota"}, Link: LinkNamespace}
+
+// flowLog is IAC-059's.
+var flowLog = Companion{
+	Types: []string{"AWS::EC2::FlowLog"},
+	Link:  LinkRef,
+	Path:  "Properties.ResourceId",
+}
+
+// auditing is IAC-084's.
+var auditing = Companion{
+	Types: []string{"Microsoft.Sql/servers/auditingSettings"},
+	Link:  LinkChild,
+}
+
+func TestCompanionSelectorBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		absent  int
+		present int
+		decided bool
+	}{
+		{
+			name:    "a budget whose selector matches the pod labels binds",
+			decided: true, present: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api, tier: web}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: api-pdb}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels: {app: api}
+`,
+		},
+		{
+			name: "a budget selecting a different workload leaves this one unprotected",
+			// The text path cannot reach this: the word PodDisruptionBudget is
+			// in the file, so it reports nothing at all.
+			decided: true, absent: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: worker-pdb}
+spec:
+  selector:
+    matchLabels: {app: worker}
+`,
+		},
+		{
+			name:    "a selector requiring more labels than the pod carries does not bind",
+			decided: true, absent: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: strict}
+spec:
+  selector:
+    matchLabels: {app: api, tier: web}
+`,
+		},
+		{
+			name:    "no budget anywhere in the document set",
+			decided: true, absent: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+`,
+		},
+		{
+			name:    "an empty selector selects every pod in the namespace",
+			decided: true, present: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: catch-all}
+spec:
+  selector:
+    matchLabels: {}
+`,
+		},
+		{
+			name:    "budgets in a different stated namespace do not bind",
+			decided: true, absent: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api, namespace: prod}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: api-pdb, namespace: staging}
+spec:
+  selector:
+    matchLabels: {app: api}
+`,
+		},
+		{
+			name: "an omitted namespace is not a mismatch",
+			// The namespace of a namespace-agnostic manifest is supplied at
+			// apply time. Reading omission as a mismatch would report every
+			// workload in every chart.
+			decided: true, present: 1,
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api, namespace: prod}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: api-pdb}
+spec:
+  selector:
+    matchLabels: {app: api}
+`,
+		},
+		{
+			name: "matchExpressions is undecidable, not unbound",
+			// Set-based requirements are a language this package does not
+			// evaluate. Reading one as "does not match" would report a workload
+			// that is very likely protected.
+			content: `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers: [{name: c, image: api:1}]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: expr}
+spec:
+  selector:
+    matchExpressions:
+      - {key: app, operator: In, values: [api]}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := EvaluateCompanion([]byte(tt.content), []string{"Deployment", "StatefulSet"}, pdb)
+			assertVerdict(t, v, tt.decided, tt.absent, tt.present)
+		})
+	}
+}
+
+// TestCompanionReportsEveryUnprotectedSubject is the quantity half of the fix.
+//
+// The text rule bounds the property search to the whole file and reports at the
+// FIRST anchor, so a manifest with three unprotected workloads produces one
+// finding. Resolution is per subject, so three do.
+func TestCompanionReportsEveryUnprotectedSubject(t *testing.T) {
+	content := `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata: {labels: {app: api}}
+    spec: {containers: [{name: c, image: api:1}]}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: worker}
+spec:
+  template:
+    metadata: {labels: {app: worker}}
+    spec: {containers: [{name: c, image: w:1}]}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: {name: db}
+spec:
+  template:
+    metadata: {labels: {app: db}}
+    spec: {containers: [{name: c, image: db:1}]}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: api-pdb}
+spec:
+  selector:
+    matchLabels: {app: api}
+`
+	v := EvaluateCompanion([]byte(content), []string{"Deployment", "StatefulSet"}, pdb)
+	assertVerdict(t, v, true, 2, 1)
+
+	names := []string{v.Absent[0].Name, v.Absent[1].Name}
+	if names[0] != "worker" || names[1] != "db" {
+		t.Errorf("unprotected workloads = %v, want [worker db]", names)
+	}
+	if v.Present[0].CompanionName != "api-pdb" {
+		t.Errorf("bound companion = %q, want api-pdb", v.Present[0].CompanionName)
+	}
+}
+
+// TestUnlinkedIsDistinguishedFromAbsent keeps the two absent cases apart. They
+// are different findings to read, and only the second is one a text search
+// could ever have produced.
+func TestUnlinkedIsDistinguishedFromAbsent(t *testing.T) {
+	workload := `
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: api}
+spec:
+  template:
+    metadata: {labels: {app: api}}
+    spec: {containers: [{name: c, image: api:1}]}
+`
+	elsewhere := workload + `---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata: {name: other}
+spec:
+  selector:
+    matchLabels: {app: worker}
+`
+
+	none := EvaluateCompanion([]byte(workload), []string{"Deployment"}, pdb)
+	assertVerdict(t, none, true, 1, 0)
+	if none.Absent[0].Unlinked {
+		t.Error("a document set with no budget at all must not report one as unlinked")
+	}
+	if got := none.Absent[0].Statement(true); !strings.Contains(got, "declares no PodDisruptionBudget") {
+		t.Errorf("statement = %q, want it to say the document set declares none", got)
+	}
+
+	other := EvaluateCompanion([]byte(elsewhere), []string{"Deployment"}, pdb)
+	assertVerdict(t, other, true, 1, 0)
+	if !other.Absent[0].Unlinked {
+		t.Error("a budget that binds elsewhere must be reported as unlinked")
+	}
+	if got := other.Absent[0].Statement(true); !strings.Contains(got, "binds to a different resource") {
+		t.Errorf("statement = %q, want it to say the budget binds elsewhere", got)
+	}
+}
+
+func TestCompanionNamespaceBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		absent  int
+		present int
+		decided bool
+	}{
+		{
+			name:    "a quota scoped to the namespace binds",
+			decided: true, present: 1,
+			content: `
+apiVersion: v1
+kind: Namespace
+metadata: {name: team-a}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata: {name: limits, namespace: team-a}
+spec: {hard: {cpu: "4"}}
+`,
+		},
+		{
+			name:    "a quota scoped to another namespace does not",
+			decided: true, absent: 1,
+			content: `
+apiVersion: v1
+kind: Namespace
+metadata: {name: team-a}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata: {name: limits, namespace: team-b}
+spec: {hard: {cpu: "4"}}
+`,
+		},
+		{
+			name:    "no quota in the document set",
+			decided: true, absent: 1,
+			content: `
+apiVersion: v1
+kind: Namespace
+metadata: {name: team-a}
+`,
+		},
+		{
+			name: "a quota with no namespace is undecidable",
+			// It is scoped when it is applied, and this file cannot say where.
+			content: `
+apiVersion: v1
+kind: Namespace
+metadata: {name: team-a}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata: {name: limits}
+spec: {hard: {cpu: "4"}}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := EvaluateCompanion([]byte(tt.content), []string{"Namespace"}, quota)
+			assertVerdict(t, v, tt.decided, tt.absent, tt.present)
+		})
+	}
+}
+
+func TestCompanionRefBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		absent  int
+		present int
+		decided bool
+	}{
+		{
+			name:    "the YAML short form binds",
+			decided: true, present: 1,
+			content: `
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Ref Vpc
+      ResourceType: VPC
+      TrafficType: ALL
+`,
+		},
+		{
+			name:    "the JSON long form binds",
+			decided: true, present: 1,
+			content: `{
+  "Resources": {
+    "Vpc": {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.0.0.0/16"}},
+    "Logs": {
+      "Type": "AWS::EC2::FlowLog",
+      "Properties": {"ResourceId": {"Ref": "Vpc"}, "TrafficType": "ALL"}
+    }
+  }
+}`,
+		},
+		{
+			name:    "Fn::Sub binds through its placeholder",
+			decided: true, present: 1,
+			content: `
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Sub "${Vpc}"
+      TrafficType: ALL
+`,
+		},
+		{
+			name: "a flow log for a different VPC leaves this one unmonitored",
+			// Two VPCs, one flow log. The text path sees "FlowLog" and reports
+			// neither; resolution reports the one nothing watches.
+			decided: true, absent: 1, present: 1,
+			content: `
+Resources:
+  Watched:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Unwatched:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.1.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Ref Watched
+      TrafficType: ALL
+`,
+		},
+		{
+			name: "a literal id names a VPC outside the template",
+			// Referring to a resource in the same template requires an
+			// intrinsic, so a literal binds to nothing declared here.
+			decided: true, absent: 1,
+			content: `
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: vpc-0a1b2c3d
+      TrafficType: ALL
+`,
+		},
+		{
+			name:    "a flow log that sets no ResourceId binds to nothing",
+			decided: true, absent: 1,
+			content: `
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties: {TrafficType: ALL}
+`,
+		},
+		{
+			name: "a reference to a parameter is undecidable",
+			// The parameter may carry this VPC at deployment time.
+			content: `
+Parameters:
+  TargetVpc: {Type: String}
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties: {CidrBlock: 10.0.0.0/16}
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Ref TargetVpc
+      TrafficType: ALL
+`,
+		},
+		{
+			name: "a tag containing the word FlowLog is not a flow log",
+			// `FlowLogsEnabled: false` satisfies the text rule's property
+			// regex, so a VPC with logging explicitly OFF reads as configured.
+			decided: true, absent: 1,
+			content: `
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags: [{Key: FlowLogsEnabled, Value: "false"}]
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := EvaluateCompanion([]byte(tt.content), []string{"AWS::EC2::VPC"}, flowLog)
+			assertVerdict(t, v, tt.decided, tt.absent, tt.present)
+		})
+	}
+}
+
+func TestCompanionChildBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		absent  int
+		present int
+		decided bool
+	}{
+		{
+			name: "a nested child binds by its nesting",
+			// No name is read, so an expression name decides nothing here.
+			decided: true, present: 1,
+			content: `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [{
+    "type": "Microsoft.Sql/servers",
+    "apiVersion": "2021-11-01",
+    "name": "[parameters('serverName')]",
+    "resources": [{
+      "type": "auditingSettings",
+      "apiVersion": "2021-11-01",
+      "name": "default",
+      "properties": {"state": "Enabled"}
+    }]
+  }]
+}`,
+		},
+		{
+			name:    "a top-level child binds through its name prefix",
+			decided: true, present: 1,
+			content: `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {"type": "Microsoft.Sql/servers", "apiVersion": "2021-11-01", "name": "sqlserver1"},
+    {
+      "type": "Microsoft.Sql/servers/auditingSettings",
+      "apiVersion": "2021-11-01",
+      "name": "sqlserver1/default",
+      "properties": {"state": "Enabled"}
+    }
+  ]
+}`,
+		},
+		{
+			name:    "a child of another server does not bind",
+			decided: true, absent: 1,
+			content: `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {"type": "Microsoft.Sql/servers", "apiVersion": "2021-11-01", "name": "sqlserver1"},
+    {
+      "type": "Microsoft.Sql/servers/auditingSettings",
+      "apiVersion": "2021-11-01",
+      "name": "other/default",
+      "properties": {"state": "Enabled"}
+    }
+  ]
+}`,
+		},
+		{
+			name:    "a server with no auditing child anywhere",
+			decided: true, absent: 1,
+			content: `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {"type": "Microsoft.Sql/servers", "apiVersion": "2021-11-01", "name": "sqlserver1"}
+  ]
+}`,
+		},
+		{
+			name: "expression names are undecidable at the top level",
+			content: `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {"type": "Microsoft.Sql/servers", "apiVersion": "2021-11-01", "name": "[parameters('s')]"},
+    {
+      "type": "Microsoft.Sql/servers/auditingSettings",
+      "apiVersion": "2021-11-01",
+      "name": "[concat(parameters('s'), '/default')]"
+    }
+  ]
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := EvaluateCompanion([]byte(tt.content), []string{"Microsoft.Sql/servers"}, auditing)
+			assertVerdict(t, v, tt.decided, tt.absent, tt.present)
+		})
+	}
+}
+
+// TestCompanionUndecidedFallsBackToText holds the rule that makes migrating a
+// rule additive: content the parser cannot read must never read as an
+// all-clear, and must never read as a finding either.
+func TestCompanionUndecidedFallsBackToText(t *testing.T) {
+	cases := map[string]string{
+		"not YAML at all":         "FROM alpine:3\nRUN echo hi\n:::{",
+		"a schema not recognised": "version: '3'\nservices:\n  web:\n    image: nginx\n",
+		"no descriptor":           "apiVersion: apps/v1\nkind: Deployment\nmetadata: {name: a}\n",
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := pdb
+			if name == "no descriptor" {
+				c = Companion{}
+			}
+			v := EvaluateCompanion([]byte(content), []string{"Deployment"}, c)
+			if v.Decided {
+				t.Fatal("verdict decided; unreadable content must fall back to text matching")
+			}
+			if v.Reason == "" {
+				t.Error("an undecided verdict must say why, for the degradation channel")
+			}
+		})
+	}
+}
+
+// TestCompanionSubjectIsNotItsOwnCompanion guards the degenerate case where a
+// rule names overlapping types: without it a resource would satisfy its own
+// requirement and no rule of this shape could ever fire.
+func TestCompanionSubjectIsNotItsOwnCompanion(t *testing.T) {
+	content := `
+apiVersion: v1
+kind: Namespace
+metadata: {name: team-a, namespace: team-a}
+`
+	c := Companion{Types: []string{"Namespace"}, Link: LinkNamespace}
+	v := EvaluateCompanion([]byte(content), []string{"Namespace"}, c)
+	assertVerdict(t, v, true, 1, 0)
+}
+
+func assertVerdict(t *testing.T, v Verdict, decided bool, absent, present int) {
+	t.Helper()
+	if v.Decided != decided {
+		t.Fatalf("Decided = %v, want %v (reason: %s)", v.Decided, decided, v.Reason)
+	}
+	if !decided {
+		return
+	}
+	if len(v.Absent) != absent {
+		t.Errorf("absent = %d, want %d: %+v", len(v.Absent), absent, v.Absent)
+	}
+	if len(v.Present) != present {
+		t.Errorf("present = %d, want %d: %+v", len(v.Present), present, v.Present)
+	}
+}

--- a/core/rules/structural/lookup.go
+++ b/core/rules/structural/lookup.go
@@ -147,3 +147,24 @@ func isSet(n *yaml.Node) bool {
 	}
 	return true
 }
+
+// nodeAt resolves a plain dotted path to its node, or nil.
+//
+// Wildcards are deliberately not accepted: this addresses ONE node — the slot a
+// companion writes its reference into — and a path that fans out has no single
+// node to return. Callers that ask a yes/no question use Has or HasAll.
+func nodeAt(props *yaml.Node, path string) *yaml.Node {
+	n := resolve(props)
+	for _, seg := range splitPath(path) {
+		if seg == "[]" || seg == "*" {
+			return nil
+		}
+		if n = mapValue(n, seg); n == nil {
+			return nil
+		}
+	}
+	if !isSet(n) {
+		return nil
+	}
+	return n
+}

--- a/core/rules/structural/resource.go
+++ b/core/rules/structural/resource.go
@@ -46,6 +46,37 @@ type Resource struct {
 	Props *yaml.Node
 	// Line is the 1-based line the resource is declared on.
 	Line int
+	// Parent is the Props node of the resource this one is declared INSIDE,
+	// or nil for a top-level resource. ARM is the only schema that nests, and
+	// nesting is itself a binding: a SQL server's `auditingSettings` declared
+	// inside the server's `resources` array belongs to that server and to no
+	// other, whatever either of them is named.
+	//
+	// Identity is the parent's node pointer rather than its name, because ARM
+	// names are usually expressions (`[parameters('serverName')]`) that this
+	// package will not evaluate. Comparing pointers answers "is this the same
+	// declaration?" exactly, and yaml.v3 allocates one node per declaration, so
+	// sorting the resource slice cannot invalidate it.
+	Parent *yaml.Node
+	// ParentType is the parent's Type, kept so QualifiedType can spell a
+	// nested child the way a top-level declaration of it would be spelled.
+	ParentType string
+}
+
+// QualifiedType returns the type a rule author writes to name this resource.
+//
+// ARM allows one child resource to be declared two ways — nested inside its
+// parent as `type: auditingSettings`, or at the top level as
+// `type: Microsoft.Sql/servers/auditingSettings` — and they mean the same
+// thing. A rule naming the child must match both, so a nested type is
+// qualified with its parent's. A type that already carries a "/" is left
+// alone: ARM permits the fully-qualified spelling in the nested position too,
+// and qualifying it twice would match nothing.
+func (r Resource) QualifiedType() string {
+	if r.ParentType == "" || strings.Contains(r.Type, "/") {
+		return r.Type
+	}
+	return r.ParentType + "/" + r.Type
 }
 
 // Resources enumerates every resource in the parsed documents.
@@ -91,12 +122,21 @@ func Resources(docs []*yaml.Node) []Resource {
 func OfTypes(resources []Resource, types []string) []Resource {
 	var out []Resource
 	for _, r := range resources {
-		for _, t := range types {
-			if strings.EqualFold(r.Type, t) {
-				out = append(out, r)
-				break
-			}
+		if matchesAnyType(r, types) {
+			out = append(out, r)
 		}
 	}
 	return out
+}
+
+// matchesAnyType reports whether r is named by any of types, under either its
+// own spelling or its qualified one.
+func matchesAnyType(r Resource, types []string) bool {
+	qualified := r.QualifiedType()
+	for _, t := range types {
+		if strings.EqualFold(r.Type, t) || strings.EqualFold(qualified, t) {
+			return true
+		}
+	}
+	return false
 }

--- a/core/rules/structural/verdict.go
+++ b/core/rules/structural/verdict.go
@@ -14,6 +14,21 @@ type Hit struct {
 	Property string
 	// Family is the schema the resource was read from.
 	Family Family
+
+	// Companion, when set, is the resource type whose existence and linkage the
+	// rule required — a PodDisruptionBudget for a workload, a flow log for a
+	// VPC. It switches Statement to the cross-resource sentences, because what
+	// was established is about the document set and not about this resource's
+	// own properties.
+	Companion string
+	// CompanionName names the bound companion on a Present hit.
+	CompanionName string
+	// Unlinked distinguishes the two ways a companion can be missing: false
+	// means the document set declares none of that type at all, true means it
+	// declares one that binds to something else. The second is the finding no
+	// text search can produce, and reading it as the first would understate
+	// what parsing established.
+	Unlinked bool
 }
 
 // Verdict is the outcome of evaluating an absence rule structurally.
@@ -102,10 +117,36 @@ func (h Hit) Statement(absent bool) string {
 	if name == "" {
 		name = "an unnamed resource"
 	}
+	if h.Companion != "" {
+		return h.companionStatement(name, absent)
+	}
 	if absent {
 		return fmt.Sprintf("the %s resource %q (%s) was parsed and sets no %s",
 			h.Family, name, h.Type, h.Property)
 	}
 	return fmt.Sprintf("the %s resource %q (%s) sets %s, which the rule's pattern did not match",
 		h.Family, name, h.Type, h.Property)
+}
+
+// companionStatement renders a cross-resource outcome.
+//
+// It says "the document set" rather than "the cluster" on purpose: what was
+// enumerated is one file's resources, and a companion in a second file is
+// outside what this evidence covers. Overstating that scope is the way a
+// per-file parse turns into a claim about a deployment.
+func (h Hit) companionStatement(name string, absent bool) string {
+	if !absent {
+		companion := h.CompanionName
+		if companion == "" {
+			companion = "an unnamed resource"
+		}
+		return fmt.Sprintf("the %s resource %q (%s) is bound to the %s %q, a linkage the rule's pattern could not check",
+			h.Family, name, h.Type, h.Companion, companion)
+	}
+	if h.Unlinked {
+		return fmt.Sprintf("the %s resource %q (%s) was parsed, and every %s in the document set binds to a different resource",
+			h.Family, name, h.Type, h.Companion)
+	}
+	return fmt.Sprintf("the %s resource %q (%s) was parsed, and the document set declares no %s",
+		h.Family, name, h.Type, h.Companion)
 }

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -101,20 +101,96 @@ every rule was placed, not sampled:
 | kind | rules | why |
 |---|---|---|
 | resource-and-attribute | **24** | the property belongs to the resource the rule names — migrated |
+| cross-resource | **7 of 8** | the property is a *different object* — migrated by companion resolution; see below |
 | not a document | 20 | Dockerfile is line-oriented; Terraform and the GCP rules are HCL; a Helm template is not valid YAML until it is rendered |
-| cross-resource | 8 | the property is a *different object*: a VPC's flow log, a Namespace's ResourceQuota, a workload's PodDisruptionBudget, an Azure server's `auditingSettings` child |
 | sub-structure anchored | 4 | anchored on `securityContext:`, `hostPath:`, `emptyDir:` or an IAM statement rather than on a resource type |
 | predicate-gated | 1 | IAC-096 applies only to a `Microsoft.Web/sites` whose `kind` is `functionapp`, and the descriptor has no field for that condition |
 
-The cross-resource group is the honest next capability: it needs resolution
-*across* resources in a document set, not within one, and the model here
-deliberately stops at one resource because a lookup that silently searched the
-whole file would be the regex behaviour with a parser attached.
+The remaining three groups are not blocked on the parser at all. Terraform needs
+an HCL dependency this scanner does not carry, a Dockerfile has no document to
+parse, and the sub-structure rules would need rewriting rather than annotating —
+each of which is a decision, not an omission.
 
-The other three are not blocked on the parser at all. Terraform needs an HCL
-dependency this scanner does not carry, a Dockerfile has no document to parse,
-and the sub-structure rules would need rewriting rather than annotating — each
-of which is a decision, not an omission.
+#### Cross-resource: 31 of 57, by resolving the companion
+
+The eight cross-resource rules ask whether a resource is protected by a
+DIFFERENT object: a VPC by a flow log, a Deployment by a PodDisruptionBudget, a
+Namespace by a ResourceQuota or LimitRange, a SQL server by an
+`auditingSettings` or `firewallRules` child, a secret by a RotationSchedule.
+None of those properties is on the resource the rule names, so the
+single-resource model could not reach any of them and the text form searched the
+whole file for the companion's NAME instead.
+
+That form is wrong in three measured ways, and `core/rules/structural`'s
+companion resolution answers all three:
+
+- **It cannot see linkage.** A PodDisruptionBudget selecting `app: api`
+  satisfies IAC-132 for every workload in the file. Measured, on a manifest with
+  three workloads and one budget that selects one of them: the text path reports
+  **0 findings**; resolution reports **2**, on the workloads nothing protects.
+- **It cannot see quantity.** `absenceSpan: "file"` evaluates once and reports at
+  the first anchor, so four unprotected Deployments were one finding. Resolution
+  decides per subject.
+- **It is satisfied by text that is not a resource.** IAC-059's property regex is
+  `(?i)FlowLog`, which a `FlowLogsEnabled: false` tag matches — so a VPC with
+  logging explicitly turned OFF read as a VPC with logging configured.
+
+Four linkage mechanisms cover the seven rules, and each is named per rule rather
+than inferred, because resolving with the wrong one answers "not bound" for
+every subject and so invents a finding on each of them:
+
+| link | binds by | rules |
+|---|---|---|
+| `ref` | a CloudFormation intrinsic naming the subject's logical name — `!Ref`, `!GetAtt`, `!Sub`, and their `Fn::` long forms | IAC-059, IAC-079 |
+| `selector` | a Kubernetes label selector matching the subject's **pod template** labels | IAC-132 |
+| `namespace` | `metadata.namespace` equalling the subject Namespace's name | IAC-133, IAC-134 |
+| `child` | ARM child nesting, or a top-level `"<parent>/<child>"` name | IAC-084, IAC-086 |
+
+The eighth, IAC-153, is cross-*step* rather than cross-resource: it asks whether
+a GitHub Actions workflow that uploads an artifact also attests it. A workflow is
+a document, but it is not one of the three schemas this package models, so
+migrating it needs a fourth family — a new schema, not a new linkage.
+
+##### The three-valued answer is what keeps this sound
+
+Linkage resolves to bound, not-bound, or **undecidable**, and the third value is
+the load-bearing one. A selector written with `matchExpressions`, an ARM name
+that is a `[concat(...)]` expression, and a flow log pointed at a template
+parameter are all cases where the answer needs information the file does not
+carry. Reading any of them as "not bound" would report a resource that is very
+likely protected. An undecidable pair therefore takes the whole file back to the
+text path — the same degradation as an unparseable document, for the same
+reason.
+
+The inverse asymmetry is deliberate too. A flow log whose `ResourceId` is a
+literal `vpc-0a1b2c3d` is decidably NOT bound to anything this template creates,
+because referring to a resource in the same template *requires* an intrinsic.
+That is a fact about the companion, not an unknown, and it is the case the text
+path most reliably gets wrong.
+
+##### What it cost, and what it found
+
+One fixture changed. IAC-059's "hardened" sample was a VPC beside a flow log
+with empty `Properties` — a flow log that targets nothing. It passed only
+because the text path counted the word. It is now the true-positive case in
+`TestCompanionRefusesAnUnboundFlowLog`, and the hardened fixture references the
+VPC as a real template would.
+
+Measured on the precision suite, with a clean sample binding three VPCs through
+three different intrinsics and a true positive whose flow log watches the *other*
+VPC: precision and recall stay at 1.00, and IAC moves from
+`corroborated=1 above=1 earned=1` to `corroborated=2 above=2 earned=2`. Suite
+earned evidence goes from 3 to 4.
+
+##### What remains unknown, and is now stated rather than implied
+
+A document set is one file. A PodDisruptionBudget in a second manifest is not
+visible, and "no companion in this file" is not "no companion anywhere". That
+limit is inherited — the text rule it replaces is scoped to one file too — but
+the claim now says what was parsed rather than what is deployed, and
+`Hit.Statement` says "the document set" for exactly that reason. Cross-FILE
+resolution is the next capability this group would want, and it needs the scan
+to hold a document set across files, which nothing does today.
 
 #### The two rules that hold this together
 

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,9 +3,9 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 37,
+  "tp": 39,
   "fn": 0,
-  "findings_per_issue": 1.0571428571428572,
+  "findings_per_issue": 1.054054054054054,
   "rules": [
     {
       "rule_id": "AI-002",
@@ -19,6 +19,16 @@
     },
     {
       "rule_id": "DATA-005",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "IAC-051",
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "rule_id": "IAC-059",
       "precision": 1,
       "recall": 1
     },

--- a/testdata/precision-suite/clean_cfn_flowlogs.yaml
+++ b/testdata/precision-suite/clean_cfn_flowlogs.yaml
@@ -1,0 +1,48 @@
+# Clean sample: every VPC below IS monitored. Any finding here is a FALSE
+# POSITIVE.
+#
+# This is the refutation half of cross-resource resolution. A flow log is a
+# separate resource that names its VPC through an intrinsic, so no lookup
+# inside the VPC can find it — which is why IAC-059's text form searched the
+# whole file for the word "FlowLog" instead. That form cannot tell which VPC a
+# flow log watches; resolution can.
+#
+# The three VPCs here are each monitored through a different intrinsic, because
+# a template may bind with any of them and all three must refute.
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ShortFormVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+
+  GetAttVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.1.0.0/16
+
+  SubVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.2.0.0/16
+
+  ShortFormLogs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Ref ShortFormVpc
+      ResourceType: VPC
+      TrafficType: ALL
+
+  GetAttLogs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !GetAtt GetAttVpc.VpcId
+      ResourceType: VPC
+      TrafficType: ALL
+
+  SubLogs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Sub "${SubVpc}"
+      ResourceType: VPC
+      TrafficType: ALL

--- a/testdata/precision-suite/tp_cfn_unmonitored_vpc.yaml
+++ b/testdata/precision-suite/tp_cfn_unmonitored_vpc.yaml
@@ -1,0 +1,28 @@
+# True positive for cross-resource resolution, and the finding the text path is
+# structurally incapable of producing.
+#
+# This template DOES contain a flow log — so IAC-059's text form searches the
+# file, finds "FlowLog", and reports nothing at all. But the flow log watches
+# WatchedVpc; UnwatchedVpc has no monitoring whatsoever. Resolving which VPC
+# the flow log names is the only way to see that.
+#
+# If a future change silences this, the rule has gone back to counting the word
+# rather than resolving the resource.
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  WatchedVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+
+  UnwatchedVpc:  # nox-expect: IAC-059
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.1.0.0/16
+
+  Logs:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      ResourceId: !Ref WatchedVpc
+      ResourceType: VPC
+      TrafficType: ALL


### PR DESCRIPTION
Seven cross-resource absence rules ask whether a resource is protected by a **different** object: a VPC by a flow log, a Deployment by a PodDisruptionBudget, a Namespace by a ResourceQuota or LimitRange, a SQL server by an `auditingSettings` or `firewallRules` child, a secret by a RotationSchedule. None of those properties is on the resource the rule names, so the single-resource structural model could not reach any of them — and the text form searched the whole file for the companion's NAME instead.

This is the capability `docs/design/rule-family-migration.md` named as the honest next one after #553.

## What the text form gets wrong

Three ways, each measured:

- **It cannot see linkage.** A PodDisruptionBudget selecting `app: api` satisfies IAC-132 for every workload in the file. On a manifest with three workloads and one budget that selects one of them, the text path reports **0 findings**; resolution reports **2**, on the workloads nothing protects.
- **It cannot see quantity.** `absenceSpan: "file"` evaluates once and reports at the first anchor, so four unprotected Deployments were one finding.
- **It is satisfied by text that is not a resource.** IAC-059's property regex is `(?i)FlowLog`, which a `FlowLogsEnabled: false` tag matches — so a VPC with logging explicitly turned **OFF** read as a VPC with logging configured.

## What this adds

`core/rules/structural/companion.go` resolves a companion across a document set. Four linkage mechanisms, each named per rule rather than inferred — resolving with the wrong one answers "not bound" for every subject and so invents a finding on each of them:

| link | binds by | rules |
|---|---|---|
| `ref` | a CloudFormation intrinsic naming the subject's logical name (`!Ref`, `!GetAtt`, `!Sub`, and their `Fn::` long forms) | IAC-059, IAC-079 |
| `selector` | a Kubernetes label selector matching the subject's **pod template** labels | IAC-132 |
| `namespace` | `metadata.namespace` equalling the subject Namespace's name | IAC-133, IAC-134 |
| `child` | ARM child nesting, or a top-level `"<parent>/<child>"` name | IAC-084, IAC-086 |

### The three-valued answer is what keeps it sound

Linkage resolves to bound, not-bound, or **undecidable**. A selector written with `matchExpressions`, an ARM `[concat(...)]` name, and a flow log pointed at a template parameter all need information the file does not carry; reading them as "not bound" would report resources that are very likely protected. An undecidable pair takes the whole file back to the text path — the same degradation as an unparseable document, for the same reason.

The inverse asymmetry is deliberate: a flow log whose `ResourceId` is a literal `vpc-0a1b2c3d` is *decidably* bound to nothing this template creates, because referring to a resource in the same template **requires** an intrinsic. That is a fact about the companion, not an unknown — and it is the case the text path most reliably gets wrong.

## One fixture changed, and it is the point

IAC-059's "hardened" sample was a VPC beside a flow log with empty `Properties` — a flow log that targets nothing. It passed only because the text path counted the word. It is now the true-positive case in `TestCompanionRefusesAnUnboundFlowLog`, and the hardened fixture references the VPC as a real template would.

A fixture written against an imprecise matcher inherits that imprecision as ground truth; when the matcher sharpens, the fixture indicts the fix rather than the bug.

## Measured

- Precision suite: **precision 1.00 / recall 1.00** unchanged, with a clean sample binding three VPCs through three different intrinsics and a true positive whose flow log watches the *other* VPC. TP 37 → 39; baseline refreshed.
- Migration metric: IAC moves from `corroborated=1 above=1 earned=1` to `corroborated=2 above=2 earned=2`. Suite earned evidence 3 → 4.
- Metamorphic sweep: **0 violations** over 1945 mutations.
- End-to-end scan of a realistic namespaced manifest: IAC-132 fires only on the workload the PDB does not select, IAC-133 is refuted by the correctly-scoped quota, IAC-134 fires with the distinct "declares no LimitRange" claim.

## Scope notes

- **IAC-153 is not migrated.** It is cross-*step*, not cross-resource: a GitHub Actions workflow uploading an artifact without attesting it. A workflow is a document but not one of the three schemas this package models, so it needs a fourth family — a new schema, not a new linkage. The doc now says 7 of 8.
- **~5% slower** on a synthetic worst case (200 all-manifest files: 20.2s → 21.3s). Each absence rule re-parses the file — pre-existing for the 24 already-migrated rules; this adds 7. A per-file parse cache would more than pay it back, but it touches the matcher's statelessness contract and belongs in its own change.
- **Cross-FILE resolution remains out of scope.** A document set is one file; a PDB in a second manifest is not visible. That limit is inherited (the text rule is per-file too), but the claim now says what was *parsed* rather than what is *deployed* — `Hit.Statement` says "the document set" for exactly that reason.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT