### PR TITLE
AI: prompt-injection dataflow reaches Go, and taint reaches into literals

### DIFF
--- a/core/analyzers/agentflow/agentflow.go
+++ b/core/analyzers/agentflow/agentflow.go
@@ -29,7 +29,14 @@
 // straight-line, intraprocedural propagation over those Units.
 //
 // SCOPE AND LIMITS (honest, deterministic first version):
-//   - Python and JS/TS only (whatever core/lexctx lexes as code).
+//   - Python, JS/TS and Go (whatever core/lexctx lexes as code, for the SDK
+//     spellings llmPromptCalls names). Go was absent until the prompt-sink
+//     vocabulary learned its case convention: `Chat.Completions.New` and
+//     `CreateChatCompletion` are the same APIs as `chat.completions.create`,
+//     and without them an AI application written in Go got no agentic dataflow
+//     analysis at all — measured as zero findings against AGENTFLOW-001 on the
+//     line-for-line Python equivalent. Other languages lex fine and will report
+//     as soon as their SDK spellings are added.
 //   - Intraprocedural and straight-line: source var → prompt arg, and LLM-call
 //     result var → sink arg, within one function body, following simple
 //     reassignment. No cross-function/cross-file flow, no control-flow graph, no
@@ -135,7 +142,12 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 		}
 		lang := lexctx.LangFromPath(art.Path)
 		if lang == lexctx.LangUnknown {
-			continue // Python and JS/TS only
+			// Any language core/lexctx lexes participates; only a file with no
+			// lexer is skipped. The gate was never Python-and-JS — that was the
+			// reach of the PROMPT SINK vocabulary below, which held only the
+			// Python/JS SDK spellings, so a Go file arrived here and then flowed
+			// from a recognised source to an unrecognised destination.
+			continue
 		}
 		content, err := os.ReadFile(art.AbsPath)
 		if err != nil {
@@ -476,6 +488,7 @@ func stmtCallsLLM(st *taint.Statement) bool {
 // the taint catalog's prompt_injection sinks — so embedding calls (which do not
 // produce steerable text output) are excluded from the AGENTFLOW-002 source set.
 var llmPromptCalls = map[string]struct{}{
+	// Python and JS/TS SDK spellings.
 	"chat.completions.create": {},
 	"completions.create":      {},
 	"ChatCompletion.create":   {},
@@ -486,6 +499,32 @@ var llmPromptCalls = map[string]struct{}{
 	"litellm.completion":      {},
 	"invoke_model":            {},
 	"converse":                {},
+
+	// Go SDK spellings. The same APIs, in the case convention Go uses — and
+	// their absence is why an AI application written in Go got NO agentic
+	// dataflow analysis at all. Measured before adding them: a Go handler
+	// taking `r.URL.Query().Get("persona")` straight into a model call produced
+	// zero findings, while the line-for-line Python equivalent produced
+	// AGENTFLOW-001. The untrusted SOURCE was already recognised for Go by the
+	// taint catalog; only the prompt SINK had no Go spelling, so the flow ran
+	// from a known source to an unknown destination and stopped.
+	"Chat.Completions.New":     {}, // openai-go
+	"Completions.New":          {}, // openai-go, legacy completions
+	"Messages.New":             {}, // anthropic-sdk-go
+	"Messages.NewStreaming":    {}, // anthropic-sdk-go
+	"CreateChatCompletion":     {}, // go-openai
+	"CreateCompletion":         {}, // go-openai
+	"GenerateContent":          {}, // google genai for Go; langchaingo
+	"GenerateFromSinglePrompt": {}, // langchaingo
+	"InvokeModel":              {}, // AWS Bedrock for Go
+	"Converse":                 {}, // AWS Bedrock for Go
+	"ConverseStream":           {}, // AWS Bedrock for Go
+
+	// .NET spellings.
+	"CompleteChat":            {}, // Azure.AI.OpenAI / OpenAI .NET
+	"CompleteChatAsync":       {},
+	"GetChatCompletions":      {}, // Azure.AI.OpenAI, earlier surface
+	"GetChatCompletionsAsync": {},
 }
 
 // isPromptCall reports whether a raw call chain is an LLM model invocation.

--- a/core/analyzers/agentflow/go_sdk_test.go
+++ b/core/analyzers/agentflow/go_sdk_test.go
@@ -1,0 +1,115 @@
+package agentflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// scanSource runs the analyzer over one file and returns its findings.
+func scanSource(t *testing.T, name, src string) []findings.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(),
+		[]discovery.Artifact{{Path: name, AbsPath: p, Type: discovery.Source}})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	return fs.Findings()
+}
+
+func fired(fs []findings.Finding, rule string) int {
+	n := 0
+	for _, f := range fs {
+		if f.RuleID == rule {
+			n++
+		}
+	}
+	return n
+}
+
+// nox is a language-agnostic scanner, and prompt-injection dataflow is its
+// flagship AI feature. It covered Python and JS/TS: the LLM prompt SINK
+// vocabulary held only the Python/JS SDK spellings, so an AI application in Go
+// got no agentic dataflow analysis at all.
+//
+// Measured before the fix: a Go handler taking `r.URL.Query().Get("persona")`
+// straight into a model call produced ZERO findings, while the line-for-line
+// Python equivalent produced AGENTFLOW-001. The untrusted SOURCE was already
+// recognised for Go by the taint catalog; only the destination had no Go name,
+// so the flow ran from a known source to an unknown sink and stopped.
+func TestGoSDKPromptCallsAreRecognised(t *testing.T) {
+	tests := []struct {
+		name string
+		call string
+	}{
+		{"openai-go", "client.Chat.Completions.New(ctx, persona)"},
+		{"anthropic-sdk-go", "client.Messages.New(ctx, persona)"},
+		{"go-openai", "client.CreateChatCompletion(ctx, persona)"},
+		{"google genai for Go", "model.GenerateContent(ctx, persona)"},
+		{"langchaingo", "llms.GenerateFromSinglePrompt(ctx, persona)"},
+		{"bedrock", "client.InvokeModel(ctx, persona)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "package p\n\nimport \"net/http\"\n\n" +
+				"func h(w http.ResponseWriter, r *http.Request) {\n" +
+				"\tpersona := r.URL.Query().Get(\"persona\")\n" +
+				"\t_ = " + tt.call + "\n}\n"
+			if got := fired(scanSource(t, "a.go", src), "AGENTFLOW-001"); got == 0 {
+				t.Errorf("AGENTFLOW-001 did not fire on %s; an untrusted value reaches "+
+					"a model prompt and nothing reported it", tt.name)
+			}
+		})
+	}
+}
+
+// The shape the official Go SDKs actually use: parameters arrive as a struct
+// literal, with the prompt nested in a slice inside it. Recognising the call
+// name alone was not enough — the taint had to be seen inside the literal.
+func TestGoStructLiteralParamsCarryTaint(t *testing.T) {
+	src := "package p\n\nimport \"net/http\"\n\n" +
+		"type Params struct {\n\tModel    string\n\tMessages []string\n}\n\n" +
+		"func h(w http.ResponseWriter, r *http.Request) {\n" +
+		"\tpersona := r.URL.Query().Get(\"persona\")\n" +
+		"\t_ = CreateChatCompletion(r.Context(), Params{\n" +
+		"\t\tModel:    \"gpt-4o\",\n" +
+		"\t\tMessages: []string{\"You are a \" + persona + \" assistant.\"},\n" +
+		"\t})\n}\n"
+	if got := fired(scanSource(t, "a.go", src), "AGENTFLOW-001"); got == 0 {
+		t.Error("AGENTFLOW-001 did not fire on the struct-literal parameter shape, " +
+			"which is how every official Go LLM SDK is called")
+	}
+}
+
+// A constant prompt is not an untrusted one. The rule needs a FLOW, and adding
+// the Go call names must not turn every model invocation into a finding.
+func TestGoPromptWithNoUntrustedInputIsClean(t *testing.T) {
+	src := "package p\n\nimport \"context\"\n\n" +
+		"func h(ctx context.Context) {\n" +
+		"\t_ = CreateChatCompletion(ctx, \"You are a helpful assistant.\")\n}\n"
+	if got := fired(scanSource(t, "a.go", src), "AGENTFLOW-001"); got != 0 {
+		t.Errorf("AGENTFLOW-001 fired %d time(s) on a model call with no untrusted "+
+			"input; the rule reports a flow, not a call", got)
+	}
+}
+
+// The Python path must be untouched by the Go additions.
+func TestPythonPathIsUnchanged(t *testing.T) {
+	src := "from flask import request\nimport openai\n\n" +
+		"client = openai.OpenAI()\n\n" +
+		"def personalize():\n" +
+		"    persona = request.json[\"persona\"]\n" +
+		"    return client.chat.completions.create(model=\"gpt-4o\", messages=[{\"role\":\"system\",\"content\":f\"You are a {persona} assistant.\"}])\n"
+	if got := fired(scanSource(t, "a.py", src), "AGENTFLOW-001"); got == 0 {
+		t.Error("AGENTFLOW-001 stopped firing on Python")
+	}
+}

--- a/core/taint/engine/composite_literal_test.go
+++ b/core/taint/engine/composite_literal_test.go
@@ -1,0 +1,116 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// readsFor extracts the variables one statement reads, which is what decides
+// whether taint reaches a sink.
+func readsFor(t *testing.T, src, marker string) []string {
+	t.Helper()
+	units := ExtractUnits("a.go", lexctx.LangGo, []byte(src))
+	for _, u := range units {
+		for i := range u.Stmts {
+			st := &u.Stmts[i]
+			for _, c := range st.Calls {
+				if strings.Contains(c, marker) {
+					return st.Reads
+				}
+			}
+		}
+	}
+	t.Fatalf("no statement calling %q found", marker)
+	return nil
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// A tainted value assembled into a composite literal is still passed to the
+// sink. Before this, the walk stopped at the brace: a struct, slice or map
+// literal was opaque, so the identifiers inside it were never read.
+//
+// It is the dominant shape in Go SDK calls — a model invocation's parameters, a
+// query config, an options struct are all composite literals — and it made Go
+// asymmetric with Python, where the equivalent nested dict was already tracked.
+func TestCompositeLiteralArgumentsAreRead(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "struct literal field",
+			src:  "package p\nfunc f(user string) { sink(Params{Query: user}) }\n",
+			want: "user",
+		},
+		{
+			name: "slice literal element",
+			src:  "package p\nfunc f(user string) { sink([]string{user}) }\n",
+			want: "user",
+		},
+		{
+			name: "map literal value",
+			src:  "package p\nfunc f(user string) { sink(map[string]string{\"k\": user}) }\n",
+			want: "user",
+		},
+		{
+			name: "nested literal, concatenated",
+			// The real SDK shape: a slice inside a struct, with the tainted
+			// value concatenated into a string.
+			src:  "package p\nfunc f(user string) { sink(Params{Messages: []string{\"you are \" + user}}) }\n",
+			want: "user",
+		},
+		{
+			name: "literal nested two deep",
+			src:  "package p\nfunc f(user string) { sink(A{B: B{C: []string{user}}}) }\n",
+			want: "user",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reads := readsFor(t, tt.src, "sink")
+			if !contains(reads, tt.want) {
+				t.Errorf("reads = %v, want to contain %q; a tainted value inside a "+
+					"composite literal never reaches the sink", reads, tt.want)
+			}
+		})
+	}
+}
+
+// A struct literal's KEYS are field names, not variables. Reading them would add
+// every field name in every literal to the statement's reads — systematic noise
+// that could taint a value because a field happened to share a variable's name.
+//
+// The cost is a tainted MAP key going unseen. That is the safe direction to
+// miss: an invented read produces findings, a missed one does not.
+func TestStructLiteralFieldNamesAreNotReads(t *testing.T) {
+	src := "package p\nfunc f() { sink(Params{Query: \"literal\", Model: \"gpt\"}) }\n"
+	reads := readsFor(t, src, "sink")
+	for _, bad := range []string{"Query", "Model"} {
+		if contains(reads, bad) {
+			t.Errorf("field name %q was read as a variable: reads = %v", bad, reads)
+		}
+	}
+}
+
+// The fix must not make every literal a source of reads. A literal with no
+// identifiers in it reads nothing.
+func TestLiteralWithNoIdentifiersReadsNothing(t *testing.T) {
+	src := "package p\nfunc f() { sink([]string{\"a\", \"b\"}) }\n"
+	reads := readsFor(t, src, "sink")
+	for _, r := range reads {
+		if r == "a" || r == "b" {
+			t.Errorf("a string literal element was read as a variable: %v", reads)
+		}
+	}
+}

--- a/core/taint/engine/extract_go.go
+++ b/core/taint/engine/extract_go.go
@@ -580,6 +580,32 @@ func (ex *goExtractor) exprVars(e ast.Expr) []string {
 			for _, a := range x.Args {
 				walk(a)
 			}
+		case *ast.CompositeLit:
+			// A struct, slice or map literal passed as an argument. Without this
+			// the walk stopped at the brace and never reached the identifiers
+			// inside, so a tainted value assembled into a literal was invisible
+			// to every Go sink.
+			//
+			// It is the dominant shape in Go SDK calls — the parameters of a
+			// model invocation, a query config, an options struct are all
+			// composite literals — and the asymmetry showed up starkly against
+			// Python, where the equivalent nested dict/list was already tracked:
+			// a Go handler taking an HTTP query parameter into
+			// `New(ctx, Params{Messages: []string{"..." + persona}})` produced
+			// nothing, while the line-for-line Python equivalent reported the
+			// flow.
+			for _, el := range x.Elts {
+				walk(el)
+			}
+		case *ast.KeyValueExpr:
+			// Only the VALUE. In a struct literal the key is a field name, not a
+			// free variable, and reading it would add every field name in every
+			// literal to the statement's reads — systematic noise that could
+			// taint a value because a field happened to share a variable's name.
+			// The cost is a tainted MAP key going unseen, which is both rare and
+			// the safe direction to miss: an invented read produces findings,
+			// a missed one does not.
+			walk(x.Value)
 		}
 	}
 	walk(e)


### PR DESCRIPTION
nox is a language-agnostic scanner and prompt-injection dataflow is its flagship AI feature. **It did not cover Go.**

Measured before touching anything:

| file | fires |
|---|---|
| `agent.py` — HTTP param → `chat.completions.create` | `AGENTFLOW-001`, `AI-PI-002`, `TAINT-AI-001` |
| `main.go` — the same flow via `Chat.Completions.New` | **nothing at all** |

The untrusted **source** was already recognised for Go by the taint catalog. Only the prompt **sink** had no Go spelling, so the flow ran from a known source to an unknown destination and stopped. `llmPromptCalls` held `chat.completions.create`, `messages.create`, `generate_content` — Python and JS/TS conventions. The same APIs in Go are `Chat.Completions.New`, `Messages.New`, `CreateChatCompletion`, `GenerateContent`, `InvokeModel`. Those are added, with the .NET spellings alongside.

## Adding the names was not enough, and the second half is the bigger fix

With the names in place, simple shapes fired and the shape **every official Go SDK actually uses** still produced nothing:

```go
CreateChatCompletion(ctx, Params{Messages: []string{"you are " + persona}})
```

`exprVars` in the Go extractor walked `Ident`, `BinaryExpr`, `SelectorExpr` and `CallExpr` — but not `*ast.CompositeLit`. The walk stopped at the brace, so the identifiers inside were never read.

**This is not an AI defect.** Any tainted value assembled into a struct, slice or map literal was invisible to **every** Go sink — SQL, exec, filesystem, SSRF — not only prompt sinks. Composite literals are how Go passes options, configs and SDK parameters, so this was a systematic blind spot in Go taint analysis that happened to surface through the AI rules.

It was found by writing the same flow in two languages and comparing: Python's nested dict/list was already tracked, Go's literal was not. That asymmetry is invisible from inside either language alone, which is also why the precision suite did not catch it — it has no sample of this shape.

### The key/value decision is lossy on purpose

Only the **value** of a `KeyValueExpr` is walked, never the key. Without type information a struct literal's key (a field name) is indistinguishable from a map literal's key (a real expression), and reading keys would add every field name in every literal to the statement's reads — noise that could taint a value because a field happened to share a variable's name.

The cost is a tainted **map key** going unseen. That is the safe direction to miss: an invented read produces findings, a missed one does not.

## Over-firing, measured in three places

Adding reads is the over-approximating direction, so it was checked against real Go code rather than argued safe:

| codebase | result |
|---|---|
| `chronos` | no change |
| `warden` | no change |
| nox itself | no change |

The fix adds reads only where taint genuinely flows into a literal that reaches a sink. Precision suite unchanged at **1.00 / 1.00** (39 TP, 0 FP, 0 FN); baseline gate passes; metamorphic sweep **0 violations** over 1945 mutations.

## It also corrects this repository's own design doc

`docs/design/rule-family-migration.md` described the remaining AI work as constant evaluation, and the assembled-from-input half as needing a capability nothing implemented. The dataflow existed in `core/analyzers/agentflow` the whole time. What was missing was the language reach.

Two scope comments claimed "Python and JS/TS only" — never true of the language gate, which only ever skipped `LangUnknown`. That described the reach of the sink vocabulary. Both now say what they mean.

## Still open

- The other twelve languages in `llmPromptCalls` have no SDK spellings. Java, Ruby, PHP, Rust and Kotlin all lex fine and will report the moment their names are added. Go is the one I could verify against real SDK shapes — adding names I cannot test would repeat the mistake of adding the Go names before checking the struct-literal case.
- Whether the other recognizer-based extractors share the composite-literal gap is **unmeasured**. Python turned out fine, so it is worth checking rather than assuming either way.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT