### PR TITLE
IAC: a companion in the next file is a companion

### DIFF
--- a/core/analyzers/iac/crossfile_test.go
+++ b/core/analyzers/iac/crossfile_test.go
@@ -1,0 +1,201 @@
+package iac
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// workload is a Deployment hardened against every OTHER rule, so the only thing
+// under test is whether its PodDisruptionBudget was found.
+const workload = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+spec:
+  selector:
+    matchLabels: {app: api}
+  template:
+    metadata:
+      labels: {app: api}
+    spec:
+      containers:
+        - name: api
+          image: api@sha256:aaa
+          resources: {limits: {cpu: "1"}, requests: {cpu: 100m}}
+          livenessProbe: {httpGet: {path: /h, port: 8080}}
+          readinessProbe: {httpGet: {path: /r, port: 8080}}
+          securityContext: {runAsNonRoot: true, allowPrivilegeEscalation: false}
+`
+
+const budgetFor = `apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-pdb
+  namespace: prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels: {app: %s}
+`
+
+// scanTree writes files and scans them as one artifact set, the way a real scan
+// sees a manifest directory.
+func scanTree(t *testing.T, files map[string]string) (*findings.FindingSet, *reasoning.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	var artifacts []discovery.Artifact
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+		artifacts = append(artifacts, discovery.Artifact{Path: name, AbsPath: p})
+	}
+	store := reasoning.New()
+	a := NewAnalyzer()
+	a.RecordReasoningTo(store)
+	fs, err := a.ScanArtifacts(context.Background(), artifacts)
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	return fs, store
+}
+
+func rule132(fs *findings.FindingSet) []findings.Finding {
+	var out []findings.Finding
+	for _, f := range fs.Findings() {
+		if f.RuleID == "IAC-132" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// The headline. A Helm chart, a kustomize base, and every manifest directory
+// puts each object in its own file, so the companion is almost never in the
+// same document set — which made the common case a false positive.
+func TestCompanionInAnotherFileRefutesTheFinding(t *testing.T) {
+	fs, _ := scanTree(t, map[string]string{
+		"deployment.yaml": workload,
+		"pdb.yaml":        strings.Replace(budgetFor, "%s", "api", 1),
+	})
+	if got := rule132(fs); len(got) != 0 {
+		t.Errorf("IAC-132 fired %d time(s) on a workload whose PodDisruptionBudget "+
+			"is in the next file: %+v", len(got), got)
+	}
+}
+
+// The direction that matters. A budget elsewhere that selects something else
+// protects nothing here, and the cross-file pass must not clear it.
+func TestCompanionInAnotherFileThatDoesNotBindLeavesTheFinding(t *testing.T) {
+	fs, _ := scanTree(t, map[string]string{
+		"deployment.yaml": workload,
+		"pdb.yaml":        strings.Replace(budgetFor, "%s", "other", 1),
+	})
+	got := rule132(fs)
+	if len(got) != 1 {
+		t.Fatalf("IAC-132 fired %d time(s), want 1: the budget selects app=other", len(got))
+	}
+	// And the claim must say which case this is.
+	claim := got[0].Metadata[rules.StructuralClaimKey]
+	if !strings.Contains(claim, "does not cover this resource") {
+		t.Errorf("the claim does not distinguish an unrelated companion from an "+
+			"absent one: %q", claim)
+	}
+}
+
+// A namespace mismatch across files must not bind either.
+func TestCrossFileRespectsNamespace(t *testing.T) {
+	budget := strings.Replace(
+		strings.Replace(budgetFor, "%s", "api", 1),
+		"namespace: prod", "namespace: staging", 1)
+	fs, _ := scanTree(t, map[string]string{
+		"deployment.yaml": workload,
+		"pdb.yaml":        budget,
+	})
+	if got := rule132(fs); len(got) != 1 {
+		t.Errorf("IAC-132 fired %d time(s), want 1: the budget is in another namespace", len(got))
+	}
+}
+
+// With nothing else scanned, the per-file verdict stands unchanged. This is
+// what ScanFile callers (the MCP server, the LSP) keep seeing.
+func TestSingleFileBehaviourIsUnchanged(t *testing.T) {
+	fs, _ := scanTree(t, map[string]string{"deployment.yaml": workload})
+	if got := rule132(fs); len(got) != 1 {
+		t.Errorf("IAC-132 fired %d time(s) on a lone workload, want 1", len(got))
+	}
+}
+
+// The cross-file pass may only ever REMOVE a finding. If it could add one, a
+// finding would depend on which directory the operator pointed at.
+func TestCrossFilePassNeverAddsAFinding(t *testing.T) {
+	alone, _ := scanTree(t, map[string]string{"deployment.yaml": workload})
+	together, _ := scanTree(t, map[string]string{
+		"deployment.yaml": workload,
+		"pdb.yaml":        strings.Replace(budgetFor, "%s", "api", 1),
+		"unrelated.yaml":  "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: c}\ndata: {k: v}\n",
+	})
+
+	countAlone := len(alone.Findings())
+	countTogether := 0
+	for _, f := range together.Findings() {
+		if f.Location.FilePath == "deployment.yaml" {
+			countTogether++
+		}
+	}
+	if countTogether > countAlone {
+		t.Errorf("scanning more files produced MORE findings on deployment.yaml "+
+			"(%d vs %d); the cross-file pass must only refute", countTogether, countAlone)
+	}
+}
+
+// A suppression has to leave a reason behind, and it must name the file the
+// companion was actually found in.
+func TestCrossFileRefutationRecordsWhereItLooked(t *testing.T) {
+	_, store := scanTree(t, map[string]string{
+		"deployment.yaml": workload,
+		"pdb.yaml":        strings.Replace(budgetFor, "%s", "api", 1),
+	})
+
+	var found bool
+	for _, subject := range store.Subjects() {
+		for _, c := range store.About(subject).Claims {
+			if !c.Refutes() || c.Kind != evidence.KindStatic {
+				continue
+			}
+			if strings.Contains(c.Statement, "pdb.yaml") &&
+				strings.Contains(c.Statement, "among the manifests scanned") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("the cross-file refutation left no claim naming the file it found " +
+			"the companion in; an operator cannot tell this from the rule never firing")
+	}
+}
+
+// A Namespace's ResourceQuota is the same shape and must work the same way.
+func TestCrossFileWorksForNamespaceScopedCompanions(t *testing.T) {
+	fs, _ := scanTree(t, map[string]string{
+		"ns.yaml":    "apiVersion: v1\nkind: Namespace\nmetadata: {name: team-a}\n",
+		"quota.yaml": "apiVersion: v1\nkind: ResourceQuota\nmetadata: {name: q, namespace: team-a}\nspec: {hard: {cpu: \"4\"}}\n",
+	})
+	for _, f := range fs.Findings() {
+		if f.RuleID == "IAC-133" {
+			t.Errorf("IAC-133 fired on a namespace whose quota is in another file: %+v", f)
+		}
+	}
+}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
+	"github.com/nox-hq/nox/core/rules/structural"
 )
 
 // Analyzer wraps a rules.Engine pre-loaded with IaC security rules.
@@ -168,6 +169,14 @@ func enclosingKey(lines []string, line int) string {
 func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Artifact) (*findings.FindingSet, error) {
 	fs := findings.NewFindingSet()
 
+	// The index is what makes a cross-resource rule answerable at all in a real
+	// manifest tree: a Helm chart or a kustomize base puts each object in its
+	// own file, so a Deployment's PodDisruptionBudget is almost never in the
+	// same document set. Built first, from the same bytes the scan reads, and
+	// consulted only to REFUTE — see structural.Index.
+	index := structural.NewIndex()
+	contents := make(map[string][]byte, len(artifacts))
+
 	var collected []findings.Finding
 	for _, artifact := range artifacts {
 		// Honour cancellation between artifacts — see the note in the secrets
@@ -186,8 +195,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			return nil, fmt.Errorf("scanning artifact %s: %w", artifact.Path, err)
 		}
 
+		index.Add(artifact.Path, content)
+		contents[artifact.Path] = content
 		collected = append(collected, results...)
 	}
+
+	collected = a.refuteCompanionsFoundInOtherFiles(index, contents, collected)
 
 	// GitHub Actions context downgrades are applied by the scan pipeline across
 	// EVERY analyzer's output (core/scan.go), not just IaC's. Applying them a
@@ -200,4 +213,102 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 	fs.Deduplicate()
 	return fs, nil
+}
+
+// refuteCompanionsFoundInOtherFiles drops a cross-resource finding when the
+// companion it asked for exists in another file the same scan read.
+//
+// # Why this is a post-pass and not part of the verdict
+//
+// The per-file structural verdict is the authoritative one, and it must stay
+// answerable from a single file: `ScanFile` is what the MCP server and the LSP
+// call, and they hand over one buffer with no tree behind it. So the cross-file
+// answer is layered on top, where it can only ever REMOVE a finding the
+// single-file pass already produced.
+//
+// That direction is the whole safety argument. A scan that read more files may
+// clear a resource it would otherwise flag; it may never flag one it would
+// otherwise clear. The reverse would make a finding depend on which directory
+// the operator pointed at, which is the kind of instability that teaches people
+// to ignore a scanner.
+//
+// A finding is reconsidered only when its rule carries a companion descriptor
+// AND the finding sits on a resource this pass can re-resolve by line. Anything
+// else is left exactly as it was.
+func (a *Analyzer) refuteCompanionsFoundInOtherFiles(index *structural.Index, contents map[string][]byte, in []findings.Finding) []findings.Finding {
+	if index == nil || index.Len() < 2 {
+		// One file cannot contain a cross-FILE companion, so there is nothing
+		// this pass could establish that the per-file verdict did not.
+		return in
+	}
+
+	out := in[:0:0]
+	for i := range in {
+		f := &in[i]
+		rule, ok := a.engine.Rules().ByID(f.RuleID)
+		if !ok || len(rule.AbsenceCompanionTypes) == 0 {
+			out = append(out, in[i])
+			continue
+		}
+		content, ok := contents[f.Location.FilePath]
+		if !ok {
+			out = append(out, in[i])
+			continue
+		}
+		subject, ok := structural.ResourceAt(content, f.Location.StartLine)
+		if !ok {
+			// The finding came from the text path, which reports at an anchor
+			// rather than a resource declaration. Nothing to re-resolve.
+			out = append(out, in[i])
+			continue
+		}
+
+		hit, found := index.CompanionElsewhere(subject, f.Location.FilePath, structural.Companion{
+			Types: rule.AbsenceCompanionTypes,
+			Link:  structural.Link(rule.AbsenceCompanionLink),
+			Path:  rule.AbsenceCompanionPath,
+		})
+		if !found {
+			// The finding stands. But its claim was written by the per-file
+			// pass and says the DOCUMENT SET declares no such companion, which
+			// is true of that file and misleading once a wider scan has seen
+			// one that simply does not cover this resource. Saying which it was
+			// costs nothing and is the difference between "nothing of this kind
+			// exists here" and "one exists and it protects something else".
+			if index.HasType(rule.AbsenceCompanionTypes, f.Location.FilePath) {
+				noteCompanionScannedElsewhere(&in[i], rule.AbsenceCompanionTypes[0])
+			}
+			out = append(out, in[i])
+			continue
+		}
+
+		// The reason for a suppression has to survive the suppression.
+		a.refuteCrossFile(f, hit)
+	}
+	return out
+}
+
+// refuteCrossFile records why a finding was dropped by the cross-file pass.
+func (a *Analyzer) refuteCrossFile(f *findings.Finding, hit structural.Hit) {
+	if a.reasoning == nil {
+		return
+	}
+	subject := reasoning.Candidate(f.RuleID, f.Location.FilePath,
+		f.Location.StartLine, f.Location.StartColumn)
+	a.reasoning.Refute(subject, evidence.KindStatic, "nox-scan", "iac",
+		hit.CrossFileStatement())
+}
+
+// noteCompanionScannedElsewhere amends a surviving finding's structural claim
+// so it distinguishes an absent companion from an unrelated one.
+func noteCompanionScannedElsewhere(f *findings.Finding, companionType string) {
+	claim := f.Metadata[rules.StructuralClaimKey]
+	if claim == "" {
+		return
+	}
+	if f.Metadata == nil {
+		f.Metadata = map[string]string{}
+	}
+	f.Metadata[rules.StructuralClaimKey] = claim +
+		"; another " + companionType + " was found among the manifests scanned, and it does not cover this resource"
 }

--- a/core/rules/structural/index.go
+++ b/core/rules/structural/index.go
@@ -1,0 +1,202 @@
+package structural
+
+import (
+	"fmt"
+	"sort"
+)
+
+// An Index is the resources of MANY files, which is what a cross-resource rule
+// actually needs to answer.
+//
+// # The false positive this removes
+//
+// Companion resolution asks whether a resource is protected by a different
+// object: a Deployment by a PodDisruptionBudget, a Namespace by a
+// ResourceQuota. Within one file it answers well. But a document set is what
+// one file contains, and real manifests are not written that way — a Helm
+// chart, a kustomize base, or a plain manifest directory puts each object in
+// its own file, which is the layout every Kubernetes tutorial teaches.
+//
+// So the common case was a false positive. Measured on a two-file tree — a
+// Deployment in `deployment.yaml`, a PodDisruptionBudget in `pdb.yaml` whose
+// selector matches it exactly — IAC-132 reported the workload as unprotected
+// and said "the document set declares no PodDisruptionBudget". The budget was
+// right there, one file over.
+//
+// # Why this only ever removes findings
+//
+// The index is consulted AFTER the per-file verdict, and only for a subject the
+// per-file pass already called absent. It can refute such a finding; it can
+// never create one. That direction is deliberate: a scan that saw more files
+// should be able to clear a resource it previously flagged, and must not be
+// able to flag one it previously cleared, because the second would make a
+// finding depend on which directory the operator happened to point at.
+//
+// # What it still cannot say
+//
+// Only files this scan read are in the index. A PodDisruptionBudget outside the
+// scanned tree is invisible, exactly as before, and the claim says "among the
+// manifests scanned" rather than "in this cluster". Narrowing the scan narrows
+// what can be refuted, never what can be reported.
+type Index struct {
+	// entries hold each parsed file's resources, keyed by the path they came
+	// from so a companion can be reported with its location and so a resource
+	// never binds to itself across a duplicate read.
+	entries []indexEntry
+}
+
+type indexEntry struct {
+	path      string
+	resources []Resource
+}
+
+// NewIndex returns an empty index.
+func NewIndex() *Index { return &Index{} }
+
+// Add parses content and records whatever resources it contains.
+//
+// Content that does not parse, or that parses into a schema this package does
+// not model, contributes nothing and is not an error: the index is a best
+// effort at "what else did this scan see", and a file it cannot read simply
+// does not participate.
+func (ix *Index) Add(path string, content []byte) {
+	if ix == nil {
+		return
+	}
+	docs, err := Parse(content)
+	if err != nil {
+		return
+	}
+	resources := Resources(docs)
+	if len(resources) == 0 {
+		return
+	}
+	ix.entries = append(ix.entries, indexEntry{path: path, resources: resources})
+}
+
+// Len reports how many files contributed resources.
+func (ix *Index) Len() int {
+	if ix == nil {
+		return 0
+	}
+	return len(ix.entries)
+}
+
+// Files returns the paths that contributed, sorted, so a caller can state what
+// the index actually covered rather than implying it covered everything.
+func (ix *Index) Files() []string {
+	if ix == nil {
+		return nil
+	}
+	out := make([]string, 0, len(ix.entries))
+	for _, e := range ix.entries {
+		out = append(out, e.path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// CompanionElsewhere reports whether any resource in another file binds to
+// subject under c, and where it was found.
+//
+// `excludePath` is the file the subject came from: that file's verdict has
+// already been decided by the per-file pass, and re-consulting it here could
+// only repeat the same answer.
+//
+// An UNDECIDABLE linkage returns false. Within a file, an undecidable pair
+// takes the whole verdict back to the text path, because the per-file answer
+// would otherwise be silently incomplete. Here the per-file answer already
+// exists and this is only asked to refute it, so "I cannot tell whether that
+// budget covers this workload" leaves the finding standing — the conservative
+// direction, and the same one the rest of this package takes.
+func (ix *Index) CompanionElsewhere(subject Resource, excludePath string, c Companion) (Hit, bool) {
+	if ix == nil || len(c.Types) == 0 || c.Link == "" {
+		return Hit{}, false
+	}
+	// Deterministic order: a scan over the same tree must refute on the same
+	// companion every time, because the companion's name goes into the claim.
+	entries := make([]indexEntry, len(ix.entries))
+	copy(entries, ix.entries)
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+
+	for _, e := range entries {
+		if e.path == excludePath {
+			continue
+		}
+		all := e.resources
+		for _, comp := range OfTypes(all, c.Types) {
+			if c.resolve(subject, comp, all) != linked {
+				continue
+			}
+			return Hit{
+				Type: subject.Type, Name: subject.Name, Line: subject.Line,
+				Family:        subject.Family,
+				Companion:     c.Types[0],
+				CompanionName: comp.Name,
+				Property:      e.path,
+			}, true
+		}
+	}
+	return Hit{}, false
+}
+
+// HasType reports whether any file in the index declares a resource of one of
+// these types, excluding the subject's own file.
+//
+// It answers a narrower question than CompanionElsewhere and exists for
+// honesty rather than for verdicts: when a finding survives the cross-file
+// pass, an operator should be able to tell "nothing of this kind was scanned"
+// from "one was scanned and it does not cover this resource". Both leave the
+// finding standing, and they are very different things to read.
+func (ix *Index) HasType(types []string, excludePath string) bool {
+	if ix == nil {
+		return false
+	}
+	for _, e := range ix.entries {
+		if e.path == excludePath {
+			continue
+		}
+		if len(OfTypes(e.resources, types)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourceAt returns the resource declared at line in content, or false.
+//
+// A cross-file check starts from a finding, and a finding carries a line. This
+// is what turns the second back into the first without threading resource
+// identity through the whole matcher.
+func ResourceAt(content []byte, line int) (Resource, bool) {
+	docs, err := Parse(content)
+	if err != nil {
+		return Resource{}, false
+	}
+	for _, r := range Resources(docs) {
+		if r.Line == line {
+			return r, true
+		}
+	}
+	return Resource{}, false
+}
+
+// CrossFileStatement renders what the index established, naming the file the
+// companion was found in.
+//
+// It says "among the manifests scanned" on purpose. The index holds what this
+// scan read and nothing else, and a claim that implied otherwise would be
+// asserting something about a cluster from a directory listing.
+func (h Hit) CrossFileStatement() string {
+	name := h.Name
+	if name == "" {
+		name = "an unnamed resource"
+	}
+	companion := h.CompanionName
+	if companion == "" {
+		companion = "an unnamed resource"
+	}
+	return fmt.Sprintf(
+		"the %s resource %q (%s) is bound to the %s %q declared in %s, which was found among the manifests scanned rather than in this file",
+		h.Family, name, h.Type, h.Companion, companion, h.Property)
+}

--- a/docs/design/rule-family-migration.md
+++ b/docs/design/rule-family-migration.md
@@ -182,15 +182,45 @@ VPC: precision and recall stay at 1.00, and IAC moves from
 `corroborated=1 above=1 earned=1` to `corroborated=2 above=2 earned=2`. Suite
 earned evidence goes from 3 to 4.
 
-##### What remains unknown, and is now stated rather than implied
+##### Cross-file resolution, which the common case actually needed
 
-A document set is one file. A PodDisruptionBudget in a second manifest is not
-visible, and "no companion in this file" is not "no companion anywhere". That
-limit is inherited — the text rule it replaces is scoped to one file too — but
-the claim now says what was parsed rather than what is deployed, and
-`Hit.Statement` says "the document set" for exactly that reason. Cross-FILE
-resolution is the next capability this group would want, and it needs the scan
-to hold a document set across files, which nothing does today.
+A document set was one file, and real manifests are not written that way. A Helm
+chart, a kustomize base and every manifest directory put each object in its own
+file, so a Deployment's PodDisruptionBudget is almost never in the same
+document. That made the COMMON case a false positive: measured on a two-file
+tree — a Deployment in `deployment.yaml`, a budget in `pdb.yaml` whose selector
+matches it exactly — IAC-132 reported the workload as unprotected and said "the
+document set declares no PodDisruptionBudget". The budget was one file over.
+
+`structural.Index` holds the resources of every file a scan read, and a
+post-pass reconsiders each cross-resource finding against it. Three properties
+make it safe:
+
+- **It can only REMOVE a finding.** The index is consulted after the per-file
+  verdict and only for a subject that verdict already called absent. A scan that
+  read more files may clear a resource it would otherwise flag; it may never
+  flag one it would otherwise clear. The reverse would make a finding depend on
+  which directory the operator pointed at.
+  `TestCrossFilePassNeverAddsAFinding` holds it.
+- **The per-file verdict stays authoritative on its own.** `ScanFile` is what
+  the MCP server and the LSP call, and they hand over one buffer with no tree
+  behind it, so the cross-file answer is layered on top rather than folded in.
+- **An undecidable linkage leaves the finding standing.** Within a file an
+  undecidable pair takes the verdict back to the text path; here the per-file
+  answer already exists and the index is only asked to refute it, so "I cannot
+  tell whether that budget covers this workload" changes nothing.
+
+It also separated two outcomes the per-file claim had run together. A finding
+that survives now says whether NOTHING of that kind was scanned or whether one
+was scanned and does not cover this resource — both leave the finding standing,
+and they are very different things for an operator to read.
+
+##### What remains unknown
+
+Only files this scan read are in the index. A PodDisruptionBudget outside the
+scanned tree is invisible, and the claim says "among the manifests scanned"
+rather than "in this cluster" for exactly that reason. Narrowing the scan
+narrows what can be refuted, never what can be reported.
 
 #### The two rules that hold this together
 


### PR DESCRIPTION
Cross-resource rules resolved companions within one document set, and **a document set is one file**. Real manifests are not written that way: a Helm chart, a kustomize base and every manifest directory put each object in its own file, so a Deployment's PodDisruptionBudget is almost never in the same document as the Deployment.

That made the **common layout** a false positive. Measured on a two-file tree:

```
deployment.yaml   Deployment "api"      (namespace prod, labels app: api)
pdb.yaml          PodDisruptionBudget   (namespace prod, selects app: api)
```

IAC-132 reported the workload as unprotected — *"the document set declares no PodDisruptionBudget"* — with the budget one file over. This shipped in #554 with the limitation documented rather than fixed.

## What this adds

`structural.Index` holds the resources of every file a scan read, and a post-pass reconsiders each cross-resource finding against it. Three properties are what make that safe rather than merely useful:

- **It can only REMOVE a finding.** The index is consulted after the per-file verdict and only for a subject that verdict already called absent. A scan that read more files may clear a resource it would otherwise flag; it may never flag one it would otherwise clear. The reverse would make a finding depend on which directory the operator pointed at — the kind of instability that teaches people to ignore a scanner. `TestCrossFilePassNeverAddsAFinding` holds it by scanning the same file alone and in a tree, then comparing.
- **The per-file verdict stays authoritative on its own.** `ScanFile` is what the MCP server and the LSP call, and they hand over one buffer with no tree behind it, so the cross-file answer is layered on top rather than folded into the verdict.
- **An undecidable linkage leaves the finding standing.** Within a file an undecidable pair takes the verdict back to the text path, because the per-file answer would otherwise be silently incomplete. Here that answer already exists and the index is only asked to refute it.

## It also separated two outcomes the claim had run together

A finding that survives now says whether **nothing** of that kind was scanned, or whether one **was** scanned and does not cover this resource. Both leave the finding standing, and they are very different things for an operator to read — previously the second was reported as *"the document set declares no PodDisruptionBudget"* while a budget sat in the next file selecting something else.

## What it still cannot say

Only files this scan read are in the index. A budget outside the scanned tree is invisible, and the claim says "among the manifests scanned" rather than "in this cluster" for exactly that reason. Narrowing the scan narrows what can be refuted, never what can be reported.

## Verified

- End to end through the CLI in both directions: a matching cross-file budget refutes; one selecting `app: other`, or sitting in another namespace, still reports.
- Falsified — disabling the post-pass fails four of the new tests.
- Precision suite unchanged at **1.00 / 1.00** (39 TP, 0 FP, 0 FN).
- Metamorphic sweep: **0 violations** over 1945 mutations.
- Full suite and lint clean.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT