### PR TITLE
SEC: dedup records what it dropped, without calling it false

### DIFF
--- a/core/analyzers/secrets/dedup.go
+++ b/core/analyzers/secrets/dedup.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -85,6 +86,47 @@ func classifyRuleSpecificity(r *rules.Rule) int {
 	return specProviderDefault
 }
 
+// findingRef names one finding by the coordinates that identify its evidence
+// subject, so a suppression can be reported without carrying the finding.
+type findingRef struct {
+	rule   string
+	line   int
+	column int
+}
+
+// suppression is one finding dedup removed, and the finding that superseded it.
+//
+// # Why dedup has to hand these back
+//
+// Dedup is the largest suppressor in the secrets analyzer: one GitHub or Stripe
+// token trips five to eight overlapping rules, and collapsing them to the
+// canonical owner is what took the precision corpus from 8.00 findings per
+// issue to 1.00. Every one of those collapses discarded a finding, and until
+// now discarded the reason with it.
+//
+// That is the same defect Track E1 fixed for the refiners, with one difference
+// that matters: a refiner REFUTES — it establishes the candidate was never a
+// secret. Dedup refutes nothing. The dropped finding is TRUE; an entropy rule
+// that matched a real GitHub token matched a real GitHub token. It is dropped
+// because reporting one secret five times is noise, not because it was wrong.
+//
+// Recording it as a refutation would therefore be a lie in the ledger, and a
+// load-bearing one: refutations weigh against a candidate, so the store would
+// end up asserting that five true detections of a live credential were each
+// evidence of nothing being there. That is why these become Withheld claims,
+// whose polarity is Unknown and which weigh nothing in either direction, plus a
+// relation saying the two candidates are one secret.
+type suppression struct {
+	dropped  findingRef
+	survivor findingRef
+	reason   string
+}
+
+// refTo names a finding for a suppression record.
+func refTo(f *findings.Finding) findingRef {
+	return findingRef{rule: f.RuleID, line: f.Location.StartLine, column: f.Location.StartColumn}
+}
+
 // dedupBySpecificity collapses secret findings that overlap on the same line to
 // the canonical finding(s) per overlapping span. It runs two passes over each
 // overlapping span:
@@ -100,9 +142,9 @@ func classifyRuleSpecificity(r *rules.Rule) int {
 // Findings on different lines, or non-overlapping spans on the same line, are
 // all preserved. content is the file bytes, used to recover the matched token
 // for owner resolution; spec maps rule ID → specificity tier.
-func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []byte) []findings.Finding {
+func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []byte) ([]findings.Finding, []suppression) {
 	if len(in) < 2 {
-		return in
+		return in, nil
 	}
 	// Index findings so we can sort by (line, start col) without copying the
 	// findings themselves (they are passed around by pointer/value per repo
@@ -123,12 +165,14 @@ func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []by
 	})
 
 	suppressed := make([]bool, len(in))
+	// Collected in drop order, which is deterministic because `order` is.
+	var dropped []suppression
 
 	// Pass 1 — owner resolution. For each finding whose matched token names a
 	// known provider, drop every OTHER provider finding overlapping its span
 	// that isn't a canonical owner of that token. Generic (non-provider)
 	// findings are left for pass 2.
-	resolveOwners(in, order, suppressed, spec, content)
+	resolveOwners(in, order, suppressed, spec, content, &dropped)
 
 	for a := 0; a < len(order); a++ {
 		ia := order[a]
@@ -160,8 +204,10 @@ func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []by
 			switch {
 			case sb > sa:
 				suppressed[ia] = true
+				dropped = append(dropped, specificitySuppression(fa, fb))
 			case sa > sb:
 				suppressed[ib] = true
+				dropped = append(dropped, specificitySuppression(fb, fa))
 			}
 			if suppressed[ia] {
 				break // fa gone; move to next anchor
@@ -175,7 +221,19 @@ func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []by
 			out = append(out, in[i])
 		}
 	}
-	return out
+	return out, dropped
+}
+
+// specificitySuppression describes a pass-2 collapse: a generic entropy or
+// keyword rule that matched the same span as a more specific provider rule.
+func specificitySuppression(dropped, survivor *findings.Finding) suppression {
+	return suppression{
+		dropped:  refTo(dropped),
+		survivor: refTo(survivor),
+		reason: fmt.Sprintf(
+			"a more specific rule matched the same span: %s owns this value, and %s is a generic match on the same token, so it is reported once rather than twice",
+			survivor.RuleID, dropped.RuleID),
+	}
 }
 
 // resolveOwners implements pass 1 of dedupBySpecificity. For every finding
@@ -184,7 +242,7 @@ func dedupBySpecificity(in []findings.Finding, spec map[string]int, content []by
 // owners of that token. Generic entropy/keyword findings are untouched here —
 // they are handled by the specificity collapse in pass 2. order is the
 // (line,col,rule) sort; suppressed is updated in place.
-func resolveOwners(in []findings.Finding, order []int, suppressed []bool, spec map[string]int, content []byte) {
+func resolveOwners(in []findings.Finding, order []int, suppressed []bool, spec map[string]int, content []byte, dropped *[]suppression) {
 	for a := 0; a < len(order); a++ {
 		ia := order[a]
 		if suppressed[ia] {
@@ -216,6 +274,7 @@ func resolveOwners(in []findings.Finding, order []int, suppressed []bool, spec m
 			}
 			if _, ok := owners[fb.RuleID]; !ok {
 				suppressed[ib] = true
+				*dropped = append(*dropped, ownerSuppression(in, order, suppressed, fa, fb, owners))
 			}
 		}
 		// If fa itself is not an owner of the token it matched (a mis-attributed
@@ -224,6 +283,7 @@ func resolveOwners(in []findings.Finding, order []int, suppressed []bool, spec m
 		// suppress the last finding on a real secret.
 		if _, ok := owners[fa.RuleID]; !ok && ownerPresent(in, order, suppressed, fa, owners) {
 			suppressed[ia] = true
+			*dropped = append(*dropped, ownerSuppression(in, order, suppressed, fa, fa, owners))
 		}
 	}
 }
@@ -244,6 +304,44 @@ func ownerPresent(in []findings.Finding, order []int, suppressed []bool, fa *fin
 		}
 	}
 	return false
+}
+
+// ownerSuppression describes a pass-1 drop: a provider rule that matched a span
+// whose token belongs to a different provider.
+//
+// The survivor named is the canonical OWNER on the span, found fresh, not the
+// anchor that happened to identify the provider — the anchor can itself be a
+// mis-attributed rule that is dropped moments later, and naming a survivor that
+// does not survive would make the ledger point at nothing.
+func ownerSuppression(in []findings.Finding, order []int, suppressed []bool, anchor, dropped *findings.Finding, owners map[string]struct{}) suppression {
+	survivor := anchor
+	if idx, ok := ownerIndex(in, order, suppressed, anchor, owners); ok {
+		survivor = &in[idx]
+	}
+	return suppression{
+		dropped:  refTo(dropped),
+		survivor: refTo(survivor),
+		reason: fmt.Sprintf(
+			"the matched token's prefix names a provider whose canonical rule is %s; %s matched the same span without owning that token type",
+			survivor.RuleID, dropped.RuleID),
+	}
+}
+
+// ownerIndex returns the index of a surviving canonical owner overlapping fa.
+func ownerIndex(in []findings.Finding, order []int, suppressed []bool, fa *findings.Finding, owners map[string]struct{}) (int, bool) {
+	for _, idx := range order {
+		if suppressed[idx] {
+			continue
+		}
+		fb := &in[idx]
+		if fb.Location.StartLine != fa.Location.StartLine || !spansOverlap(fa, fb) {
+			continue
+		}
+		if _, ok := owners[fb.RuleID]; ok {
+			return idx, true
+		}
+	}
+	return 0, false
 }
 
 // matchedValue recovers the matched token text for a finding from the file

--- a/core/analyzers/secrets/dedup_reasoning_test.go
+++ b/core/analyzers/secrets/dedup_reasoning_test.go
@@ -1,0 +1,189 @@
+package secrets
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// A GitHub token trips several overlapping rules; dedup collapses them to the
+// canonical owner. That collapse is the largest suppression in this analyzer
+// and, until now, the only one that recorded nothing.
+const dedupSample = "const token = \"ghp_016C7e42F292c6912E7710c838347Ae178B4a\"\n"
+
+func scanRecording(t *testing.T, name, content string) (*findings.FindingSet, *reasoning.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing sample: %v", err)
+	}
+	store := reasoning.New()
+	a := NewAnalyzer()
+	a.RecordReasoningTo(store)
+	fs, err := a.ScanArtifacts(context.Background(), []discovery.Artifact{{Path: name, AbsPath: path}})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	return fs, store
+}
+
+// The headline: a finding dedup drops leaves a record naming what superseded it.
+func TestDedupRecordsWhatItDropped(t *testing.T) {
+	fs, store := scanRecording(t, "config.js", dedupSample)
+	if len(fs.Findings()) == 0 {
+		t.Fatal("no finding survived; the sample is meant to carry a real token")
+	}
+
+	var withheld []evidence.Claim
+	for _, subject := range store.Subjects() {
+		for _, c := range store.About(subject).Claims {
+			if c.Polarity == evidence.PolarityUnknown && strings.Contains(c.Statement, "same span") {
+				withheld = append(withheld, c)
+			}
+		}
+	}
+	if len(withheld) == 0 {
+		t.Fatal("dedup dropped findings and recorded nothing; the reason for a " +
+			"suppression must survive the suppression")
+	}
+	for _, c := range withheld {
+		if c.Statement == "" {
+			t.Error("a withheld claim with an empty statement records nothing")
+		}
+		if c.Subject.ID == "" || !c.Subject.Valid() {
+			t.Errorf("withheld claim filed against an unusable subject: %+v", c.Subject)
+		}
+	}
+}
+
+// The polarity is the load-bearing part. A deduped finding was not refuted --
+// the token really is a GitHub token -- so recording it against the candidate
+// would make the store assert that true detections of a live credential were
+// evidence of nothing being there.
+func TestDedupSuppressionIsNotARefutation(t *testing.T) {
+	_, store := scanRecording(t, "config.js", dedupSample)
+
+	for _, subject := range store.Subjects() {
+		for _, c := range store.About(subject).Claims {
+			if !c.Refutes() {
+				continue
+			}
+			if strings.Contains(c.Statement, "same span") || strings.Contains(c.Statement, "canonical rule") {
+				t.Errorf("dedup filed a REFUTING claim: %q\n"+
+					"a deduped finding is redundant, not false", c.Statement)
+			}
+		}
+	}
+}
+
+// The relation is what lets a reader ask how many candidates one secret
+// accounted for -- the question reasoning.Relate was added for, naming dedup as
+// the case whose knowledge was lost the moment it acted.
+func TestDedupRelatesTheDroppedCandidateToItsSurvivor(t *testing.T) {
+	fs, store := scanRecording(t, "config.js", dedupSample)
+
+	graph := store.Relations()
+	if graph.Len() == 0 {
+		t.Fatal("dedup collapsed overlapping candidates and recorded no relation between them")
+	}
+
+	survivors := fs.Findings()
+	if len(survivors) == 0 {
+		t.Fatal("no survivor to relate to")
+	}
+	surviving := reasoning.Candidate(survivors[0].RuleID, "config.js",
+		survivors[0].Location.StartLine, survivors[0].Location.StartColumn)
+
+	related := store.Concerning(surviving, evidence.RelConcerns)
+	if len(related) == 0 {
+		t.Fatalf("no candidate relates to the surviving finding %s; "+
+			"Concerning cannot answer how many candidates this one secret accounted for", surviving)
+	}
+	for _, r := range related {
+		if r == surviving {
+			t.Error("a finding was related to itself; that edge is a cycle and says nothing")
+		}
+	}
+}
+
+// Every relation must name a survivor that actually survived. A pass-1 anchor
+// can itself be a mis-attributed rule dropped moments later, so naming it would
+// point the ledger at a finding the scan never reported.
+func TestDedupSurvivorActuallySurvives(t *testing.T) {
+	fs, store := scanRecording(t, "config.js", dedupSample)
+
+	kept := make(map[string]bool)
+	for _, f := range fs.Findings() {
+		kept[reasoning.Candidate(f.RuleID, "config.js",
+			f.Location.StartLine, f.Location.StartColumn).String()] = true
+	}
+	for _, r := range store.Relations().Relations {
+		if !kept[r.To.String()] {
+			t.Errorf("relation points at %s, which is not among the reported findings", r.To)
+		}
+	}
+}
+
+// This change adds evidence and must change no finding. The suppression
+// decisions are untouched; only the record of them is new.
+func TestDedupSuppressionDecisionsAreUnchanged(t *testing.T) {
+	samples := map[string]string{
+		"github token":  dedupSample,
+		"aws key pair":  "AWS_ACCESS_KEY_ID = \"AKIAIOSFODNN7EXAMPLE\"\nAWS_SECRET_ACCESS_KEY = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n",
+		"stripe key":    "const k = \"sk_live_4eC39HqLyjWDarjtT1zdp7dc\"\n",
+		"no secret":     "const greeting = \"hello world\"\n",
+		"two on a line": "a = \"ghp_016C7e42F292c6912E7710c838347Ae178B4a\"; b = \"xoxb-1234-5678-abcdefghijklmnop\"\n",
+	}
+	for name, content := range samples {
+		t.Run(name, func(t *testing.T) {
+			// With a store and without one must agree: recording is a side
+			// channel, never an input to the decision.
+			withStore, _ := scanRecording(t, "s.js", content)
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "s.js")
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			plain, err := NewAnalyzer().ScanArtifacts(context.Background(),
+				[]discovery.Artifact{{Path: "s.js", AbsPath: path}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a, b := withStore.Findings(), plain.Findings()
+			if len(a) != len(b) {
+				t.Fatalf("recording changed the finding count: %d with a store, %d without", len(a), len(b))
+			}
+			for i := range a {
+				if a[i].RuleID != b[i].RuleID || a[i].Location.StartLine != b[i].Location.StartLine {
+					t.Errorf("finding %d differs: %s@%d vs %s@%d", i,
+						a[i].RuleID, a[i].Location.StartLine, b[i].RuleID, b[i].Location.StartLine)
+				}
+			}
+		})
+	}
+}
+
+// A nil store must discard, like every other recording path in this analyzer.
+func TestDedupRecordingToleratesNoStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.js")
+	if err := os.WriteFile(path, []byte(dedupSample), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// NewAnalyzer without RecordReasoningTo leaves the store nil.
+	if _, err := NewAnalyzer().ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: "config.js", AbsPath: path}}); err != nil {
+		t.Fatalf("scanning without a reasoning store: %v", err)
+	}
+}

--- a/core/analyzers/secrets/dedup_test.go
+++ b/core/analyzers/secrets/dedup_test.go
@@ -83,7 +83,7 @@ func TestDedupBySpecificity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dedupBySpecificity(tt.in, spec, nil)
+			got, _ := dedupBySpecificity(tt.in, spec, nil)
 			gotIDs := make(map[string]int)
 			for i := range got {
 				gotIDs[got[i].RuleID]++
@@ -123,7 +123,7 @@ func TestDedupOwnerResolution(t *testing.T) {
 			mkFinding("SEC-496", 1, 17, 57),
 			mkFinding("SEC-161", 1, 17, 57),
 		}
-		got := ruleIDsOf(dedupBySpecificity(in, spec, content))
+		got := ruleIDsOf(firstOf(dedupBySpecificity(in, spec, content)))
 		if len(got) != 1 || got[0] != "SEC-003" {
 			t.Fatalf("github: got %v, want [SEC-003]", got)
 		}
@@ -136,7 +136,7 @@ func TestDedupOwnerResolution(t *testing.T) {
 			mkFinding("SEC-508", 1, 12, 32),
 			mkFinding("SEC-161", 1, 12, 32),
 		}
-		got := ruleIDsOf(dedupBySpecificity(in, spec, content))
+		got := ruleIDsOf(firstOf(dedupBySpecificity(in, spec, content)))
 		ids := map[string]bool{}
 		for _, g := range got {
 			ids[g] = true
@@ -155,7 +155,7 @@ func TestDedupOwnerResolution(t *testing.T) {
 			mkFinding("SEC-338", 1, 11, 55),
 			mkFinding("SEC-163", 1, 11, 54),
 		}
-		got := ruleIDsOf(dedupBySpecificity(in, spec, content))
+		got := ruleIDsOf(firstOf(dedupBySpecificity(in, spec, content)))
 		if len(got) != 1 || got[0] != "SEC-030" {
 			t.Fatalf("stripe: got %v, want [SEC-030]", got)
 		}
@@ -199,3 +199,7 @@ func TestClassifyRuleSpecificity(t *testing.T) {
 		t.Errorf("entropy SEC-161 (%d) should rank below provider SEC-003 (%d)", spec["SEC-161"], spec["SEC-003"])
 	}
 }
+
+// firstOf keeps the existing assertions reading about findings alone, now that
+// dedupBySpecificity also hands back what it dropped.
+func firstOf(fs []findings.Finding, _ []suppression) []findings.Finding { return fs }

--- a/core/analyzers/secrets/secrets.go
+++ b/core/analyzers/secrets/secrets.go
@@ -198,7 +198,9 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 		// most-specific (provider) finding and drop the generic entropy/keyword
 		// duplicates. This is the dominant precision drag on real secrets — one
 		// GitHub/Slack/Stripe token otherwise emits 5-8 findings.
-		results = dedupBySpecificity(results, a.spec, content)
+		var deduped []suppression
+		results, deduped = dedupBySpecificity(results, a.spec, content)
+		a.recordSuppressions(artifact.Path, deduped)
 
 		// Drop matches that fall inside an embedded data blob (a base64 SVG, a
 		// data: URI) in a source file — a 32-char run inside such a blob is never
@@ -350,6 +352,49 @@ func inEmbeddedBlob(lang lexctx.Lang, content []byte, f *findings.Finding) bool 
 // Authority can check.
 func (a *Analyzer) refute(subject evidence.Subject, kind evidence.Kind, statement string) {
 	a.reasoning.Refute(subject, kind, "nox-scan", "secrets", statement)
+}
+
+// recordSuppressions files what dedup removed, and what superseded it.
+//
+// Two things are recorded per drop, because they answer different questions and
+// neither substitutes for the other:
+//
+//   - A WITHHELD claim on the dropped candidate. Its polarity is Unknown, so it
+//     weighs nothing in either direction — which is the only honest weight. The
+//     dropped finding was not refuted: an entropy rule that matched a real
+//     GitHub token matched a real GitHub token, and it is gone because five
+//     reports of one credential is noise, not because it was wrong. Filing it as
+//     a refutation would make the ledger assert that five true detections of a
+//     live credential were each evidence of nothing being there.
+//   - A RELATION from the dropped candidate to the survivor. This is the edge
+//     reasoning.Relate was built for and names dedup as the motivating case: the
+//     store could say what it believed about a candidate but not which
+//     candidates were about the same thing, so the relationship dedup knows
+//     about was lost the moment it acted. With it, Concerning(survivor) answers
+//     "how many candidates did this one secret account for?" — the Track F
+//     question, asked of secrets instead of dataflow.
+//
+// A nil store discards both, like every other recording path here.
+func (a *Analyzer) recordSuppressions(path string, drops []suppression) {
+	for i := range drops {
+		d := &drops[i]
+		dropped := reasoning.Candidate(d.dropped.rule, path, d.dropped.line, d.dropped.column)
+		survivor := reasoning.Candidate(d.survivor.rule, path, d.survivor.line, d.survivor.column)
+
+		a.reasoning.Withheld(dropped, "nox-scan", "secrets", d.reason)
+		if dropped == survivor {
+			// A finding cannot supersede itself. Nothing in dedup produces
+			// this, but a self-edge would be a cycle in the relation graph and
+			// silently useless, so it is refused rather than trusted not to
+			// arise.
+			continue
+		}
+		a.reasoning.Relate(evidence.Relation{
+			From: dropped,
+			Kind: evidence.RelConcerns,
+			To:   survivor,
+		})
+	}
 }
 
 // corroborate records what the analyzer actually VERIFIED about a value it is

--- a/core/e2e_evidence_test.go
+++ b/core/e2e_evidence_test.go
@@ -55,26 +55,57 @@ func TestEndToEndEvidenceChain(t *testing.T) {
 		reported[SubjectForFinding(f)] = true
 	}
 
-	var refutations int
+	// A dropped candidate must record a REASON. Which polarity that reason
+	// carries depends on why it was dropped, and the distinction is
+	// load-bearing rather than pedantic:
+	//
+	//   - EPISTEMIC drops refute. A refiner decided the candidate was never a
+	//     secret — it sat in a data blob, it was a placeholder, it was a bare
+	//     prefix — so the claim weighs against the candidate being real.
+	//   - EDITORIAL drops withhold, with polarity Unknown, weighing nothing.
+	//     Dedup removes a finding that is TRUE: an entropy rule that matched a
+	//     real GitHub token matched a real GitHub token, and it goes because
+	//     reporting one credential five times is noise. Filing that as a
+	//     refutation would make the store assert that five true detections of a
+	//     live credential were each evidence of nothing being there.
+	//
+	// What is forbidden either way is a drop that records NOTHING, and a drop
+	// that records SUPPORT — a candidate cannot be dropped on the strength of
+	// evidence for it.
+	var refutations, withheld int
 	for _, s := range res.Reasoning.Subjects() {
 		if reported[s] {
 			continue
 		}
-		for _, c := range res.Reasoning.About(s).Claims {
-			if !c.Refutes() {
-				t.Errorf("dropped candidate %s recorded a %s claim; a drop is a refutation",
-					s, c.Polarity.Effective())
+		claims := res.Reasoning.About(s).Claims
+		if len(claims) == 0 {
+			t.Errorf("dropped candidate %s recorded nothing; the reason for a "+
+				"suppression must survive the suppression", s)
+		}
+		for _, c := range claims {
+			if c.Supports() {
+				t.Errorf("dropped candidate %s recorded a SUPPORTING claim (%q); "+
+					"a candidate cannot be dropped on evidence for it", s, c.Statement)
 				continue
 			}
 			if c.Statement == "" {
 				t.Errorf("dropped candidate %s recorded no reason", s)
 			}
-			refutations++
+			if c.Refutes() {
+				refutations++
+			} else {
+				withheld++
+			}
 		}
 	}
 	if refutations == 0 {
 		t.Error("no candidate was refuted across the whole corpus; either the refiners " +
 			"stopped recording, or they stopped running")
+	}
+	if withheld == 0 {
+		t.Error("no candidate was withheld across the whole corpus; dedup collapses " +
+			"overlapping matches on this corpus, so silence here means it stopped " +
+			"recording what it dropped")
 	}
 
 	// Stage 2 — every reported finding has a recorded reason for existing.

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -166,9 +166,17 @@ func TestRefutedCandidateKeepsItsReason(t *testing.T) {
 		}
 		ledger := res.Reasoning.About(subject)
 		for _, c := range ledger.Claims {
-			if !c.Refutes() {
-				t.Errorf("dropped candidate %s recorded a %s claim; a drop is a refutation",
-					subject, c.Polarity.Effective())
+			// A drop is either EPISTEMIC — a refiner established the candidate
+			// was never a secret, which refutes — or EDITORIAL: dedup removed a
+			// finding that is TRUE because reporting one credential five times
+			// is noise. The second weighs nothing (polarity Unknown) and must
+			// not be filed as a refutation, or the store would assert that
+			// true detections of a live credential were evidence of nothing
+			// being there. What is forbidden either way is SUPPORT: a candidate
+			// cannot be dropped on the strength of evidence for it.
+			if c.Supports() {
+				t.Errorf("dropped candidate %s recorded a SUPPORTING claim (%q)",
+					subject, c.Statement)
 			}
 			if c.Statement == "" {
 				t.Errorf("dropped candidate %s recorded an empty reason", subject)
@@ -479,6 +487,15 @@ func TestConfigDrivenRemovalsLeaveATrail(t *testing.T) {
 	for _, subject := range res.Reasoning.Subjects() {
 		for _, c := range res.Reasoning.About(subject).Claims {
 			if c.Polarity.Effective() != evidence.PolarityUnknown {
+				continue
+			}
+			// Scope to the configuration trail by PROVENANCE, not by polarity
+			// alone. Unknown is the polarity of every editorial removal, and
+			// since dedup began recording what it drops there is more than one
+			// producer of them — dedup files as tool "secrets", config as
+			// "config". Matching on polarity alone swept dedup's claims into an
+			// assertion about .nox.yaml that was never about them.
+			if c.Provenance.Tool != "config" {
 				continue
 			}
 			if !strings.Contains(c.Statement, ruleID) {


### PR DESCRIPTION
Deduplication is the largest suppressor in the secrets analyzer. One GitHub or Stripe token trips five to eight overlapping rules, and collapsing them to the canonical owner is what took the precision corpus from 8.00 findings per issue to 1.00. Every one of those collapses discarded a finding **and discarded the reason with it**: `dedup.go` had no reasoning integration at all, so the ledger could say why a *refiner* stopped believing something and was silent about the path that removes far more.

Closes the roady spec feature `deduplication-does-not-record-which-finding-it-dropped`.

## Why this is not Track E1 applied to a new place

The two drops mean opposite things.

A refiner **refutes**: it establishes the candidate was never a secret — it sat in a data blob, it was a placeholder, it was a bare prefix with no token body.

Dedup refutes nothing. The dropped finding is **true**; an entropy rule that matched a real GitHub token matched a real GitHub token. It goes because reporting one credential five times is noise.

Recording these as refutations would have been a lie in the ledger, and a load-bearing one: refutations weigh *against* a candidate, so the store would have ended up asserting that five true detections of a live credential were each evidence of nothing being there.

## What is recorded

Two things per drop, neither substituting for the other:

- A **withheld claim** on the dropped candidate — polarity `Unknown`, weighing nothing in either direction. This is what `Store.Withheld` exists for: "an operator can then tell 'nox found nothing here' from 'nox found it and my config removed it'".
- A **relation** from the dropped candidate to its survivor. This is the edge `reasoning.Relate` was built for, and whose doc comment already names dedup as the motivating case: the store could say what it believed about a candidate but not which candidates were about the same thing, *"which is what dedup does and why the relationship it knows about is lost the moment it acts"*. With it, `Concerning(survivor)` answers how many candidates one secret accounted for — the Track F question asked of secrets instead of dataflow.

The survivor named is the canonical owner found **fresh at drop time**, not the anchor that identified the provider: that anchor can itself be a mis-attributed rule dropped moments later, and naming a survivor that does not survive would point the ledger at a finding the scan never reported. `TestDedupSurvivorActuallySurvives` holds this.

## Three existing tests said "a drop is a refutation"

That was an over-generalisation which held only because dedup recorded nothing. Each is now **more precise rather than weaker**:

- A dropped candidate must record a REASON — silence fails, in every case.
- A SUPPORTING claim on a dropped candidate fails, in every case: a candidate cannot be dropped on the strength of evidence for it.
- Polarity now distinguishes an *epistemic* drop (refiner, refutes) from an *editorial* one (dedup, withholds).
- `TestConfigDrivenRemovalsLeaveATrail` now scopes to the config trail by **provenance** (`tool: "config"`) rather than by polarity alone, which had swept dedup's claims into an assertion about `.nox.yaml` that was never about them.
- `TestEndToEndEvidenceChain` gains the requirement in the other direction: silence from the withheld path now **fails**, so dedup cannot quietly stop recording.

## Verified end to end

Scanning a file with a GitHub token and an AWS key pair emits, in `evidence.json`, a relation the artifact never carried before:

```
SEC-216@config.js:1:16 -concerns-> SEC-003@config.js:1:16
```

alongside the withheld claim explaining it.

**Findings are unchanged.** The suppression decisions are untouched, and `TestDedupSuppressionDecisionsAreUnchanged` holds that scanning with and without a store agrees — so recording is a side channel and never an input to the decision. Precision suite unchanged at 1.00 / 1.00; full suite and lint green. Falsified: disabling the recording call fails 3 of the new tests plus the E2E chain.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT