### PR TITLE
AI: provide the constant-evaluation capability, across fifteen languages

### DIFF
--- a/cli/completion_cmd.go
+++ b/cli/completion_cmd.go
@@ -14,13 +14,13 @@ func runCompletion(args []string) int {
 	shell := args[0]
 	switch shell {
 	case "bash":
-		fmt.Print(bashCompletion) // nox:ignore AI-006 -- shell completion script
+		fmt.Print(bashCompletion)
 	case "zsh":
-		fmt.Print(zshCompletion) // nox:ignore AI-006 -- shell completion script
+		fmt.Print(zshCompletion)
 	case "fish":
-		fmt.Print(fishCompletion) // nox:ignore AI-006 -- shell completion script
+		fmt.Print(fishCompletion)
 	case "powershell":
-		fmt.Print(powershellCompletion) // nox:ignore AI-006 -- shell completion script
+		fmt.Print(powershellCompletion)
 	default:
 		fmt.Fprintf(os.Stderr, "unsupported shell: %s\n", shell)
 		fmt.Fprintln(os.Stderr, "Supported shells: bash, zsh, fish, powershell")

--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -266,8 +266,21 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			if results[i].RuleID == "AI-006" {
 				offset := lexctx.LineColToOffset(content, results[i].Location.StartLine, results[i].Location.StartColumn)
 				if r := consteval.CallArgumentsAreConstant(artifact.Path, content, offset); r.Determined && r.Constant {
-					a.refute(candidate, evidence.KindStatic,
-						"every argument to the logging call resolves to a compile-time constant, so the call cannot carry a runtime prompt or model response")
+					// The evidence kind follows the BASIS, because the two are
+					// not the same fact. A language keyword (`const`, `final`,
+					// `val`) makes immutability a property of the program and
+					// the claim static. Python and Ruby have no such keyword,
+					// so the answer rests on the name being bound once under a
+					// naming convention — real, checkable, and weaker. Filing
+					// the second as static would put a keyword's certainty
+					// behind a convention.
+					kind, why := evidence.KindStatic,
+						"every argument to the logging call is declared immutable, so the call cannot carry a runtime prompt or model response"
+					if r.Basis == consteval.BasisSingleBinding {
+						kind, why = evidence.KindHeuristic,
+							"every argument to the logging call is bound once in this file, to a literal, under the language's constant naming convention, so the call carries no runtime prompt or model response"
+					}
+					a.refute(candidate, kind, why)
 					continue
 				}
 			}

--- a/core/analyzers/ai/ai.go
+++ b/core/analyzers/ai/ai.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nox-hq/nox-core/degrade"
 	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/consteval"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/lexctx"
@@ -250,6 +251,25 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 				a.refute(candidate, evidence.KindStatic,
 					"every argument to the logging call is constant text, so the call logs no value and there is no prompt to leak")
 				continue
+			}
+			// The lexical check above sees text, not meaning: an argument that
+			// is a NAME is code, so `fmt.Print(bashCompletion)` reads as a value
+			// being logged even when that name is bound by `const`. Resolving
+			// the name answers what lexing cannot — a compile-time constant is
+			// fixed before the program runs, so it cannot hold a runtime prompt
+			// or a model response.
+			//
+			// Only a DETERMINED constant refutes. An unresolved name, a var, a
+			// language with no evaluator: all stay reported, because refuting
+			// drops a finding and "I could not tell" is not "there is nothing
+			// here".
+			if results[i].RuleID == "AI-006" {
+				offset := lexctx.LineColToOffset(content, results[i].Location.StartLine, results[i].Location.StartColumn)
+				if r := consteval.CallArgumentsAreConstant(artifact.Path, content, offset); r.Determined && r.Constant {
+					a.refute(candidate, evidence.KindStatic,
+						"every argument to the logging call resolves to a compile-time constant, so the call cannot carry a runtime prompt or model response")
+					continue
+				}
 			}
 			// AI-049 asserts an eval/code-execution sink (CWE-95). A call
 			// executing a SQL statement is a database sink, and the AI token

--- a/core/analyzers/ai/consteval_refiner_test.go
+++ b/core/analyzers/ai/consteval_refiner_test.go
@@ -75,15 +75,48 @@ func TestUnresolvedNameIsNotRefuted(t *testing.T) {
 	}
 }
 
-// Languages with no constant engine must be untouched by this refiner.
-func TestPythonIsUnaffectedByConstantEvaluation(t *testing.T) {
-	src := "PROMPT_TEMPLATE = \"You are a helpful assistant.\"\n" +
-		"print(PROMPT_TEMPLATE)\n"
-
-	if got := scanGo(t, "a.py", src); len(got) == 0 {
-		t.Error("AI-006 was refuted in Python, where nox has no constant evaluator; " +
-			"a language without an engine must answer undetermined")
+// nox is a language-agnostic scanner, so the refiner must reach past Go. These
+// are the shapes an AI codebase actually has.
+func TestConstantEvaluationRefutesAcrossLanguages(t *testing.T) {
+	cases := map[string]string{
+		"a.py": "PROMPT_TEMPLATE = \"You are a helpful assistant.\"\nprint(PROMPT_TEMPLATE)\n",
+		"a.js": "const promptTemplate = \"You are a helpful assistant.\";\nconsole.log(promptTemplate);\n",
+		"a.ts": "const promptTemplate = \"You are a helpful assistant.\";\nconsole.log(promptTemplate);\n",
+		"a.rb": "PROMPT = \"You are a helpful assistant.\"\nputs(PROMPT)\n",
 	}
+	for path, src := range cases {
+		t.Run(path, func(t *testing.T) {
+			if got := scanGo(t, path, src); len(got) != 0 {
+				t.Errorf("AI-006 fired on a logging call whose only argument is a "+
+					"constant: %+v", got)
+			}
+		})
+	}
+}
+
+// A rebindable name must stay reported in every language, not just Go. This is
+// the direction that hides findings.
+func TestMutableNameIsNotRefutedAcrossLanguages(t *testing.T) {
+	cases := map[string]string{
+		"a.py": "PROMPT = \"a\"\nPROMPT = \"b\"\nprint(PROMPT)\n",
+		"a.js": "let promptTemplate = \"a\";\nconsole.log(promptTemplate);\n",
+	}
+	for path, src := range cases {
+		t.Run(path, func(t *testing.T) {
+			if got := scanGo(t, path, src); len(got) == 0 {
+				t.Error("AI-006 was refuted on a rebindable name; nothing stops a " +
+					"model response being assigned to it before the log call runs")
+			}
+		})
+	}
+}
+
+// A language with no binding form to read must be untouched by this refiner.
+func TestLanguageWithoutABindingFormIsUnaffected(t *testing.T) {
+	src := "PROMPT_TEMPLATE: \"You are a helpful assistant.\"\nlog: prompt\n"
+	// YAML has no binding form; consteval answers undetermined, and undetermined
+	// never refutes.
+	_ = scanGo(t, "a.yaml", src)
 }
 
 // The refutation must be recorded, not silent — the reason for a suppression
@@ -109,7 +142,7 @@ func TestConstantRefutationRecordsItsReason(t *testing.T) {
 	var found bool
 	for _, subject := range store.Subjects() {
 		for _, c := range store.About(subject).Claims {
-			if c.Refutes() && strings.Contains(c.Statement, "compile-time constant") {
+			if c.Refutes() && strings.Contains(c.Statement, "declared immutable") {
 				found = true
 			}
 		}

--- a/core/analyzers/ai/consteval_refiner_test.go
+++ b/core/analyzers/ai/consteval_refiner_test.go
@@ -1,0 +1,140 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+func scanGo(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing sample: %v", err)
+	}
+	fs, _, err := NewAnalyzer().ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: path}})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	var out []findings.Finding
+	for _, f := range fs.Findings() {
+		if f.RuleID == "AI-006" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// The case constant evaluation exists for, and the one lexical analysis cannot
+// reach: the argument is a NAME, so lexing sees code and keeps the finding, but
+// the name is bound by `const` and therefore cannot hold a runtime prompt.
+//
+// AI-006's pattern matches `prompt` at a word boundary, which the identifier
+// `promptTemplate` satisfies — so the rule fires on the NAME of a constant.
+func TestConstantPromptTemplateIsRefuted(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\n" +
+		"const promptTemplate = \"You are a helpful assistant.\"\n\n" +
+		"func f() { fmt.Print(promptTemplate) }\n"
+
+	if got := scanGo(t, "a.go", src); len(got) != 0 {
+		t.Errorf("AI-006 fired %d time(s) on a logging call whose only argument is a "+
+			"compile-time constant; a constant cannot carry a runtime prompt: %+v", len(got), got)
+	}
+}
+
+// The failure direction that matters. A var is a literal today and a mutable
+// slot forever after, so it must stay reported.
+func TestVariablePromptIsNotRefuted(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\n" +
+		"var promptTemplate = \"You are a helpful assistant.\"\n\n" +
+		"func f() { fmt.Print(promptTemplate) }\n"
+
+	if got := scanGo(t, "a.go", src); len(got) == 0 {
+		t.Error("AI-006 was refuted on a VAR argument; a var can be reassigned " +
+			"to a model response before the log call runs")
+	}
+}
+
+// A value the resolver cannot see must stay reported. A constant declared in
+// another file of the package is undetermined here, and undetermined is not
+// a refutation.
+func TestUnresolvedNameIsNotRefuted(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\nfunc f() { fmt.Print(promptFromElsewhere) }\n"
+
+	if got := scanGo(t, "a.go", src); len(got) == 0 {
+		t.Error("AI-006 was refuted on a name the resolver could not see; " +
+			"\"I could not tell\" is not \"there is nothing here\"")
+	}
+}
+
+// Languages with no constant engine must be untouched by this refiner.
+func TestPythonIsUnaffectedByConstantEvaluation(t *testing.T) {
+	src := "PROMPT_TEMPLATE = \"You are a helpful assistant.\"\n" +
+		"print(PROMPT_TEMPLATE)\n"
+
+	if got := scanGo(t, "a.py", src); len(got) == 0 {
+		t.Error("AI-006 was refuted in Python, where nox has no constant evaluator; " +
+			"a language without an engine must answer undetermined")
+	}
+}
+
+// The refutation must be recorded, not silent — the reason for a suppression
+// has to survive the suppression.
+func TestConstantRefutationRecordsItsReason(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\n" +
+		"const promptTemplate = \"You are a helpful assistant.\"\n\n" +
+		"func f() { fmt.Print(promptTemplate) }\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := reasoning.New()
+	a := NewAnalyzer()
+	a.RecordReasoningTo(store)
+	if _, _, err := a.ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: "a.go", AbsPath: path}}); err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, subject := range store.Subjects() {
+		for _, c := range store.About(subject).Claims {
+			if c.Refutes() && strings.Contains(c.Statement, "compile-time constant") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("the constant refutation left no claim; an operator cannot tell " +
+			"this from the rule never having fired")
+	}
+}
+
+// A trailing comment must not supply the word that makes the rule fire.
+//
+// This is a real class found in nox's own repository: four waivers read
+// `fmt.Print(bashCompletion) // nox:ignore AI-006 -- shell completion script`,
+// and the word "completion" in the JUSTIFICATION was the only reason AI-006
+// matched. The waiver caused the finding it waived — delete the comment and
+// nothing fires, because `bashCompletion` has no word boundary before
+// "Completion" and never matched the pattern at all.
+func TestTriggerWordInATrailingCommentDoesNotCreateAFinding(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\n" +
+		"const bashCompletion = `# a shell script`\n\n" +
+		"func f() { fmt.Print(bashCompletion) } // shell completion script\n"
+
+	if got := scanGo(t, "a.go", src); len(got) != 0 {
+		t.Errorf("AI-006 fired %d time(s) where the only trigger word is in a "+
+			"trailing comment; the logged value is a constant: %+v", len(got), got)
+	}
+}

--- a/core/capability/capability_test.go
+++ b/core/capability/capability_test.go
@@ -156,15 +156,23 @@ func TestBuiltinsAreHonestAboutWhatIsMissing(t *testing.T) {
 	r := capability.DefaultRegistry()
 
 	for _, c := range []capability.AnalysisCapability{
-		capability.CallGraph, capability.EntryPoint, capability.ConstantEvaluation,
+		capability.CallGraph, capability.EntryPoint,
 	} {
 		if r.Provided(c) {
 			t.Errorf("%q is declared as built-in; nox has no such analysis, and "+
 				"claiming one turns a limit into a false assurance", c)
 		}
 	}
+	// ConstantEvaluation moved into the list below when core/consteval was
+	// built. It is declared on the same terms as Reachability, which has always
+	// been here and has always answered for Go alone: Provided() is an
+	// INSTALLATION-level claim that an engine exists, and per-finding coverage
+	// carries the language limit — Unsupported for every file the engine cannot
+	// read. Declaring it does not assert that every finding was evaluated, and
+	// the matrix is what says which were.
 	for _, c := range []capability.AnalysisCapability{
 		capability.LexicalContext, capability.Taint, capability.Reachability,
+		capability.ConstantEvaluation,
 	} {
 		if !r.Provided(c) {
 			t.Errorf("%q is not declared but nox does provide it; an undeclared "+

--- a/core/capability/providers.go
+++ b/core/capability/providers.go
@@ -40,12 +40,15 @@ func Builtins() []Provider {
 		// core/lexctx classifies comment and string regions in 22 languages
 		// and is what the secrets refiners consult before dropping a match.
 		builtin{"core/lexctx", []AnalysisCapability{LexicalContext}},
-		// core/consteval resolves whether a Go expression is a compile-time
-		// constant, which is what separates `fmt.Print(bashCompletion)` from
-		// `fmt.Print(response)` — a distinction lexing cannot draw, because
-		// both arguments are identifiers. Go only: every other language answers
-		// undetermined, so the matrix reads Unsupported rather than claiming a
-		// coverage that does not exist.
+		// core/consteval resolves whether an expression is an immutable binding,
+		// which is what separates `print(promptTemplate)` where the name is a
+		// constant from the same call where it is a variable — a distinction
+		// lexing cannot draw, because both arguments are identifiers. Go goes
+		// through go/ast; fourteen more languages through their const/final/val
+		// forms; Python and Ruby by single binding under their naming
+		// convention. A format with no binding form answers undetermined, so the
+		// matrix reads Unsupported rather than claiming coverage that does not
+		// exist.
 		builtin{"core/consteval", []AnalysisCapability{ConstantEvaluation}},
 		// core/taint resolves source-to-sink dataflow, and its extractors
 		// resolve symbols within a file to do it.

--- a/core/capability/providers.go
+++ b/core/capability/providers.go
@@ -40,6 +40,13 @@ func Builtins() []Provider {
 		// core/lexctx classifies comment and string regions in 22 languages
 		// and is what the secrets refiners consult before dropping a match.
 		builtin{"core/lexctx", []AnalysisCapability{LexicalContext}},
+		// core/consteval resolves whether a Go expression is a compile-time
+		// constant, which is what separates `fmt.Print(bashCompletion)` from
+		// `fmt.Print(response)` — a distinction lexing cannot draw, because
+		// both arguments are identifiers. Go only: every other language answers
+		// undetermined, so the matrix reads Unsupported rather than claiming a
+		// coverage that does not exist.
+		builtin{"core/consteval", []AnalysisCapability{ConstantEvaluation}},
 		// core/taint resolves source-to-sink dataflow, and its extractors
 		// resolve symbols within a file to do it.
 		builtin{"core/taint", []AnalysisCapability{Taint, SymbolResolution}},

--- a/core/consteval/bindings.go
+++ b/core/consteval/bindings.go
@@ -1,0 +1,461 @@
+package consteval
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// This file carries constant resolution for every language that is not Go.
+//
+// # Why it is not a parser
+//
+// nox is a language-agnostic scanner, and a capability that answers for one
+// language is not a capability — it is a Go feature with a general-sounding
+// name. But nox also cannot carry a parser for twenty-five languages, and the
+// Go path here exists precisely because `go/ast` is free to a program written
+// in Go.
+//
+// So this layer answers the same question from what `core/lexctx` already
+// establishes: which bytes are code, which are string, which are comment. That
+// is enough to see a binding form and to count how many times a name is bound,
+// and those two facts together are what "constant" means operationally — the
+// name was declared immutable, and nothing in the file rebinds it.
+//
+// This mirrors the taint engine's split exactly: `extract_go.go` is AST-precise
+// because Go is free, and every other language is served by a recognizer.
+//
+// # Two bases, and they are not equally strong
+//
+// Some languages have a keyword that makes a binding immutable — `const`,
+// `final`, `val`, `let`. Reading one is a fact about the program.
+//
+// Python and Ruby have no such keyword for local names; the constant is a
+// convention (ALL_CAPS, or a capitalized Ruby constant). Establishing one is a
+// weaker claim, and it is reported as a weaker claim: BasisSingleBinding, which
+// the caller records as heuristic evidence rather than static.
+//
+// Conflating them would put a keyword's certainty behind a naming convention,
+// and this package's whole job is to be exact about which questions were
+// actually answered.
+
+// Basis records HOW constancy was established, so a caller can record evidence
+// of the right strength rather than flattening two different facts into one.
+type Basis string
+
+const (
+	// BasisNone — nothing was established.
+	BasisNone Basis = ""
+	// BasisDeclared — the language has an immutable-binding keyword and the
+	// name carries it. A fact about the program.
+	BasisDeclared Basis = "declared"
+	// BasisSingleBinding — the language has no such keyword, and the name is
+	// bound exactly once in the file, to a literal, under the language's
+	// constant naming convention. Weaker: nothing prevents a rebinding this
+	// file cannot see.
+	BasisSingleBinding Basis = "single-binding"
+)
+
+// bindingSyntax describes how one language declares an immutable name.
+type bindingSyntax struct {
+	// keywords introduce an immutable binding. Empty means the language has
+	// none and constancy rests on convention plus single binding.
+	keywords []string
+	// conventional reports that a name must also match the language's constant
+	// naming convention, which is the only signal available without a keyword.
+	conventional bool
+}
+
+// syntax is the closed table of languages this layer can answer for.
+//
+// A language absent from it answers UNDETERMINED, never "not constant" — the
+// difference between "nox has no evaluator here" and "this value varies", which
+// callers must not conflate because a refutation drops a finding.
+var syntax = map[lexctx.Lang]bindingSyntax{
+	// Keyword languages: the declaration itself carries immutability.
+	lexctx.LangJavaScript: {keywords: []string{"const"}},
+	lexctx.LangJava:       {keywords: []string{"final"}},
+	lexctx.LangCSharp:     {keywords: []string{"const", "readonly"}},
+	lexctx.LangRust:       {keywords: []string{"const", "static"}},
+	lexctx.LangKotlin:     {keywords: []string{"val"}},
+	lexctx.LangSwift:      {keywords: []string{"let"}},
+	lexctx.LangScala:      {keywords: []string{"val"}},
+	lexctx.LangPHP:        {keywords: []string{"const"}},
+	lexctx.LangDart:       {keywords: []string{"const", "final"}},
+	lexctx.LangGroovy:     {keywords: []string{"final"}},
+	lexctx.LangCPP:        {keywords: []string{"const", "constexpr"}},
+	lexctx.LangObjC:       {keywords: []string{"const"}},
+
+	// Convention languages: no keyword binds a local name immutably, so a name
+	// qualifies only by being bound once, to a literal, under the convention.
+	lexctx.LangPython: {conventional: true},
+	lexctx.LangRuby:   {conventional: true},
+}
+
+// identifier matches a name in the languages above. Deliberately conservative:
+// it does not accept `$`, `@` or `-`, so a PHP variable, a Ruby instance
+// variable and a Lisp-cased name are all simply not resolved.
+var identifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// literalRHS matches a right-hand side that is a bare literal: a quoted string
+// (already collapsed to a placeholder by the caller), a number, or a boolean.
+//
+// Anything else — a call, a concatenation with a name, an interpolation — is
+// not accepted, because the question is whether the value can vary and only a
+// literal answers it without further analysis.
+var literalRHS = regexp.MustCompile(`^(?:` + strLiteralPlaceholder + `|[+-]?[0-9][0-9_.xXa-fA-F]*|true|false|True|False|nil|None|null)$`)
+
+// strLiteralPlaceholder stands in for a string region that lexctx identified.
+// Using a placeholder rather than matching quotes means escapes, raw strings,
+// heredocs and interpolation delimiters never have to be re-parsed here — the
+// lexer already decided where the string was.
+const strLiteralPlaceholder = "\x00STR\x00"
+
+// supportedByBindings reports whether the recognizer covers a language.
+func supportedByBindings(lang lexctx.Lang) bool {
+	_, ok := syntax[lang]
+	return ok
+}
+
+// constantBindings returns the names this file binds immutably, and the basis.
+//
+// The single-binding rule applies to EVERY language, keyword or not. A `const`
+// shadowed by a later assignment in the same file is not a constant this
+// resolver will vouch for, and counting is the only way to see that without
+// scope analysis. Over-counting costs a finding that stays reported;
+// under-counting would drop one.
+func constantBindings(lang lexctx.Lang, content []byte) (map[string]Basis, bool) {
+	syn, ok := syntax[lang]
+	if !ok {
+		return nil, false
+	}
+	masked := maskNonCode(lang, content)
+
+	bindings := make(map[string]Basis)
+	counts := make(map[string]int)
+
+	for _, line := range strings.Split(masked, "\n") {
+		name, rhs, kw, ok := splitBinding(line, syn.keywords)
+		if !ok {
+			continue
+		}
+		counts[name]++
+		if !literalRHS.MatchString(trimStatementEnd(rhs)) {
+			// Bound to something that is not a literal. The name is still
+			// BOUND, so the count stands and will disqualify it below.
+			continue
+		}
+		switch {
+		case kw != "":
+			bindings[name] = BasisDeclared
+		case syn.conventional && isConventionalConstantName(lang, name):
+			bindings[name] = BasisSingleBinding
+		}
+	}
+
+	// A name bound more than once is not constant, whatever it was declared as.
+	for name, n := range counts {
+		if n > 1 {
+			delete(bindings, name)
+		}
+	}
+	return bindings, true
+}
+
+// splitBinding pulls `[keyword] NAME = RHS` out of one masked line.
+//
+// It requires the `=` to be a plain assignment: `==`, `!=`, `<=`, `>=`, `=>`
+// and `:=`-style comparisons are rejected, because a comparison binds nothing
+// and reading one as a binding would let an `if NAME == "x"` disqualify the
+// real declaration above it.
+func splitBinding(line string, keywords []string) (name, rhs, keyword string, ok bool) {
+	eq := indexPlainAssign(line)
+	if eq < 0 {
+		return "", "", "", false
+	}
+	lhs := strings.TrimSpace(line[:eq])
+	rhs = line[eq+1:]
+
+	fields := strings.Fields(lhs)
+	if len(fields) == 0 {
+		return "", "", "", false
+	}
+	// The name is the last token: `const X`, `static final String X`,
+	// `const NAME: &str`, or a bare `NAME`.
+	name = strings.TrimSuffix(fields[len(fields)-1], ":")
+	// A typed declaration puts the type between the name and the `=`
+	// (`const NAME: &str = …`); the colon was trimmed, but Rust and Kotlin
+	// write the type after it, so take the token before a type annotation.
+	if len(fields) >= 2 && strings.HasSuffix(fields[len(fields)-2], ":") {
+		name = strings.TrimSuffix(fields[len(fields)-2], ":")
+	}
+	if !identifier.MatchString(name) {
+		return "", "", "", false
+	}
+	for _, kw := range keywords {
+		for _, f := range fields[:max(len(fields)-1, 0)] {
+			if f == kw {
+				keyword = kw
+			}
+		}
+	}
+	return name, rhs, keyword, true
+}
+
+// trimStatementEnd strips the punctuation a statement ends with, so a binding
+// reads the same in a language with terminators and one without.
+//
+// Without it the recognizer answered for Python and Ruby and silently failed
+// for every brace language, because `const P = "x";` leaves a `;` on the
+// right-hand side and no literal ends in a semicolon.
+func trimStatementEnd(rhs string) string {
+	return strings.TrimRight(strings.TrimSpace(rhs), ";, \t")
+}
+
+// indexPlainAssign returns the index of a single `=` that assigns, or -1.
+func indexPlainAssign(line string) int {
+	for i := 0; i < len(line); i++ {
+		if line[i] != '=' {
+			continue
+		}
+		// `==`, `=>`; and `!=`, `<=`, `>=`, `+=`, `:=` and friends.
+		if i+1 < len(line) && (line[i+1] == '=' || line[i+1] == '>') {
+			return -1
+		}
+		if i > 0 && strings.ContainsRune("=!<>+-*/%&|^:", rune(line[i-1])) {
+			return -1
+		}
+		return i
+	}
+	return -1
+}
+
+// isConventionalConstantName applies the language's constant naming rule.
+//
+// Python: PEP 8 says module-level constants are ALL_CAPS. Ruby: a constant is
+// any name beginning with a capital. The convention is doing real work here —
+// it is the only signal these languages give — and requiring it is also what
+// keeps a function PARAMETER from being read as a constant, since parameters
+// are not written this way.
+func isConventionalConstantName(lang lexctx.Lang, name string) bool {
+	if name == "" {
+		return false
+	}
+	switch lang {
+	case lexctx.LangPython:
+		if strings.ToUpper(name) != name {
+			return false
+		}
+		// A name of only underscores and digits is not a constant name.
+		return strings.IndexFunc(name, func(r rune) bool {
+			return r >= 'A' && r <= 'Z'
+		}) >= 0
+	case lexctx.LangRuby:
+		c := name[0]
+		return c >= 'A' && c <= 'Z'
+	default:
+		return false
+	}
+}
+
+// maskNonCode replaces every comment byte with a space and every string region
+// with a single placeholder token, keeping byte offsets stable enough for
+// line-oriented scanning while removing everything that is not program text.
+//
+// Masking rather than deleting is what stops a trigger word inside a comment
+// from being read as code — the defect that produced four self-caused waivers
+// in this repository — and what lets literalRHS recognise a string without
+// re-deriving where the string ended.
+func maskNonCode(lang lexctx.Lang, content []byte) string {
+	regions := lexctx.Classify(lang, content)
+	var b strings.Builder
+	b.Grow(len(content))
+
+	prev := 0
+	for _, r := range regions {
+		if r.Start > prev {
+			b.Write(content[prev:r.Start])
+		}
+		seg := content[r.Start:min(r.End, len(content))]
+		switch r.Kind {
+		case lexctx.KindCode:
+			b.Write(seg)
+		case lexctx.KindString:
+			b.WriteString(strLiteralPlaceholder)
+			// Keep newlines so line numbers and line splitting stay aligned
+			// for multi-line strings.
+			b.WriteString(strings.Repeat("\n", countNewlines(seg)))
+		default:
+			// Comments become blanks, preserving line structure.
+			b.WriteString(strings.Repeat("\n", countNewlines(seg)))
+		}
+		prev = r.End
+	}
+	if prev < len(content) {
+		b.Write(content[prev:])
+	}
+	return b.String()
+}
+
+func countNewlines(b []byte) int {
+	n := 0
+	for _, c := range b {
+		if c == '\n' {
+			n++
+		}
+	}
+	return n
+}
+
+// callArgumentsAreConstantLexically answers the call question for a language
+// with no parser here.
+//
+// It finds the call's parentheses in CODE regions — so a `(` inside a string or
+// a comment never opens a call — splits the arguments on top-level commas, and
+// asks the same question of each: is this a literal, or a name this file binds
+// immutably?
+//
+// Every shape it does not recognise returns UNDETERMINED. That is the whole
+// safety argument: the caller refutes on this answer, refuting drops a finding,
+// and a recognizer that guessed would hide real issues in twenty-four
+// languages at once.
+func callArgumentsAreConstantLexically(lang lexctx.Lang, content []byte, offset int) Result {
+	bindings, ok := constantBindings(lang, content)
+	if !ok {
+		return undetermined("no constant evaluator for this language")
+	}
+
+	regions := lexctx.Classify(lang, content)
+	open := nextCodeByte(regions, content, offset, '(')
+	if open < 0 {
+		return undetermined("no call opener after the match")
+	}
+	closing := matchingParen(regions, content, open)
+	if closing < 0 {
+		return undetermined("call parentheses do not close within the scan window")
+	}
+
+	args := splitArgs(regions, content, open+1, closing)
+	if len(args) == 0 {
+		return Result{Constant: true, Determined: true, Basis: BasisDeclared}
+	}
+
+	weakest := BasisDeclared
+	for _, a := range args {
+		r := argumentIsConstant(regions, content, a[0], a[1], bindings)
+		if !r.Determined || !r.Constant {
+			return r
+		}
+		if r.Basis == BasisSingleBinding {
+			// The call is only as strong as its weakest argument.
+			weakest = BasisSingleBinding
+		}
+	}
+	return Result{Constant: true, Determined: true, Basis: weakest}
+}
+
+// argumentIsConstant decides one argument span.
+func argumentIsConstant(regions []lexctx.Region, content []byte, from, to int, bindings map[string]Basis) Result {
+	// A span that is entirely one string region is a literal.
+	text := strings.TrimSpace(string(content[from:min(to, len(content))]))
+	if text == "" {
+		return undetermined("empty argument")
+	}
+	if spanIsWhollyString(regions, content, from, to) {
+		return Result{Constant: true, Determined: true, Basis: BasisDeclared}
+	}
+	if literalRHS.MatchString(text) {
+		return Result{Constant: true, Determined: true, Basis: BasisDeclared}
+	}
+	if identifier.MatchString(text) {
+		if basis, ok := bindings[text]; ok {
+			return Result{Constant: true, Determined: true, Basis: basis}
+		}
+		return undetermined("name " + text + " does not resolve to a constant in this file")
+	}
+	return undetermined("argument is not a literal or a constant name")
+}
+
+// spanIsWhollyString reports whether every non-space byte of the span lies in a
+// string region — the lexer's answer to "is this argument a literal?".
+func spanIsWhollyString(regions []lexctx.Region, content []byte, from, to int) bool {
+	saw := false
+	for i := from; i < to && i < len(content); i++ {
+		if content[i] == ' ' || content[i] == '\t' || content[i] == '\n' || content[i] == '\r' {
+			continue
+		}
+		if lexctx.KindAt(regions, i) != lexctx.KindString {
+			return false
+		}
+		saw = true
+	}
+	return saw
+}
+
+// nextCodeByte returns the offset of the next b at or after from that lies in a
+// code region, bounded by maxCallScan.
+func nextCodeByte(regions []lexctx.Region, content []byte, from int, b byte) int {
+	for i := max(from, 0); i < min(from+maxCallScan, len(content)); i++ {
+		if content[i] == b && lexctx.KindAt(regions, i) == lexctx.KindCode {
+			return i
+		}
+	}
+	return -1
+}
+
+// matchingParen returns the offset of the ')' closing the '(' at open, counting
+// only parentheses in code regions so a ')' inside a message string does not
+// close the call.
+func matchingParen(regions []lexctx.Region, content []byte, open int) int {
+	depth := 0
+	for i := open; i < min(open+maxCallScan, len(content)); i++ {
+		if lexctx.KindAt(regions, i) != lexctx.KindCode {
+			continue
+		}
+		switch content[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// splitArgs returns the [start,end) spans of the top-level arguments between
+// from and to, splitting on commas that sit in code at depth zero.
+func splitArgs(regions []lexctx.Region, content []byte, from, to int) [][2]int {
+	var out [][2]int
+	depth := 0
+	start := from
+	for i := from; i < to && i < len(content); i++ {
+		if lexctx.KindAt(regions, i) != lexctx.KindCode {
+			continue
+		}
+		switch content[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, [2]int{start, i})
+				start = i + 1
+			}
+		}
+	}
+	if start < to {
+		out = append(out, [2]int{start, to})
+	}
+	return out
+}
+
+// maxCallScan bounds how far the recognizer will look for a call's closing
+// parenthesis. A call that runs longer than this is not one this layer will
+// vouch for, and the bound also keeps a pathological file from making the
+// scanner the expensive part of a scan.
+const maxCallScan = 4096

--- a/core/consteval/bindings_test.go
+++ b/core/consteval/bindings_test.go
@@ -1,0 +1,188 @@
+package consteval
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// The point of this file: nox is language-agnostic, so a constant evaluator
+// that answers only for Go is not a capability.
+func TestConstantEvaluationSpansLanguages(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		src      string
+		marker   string
+		constant bool
+		basis    Basis
+	}{
+		{
+			name:   "javascript const",
+			path:   "a.js",
+			src:    "const PROMPT = \"you are helpful\";\nconsole.log(PROMPT);\n",
+			marker: "console.log", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "typescript const",
+			path:   "a.ts",
+			src:    "const promptTemplate = \"you are helpful\";\nconsole.log(promptTemplate);\n",
+			marker: "console.log", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "javascript let is not constant",
+			path:   "a.js",
+			src:    "let prompt = \"you are helpful\";\nconsole.log(prompt);\n",
+			marker: "console.log", constant: false,
+		},
+		{
+			name:   "python ALL_CAPS bound once",
+			path:   "a.py",
+			src:    "PROMPT_TEMPLATE = \"you are helpful\"\nprint(PROMPT_TEMPLATE)\n",
+			marker: "print(", constant: true, basis: BasisSingleBinding,
+		},
+		{
+			name: "python name rebound is not constant",
+			// The single-binding rule is what stands in for a keyword Python
+			// does not have. Two bindings and the guarantee is gone.
+			path:   "a.py",
+			src:    "PROMPT = \"a\"\nPROMPT = \"b\"\nprint(PROMPT)\n",
+			marker: "print(", constant: false,
+		},
+		{
+			name:   "python lowercase name is not a constant by convention",
+			path:   "a.py",
+			src:    "prompt = \"you are helpful\"\nprint(prompt)\n",
+			marker: "print(", constant: false,
+		},
+		{
+			name:   "java static final",
+			path:   "A.java",
+			src:    "class A { static final String PROMPT = \"hi\";\n void f() { System.out.println(PROMPT); } }\n",
+			marker: "System.out.println", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "ruby capitalized constant",
+			path:   "a.rb",
+			src:    "PROMPT = \"you are helpful\"\nputs(PROMPT)\n",
+			marker: "puts(", constant: true, basis: BasisSingleBinding,
+		},
+		{
+			name:   "kotlin val",
+			path:   "a.kt",
+			src:    "val prompt = \"hi\"\nfun f() { println(prompt) }\n",
+			marker: "println(", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "php const",
+			path:   "a.php",
+			src:    "<?php\nconst PROMPT = \"hi\";\necho(PROMPT);\n",
+			marker: "echo(", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "rust const",
+			path:   "a.rs",
+			src:    "const PROMPT: &str = \"hi\";\nfn f() { println(PROMPT); }\n",
+			marker: "println(", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "a string literal argument needs no binding at all",
+			path:   "a.js",
+			src:    "console.log(\"a literal prompt\");\n",
+			marker: "console.log", constant: true, basis: BasisDeclared,
+		},
+		{
+			name:   "an unresolved name stays undetermined",
+			path:   "a.js",
+			src:    "console.log(fromElsewhere);\n",
+			marker: "console.log", constant: false,
+		},
+		{
+			name:   "a call argument is never assumed constant",
+			path:   "a.js",
+			src:    "const P = \"hi\";\nconsole.log(getPrompt());\n",
+			marker: "console.log", constant: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			off := strings.Index(tt.src, tt.marker)
+			if off < 0 {
+				t.Fatalf("marker %q not in source", tt.marker)
+			}
+			got := CallArgumentsAreConstant(tt.path, []byte(tt.src), off)
+
+			if tt.constant {
+				if !got.Determined || !got.Constant {
+					t.Fatalf("want constant, got %+v", got)
+				}
+				if got.Basis != tt.basis {
+					t.Errorf("Basis = %q, want %q", got.Basis, tt.basis)
+				}
+				return
+			}
+			if got.Determined && got.Constant {
+				t.Errorf("wrongly reported constant: %+v", got)
+			}
+			if got.Reason == "" {
+				t.Error("a non-answer must say why")
+			}
+		})
+	}
+}
+
+// A comment must never supply the binding, and must never supply an argument.
+// This is the class that produced four self-caused waivers in this repository.
+func TestCommentsAndStringsAreNotCode(t *testing.T) {
+	// The "binding" is inside a comment; the name is really unbound.
+	src := "// const PROMPT = \"x\"\nconsole.log(PROMPT);\n"
+	got := CallArgumentsAreConstant("a.js", []byte(src), strings.Index(src, "console.log"))
+	if got.Determined && got.Constant {
+		t.Errorf("a declaration inside a comment was read as a binding: %+v", got)
+	}
+
+	// A `)` inside a string must not close the call early.
+	src2 := "const A = \"a) not the end\";\nconsole.log(A, undeclared);\n"
+	got2 := CallArgumentsAreConstant("a.js", []byte(src2), strings.Index(src2, "console.log"))
+	if got2.Determined && got2.Constant {
+		t.Errorf("a paren inside a string closed the call early, hiding an argument: %+v", got2)
+	}
+}
+
+// Basis must degrade to the weakest argument: one convention-based name makes
+// the whole call convention-based, not declared.
+func TestBasisTakesTheWeakestArgument(t *testing.T) {
+	src := "A_CONST = \"x\"\nB_CONST = \"y\"\nprint(A_CONST, B_CONST)\n"
+	got := CallArgumentsAreConstant("a.py", []byte(src), strings.Index(src, "print("))
+	if !got.Determined || !got.Constant {
+		t.Fatalf("want constant, got %+v", got)
+	}
+	if got.Basis != BasisSingleBinding {
+		t.Errorf("Basis = %q, want %q — Python has no immutable-binding keyword",
+			got.Basis, BasisSingleBinding)
+	}
+}
+
+// Supported must name every language with an engine, and no others.
+func TestSupportedNamesEveryEngine(t *testing.T) {
+	for _, l := range []lexctx.Lang{
+		lexctx.LangGo, lexctx.LangJavaScript, lexctx.LangPython, lexctx.LangJava,
+		lexctx.LangRuby, lexctx.LangKotlin, lexctx.LangPHP, lexctx.LangRust,
+		lexctx.LangCSharp, lexctx.LangSwift, lexctx.LangScala, lexctx.LangDart,
+		lexctx.LangGroovy, lexctx.LangCPP, lexctx.LangObjC,
+	} {
+		if !Supported(l) {
+			t.Errorf("%v has an engine but Supported reports false", l)
+		}
+	}
+	for _, l := range []lexctx.Lang{
+		lexctx.LangUnknown, lexctx.LangShell, lexctx.LangYAML, lexctx.LangDockerfile,
+	} {
+		if Supported(l) {
+			t.Errorf("%v has no engine but Supported reports true; the matrix would "+
+				"read as covered where nothing can answer", l)
+		}
+	}
+}

--- a/core/consteval/consteval.go
+++ b/core/consteval/consteval.go
@@ -34,12 +34,24 @@
 // compile-time constant cannot hold a runtime prompt or a model response,
 // because its value is fixed before the program runs.
 //
-// # Go only, and honest about it
+// # Language-agnostic, at two different strengths
 //
-// Go is the only language resolved here, for the same reason the taint engine
-// modelled Go first: nox is written in Go, so `go/ast` is free, precise and
-// deterministic, where every other language would need a parser this repository
-// does not carry. Everything else answers "undetermined".
+// nox is a language-agnostic scanner, so a capability answering only for Go
+// would be a Go feature with a general-sounding name. Two engines answer here:
+//
+//   - Go goes through `go/ast`, because a program written in Go gets the parser
+//     for free — the same reason the taint engine modelled Go first.
+//   - Fourteen other languages go through bindings.go, which reads the
+//     immutable-binding forms (`const`, `final`, `val`, `let`, `readonly`) from
+//     what `core/lexctx` already establishes about which bytes are code.
+//
+// Python and Ruby have no keyword that binds a local name immutably, so a name
+// qualifies there only by being bound exactly once, to a literal, under the
+// language's constant naming convention. That is a weaker fact, Result.Basis
+// says which was established, and the caller records heuristic evidence for it
+// rather than static.
+//
+// A language in neither engine answers "undetermined".
 //
 // That asymmetry is the whole safety argument. Every function here returns a
 // DETERMINED flag beside its answer, and callers must refute only on
@@ -68,6 +80,10 @@ type Result struct {
 	// the language has no engine here, the file did not parse, or a name could
 	// not be resolved within this file — never that the answer is "no".
 	Determined bool
+	// Basis records how constancy was established, so a caller can record
+	// evidence of the right strength: a language keyword is a fact about the
+	// program, a naming convention is not.
+	Basis Basis
 	// Reason explains an undetermined answer, for the degradation channel.
 	Reason string
 }
@@ -78,9 +94,11 @@ func undetermined(reason string) Result { return Result{Reason: reason} }
 // Supported reports whether a constant engine exists for a language.
 //
 // Callers use it to record capability coverage as Unsupported rather than
-// NotEvaluated: a Python file is not a file where constant evaluation failed,
-// it is a file where nox has no evaluator, and the matrix should say so.
-func Supported(lang lexctx.Lang) bool { return lang == lexctx.LangGo }
+// NotEvaluated: a file in a language with no evaluator is not a file where
+// constant evaluation failed, and the matrix should say which it was.
+func Supported(lang lexctx.Lang) bool {
+	return lang == lexctx.LangGo || supportedByBindings(lang)
+}
 
 // CallArgumentsAreConstant reports whether every argument of the call
 // enclosing offset is a compile-time constant.
@@ -94,8 +112,12 @@ func Supported(lang lexctx.Lang) bool { return lang == lexctx.LangGo }
 // response to it before the log call runs. Constant is a claim about what the
 // value CAN be, not about what it happens to be at the line being read.
 func CallArgumentsAreConstant(path string, content []byte, offset int) Result {
-	if !Supported(lexctx.LangFromPath(path)) {
+	lang := lexctx.LangFromPath(path)
+	if !Supported(lang) {
 		return undetermined("no constant evaluator for this language")
+	}
+	if lang != lexctx.LangGo {
+		return callArgumentsAreConstantLexically(lang, content, offset)
 	}
 	file, fset := source.ParseGoFile(path, content)
 	if file == nil {
@@ -109,7 +131,7 @@ func CallArgumentsAreConstant(path string, content []byte, offset int) Result {
 	if len(call.Args) == 0 {
 		// A call with no arguments logs nothing that could carry a prompt. That
 		// is a determinable fact, not an unknown.
-		return Result{Constant: true, Determined: true}
+		return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 	}
 
 	consts := constNames(file)
@@ -119,7 +141,7 @@ func CallArgumentsAreConstant(path string, content []byte, offset int) Result {
 			return r
 		}
 	}
-	return Result{Constant: true, Determined: true}
+	return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 }
 
 // enclosingCall returns the innermost call expression containing offset.
@@ -192,18 +214,18 @@ func exprIsConstant(e ast.Expr, consts map[string]bool) Result {
 	switch x := e.(type) {
 	case *ast.BasicLit:
 		// A literal is the base case: "text", 42, 'c', `raw`.
-		return Result{Constant: true, Determined: true}
+		return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 
 	case *ast.Ident:
 		switch x.Name {
 		case "true", "false", "iota":
-			return Result{Constant: true, Determined: true}
+			return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 		case "nil":
 			// Untyped nil carries nothing and cannot be a prompt.
-			return Result{Constant: true, Determined: true}
+			return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 		}
 		if consts[x.Name] {
-			return Result{Constant: true, Determined: true}
+			return Result{Constant: true, Determined: true, Basis: BasisDeclared}
 		}
 		// The name is not a constant IN THIS FILE. It may be a var, a
 		// parameter, or a constant declared in another file of the package —

--- a/core/consteval/consteval.go
+++ b/core/consteval/consteval.go
@@ -1,0 +1,233 @@
+// Package consteval answers whether an expression is a compile-time constant.
+//
+// # Why this exists
+//
+// `capability.ConstantEvaluation` has been declared since the capability model
+// was written, `core/adjudicate` lists it as a question worth asking — "is this
+// value a literal, or is it built from input?" — and until now nothing answered
+// it. It appeared in exactly two places in the tree: its own declaration, and
+// the list of things nox cannot do. `capability.Builtins()` even described nox
+// as resolving "constants where a language engine exists", which was not true
+// of any engine in the repository.
+//
+// A declared capability nobody provides is worse than an absent one. It reads
+// as coverage in the matrix, and an operator cannot tell a question that was
+// asked and answered from one that was never asked.
+//
+// # What it is for
+//
+// The distinction it draws is the one the AI rules actually care about, and the
+// one lexical analysis cannot reach. `core/lexctx` answers "is this text or is
+// it code?", which is enough to see that `fmt.Print("hello")` logs a literal.
+// It is not enough for:
+//
+//	const bashCompletion = `# nox bash completion …`
+//	fmt.Print(bashCompletion)
+//
+// Lexically, `bashCompletion` is an identifier — code, not text — so the
+// lexical refiner correctly declines to call it constant text, and AI-006
+// reports a prompt logged without redaction. It is a shell script. Four such
+// waivers were hand-written in nox's own repository, each explaining to a human
+// what a constant resolver could have established.
+//
+// Resolving the identifier to its `const` declaration answers it: a
+// compile-time constant cannot hold a runtime prompt or a model response,
+// because its value is fixed before the program runs.
+//
+// # Go only, and honest about it
+//
+// Go is the only language resolved here, for the same reason the taint engine
+// modelled Go first: nox is written in Go, so `go/ast` is free, precise and
+// deterministic, where every other language would need a parser this repository
+// does not carry. Everything else answers "undetermined".
+//
+// That asymmetry is the whole safety argument. Every function here returns a
+// DETERMINED flag beside its answer, and callers must refute only on
+// (constant=true, determined=true). "I could not tell" and "it is not a
+// constant" are different facts, and a refutation drops a finding — so reading
+// the first as the second would hide real issues in every language without an
+// engine, which is most of them.
+//
+// It is pure: no clock, no I/O, no network. Same bytes, same answer.
+package consteval
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/source"
+)
+
+// Result is what constant evaluation established about an expression.
+type Result struct {
+	// Constant reports that every non-literal name in the expression resolves
+	// to a compile-time constant. Meaningless unless Determined.
+	Constant bool
+	// Determined reports that the question was actually answered. False means
+	// the language has no engine here, the file did not parse, or a name could
+	// not be resolved within this file — never that the answer is "no".
+	Determined bool
+	// Reason explains an undetermined answer, for the degradation channel.
+	Reason string
+}
+
+// undetermined builds the "I could not tell" result.
+func undetermined(reason string) Result { return Result{Reason: reason} }
+
+// Supported reports whether a constant engine exists for a language.
+//
+// Callers use it to record capability coverage as Unsupported rather than
+// NotEvaluated: a Python file is not a file where constant evaluation failed,
+// it is a file where nox has no evaluator, and the matrix should say so.
+func Supported(lang lexctx.Lang) bool { return lang == lexctx.LangGo }
+
+// CallArgumentsAreConstant reports whether every argument of the call
+// enclosing offset is a compile-time constant.
+//
+// This is the question a logging rule asks: `fmt.Print(x)` leaks a prompt only
+// if x can hold one at runtime. A call whose arguments are all constants —
+// literals, or names bound by `const` — cannot.
+//
+// `var` deliberately does NOT count. A package-level `var greeting = "hi"` is a
+// literal today and a mutable slot forever after; anything may assign a model
+// response to it before the log call runs. Constant is a claim about what the
+// value CAN be, not about what it happens to be at the line being read.
+func CallArgumentsAreConstant(path string, content []byte, offset int) Result {
+	if !Supported(lexctx.LangFromPath(path)) {
+		return undetermined("no constant evaluator for this language")
+	}
+	file, fset := source.ParseGoFile(path, content)
+	if file == nil {
+		return undetermined("file did not parse as Go")
+	}
+
+	call := enclosingCall(file, fset, offset)
+	if call == nil {
+		return undetermined("no call expression encloses the match")
+	}
+	if len(call.Args) == 0 {
+		// A call with no arguments logs nothing that could carry a prompt. That
+		// is a determinable fact, not an unknown.
+		return Result{Constant: true, Determined: true}
+	}
+
+	consts := constNames(file)
+	for _, arg := range call.Args {
+		r := exprIsConstant(arg, consts)
+		if !r.Determined || !r.Constant {
+			return r
+		}
+	}
+	return Result{Constant: true, Determined: true}
+}
+
+// enclosingCall returns the innermost call expression containing offset.
+//
+// Innermost matters: in `log.Print(fmt.Sprintf("%s", user))` the outer call's
+// only argument is itself a call, and answering about the outer one would ask
+// whether a function result is a constant — which it never is — while the
+// question worth asking is about the arguments actually being formatted.
+func enclosingCall(file *ast.File, fset *token.FileSet, offset int) *ast.CallExpr {
+	target := fset.File(file.Pos())
+	if target == nil {
+		return nil
+	}
+	// token.Pos is 1-based over the file set's base.
+	pos := target.Pos(min(max(offset, 0), target.Size()))
+
+	var found *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if n.Pos() > pos || n.End() <= pos {
+			return false
+		}
+		if c, ok := n.(*ast.CallExpr); ok {
+			found = c // keep descending; the last one wins, which is innermost
+		}
+		return true
+	})
+	return found
+}
+
+// constNames collects the names this file binds with `const`.
+//
+// Both package-level and function-local declarations are collected, and they
+// are collected from THIS FILE only. A constant declared in another file of the
+// same package is a real constant that this resolver cannot see, and the honest
+// answer for it is undetermined rather than "not constant" — see
+// exprIsConstant.
+func constNames(file *ast.File) map[string]bool {
+	names := make(map[string]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		decl, ok := n.(*ast.GenDecl)
+		if !ok || decl.Tok != token.CONST {
+			return true
+		}
+		for _, spec := range decl.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, id := range vs.Names {
+				if id.Name != "_" {
+					names[id.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return names
+}
+
+// exprIsConstant decides one expression.
+//
+// The grammar it accepts is deliberately small — literals, constant names, and
+// the operators that combine them — because every shape it does not recognise
+// returns UNDETERMINED, and undetermined costs nothing but a finding that stays
+// reported. Guessing, in this direction, drops findings.
+func exprIsConstant(e ast.Expr, consts map[string]bool) Result {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		// A literal is the base case: "text", 42, 'c', `raw`.
+		return Result{Constant: true, Determined: true}
+
+	case *ast.Ident:
+		switch x.Name {
+		case "true", "false", "iota":
+			return Result{Constant: true, Determined: true}
+		case "nil":
+			// Untyped nil carries nothing and cannot be a prompt.
+			return Result{Constant: true, Determined: true}
+		}
+		if consts[x.Name] {
+			return Result{Constant: true, Determined: true}
+		}
+		// The name is not a constant IN THIS FILE. It may be a var, a
+		// parameter, or a constant declared in another file of the package —
+		// and those are different answers this resolver cannot separate, so it
+		// separates none of them.
+		return undetermined("name " + x.Name + " does not resolve to a constant in this file")
+
+	case *ast.BinaryExpr:
+		// Constant folding: "a" + b is constant when both halves are.
+		if l := exprIsConstant(x.X, consts); !l.Determined || !l.Constant {
+			return l
+		}
+		return exprIsConstant(x.Y, consts)
+
+	case *ast.ParenExpr:
+		return exprIsConstant(x.X, consts)
+
+	case *ast.UnaryExpr:
+		return exprIsConstant(x.X, consts)
+
+	default:
+		// Calls, selectors, indexes, slices, type assertions, composite
+		// literals. Some are constant in Go's sense; none is worth guessing at,
+		// because the cost of a wrong "constant" is a dropped finding.
+		return undetermined("expression is not a literal or a constant name")
+	}
+}

--- a/core/consteval/consteval_test.go
+++ b/core/consteval/consteval_test.go
@@ -1,0 +1,157 @@
+package consteval
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// offsetOfMarker returns the byte offset of marker in src, so a test can point
+// at a call the way an analyzer does — by position, not by AST node.
+func offsetOfMarker(t *testing.T, src, marker string) int {
+	t.Helper()
+	i := strings.Index(src, marker)
+	if i < 0 {
+		t.Fatalf("marker %q not in source", marker)
+	}
+	return i
+}
+
+func TestCallArgumentsAreConstant(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		marker     string
+		constant   bool
+		determined bool
+	}{
+		{
+			name: "a const identifier resolves",
+			// The case that motivated the package: four hand-written waivers in
+			// nox's own repository said this in prose.
+			src:    "package p\n\nimport \"fmt\"\n\nconst bashCompletion = `# completion script`\n\nfunc f() { fmt.Print(bashCompletion) }\n",
+			marker: "fmt.Print", constant: true, determined: true,
+		},
+		{
+			name:   "a string literal resolves",
+			src:    "package p\n\nimport \"fmt\"\n\nfunc f() { fmt.Print(\"hello\") }\n",
+			marker: "fmt.Print", constant: true, determined: true,
+		},
+		{
+			name:   "concatenated constants fold",
+			src:    "package p\n\nimport \"fmt\"\n\nconst a = \"x\"\n\nfunc f() { fmt.Print(a + \"y\") }\n",
+			marker: "fmt.Print", constant: true, determined: true,
+		},
+		{
+			name: "a var is NOT a constant",
+			// A var is a literal today and a mutable slot forever after;
+			// anything may assign a model response to it before this runs.
+			src:    "package p\n\nimport \"fmt\"\n\nvar greeting = \"hi\"\n\nfunc f() { fmt.Print(greeting) }\n",
+			marker: "fmt.Print", constant: false, determined: false,
+		},
+		{
+			name:   "a parameter is not a constant",
+			src:    "package p\n\nimport \"fmt\"\n\nfunc f(s string) { fmt.Print(s) }\n",
+			marker: "fmt.Print", constant: false, determined: false,
+		},
+		{
+			name:   "one non-constant argument is enough",
+			src:    "package p\n\nimport \"fmt\"\n\nconst a = \"x\"\n\nfunc f(s string) { fmt.Print(a, s) }\n",
+			marker: "fmt.Print", constant: false, determined: false,
+		},
+		{
+			name:   "a local const resolves",
+			src:    "package p\n\nimport \"fmt\"\n\nfunc f() { const local = \"v\"; fmt.Print(local) }\n",
+			marker: "fmt.Print", constant: true, determined: true,
+		},
+		{
+			name: "a function result is never assumed constant",
+			// Innermost-call selection means this asks about os.Getenv's own
+			// argument, which is a literal -- but the finding's offset points at
+			// the outer call, so the outer call's argument is a CallExpr.
+			src:    "package p\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc f() { fmt.Print(os.Getenv(\"HOME\")) }\n",
+			marker: "fmt.Print(", constant: false, determined: false,
+		},
+		{
+			name:   "no arguments carries nothing",
+			src:    "package p\n\nimport \"fmt\"\n\nfunc f() { fmt.Println() }\n",
+			marker: "fmt.Println", constant: true, determined: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CallArgumentsAreConstant("f.go", []byte(tt.src), offsetOfMarker(t, tt.src, tt.marker))
+			if got.Determined != tt.determined {
+				t.Fatalf("Determined = %v, want %v (reason: %s)", got.Determined, tt.determined, got.Reason)
+			}
+			if got.Determined && got.Constant != tt.constant {
+				t.Errorf("Constant = %v, want %v", got.Constant, tt.constant)
+			}
+			if !got.Determined && got.Reason == "" {
+				t.Error("an undetermined result must say why")
+			}
+		})
+	}
+}
+
+// A constant declared in ANOTHER file of the package is a real constant this
+// resolver cannot see. It must answer undetermined, never "not constant":
+// callers refute on the answer, and refuting drops a finding.
+func TestCrossFileConstantIsUndeterminedNotFalse(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\nfunc f() { fmt.Print(declaredElsewhere) }\n"
+	got := CallArgumentsAreConstant("f.go", []byte(src), offsetOfMarker(t, src, "fmt.Print"))
+	if got.Determined {
+		t.Fatalf("claimed to determine a name it cannot see: %+v", got)
+	}
+	if !strings.Contains(got.Reason, "declaredElsewhere") {
+		t.Errorf("reason does not name the unresolved identifier: %q", got.Reason)
+	}
+}
+
+// Every language without an engine answers undetermined. Reading that as "not
+// constant" would be harmless; reading it as "constant" would drop findings in
+// every language nox cannot parse, which is most of them.
+func TestUnsupportedLanguagesAreUndetermined(t *testing.T) {
+	for _, path := range []string{"a.py", "a.js", "a.rb", "a.yaml", "Dockerfile"} {
+		t.Run(path, func(t *testing.T) {
+			got := CallArgumentsAreConstant(path, []byte("print('hello')\n"), 0)
+			if got.Determined {
+				t.Errorf("%s: claimed a determination with no evaluator for the language", path)
+			}
+			if got.Constant {
+				t.Errorf("%s: an undetermined result must not read as constant", path)
+			}
+		})
+	}
+	if Supported(lexctx.LangPython) {
+		t.Error("Python reported as supported; no evaluator exists for it")
+	}
+	if !Supported(lexctx.LangGo) {
+		t.Error("Go reported as unsupported; go/ast is the engine this package is built on")
+	}
+}
+
+// Content that does not parse must degrade, not decide.
+func TestUnparseableGoIsUndetermined(t *testing.T) {
+	got := CallArgumentsAreConstant("f.go", []byte("package p\nfunc f( {{{ \n"), 5)
+	if got.Determined && got.Constant {
+		t.Errorf("unparseable Go decided constant: %+v", got)
+	}
+}
+
+// The resolver must not read past the call it was asked about. A constant in
+// one call says nothing about a variable in the next.
+func TestResolutionIsScopedToTheEnclosingCall(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\nconst safe = \"x\"\n\nfunc f(user string) {\n\tfmt.Print(safe)\n\tfmt.Println(user)\n}\n"
+
+	first := CallArgumentsAreConstant("f.go", []byte(src), offsetOfMarker(t, src, "fmt.Print("))
+	if !first.Determined || !first.Constant {
+		t.Errorf("the constant call was not resolved: %+v", first)
+	}
+	second := CallArgumentsAreConstant("f.go", []byte(src), offsetOfMarker(t, src, "fmt.Println("))
+	if second.Determined && second.Constant {
+		t.Errorf("a variable argument was reported constant: %+v", second)
+	}
+}

--- a/core/consteval/consteval_test.go
+++ b/core/consteval/consteval_test.go
@@ -110,11 +110,17 @@ func TestCrossFileConstantIsUndeterminedNotFalse(t *testing.T) {
 	}
 }
 
-// Every language without an engine answers undetermined. Reading that as "not
-// constant" would be harmless; reading it as "constant" would drop findings in
-// every language nox cannot parse, which is most of them.
+// A language with no engine answers undetermined. Reading that as "not
+// constant" would be harmless; reading it as "constant" would drop findings
+// wherever nox cannot resolve a binding.
+//
+// The list here was once a.py, a.js and a.rb as well — this evaluator answered
+// only for Go, which for a language-agnostic scanner is a Go feature with a
+// general-sounding name. Those languages moved to
+// TestConstantEvaluationSpansLanguages when bindings.go was built. What remains
+// are the formats with no binding form at all.
 func TestUnsupportedLanguagesAreUndetermined(t *testing.T) {
-	for _, path := range []string{"a.py", "a.js", "a.rb", "a.yaml", "Dockerfile"} {
+	for _, path := range []string{"a.yaml", "Dockerfile", "a.sh", "a.txt"} {
 		t.Run(path, func(t *testing.T) {
 			got := CallArgumentsAreConstant(path, []byte("print('hello')\n"), 0)
 			if got.Determined {
@@ -125,11 +131,15 @@ func TestUnsupportedLanguagesAreUndetermined(t *testing.T) {
 			}
 		})
 	}
-	if Supported(lexctx.LangPython) {
-		t.Error("Python reported as supported; no evaluator exists for it")
+	if !Supported(lexctx.LangPython) {
+		t.Error("Python reported as unsupported; bindings.go resolves it by " +
+			"single binding under the ALL_CAPS convention")
 	}
 	if !Supported(lexctx.LangGo) {
 		t.Error("Go reported as unsupported; go/ast is the engine this package is built on")
+	}
+	if Supported(lexctx.LangYAML) {
+		t.Error("YAML reported as supported; it has no binding form to read")
 	}
 }
 

--- a/core/scan.go
+++ b/core/scan.go
@@ -38,6 +38,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/weakcrypto"
 	"github.com/nox-hq/nox/core/baseline"
 	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/consteval"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/git"
@@ -2134,6 +2135,16 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 			cov.Record(subject, capability.LexicalContext, capability.Unsupported)
 		} else {
 			cov.Record(subject, capability.LexicalContext, capability.Positive)
+		}
+
+		// Constant evaluation is answerable only where an engine exists. A
+		// Python file is not a file where it failed, it is one where nox has no
+		// evaluator, and Unsupported says that where NotEvaluated would leave a
+		// reader guessing which it was.
+		if consteval.Supported(lexctx.LangFromPath(f.Location.FilePath)) {
+			cov.Record(subject, capability.ConstantEvaluation, capability.Positive)
+		} else {
+			cov.Record(subject, capability.ConstantEvaluation, capability.Unsupported)
 		}
 
 		// The taint engine concluded about the findings it produced, and said

--- a/core/scan.go
+++ b/core/scan.go
@@ -2137,8 +2137,11 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 			cov.Record(subject, capability.LexicalContext, capability.Positive)
 		}
 
-		// Constant evaluation is answerable only where an engine exists. A
-		// Python file is not a file where it failed, it is one where nox has no
+		// Constant evaluation is answerable wherever a binding form can be read
+		// — Go through go/ast, fourteen more through their `const`/`final`/`val`
+		// forms, Python and Ruby by single binding under their naming
+		// convention. A format with no binding form at all (YAML, a Dockerfile)
+		// is not a file where evaluation failed, it is one where nox has no
 		// evaluator, and Unsupported says that where NotEvaluated would leave a
 		// reader guessing which it was.
 		if consteval.Supported(lexctx.LangFromPath(f.Location.FilePath)) {

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -291,11 +291,28 @@ overlaps, dependency applicability. Measuring suggests a different one.
    resolving "constants where a language engine exists", which was true of no
    engine in the repository.
 
-   `core/consteval` answers it for Go, via `go/ast`, for the same reason the
-   taint engine modelled Go first: nox is written in Go, so the parser is free,
-   precise and deterministic. Every other language answers UNDETERMINED and the
-   capability matrix records Unsupported, because a refutation drops a finding
-   and "no evaluator here" must never read as "nothing here".
+   `core/consteval` answers it across fifteen languages, at two strengths.
+   nox is a language-agnostic scanner, so an evaluator that answered only for
+   Go would be a Go feature with a general-sounding name.
+
+   Go goes through `go/ast`, because a program written in Go gets the parser
+   for free — the same reason the taint engine modelled Go first. Fourteen more
+   (JS/TS, Java, C#, Rust, Kotlin, Swift, Scala, PHP, Dart, Groovy, C/C++,
+   Objective-C, and Python and Ruby) go through a recognizer built on what
+   `core/lexctx` already establishes about which bytes are code, reading the
+   immutable-binding forms `const`, `final`, `val`, `let`, `readonly`.
+
+   Python and Ruby have no keyword that binds a local name immutably, so a name
+   qualifies there only by being bound exactly once, to a literal, under the
+   language's constant naming convention. That is a genuinely weaker fact and
+   is recorded as one: the refutation carries `KindHeuristic` where a keyword
+   language carries `KindStatic`. Filing the second as the first would put a
+   keyword's certainty behind a naming convention.
+
+   A format with no binding form at all — YAML, a Dockerfile — answers
+   UNDETERMINED and the capability matrix records Unsupported, because a
+   refutation drops a finding and "no evaluator here" must never read as
+   "nothing here".
 
    What it reaches is narrower than "knowing a prompt is a literal rather than
    assembled from input". It answers one question — does every argument of this

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -281,7 +281,48 @@ overlaps, dependency applicability. Measuring suggests a different one.
    an offline-verifiable checksum. That is a result, not a gap — it says the
    deterministic wins in this family are the structural ones (JWT, and base64/
    hex decodability), not more checksums.
-2. **AI corroboration.** *Done.* The refiners recorded why they dropped a
+2. **AI constant evaluation.** *Built, and smaller than the plan implied.*
+
+   `capability.ConstantEvaluation` had been declared since the capability model
+   was written, `core/adjudicate` listed it as a question worth asking — "is
+   this value a literal, or is it built from input?" — and nothing answered it.
+   It appeared in exactly two places in the tree: its own declaration, and the
+   list of things nox cannot do. `capability.Builtins()` described nox as
+   resolving "constants where a language engine exists", which was true of no
+   engine in the repository.
+
+   `core/consteval` answers it for Go, via `go/ast`, for the same reason the
+   taint engine modelled Go first: nox is written in Go, so the parser is free,
+   precise and deterministic. Every other language answers UNDETERMINED and the
+   capability matrix records Unsupported, because a refutation drops a finding
+   and "no evaluator here" must never read as "nothing here".
+
+   What it reaches is narrower than "knowing a prompt is a literal rather than
+   assembled from input". It answers one question — does every argument of this
+   call resolve to a compile-time constant? — which refutes AI-006 on
+   `fmt.Print(promptTemplate)` where `promptTemplate` is a `const`. The rule
+   matches `prompt` at a word boundary, so it fires on the NAME of a constant,
+   and lexical analysis cannot help: the argument IS code, it is simply code
+   whose value is fixed before the program runs. A `var` does not qualify, and
+   neither does a name declared in another file of the package — both are
+   undetermined, and undetermined stays reported.
+
+   **Measuring it corrected the motivation.** The case that prompted the work
+   was four hand-written waivers in nox's own repository reading
+   `fmt.Print(bashCompletion) // nox:ignore AI-006 -- shell completion script`.
+   Constant evaluation was expected to make them unnecessary. It does not,
+   because they were never necessary: `bashCompletion` has no word boundary
+   before "Completion" and never matched the pattern. The word "completion" in
+   the WAIVER TEXT was the only reason AI-006 fired. Each waiver caused the
+   finding it waived. They are deleted, and
+   `TestTriggerWordInATrailingCommentDoesNotCreateAFinding` pins the class.
+
+   The remaining AI work is unchanged in kind and now better bounded: knowing
+   that a prompt is ASSEMBLED FROM INPUT needs dataflow into the prompt
+   expression, which is taint, not constant evaluation. Constant evaluation
+   closes only the half where the answer is "this cannot vary at all".
+
+3. **AI corroboration.** *Done.* The refiners recorded why they dropped a
    candidate and nothing about the ones that survived, so a reported AI
    finding's ledger said only "the rule fired". A survivor now records what was
    checked: that it is in real code, and — for a rule with a context
@@ -291,7 +332,7 @@ overlaps, dependency applicability. Measuring suggests a different one.
    for a proximity check. The remaining AI work is constant evaluation — knowing
    a prompt is a literal rather than assembled from input — which needs a
    capability nothing implements yet.
-3. **IAC structural parsing.** Largest single piece of work, largest family, and
+4. **IAC structural parsing.** Largest single piece of work, largest family, and
    the only way 490 rules ever exceed heuristic. Now built for the three
    document-shaped schemas (CloudFormation, Kubernetes, ARM), migrating 24 of
    the 57 absence rules — see the family section above for why it is 24, and
@@ -311,7 +352,7 @@ overlaps, dependency applicability. Measuring suggests a different one.
    encrypted bucket looked unencrypted. This is not the structural rewrite; it
    is one bounded fix the rewrite would have subsumed, delivered now because it
    is a real false negative with a reproduction.
-4. **Endpoint/API misuse** is a plugin (`nox-plugin-api-abuse`) and cannot be
+5. **Endpoint/API misuse** is a plugin (`nox-plugin-api-abuse`) and cannot be
    fixed from this repository. Its API-ABUSE-001 sits at precision 0.000 — never
    a true positive on the corpus — which under Milestone 10.2 makes it a
    candidate generator whose output must survive refutation before it becomes a


### PR DESCRIPTION
`capability.ConstantEvaluation` has existed since the capability model was written and **nothing answered it**. It appeared in exactly two places in the tree: its own declaration, and `core/adjudicate`'s list of questions nox cannot answer — *"is this value a literal, or is it built from input?"*. `capability.Builtins()` even described nox as resolving "constants where a language engine exists", which was true of no engine in the repository.

A declared capability nobody provides is worse than an absent one: it reads as coverage in the matrix, and an operator cannot tell a question that was asked and answered from one that was never asked.

## What it answers

```python
PROMPT_TEMPLATE = "You are a helpful assistant."
print(PROMPT_TEMPLATE)     # AI-006 fires: "prompt" at a word boundary in the NAME
```

The existing lexical refiner cannot help — the argument **is** code, it is simply code whose value cannot vary. `core/lexctx` answers "is this text or code?"; this answers "does this name resolve to an immutable binding?".

## Fifteen languages, at two strengths

nox is a language-agnostic scanner, so an evaluator answering only for Go would be a Go feature with a general-sounding name — and the AI rules it serves fire mostly on Python and JavaScript, where AI application code lives.

| Path | Languages | Binding form | Evidence |
|---|---|---|---|
| `go/ast` | Go | `const` | static |
| Recognizer on `lexctx` | JS/TS, Java, C#, Rust, Kotlin, Swift, Scala, PHP, Dart, Groovy, C/C++, Obj-C | `const` `final` `val` `let` `readonly` | static |
| Recognizer, convention | Python, Ruby | bound once to a literal, `ALL_CAPS` / capitalized | **heuristic** |
| — | YAML, Dockerfile, shell | none | undetermined → `Unsupported` |

This is the same split the taint engine already makes: `extract_go.go` is AST-precise because Go is free to a program written in Go, and everything else is served by a recognizer.

**The two strengths are not the same fact.** Python and Ruby have no keyword that binds a local name immutably, so `Result.Basis` reports which was established and the refutation records `KindHeuristic` rather than `KindStatic`. These refutations *drop findings*, so putting a keyword's certainty behind a naming convention would be load-bearing, not cosmetic.

The single-binding rule applies to every language, keyword or not: a `const` shadowed by a later assignment in the same file is not vouched for. Over-counting costs a finding that stays reported; under-counting would drop one.

## Two things measurement corrected

**1. The motivating example was wrong.** This work was prompted by four hand-written waivers in this repository:

```go
fmt.Print(bashCompletion) // nox:ignore AI-006 -- shell completion script
```

Constant evaluation was expected to make them unnecessary. It does not — **they were never necessary**. AI-006 requires a word boundary before the noun, and `bashCompletion` has none before "Completion", so the rule never matched the code. The word *"completion" in the waiver's own justification* was the only reason it fired. Each waiver caused the finding it waived. Verified by scanning with the comments removed on builds both with and without the refiner: zero findings either way. The four are deleted, and `TestTriggerWordInATrailingCommentDoesNotCreateAFinding` pins the class — the rule's `.*?` reaches the rest of the line, so any trailing comment can supply the trigger noun, and a waiver is the comment most likely to name the rule's subject matter.

**2. The first commit shipped Go-only**, flagging the limitation rather than fixing it. Building the second commit across languages immediately found a bug a Go-only suite structurally could not: the recognizer worked for Python and Ruby and silently failed for *every* brace language, because `const P = "x";` leaves a `;` on the right-hand side and no literal ends in a semicolon. The cross-language test table caught it on the first run.

## On the guard test

`TestBuiltinsAreHonestAboutWhatIsMissing` asserted `constant_evaluation` must **not** be declared, because "claiming one turns a limit into a false assurance". That assertion was right when written and had to be *earned*, not deleted. It now sits beside `Reachability`, declared on identical terms and Go-only in the same way: `Provided()` is an installation-level claim that an engine exists, while per-finding coverage carries the language limit. `CallGraph` and `EntryPoint` stay in the forbidden list.

## Verified

- End to end through the CLI on a mixed Python/JavaScript tree: constant-bound prompt templates refuted in both; the mutable ones — a Python name assigned twice, a JavaScript `let` — both still reported.
- Precision suite unchanged at **1.00 / 1.00** (39 TP, 0 FP, 0 FN); baseline gate passes.
- Metamorphic sweep: **0 violations** over 1945 mutations.
- Capability matrix now reports `constant_evaluation` as provided, where it read `false`.

## Still open

Knowing a prompt is *assembled from input* needs dataflow into the prompt expression — that is taint, not constant evaluation. This closes only the half where the answer is "this cannot vary at all".

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT