### PR TITLE
TAINT: resolve aliases, so the canonical spelling is not the missed one

### DIFF
--- a/core/taint/engine.go
+++ b/core/taint/engine.go
@@ -60,6 +60,15 @@ type SinkArgInfo struct {
 	// positional argument. For cursor.execute the SQL string is arg 0; a tainted
 	// value only in arg 1 (the params tuple) is the SAFE parameterized form.
 	FirstArgTainted bool
+	// ShellProgram records that the program being executed is itself a shell:
+	// `subprocess.run(["sh", "-c", cmd])`, `spawn("bash", ["-c", cmd])`.
+	//
+	// The arg-vector exemption exists because passing a tainted value as its own
+	// argv element means no shell parses it. Naming a shell as the PROGRAM is
+	// precisely how that premise fails, and it is the ordinary way a command is
+	// run through an argv-taking API — so without this the exemption silenced
+	// the classic injection it was never meant to cover.
+	ShellProgram bool
 	// PositionalVars lists, per positional argument slot (index 0 = first
 	// positional), the variable identifiers appearing in that slot. It lets the
 	// interprocedural summary pass map a caller's argument position to the

--- a/core/taint/engine/args.go
+++ b/core/taint/engine/args.go
@@ -21,6 +21,15 @@ func argInfo(lang langKind, c callChain) sinkArgDraft {
 			info.shellTrue = true
 		}
 	}
+	// The program is the first positional argument, read RAW so the string
+	// literal naming it survives.
+	for _, p := range rawParts {
+		if isKeywordArg(p) {
+			continue
+		}
+		info.shellProgram = namesShellProgram(p)
+		break
+	}
 
 	seen := map[string]struct{}{}
 	for idx, p := range codeParts {
@@ -155,4 +164,70 @@ func isShellTrue(lang langKind, p string) bool {
 		return strings.Contains(compact, "shell:true")
 	}
 	return strings.Contains(compact, "shell=True")
+}
+
+// shellPrograms are the interpreters whose presence as the PROGRAM voids the
+// arg-vector exemption.
+//
+// The exemption's premise is that a tainted value passed as its own argv
+// element is never parsed by a shell. Running a shell AS the program is exactly
+// how that premise fails, and `sh -c "…"` is the ordinary way a command line is
+// executed through an argv-taking API — so the exemption was silencing the
+// classic injection rather than the safe case it was written for.
+//
+// Basename-matched, so `/bin/sh` and `/usr/bin/env` resolve. `env` is included
+// because `env sh -c …` and `env VAR=1 sh -c …` reach a shell just as directly.
+var shellPrograms = map[string]bool{
+	"sh": true, "bash": true, "zsh": true, "dash": true, "ash": true,
+	"ksh": true, "csh": true, "tcsh": true, "fish": true, "busybox": true,
+	"cmd": true, "cmd.exe": true, "powershell": true, "powershell.exe": true,
+	"pwsh": true, "env": true,
+}
+
+// namesShellProgram reports whether a call's first positional argument names a
+// shell, either directly (`spawn("sh", …)`) or as the head of an argv vector
+// (`subprocess.run(["sh", "-c", …])`).
+//
+// It reads the RAW argument text, literals intact, because the program name is
+// a string literal and the code view blanks it.
+func namesShellProgram(raw string) bool {
+	arg := strings.TrimSpace(raw)
+	if arg == "" {
+		return false
+	}
+	// An argv vector: take its first element.
+	if strings.HasPrefix(arg, "[") || strings.HasPrefix(arg, "(") {
+		inner := strings.TrimLeft(arg, "[(")
+		if i := strings.IndexAny(inner, ",])"); i >= 0 {
+			arg = inner[:i]
+		} else {
+			arg = inner
+		}
+	}
+	return shellPrograms[shellBasename(unquoteLiteral(arg))]
+}
+
+// unquoteLiteral strips one layer of surrounding quotes, returning "" when the
+// text is not a quoted literal — an identifier naming the program is unknown,
+// not a shell.
+func unquoteLiteral(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return ""
+	}
+	q := s[0]
+	if (q != '"' && q != '\'' && q != '`') || s[len(s)-1] != q {
+		return ""
+	}
+	return s[1 : len(s)-1]
+}
+
+// shellBasename reduces a program path to the executable name, so `/bin/sh`
+// and `sh` are the same program.
+func shellBasename(p string) string {
+	p = strings.TrimSpace(p)
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
+		p = p[i+1:]
+	}
+	return strings.ToLower(p)
 }

--- a/core/taint/engine/extract.go
+++ b/core/taint/engine/extract.go
@@ -63,6 +63,12 @@ type sinkArgDraft struct {
 	argCount        int
 	shellTrue       bool
 	firstArgTainted bool
+	// shellProgram records that the PROGRAM being executed is itself a shell —
+	// `subprocess.run(["sh", "-c", cmd])`, `spawn("bash", ["-c", cmd])`. The
+	// arg-vector exemption rests on the premise that no shell interprets the
+	// arguments, and naming a shell as the program is exactly how that premise
+	// fails.
+	shellProgram bool
 	// positionalVars lists, per positional argument slot, the variable names in
 	// that slot (index 0 = first positional). Used by the interprocedural pass to
 	// bind a caller argument position to a callee parameter index.

--- a/core/taint/engine/extract_go.go
+++ b/core/taint/engine/extract_go.go
@@ -518,6 +518,11 @@ func (ex *goExtractor) collectExpr(st *stmtDraft, e ast.Expr) {
 func (ex *goExtractor) callArgInfo(call *ast.CallExpr) sinkArgDraft {
 	var info sinkArgDraft
 	seen := map[string]struct{}{}
+	// The program is the first argument. `exec.Command("sh", "-c", cmd)` runs a
+	// shell, which voids the arg-vector exemption — see SinkArgInfo.ShellProgram.
+	if len(call.Args) > 0 {
+		info.shellProgram = namesShellProgram(goExprText(call.Args[0]))
+	}
 	for idx, arg := range call.Args {
 		info.argCount++
 		firstIsLiteralOrVector := idx == 0 && (isStringLiteral(arg) || isCompositeVector(arg))
@@ -797,4 +802,14 @@ func isGoKeyword(s string) bool {
 		return true
 	}
 	return false
+}
+
+// goExprText renders a basic literal back to its source form so the shell-program
+// check can read the program name. Anything that is not a literal returns "",
+// which reads as "unknown program", never as a shell.
+func goExprText(e ast.Expr) string {
+	if lit, ok := e.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+		return lit.Value
+	}
+	return ""
 }

--- a/core/taint/engine/go_safe_idioms_test.go
+++ b/core/taint/engine/go_safe_idioms_test.go
@@ -1,0 +1,84 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// sinkArgsFor returns the argument-shape evidence recorded for a call.
+func sinkArgsFor(t *testing.T, src, call string) (shellProgram, firstArgTainted bool, argCount int) {
+	t.Helper()
+	for _, u := range ExtractUnits("a.go", lexctx.LangGo, []byte(src)) {
+		for i := range u.Stmts {
+			for name, info := range u.Stmts[i].SinkArgs {
+				if strings.Contains(name, call) {
+					return info.ShellProgram, info.FirstArgTainted, info.ArgCount
+				}
+			}
+		}
+	}
+	t.Fatalf("no sink args recorded for %q", call)
+	return
+}
+
+// Go's two standard safe forms — a parameterized query and an arg-vector exec —
+// were false positives whenever the value was actually tainted. The corpus
+// could not see it: clean_safe_db.go took its values as function PARAMETERS, so
+// nothing flowed and the sample stayed clean whether the guards worked or not.
+func TestGoArgVectorExecIsNotAShell(t *testing.T) {
+	src := "package p\nimport \"os/exec\"\nfunc f(dir string) { exec.Command(\"ls\", \"-la\", \"--\", dir) }\n"
+	shell, firstTainted, _ := sinkArgsFor(t, src, "exec.Command")
+	if shell {
+		t.Error(`exec.Command("ls", …) reported a shell program`)
+	}
+	if firstTainted {
+		t.Error("a string-literal program was recorded as a tainted first argument")
+	}
+}
+
+// …but naming a shell as the program voids the exemption. This is what keeps
+// tp_cmdinjection.go a true positive.
+func TestGoShellProgramIsDetected(t *testing.T) {
+	for _, prog := range []string{`"sh"`, `"bash"`, `"/bin/sh"`, `"/usr/bin/env"`} {
+		src := "package p\nimport \"os/exec\"\nfunc f(c string) { exec.Command(" + prog + ", \"-c\", c) }\n"
+		shell, _, _ := sinkArgsFor(t, src, "exec.Command")
+		if !shell {
+			t.Errorf("exec.Command(%s, \"-c\", …) was not recognised as running a shell", prog)
+		}
+	}
+}
+
+// A program named by a variable is UNKNOWN, not a shell. Reading it as one
+// would void the exemption wherever the program is computed.
+func TestGoVariableProgramIsNotAShell(t *testing.T) {
+	src := "package p\nimport \"os/exec\"\nfunc f(prog, arg string) { exec.Command(prog, arg) }\n"
+	shell, _, _ := sinkArgsFor(t, src, "exec.Command")
+	if shell {
+		t.Error("a variable program name was treated as a shell")
+	}
+}
+
+// A parameterized query passes the value AFTER the query string, so the taint is
+// not in the first argument — the shape the exemption keys on.
+func TestGoParameterizedQueryKeepsTaintOutOfArgZero(t *testing.T) {
+	src := "package p\nimport \"database/sql\"\nfunc f(db *sql.DB, id string) { db.Query(\"SELECT x FROM t WHERE id = $1\", id) }\n"
+	_, firstTainted, argCount := sinkArgsFor(t, src, "db.Query")
+	if firstTainted {
+		t.Error("a parameterized query recorded the taint in the query string")
+	}
+	if argCount < 2 {
+		t.Errorf("argCount = %d, want >= 2; the exemption requires a params argument", argCount)
+	}
+}
+
+// Concatenating into the query string puts the taint in argument zero, which is
+// what keeps tp_sqlinjection.go a true positive.
+func TestGoConcatenatedQueryTaintsArgZero(t *testing.T) {
+	src := "package p\nimport \"database/sql\"\nfunc f(db *sql.DB, id string) { db.Query(\"SELECT x FROM t WHERE id = '\" + id + \"'\") }\n"
+	_, firstTainted, _ := sinkArgsFor(t, src, "db.Query")
+	if !firstTainted {
+		t.Error("a concatenated query did not record the taint in the query string")
+	}
+}

--- a/core/taint/engine/imports.go
+++ b/core/taint/engine/imports.go
@@ -35,6 +35,36 @@ import (
 // Go never had this problem: `extract_go.go` resolves aliases through
 // `core/source.ImportAliases`. This brings the recognizer languages up to that.
 //
+// # The same defect, one layer over: Clojure, Elixir and C#
+//
+// Those three name their sinks by a MODULE or TYPE name that an alias renames,
+// and the catalog handled it by enumerating the aliases its author expected --
+// `shell/sh` beside `clojure.java.shell/sh`, `io/reader`, `jdbc/query`. That
+// works only for the alias someone anticipated. Measured, varying nothing but
+// the `:as`:
+//
+//	(:require [clojure.java.shell :as shell])   shell/sh   MATCHED (enumerated)
+//	(:require [clojure.java.shell :as sh])      sh/sh      missed
+//	(:require [clojure.java.shell :as sh2])     sh2/sh     missed
+//
+// `sh` is the canonical alias -- it is the one in clojure.java.shell's own
+// docstring -- so the command-injection sink was invisible on the dominant
+// spelling while scoring a match on the unusual one. Resolving `:as` replaces
+// the guesswork: any alias reaches the qualified name the catalog already has.
+//
+// Elixir and C# take the mirror form. Their catalog entries are BARE module and
+// type names (`System.cmd`, `Repo.query`, `Process.Start`), which is what
+// unaliased code writes, so the resolution target is the LAST segment of the
+// alias's right-hand side rather than the whole path:
+//
+//	alias MyApp.Repo, as: DB           DB.query    -> Repo.query
+//	using Proc = System.Diagnostics.Process;   Proc.Start -> Process.Start
+//
+// Known limit, stated rather than papered over: a C# alias that names a
+// NAMESPACE (`using D = System.Diagnostics;` then `D.Process.Start`) resolves to
+// neither the bare nor the fully-qualified form the catalog carries, and is
+// still missed. The common type-alias case is what this handles.
+//
 // # Why it adds chains rather than replacing them
 //
 // An expansion is recorded ALONGSIDE the original chain, never instead of it.
@@ -56,23 +86,43 @@ var (
 	jsImport = regexp.MustCompile(`^\s*import\s+(.+?)\s+from\s*['"]([^'"]+)['"]`)
 )
 
+// aliasTable maps a local name to the name it resolves to, together with the
+// separator that joins a call chain in this language. The separator travels
+// WITH the table because it is a property of the same language decision: a
+// Clojure chain is `sh/sh`, a Python one `os.system`, and expanding either with
+// the other's separator would silently produce a name that matches nothing.
+type aliasTable struct {
+	names map[string]string
+	sep   string
+}
+
+func (t aliasTable) empty() bool { return len(t.names) == 0 }
+
 // importAliases maps a local name to the qualified path it refers to.
 //
-// A value may be a module ("os", "child_process") or a fully qualified member
-// ("os.system"), which is why callers must join the remainder of a chain onto
-// it rather than assuming one or the other.
-func importAliases(lang lexctx.Lang, content []byte) map[string]string {
+// A value may be a module ("os", "child_process"), a fully qualified member
+// ("os.system"), or -- for the languages whose catalog entries are bare -- a
+// simple module or type name ("Process"). Callers join the remainder of a chain
+// onto it rather than assuming one or the other.
+func importAliases(lang lexctx.Lang, content []byte) aliasTable {
 	switch lang {
 	case lexctx.LangPython:
-		return pythonAliases(content)
+		return aliasTable{names: pythonAliases(content), sep: "."}
 	case lexctx.LangJavaScript:
-		return javascriptAliases(content)
+		return aliasTable{names: javascriptAliases(content), sep: "."}
+	case lexctx.LangClojure:
+		return aliasTable{names: clojureAliases(content), sep: "/"}
+	case lexctx.LangElixir:
+		return aliasTable{names: elixirAliases(content), sep: "."}
+	case lexctx.LangCSharp:
+		return aliasTable{names: csharpAliases(content), sep: "."}
 	default:
 		// Every other language keeps today's behaviour. Go resolves its own
-		// aliases in the AST extractor; the rest are unmeasured, and adding
-		// guesses for import syntaxes nobody has checked would be the same
-		// mistake in a new place.
-		return nil
+		// aliases in the AST extractor; the rest were probed and either show no
+		// gap (Rust's `use x as y` already reaches the sink) or name their sinks
+		// by a convention no alias renames. Adding guesses for import syntaxes
+		// nobody has checked would be the same mistake in a new place.
+		return aliasTable{}
 	}
 }
 
@@ -189,25 +239,100 @@ func splitJSMember(s string) (name, alias string) {
 	return splitAs(s)
 }
 
-// expandChain returns the qualified form of a dotted chain, or "" when the head
-// is not an imported name.
+// clojureAliases reads `:as` (and `:as-alias`) out of ns/require libspecs.
+//
+// Every alias in Clojure is introduced by the same vector shape --
+// `[some.namespace :as local]` -- whether it appears in an `(ns …)` form, a
+// top-level `(require '[…])`, or a multi-line `:require` block. One pattern
+// covers all three, which is why this is a resolution rather than a list of
+// namespaces someone remembered.
+var cljAlias = regexp.MustCompile(`\[\s*([A-Za-z][\w.$*+!?<>=-]*)\s+:as(?:-alias)?\s+([A-Za-z][\w.$*+!?<>=-]*)`)
+
+func clojureAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, m := range cljAlias.FindAllStringSubmatch(string(content), -1) {
+		ns, local := m[1], m[2]
+		if ns == local {
+			continue // nothing to resolve
+		}
+		out[local] = ns
+	}
+	return out
+}
+
+// elixirAliases reads `alias Some.Module, as: Local`.
+//
+// Plain `alias MyApp.Repo` is deliberately skipped: it binds `Repo`, which is
+// already the bare name the catalog carries, so there is nothing to expand.
+var exAlias = regexp.MustCompile(`^\s*alias\s+([A-Z][\w.]*)\s*,\s*as:\s*([A-Z]\w*)`)
+
+func elixirAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		m := exAlias.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		// The catalog names Elixir sinks bare (`System.cmd`, `Repo.query`), so
+		// the target is the last segment, not the whole path.
+		if target := lastSegment(m[1], "."); target != m[2] {
+			out[m[2]] = target
+		}
+	}
+	return out
+}
+
+// csharpAliases reads `using Local = Some.Qualified.Type;`.
+//
+// The `using var x = …` declaration and `using static …` share the keyword but
+// not the shape: both are excluded by requiring a single identifier before the
+// `=` and a plain dotted name after it.
+var csUsingAlias = regexp.MustCompile(`^\s*(?:global\s+)?using\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_][\w.]*)\s*;`)
+
+func csharpAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		m := csUsingAlias.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		// As in Elixir, the catalog names the TYPE (`Process.Start`), so the
+		// alias resolves to the last segment.
+		if target := lastSegment(m[2], "."); target != m[1] {
+			out[m[1]] = target
+		}
+	}
+	return out
+}
+
+// lastSegment returns the final component of a separated path.
+func lastSegment(s, sep string) string {
+	if i := strings.LastIndex(s, sep); i >= 0 {
+		return s[i+len(sep):]
+	}
+	return s
+}
+
+// expandChain returns the resolved form of a chain, or "" when the head is not
+// an imported name.
 //
 // `system` with system→os.system becomes "os.system"; `o.system` with o→os
 // becomes "os.system"; `cp.exec` with cp→child_process becomes
-// "child_process.exec".
-func expandChain(chain string, aliases map[string]string) string {
-	if len(aliases) == 0 || chain == "" {
+// "child_process.exec"; `sh/sh` with sh→clojure.java.shell becomes
+// "clojure.java.shell/sh".
+func expandChain(chain string, t aliasTable) string {
+	if t.empty() || chain == "" {
 		return ""
 	}
-	head, rest, _ := strings.Cut(chain, ".")
-	qualified, ok := aliases[head]
+	head, rest, _ := strings.Cut(chain, t.sep)
+	qualified, ok := t.names[head]
 	if !ok {
 		return ""
 	}
 	if rest == "" {
 		return qualified
 	}
-	return qualified + "." + rest
+	return qualified + t.sep + rest
 }
 
 // applyImportAliases adds the qualified form of every call and chain a statement
@@ -215,22 +340,22 @@ func expandChain(chain string, aliases map[string]string) string {
 // through an alias or a destructured import.
 //
 // Additions only: see the package note on why nothing is replaced.
-func applyImportAliases(drafts []unitDraft, aliases map[string]string) {
-	if len(aliases) == 0 {
+func applyImportAliases(drafts []unitDraft, t aliasTable) {
+	if t.empty() {
 		return
 	}
 	for i := range drafts {
 		for j := range drafts[i].stmts {
 			st := &drafts[i].stmts[j]
-			st.calls = withExpansions(st.calls, aliases)
-			st.chains = withExpansions(st.chains, aliases)
-			expandSinkArgs(st, aliases)
+			st.calls = withExpansions(st.calls, t)
+			st.chains = withExpansions(st.chains, t)
+			expandSinkArgs(st, t)
 		}
 	}
 }
 
 // withExpansions returns the list plus any qualified forms not already present.
-func withExpansions(in []string, aliases map[string]string) []string {
+func withExpansions(in []string, t aliasTable) []string {
 	if len(in) == 0 {
 		return in
 	}
@@ -240,7 +365,7 @@ func withExpansions(in []string, aliases map[string]string) []string {
 	}
 	out := in
 	for _, c := range in {
-		expanded := expandChain(c, aliases)
+		expanded := expandChain(c, t)
 		if expanded == "" {
 			continue
 		}
@@ -257,12 +382,12 @@ func withExpansions(in []string, aliases map[string]string) []string {
 // qualified name, so the argument shape a sink is judged on survives the
 // rewrite. Without it a call would match the catalog by its expanded name and
 // then be judged on no argument evidence at all.
-func expandSinkArgs(st *stmtDraft, aliases map[string]string) {
+func expandSinkArgs(st *stmtDraft, t aliasTable) {
 	if len(st.sinkArgs) == 0 {
 		return
 	}
 	for call, info := range st.sinkArgs {
-		expanded := expandChain(call, aliases)
+		expanded := expandChain(call, t)
 		if expanded == "" {
 			continue
 		}

--- a/core/taint/engine/imports.go
+++ b/core/taint/engine/imports.go
@@ -1,0 +1,274 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// Import resolution for the recognizer-based extractors.
+//
+// # The gap this closes
+//
+// The taint catalog names sinks by their qualified dotted path — `os.system`,
+// `child_process.exec`, `subprocess.run` — and the recognizers recorded the call
+// chain exactly as written. So a sink matched only when the local name in the
+// source happened to equal the module name:
+//
+//	import os                                  os.system(...)      MATCHED
+//	import os as o                             o.system(...)       missed
+//	from os import system                      system(...)         missed
+//
+//	const child_process = require('child_process')   .exec(...)    MATCHED
+//	const cp = require('child_process')              cp.exec(...)  missed
+//	const { exec } = require('child_process')        exec(...)     missed
+//	import { exec } from 'child_process'             exec(...)     missed
+//	import cp from 'child_process'                   cp.exec(...)  missed
+//
+// The one shape that worked is the one almost nobody writes. `from os import
+// system`, `import numpy as np` and destructured requires are the ordinary
+// idioms, so taint analysis was silently inert on most real Python and Node
+// code — measured as: the same textbook command injection reported only when
+// the import was written the unusual way.
+//
+// Go never had this problem: `extract_go.go` resolves aliases through
+// `core/source.ImportAliases`. This brings the recognizer languages up to that.
+//
+// # Why it adds chains rather than replacing them
+//
+// An expansion is recorded ALONGSIDE the original chain, never instead of it.
+// Nothing that matched before can stop matching, so the change cannot remove a
+// finding; it can only let a call that was already written be recognised for
+// what it is. A local function that shadows an imported name costs a redundant
+// chain, not a lost one.
+
+// pyImport matches Python's two import forms, capturing module, names and alias.
+var (
+	pyPlainImport = regexp.MustCompile(`^\s*import\s+([A-Za-z_][\w.]*)(?:\s+as\s+([A-Za-z_]\w*))?\s*$`)
+	pyFromImport  = regexp.MustCompile(`^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+(.+)$`)
+
+	// jsRequire matches `const x = require('mod')` and
+	// `const { a, b: c } = require('mod')`, plus let/var.
+	jsRequire = regexp.MustCompile(`^\s*(?:const|let|var)\s+(\{[^}]*\}|[A-Za-z_$][\w$]*)\s*=\s*require\(\s*['"]([^'"]+)['"]\s*\)`)
+	// jsImport matches ESM: `import x from 'mod'`, `import { a, b as c } from
+	// 'mod'`, `import * as x from 'mod'`.
+	jsImport = regexp.MustCompile(`^\s*import\s+(.+?)\s+from\s*['"]([^'"]+)['"]`)
+)
+
+// importAliases maps a local name to the qualified path it refers to.
+//
+// A value may be a module ("os", "child_process") or a fully qualified member
+// ("os.system"), which is why callers must join the remainder of a chain onto
+// it rather than assuming one or the other.
+func importAliases(lang lexctx.Lang, content []byte) map[string]string {
+	switch lang {
+	case lexctx.LangPython:
+		return pythonAliases(content)
+	case lexctx.LangJavaScript:
+		return javascriptAliases(content)
+	default:
+		// Every other language keeps today's behaviour. Go resolves its own
+		// aliases in the AST extractor; the rest are unmeasured, and adding
+		// guesses for import syntaxes nobody has checked would be the same
+		// mistake in a new place.
+		return nil
+	}
+}
+
+// pythonAliases reads `import` and `from … import` statements.
+func pythonAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		if m := pyPlainImport.FindStringSubmatch(line); m != nil {
+			module, alias := m[1], m[2]
+			if alias != "" {
+				out[alias] = module
+			}
+			continue
+		}
+		m := pyFromImport.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		module, names := m[1], m[2]
+		if strings.Contains(names, "*") {
+			// `from x import *` binds names this resolver cannot enumerate.
+			// Skipping is the safe direction: no expansion, no invented chain.
+			continue
+		}
+		names = strings.Trim(strings.TrimSpace(names), "()")
+		for _, part := range strings.Split(names, ",") {
+			name, alias := splitAs(part)
+			if name == "" {
+				continue
+			}
+			local := alias
+			if local == "" {
+				local = name
+			}
+			out[local] = module + "." + name
+		}
+	}
+	return out
+}
+
+// javascriptAliases reads CommonJS requires and ESM imports.
+func javascriptAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		if m := jsRequire.FindStringSubmatch(line); m != nil {
+			addJSBinding(out, m[1], m[2])
+			continue
+		}
+		if m := jsImport.FindStringSubmatch(line); m != nil {
+			addJSBinding(out, strings.TrimSpace(m[1]), m[2])
+		}
+	}
+	return out
+}
+
+// addJSBinding records one import clause against its module.
+//
+// The clause is either a destructuring pattern (`{ exec, spawn: run }`), a
+// namespace form (`* as cp`), or a single name bound to the module itself.
+func addJSBinding(out map[string]string, clause, module string) {
+	clause = strings.TrimSpace(clause)
+	switch {
+	case strings.HasPrefix(clause, "{"):
+		inner := strings.Trim(clause, "{}")
+		for _, part := range strings.Split(inner, ",") {
+			name, alias := splitJSMember(part)
+			if name == "" {
+				continue
+			}
+			local := alias
+			if local == "" {
+				local = name
+			}
+			out[local] = module + "." + name
+		}
+	case strings.HasPrefix(clause, "*"):
+		// `import * as cp from 'mod'` — cp IS the module. What remains after the
+		// star is `as cp`, which is not the `name as alias` shape splitAs reads.
+		fields := strings.Fields(strings.TrimPrefix(clause, "*"))
+		if len(fields) == 2 && fields[0] == "as" && isSimpleIdent(fields[1]) {
+			out[fields[1]] = module
+		}
+	default:
+		// `const cp = require('mod')` / `import cp from 'mod'`. A default import
+		// is not literally the namespace, but for sink matching it is the object
+		// whose members the catalog names, which is the question being asked.
+		if isSimpleIdent(clause) {
+			out[clause] = module
+		}
+	}
+}
+
+// splitAs splits `name as alias`, returning the name and the alias ("" if none).
+func splitAs(s string) (name, alias string) {
+	fields := strings.Fields(strings.TrimSpace(s))
+	switch len(fields) {
+	case 1:
+		return fields[0], ""
+	case 3:
+		if fields[1] == "as" {
+			return fields[0], fields[2]
+		}
+	}
+	return "", ""
+}
+
+// splitJSMember splits a destructured member, which renames with `:` in
+// CommonJS (`{ exec: run }`) and with `as` in ESM (`{ exec as run }`).
+func splitJSMember(s string) (name, alias string) {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, ":"); i >= 0 {
+		return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:])
+	}
+	return splitAs(s)
+}
+
+// expandChain returns the qualified form of a dotted chain, or "" when the head
+// is not an imported name.
+//
+// `system` with system→os.system becomes "os.system"; `o.system` with o→os
+// becomes "os.system"; `cp.exec` with cp→child_process becomes
+// "child_process.exec".
+func expandChain(chain string, aliases map[string]string) string {
+	if len(aliases) == 0 || chain == "" {
+		return ""
+	}
+	head, rest, _ := strings.Cut(chain, ".")
+	qualified, ok := aliases[head]
+	if !ok {
+		return ""
+	}
+	if rest == "" {
+		return qualified
+	}
+	return qualified + "." + rest
+}
+
+// applyImportAliases adds the qualified form of every call and chain a statement
+// records, so a catalog entry naming the module path matches a call written
+// through an alias or a destructured import.
+//
+// Additions only: see the package note on why nothing is replaced.
+func applyImportAliases(drafts []unitDraft, aliases map[string]string) {
+	if len(aliases) == 0 {
+		return
+	}
+	for i := range drafts {
+		for j := range drafts[i].stmts {
+			st := &drafts[i].stmts[j]
+			st.calls = withExpansions(st.calls, aliases)
+			st.chains = withExpansions(st.chains, aliases)
+			expandSinkArgs(st, aliases)
+		}
+	}
+}
+
+// withExpansions returns the list plus any qualified forms not already present.
+func withExpansions(in []string, aliases map[string]string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	for _, c := range in {
+		seen[c] = struct{}{}
+	}
+	out := in
+	for _, c := range in {
+		expanded := expandChain(c, aliases)
+		if expanded == "" {
+			continue
+		}
+		if _, dup := seen[expanded]; dup {
+			continue
+		}
+		seen[expanded] = struct{}{}
+		out = append(out, expanded)
+	}
+	return out
+}
+
+// expandSinkArgs mirrors each per-call argument record under the call's
+// qualified name, so the argument shape a sink is judged on survives the
+// rewrite. Without it a call would match the catalog by its expanded name and
+// then be judged on no argument evidence at all.
+func expandSinkArgs(st *stmtDraft, aliases map[string]string) {
+	if len(st.sinkArgs) == 0 {
+		return
+	}
+	for call, info := range st.sinkArgs {
+		expanded := expandChain(call, aliases)
+		if expanded == "" {
+			continue
+		}
+		if _, exists := st.sinkArgs[expanded]; exists {
+			continue
+		}
+		st.sinkArgs[expanded] = info
+	}
+}

--- a/core/taint/engine/imports_test.go
+++ b/core/taint/engine/imports_test.go
@@ -1,0 +1,134 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+func TestPythonImportAliases(t *testing.T) {
+	src := `import os
+import os.path as p
+import subprocess as sp
+from os import system
+from os import system as sys_call
+from subprocess import run, Popen
+from json import *
+`
+	got := importAliases(lexctx.LangPython, []byte(src))
+	want := map[string]string{
+		"p":        "os.path",
+		"sp":       "subprocess",
+		"system":   "os.system",
+		"sys_call": "os.system",
+		"run":      "subprocess.run",
+		"Popen":    "subprocess.Popen",
+	}
+	for local, qualified := range want {
+		if got[local] != qualified {
+			t.Errorf("%s → %q, want %q", local, got[local], qualified)
+		}
+	}
+	// A plain `import os` needs no entry: the name already IS the module, which
+	// is the one shape that always matched.
+	if _, ok := got["os"]; ok {
+		t.Error("plain `import os` created a redundant alias")
+	}
+	// `from json import *` binds names this resolver cannot enumerate, and
+	// guessing would invent chains.
+	if len(got) != len(want) {
+		t.Errorf("unexpected aliases: got %v", got)
+	}
+}
+
+func TestJavaScriptImportAliases(t *testing.T) {
+	src := `const cp = require("child_process");
+const { exec } = require("child_process");
+const { spawn: launch } = require("child_process");
+import fs from "fs";
+import { readFile } from "fs";
+import { readFile as rf } from "fs";
+import * as path from "path";
+`
+	got := importAliases(lexctx.LangJavaScript, []byte(src))
+	want := map[string]string{
+		"cp":       "child_process",
+		"exec":     "child_process.exec",
+		"launch":   "child_process.spawn",
+		"fs":       "fs",
+		"readFile": "fs.readFile",
+		"rf":       "fs.readFile",
+		"path":     "path",
+	}
+	for local, qualified := range want {
+		if got[local] != qualified {
+			t.Errorf("%s → %q, want %q", local, got[local], qualified)
+		}
+	}
+}
+
+func TestExpandChain(t *testing.T) {
+	aliases := map[string]string{
+		"system": "os.system",     // from-import of a member
+		"o":      "os",            // aliased module
+		"cp":     "child_process", // aliased module
+	}
+	tests := []struct{ in, want string }{
+		{"system", "os.system"},
+		{"o.system", "os.system"},
+		{"cp.exec", "child_process.exec"},
+		{"cp.exec.sync", "child_process.exec.sync"},
+		{"unknown", ""},
+		{"unknown.member", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := expandChain(tt.in, aliases); got != tt.want {
+			t.Errorf("expandChain(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// Expansion ADDS, never replaces. Nothing that matched before can stop
+// matching, so the change cannot remove a finding.
+func TestExpansionIsAdditive(t *testing.T) {
+	aliases := map[string]string{"o": "os"}
+	got := withExpansions([]string{"o.system", "print"}, aliases)
+
+	for _, want := range []string{"o.system", "print", "os.system"} {
+		var found bool
+		for _, g := range got {
+			if g == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%q missing from %v", want, got)
+		}
+	}
+}
+
+// Languages with no resolver keep today's behaviour exactly. Guessing at import
+// syntaxes nobody has checked would be the same defect in a new place.
+func TestUnresolvedLanguagesGetNoAliases(t *testing.T) {
+	for _, lang := range []lexctx.Lang{
+		lexctx.LangGo, lexctx.LangRuby, lexctx.LangJava, lexctx.LangPHP, lexctx.LangRust,
+	} {
+		if got := importAliases(lang, []byte("import os\nfrom os import system\n")); len(got) != 0 {
+			t.Errorf("%v returned aliases from a resolver it does not have: %v", lang, got)
+		}
+	}
+}
+
+// A commented-out import must not bind a name. lexctx blanks comments before
+// the recognizer runs, but importAliases reads raw content, so this is checked
+// rather than assumed.
+func TestImportsInsideStringsAndCommentsAreStillLineMatched(t *testing.T) {
+	// Documenting current behaviour honestly: the resolver is line-based over
+	// raw content, so a commented import DOES bind. The cost is an extra chain
+	// that matches nothing real, never a lost one — expansion is additive.
+	got := importAliases(lexctx.LangPython, []byte("# from os import system\n"))
+	if len(got) != 0 {
+		t.Logf("known limit: a commented import binds a name (%v); additive expansion makes this harmless", got)
+	}
+}

--- a/core/taint/engine/imports_test.go
+++ b/core/taint/engine/imports_test.go
@@ -15,7 +15,7 @@ from os import system as sys_call
 from subprocess import run, Popen
 from json import *
 `
-	got := importAliases(lexctx.LangPython, []byte(src))
+	got := importAliases(lexctx.LangPython, []byte(src)).names
 	want := map[string]string{
 		"p":        "os.path",
 		"sp":       "subprocess",
@@ -50,7 +50,7 @@ import { readFile } from "fs";
 import { readFile as rf } from "fs";
 import * as path from "path";
 `
-	got := importAliases(lexctx.LangJavaScript, []byte(src))
+	got := importAliases(lexctx.LangJavaScript, []byte(src)).names
 	want := map[string]string{
 		"cp":       "child_process",
 		"exec":     "child_process.exec",
@@ -68,11 +68,11 @@ import * as path from "path";
 }
 
 func TestExpandChain(t *testing.T) {
-	aliases := map[string]string{
+	aliases := aliasTable{sep: ".", names: map[string]string{
 		"system": "os.system",     // from-import of a member
 		"o":      "os",            // aliased module
 		"cp":     "child_process", // aliased module
-	}
+	}}
 	tests := []struct{ in, want string }{
 		{"system", "os.system"},
 		{"o.system", "os.system"},
@@ -92,7 +92,7 @@ func TestExpandChain(t *testing.T) {
 // Expansion ADDS, never replaces. Nothing that matched before can stop
 // matching, so the change cannot remove a finding.
 func TestExpansionIsAdditive(t *testing.T) {
-	aliases := map[string]string{"o": "os"}
+	aliases := aliasTable{sep: ".", names: map[string]string{"o": "os"}}
 	got := withExpansions([]string{"o.system", "print"}, aliases)
 
 	for _, want := range []string{"o.system", "print", "os.system"} {
@@ -114,8 +114,8 @@ func TestUnresolvedLanguagesGetNoAliases(t *testing.T) {
 	for _, lang := range []lexctx.Lang{
 		lexctx.LangGo, lexctx.LangRuby, lexctx.LangJava, lexctx.LangPHP, lexctx.LangRust,
 	} {
-		if got := importAliases(lang, []byte("import os\nfrom os import system\n")); len(got) != 0 {
-			t.Errorf("%v returned aliases from a resolver it does not have: %v", lang, got)
+		if got := importAliases(lang, []byte("import os\nfrom os import system\n")); len(got.names) != 0 {
+			t.Errorf("%v returned aliases from a resolver it does not have: %v", lang, got.names)
 		}
 	}
 }
@@ -127,8 +127,121 @@ func TestImportsInsideStringsAndCommentsAreStillLineMatched(t *testing.T) {
 	// Documenting current behaviour honestly: the resolver is line-based over
 	// raw content, so a commented import DOES bind. The cost is an extra chain
 	// that matches nothing real, never a lost one — expansion is additive.
-	got := importAliases(lexctx.LangPython, []byte("# from os import system\n"))
+	got := importAliases(lexctx.LangPython, []byte("# from os import system\n")).names
 	if len(got) != 0 {
 		t.Logf("known limit: a commented import binds a name (%v); additive expansion makes this harmless", got)
+	}
+}
+
+// Clojure introduces every alias with the same libspec vector, so one pattern
+// has to cover the (ns …) form, a top-level (require '[…]), and a multi-line
+// :require block. `:as-alias` binds a name exactly like `:as` does.
+func TestClojureAliases(t *testing.T) {
+	src := `(ns app.handler
+  (:require [clojure.java.shell :as sh]
+            [clojure.java.io :as io]
+            [clj-http.client :as http :refer [get]]
+            [next.jdbc :as-alias njdbc]
+            [clojure.string]))
+
+(require '[clojure.java.jdbc :as jdbc])
+`
+	got := importAliases(lexctx.LangClojure, []byte(src))
+	if got.sep != "/" {
+		t.Fatalf("clojure chains join with /, got %q", got.sep)
+	}
+	want := map[string]string{
+		"sh":    "clojure.java.shell",
+		"io":    "clojure.java.io",
+		"http":  "clj-http.client",
+		"njdbc": "next.jdbc",
+		"jdbc":  "clojure.java.jdbc",
+	}
+	for local, ns := range want {
+		if got.names[local] != ns {
+			t.Errorf("%s → %q, want %q", local, got.names[local], ns)
+		}
+	}
+	// A require with no :as binds nothing to resolve.
+	if _, ok := got.names["clojure.string"]; ok {
+		t.Error("a plain require created an alias")
+	}
+}
+
+// The gap this closes, stated as the measurement that found it: `sh` is the
+// canonical alias for clojure.java.shell -- it is the one in that namespace's
+// own docstring -- and it resolved to nothing, while the unusual `shell` matched
+// only because the catalog happened to enumerate it.
+func TestClojureCanonicalShellAliasResolves(t *testing.T) {
+	for _, alias := range []string{"sh", "shell", "sh2", "shell-utils"} {
+		src := "(ns p (:require [clojure.java.shell :as " + alias + "]))\n"
+		table := importAliases(lexctx.LangClojure, []byte(src))
+		got := expandChain(alias+"/sh", table)
+		if got != "clojure.java.shell/sh" {
+			t.Errorf(":as %s → %q, want clojure.java.shell/sh", alias, got)
+		}
+	}
+}
+
+// Elixir and C# name their sinks BARE (`System.cmd`, `Process.Start`), so an
+// alias resolves to the last segment, not the whole path. Resolving to the full
+// path would produce a name the catalog does not carry.
+func TestElixirAliases(t *testing.T) {
+	src := `defmodule App do
+  alias MyApp.Repo, as: DB
+  alias System, as: Sys
+  alias MyApp.Repo
+  alias MyApp.{Accounts, Billing}
+end
+`
+	got := importAliases(lexctx.LangElixir, []byte(src)).names
+	if got["DB"] != "Repo" {
+		t.Errorf(`DB → %q, want "Repo"`, got["DB"])
+	}
+	if got["Sys"] != "System" {
+		t.Errorf(`Sys → %q, want "System"`, got["Sys"])
+	}
+	// Plain `alias MyApp.Repo` already binds the bare name the catalog uses, so
+	// there is nothing to expand and inventing an entry would only add noise.
+	if len(got) != 2 {
+		t.Errorf("unexpected aliases: %v", got)
+	}
+}
+
+func TestCSharpUsingAliases(t *testing.T) {
+	src := `using System.Diagnostics;
+using Proc = System.Diagnostics.Process;
+global using Sb = System.Text.StringBuilder;
+using static System.Math;
+using var stream = File.OpenRead(path);
+using (var conn = new SqlConnection(cs)) { }
+`
+	got := importAliases(lexctx.LangCSharp, []byte(src)).names
+	if got["Proc"] != "Process" {
+		t.Errorf(`Proc → %q, want "Process"`, got["Proc"])
+	}
+	if got["Sb"] != "StringBuilder" {
+		t.Errorf(`Sb → %q, want "StringBuilder"`, got["Sb"])
+	}
+	// `using static`, a using DECLARATION and a using STATEMENT share the
+	// keyword but not the shape; binding any of them would invent a chain.
+	if len(got) != 2 {
+		t.Errorf("unexpected aliases: %v", got)
+	}
+}
+
+// The separator belongs to the table because expanding a Clojure chain with a
+// dot -- or a Python one with a slash -- yields a name that matches nothing, and
+// does so silently.
+func TestSeparatorIsPerLanguage(t *testing.T) {
+	clj := aliasTable{sep: "/", names: map[string]string{"sh": "clojure.java.shell"}}
+	if got := expandChain("sh/sh", clj); got != "clojure.java.shell/sh" {
+		t.Errorf("clojure: got %q", got)
+	}
+	// The same chain read with a dot separator finds no head and expands to
+	// nothing, rather than to a plausible-looking wrong answer.
+	dotted := aliasTable{sep: ".", names: map[string]string{"sh": "clojure.java.shell"}}
+	if got := expandChain("sh/sh", dotted); got != "" {
+		t.Errorf("wrong separator should expand to nothing, got %q", got)
 	}
 }

--- a/core/taint/engine/shellprog_test.go
+++ b/core/taint/engine/shellprog_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import "testing"
+
+// The arg-vector exemption rests on the premise that a tainted value passed as
+// its own argv element is never parsed by a shell. Naming a shell as the
+// PROGRAM is how that premise fails.
+func TestNamesShellProgram(t *testing.T) {
+	shells := []string{
+		`"sh"`, `'bash'`, `"zsh"`, `"dash"`, `"ksh"`, `"fish"`,
+		`"/bin/sh"`, `"/usr/bin/bash"`, `'/bin/zsh'`,
+		`"cmd"`, `"cmd.exe"`, `"powershell"`, `"pwsh"`, `"env"`,
+		`"SH"`, `"/bin/BASH"`, // basename-matched, case-folded
+		`["sh", "-c", cmd]`,           // argv vector head
+		`[ "/bin/bash" , "-c", cmd ]`, // spacing
+		`("sh", "-c", cmd)`,           // tuple form
+	}
+	for _, s := range shells {
+		if !namesShellProgram(s) {
+			t.Errorf("namesShellProgram(%s) = false, want true", s)
+		}
+	}
+
+	notShells := []string{
+		``, `"ls"`, `"git"`, `"/usr/bin/git"`, `"python3"`, `"node"`,
+		`["ls", "-la", user]`, `["git", "log", user]`,
+		// An identifier naming the program is UNKNOWN, not a shell. Guessing
+		// would void the exemption for every call whose program is a variable.
+		`prog`, `argv[0]`, `cmd`,
+		// A shell name inside a later argument is not the program.
+		`["git", "commit", "-m", "use sh -c here"]`,
+	}
+	for _, s := range notShells {
+		if namesShellProgram(s) {
+			t.Errorf("namesShellProgram(%s) = true, want false", s)
+		}
+	}
+}
+
+func TestShellBasename(t *testing.T) {
+	for in, want := range map[string]string{
+		"/bin/sh": "sh", "sh": "sh", `C:\Windows\cmd.exe`: "cmd.exe",
+		"/usr/local/bin/BASH": "bash", "": "",
+	} {
+		if got := shellBasename(in); got != want {
+			t.Errorf("shellBasename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A program named by an identifier is unknown. Reading it as a shell would void
+// the exemption wherever the program is a variable, turning every safe argv exec
+// back into a finding.
+func TestUnquotedProgramIsNotAShell(t *testing.T) {
+	if unquoteLiteral("prog") != "" {
+		t.Error("an identifier was read as a quoted literal")
+	}
+	if namesShellProgram("[prog, \"-c\", cmd]") {
+		t.Error("a variable program name was treated as a shell")
+	}
+}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -890,6 +890,20 @@ func (e *StructuralEngine) sinkArgShapeDangerous(sink *taint.Sink, info taint.Si
 		}
 		return true
 	case "subprocess.run", "subprocess.call", "subprocess.Popen",
+		// check_output takes the same (args-vector | string, shell=) shape as
+		// its siblings and was simply missing from this list, so
+		// `subprocess.check_output(["git", "log", tainted])` — a safe argv exec
+		// — reported a command injection while the identical call through
+		// subprocess.run did not. Found on httpie, where it is the only taint
+		// finding in the repository and is not an injection.
+		"subprocess.check_output",
+		// child_process.execFile is deliberately NOT here. It looks like spawn's
+		// shape — (file, args[]), no shell — but adding it measurably traded a
+		// false positive for a false NEGATIVE: `execFile("sh", ["-c", tainted])`
+		// runs a shell as the program, and the exemption silenced it. The same
+		// hole exists for the spawn entry above and predates this list; it is
+		// left alone rather than widened, because a missed injection costs more
+		// than a reported safe call.
 		"child_process.spawn":
 		// An arg-vector exec (list/array first arg) without shell=True is safe.
 		// We approximate "arg vector" as: shell not True and the first argument

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -15,6 +15,11 @@ import (
 // filePath and language are attached to every Unit so findings can be located.
 func ExtractUnits(filePath string, lang lexctx.Lang, content []byte) []taint.Unit {
 	drafts := extractUnits(lang, content)
+	// A sink is named in the catalog by its qualified path, and the recognizers
+	// record a call exactly as written — so `from os import system; system(x)`
+	// matched nothing. Expanding through the file's imports is what lets an
+	// ordinary import idiom be recognised. Additions only; see imports.go.
+	applyImportAliases(drafts, importAliases(lang, content))
 	units := make([]taint.Unit, 0, len(drafts))
 	for i := range drafts {
 		d := drafts[i]

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -65,6 +65,7 @@ func toStatement(d *stmtDraft) taint.Statement {
 				ArgCount:              a.argCount,
 				ShellTrue:             a.shellTrue,
 				FirstArgTainted:       a.firstArgTainted,
+				ShellProgram:          a.shellProgram,
 				PositionalVars:        copyPositional(a.positionalVars),
 				PositionalArgs:        append([]string(nil), a.positionalArgs...),
 				PromptRoles:           copyRoles(a.promptRoles),
@@ -880,7 +881,17 @@ func (e *StructuralEngine) sinkArgShapeDangerous(sink *taint.Sink, info taint.Si
 		// list/varargs in the 2nd+ positional slot — `sql.rows("... = ?", [id])` /
 		// `sql.executeQuery("... = ?", [id])` — rather than interpolating the tainted
 		// value into the SQL string (1st positional). Matched on the method suffix.
-		"rows", "executeQuery", "firstRow", "eachRow":
+		"rows", "executeQuery", "firstRow", "eachRow",
+		// Go's database/sql binds parameters positionally after the query
+		// string: db.Query("… WHERE id = $1", id). The driver binds id, so it is
+		// the parameterized form — and its absence here made the standard safe
+		// Go query a false positive. tp_sqlinjection.go stays a true positive
+		// because it CONCATENATES into the query string, which puts the taint in
+		// the first argument.
+		"db.Query", "db.QueryContext", "db.QueryRow", "db.QueryRowContext",
+		"db.Exec", "db.ExecContext",
+		"tx.Query", "tx.QueryContext", "tx.QueryRow", "tx.QueryRowContext",
+		"tx.Exec", "tx.ExecContext":
 		// Parameterized query: the tainted value is passed as the params
 		// argument (2nd positional), NOT interpolated into the SQL string
 		// (1st positional). Safe only when there is more than one positional
@@ -904,12 +915,29 @@ func (e *StructuralEngine) sinkArgShapeDangerous(sink *taint.Sink, info taint.Si
 		// hole exists for the spawn entry above and predates this list; it is
 		// left alone rather than widened, because a missed injection costs more
 		// than a reported safe call.
-		"child_process.spawn":
+		"child_process.spawn",
+		// Go's exec.Command takes (program, args...) — an arg vector by
+		// construction, never a shell unless the program is one. Its absence
+		// here made `exec.Command("ls", "-la", dir)` with a tainted dir a false
+		// positive, which is the standard safe form in every Go service.
+		// tp_cmdinjection.go stays a true positive because it runs
+		// exec.Command("sh", "-c", …) — caught by the ShellProgram guard below.
+		"exec.Command", "exec.CommandContext":
 		// An arg-vector exec (list/array first arg) without shell=True is safe.
 		// We approximate "arg vector" as: shell not True and the first argument
 		// is not a bare tainted string (FirstArgTainted false means the command
 		// is a list literal or constant). shell=True always re-arms it.
 		if info.ShellTrue {
+			return true
+		}
+		// …unless the PROGRAM is itself a shell. The exemption rests on the
+		// premise that a tainted value passed as its own argv element is never
+		// parsed by a shell, and `run(["sh", "-c", cmd])` is exactly how that
+		// premise fails — it is also the ordinary way a command line is executed
+		// through an argv-taking API. Measured before this guard: five of six
+		// shell-program injections across subprocess.* and spawn were silenced,
+		// which is the classic injection the exemption was never meant to cover.
+		if info.ShellProgram {
 			return true
 		}
 		if !info.FirstArgTainted {

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -6,8 +6,12 @@ ground truth** — what a *correct* scanner should do — so real false positive
 and false negatives surface as a number below 1.0. That is the point: a corpus
 that always scores 1.0 measures nothing.
 
-The corpus spans **Python, JS/TS, and Go** (`clean_*.{py,js,ts,go}` /
-`tp_*.{py,go}`). Go samples were added once `lexctx` began classifying Go
+The corpus spans **Python, JS/TS, Go, Clojure, Elixir and C#**
+(`clean_*.{py,js,ts,go}` / `tp_*.{py,go,clj,ex,cs}`). The last three arrived
+with alias resolution: the suite had NO sample in any of them, so it scored 1.00
+while the engine was blind to the canonical `(:require [clojure.java.shell :as
+sh])` spelling of its highest-severity Clojure sink. A corpus that does not span
+a language cannot report on it. Go samples were added once `lexctx` began classifying Go
 (#197): nox is now measured in its own language for the first time. Adding them
 first *lowered* recall (the six Go taint classes were genuine false negatives
 until a Go taint model existed); the Go taint model has since landed

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,9 +3,9 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 47,
+  "tp": 52,
   "fn": 0,
-  "findings_per_issue": 1.0444444444444445,
+  "findings_per_issue": 1.04,
   "rules": [
     {
       "rule_id": "AI-002",

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,9 +3,9 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 44,
+  "tp": 47,
   "fn": 0,
-  "findings_per_issue": 1.0476190476190477,
+  "findings_per_issue": 1.0444444444444445,
   "rules": [
     {
       "rule_id": "AI-002",

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,9 +3,9 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 39,
+  "tp": 44,
   "fn": 0,
-  "findings_per_issue": 1.054054054054054,
+  "findings_per_issue": 1.0476190476190477,
   "rules": [
     {
       "rule_id": "AI-002",

--- a/testdata/precision-suite/clean_argv_exec.py
+++ b/testdata/precision-suite/clean_argv_exec.py
@@ -1,0 +1,23 @@
+# Clean sample: every exec below passes the tainted value as a separate ARGV
+# element, so no shell interprets it. Any finding here is a FALSE POSITIVE.
+#
+# A real taint SOURCE is required for this to test anything. clean_safe_db.py
+# takes `user_input` as a function parameter, so nothing flows into its
+# subprocess calls and it stays clean whether the arg-vector exemption works or
+# not — it cannot detect a regression in the thing it appears to guard.
+# sys.argv is a source, so these lines are genuinely reachable taint.
+#
+# check_output was missing from the arg-vector exemption that run/call/Popen
+# have, so it reported a command injection where the identical subprocess.run
+# call did not. Found on httpie, where it was the repository's only taint
+# finding and was not an injection.
+import subprocess
+import sys
+
+
+def run():
+    user = sys.argv[1]
+    subprocess.check_output(["git", "log", user])
+    subprocess.run(["ls", "-la", user])
+    subprocess.call(["echo", user])
+    subprocess.Popen(["cat", user])

--- a/testdata/precision-suite/clean_safe_db.go
+++ b/testdata/precision-suite/clean_safe_db.go
@@ -1,21 +1,31 @@
 // Safe database and command idioms in Go — every one is the correct, guarded
 // form, so a precise scanner fires nothing. Zero findings expected.
+//
+// The values come from an http.Request, a real taint SOURCE. That is
+// load-bearing: this file previously took its values as function PARAMETERS, so
+// nothing flowed into these calls and the sample stayed clean whether the
+// parameterized-query and arg-vector refinements worked, broke, or were
+// deleted. A clean sample with no source proves nothing — it reads like a guard
+// and is inert.
 package store
 
 import (
 	"database/sql"
+	"net/http"
 	"os/exec"
 )
 
 // lookup uses a parameterized query ($1 placeholder) — the driver binds the
 // value, so no injection is possible.
-func lookup(db *sql.DB, id string) (*sql.Rows, error) {
+func lookup(db *sql.DB, r *http.Request) (*sql.Rows, error) {
+	id := r.URL.Query().Get("id")
 	return db.Query("SELECT name, email FROM users WHERE id = $1", id)
 }
 
 // listDir runs a fixed argument vector (no shell), with the user value passed
 // as a distinct argument rather than interpolated into a command string.
-func listDir(dir string) ([]byte, error) {
+func listDir(r *http.Request) ([]byte, error) {
+	dir := r.URL.Query().Get("dir")
 	return exec.Command("ls", "-la", "--", dir).Output()
 }
 
@@ -23,7 +33,8 @@ func listDir(dir string) ([]byte, error) {
 var allowedRegions = map[string]bool{"us-east-1": true, "eu-west-1": true}
 
 // region validates input against the allowlist before use.
-func region(candidate string) string {
+func region(r *http.Request) string {
+	candidate := r.URL.Query().Get("region")
 	if allowedRegions[candidate] {
 		return candidate
 	}

--- a/testdata/precision-suite/clean_safe_db.py
+++ b/testdata/precision-suite/clean_safe_db.py
@@ -1,5 +1,16 @@
-import subprocess, shlex
-def run(user_input, sql, db):
+# Safe database and command idioms — every one is the correct, guarded form, so
+# a precise scanner fires nothing. Zero findings expected.
+#
+# The values come from sys.argv, a real taint SOURCE. That is load-bearing:
+# this file previously took `user_input` as a function PARAMETER, so nothing
+# flowed into these calls and the sample stayed clean whether the arg-vector and
+# parameterized-query refinements worked, broke, or were deleted. A clean sample
+# with no source proves nothing — it reads like a guard and is inert.
+import subprocess, shlex, sys
+
+
+def run(db):
+    user_input = sys.argv[1]
     subprocess.run(["ls", "-la", user_input])          # arg vector, not a shell
     db.execute("SELECT * FROM t WHERE id = %s", (user_input,))  # parameterized
     subprocess.run("grep " + shlex.quote(user_input), shell=True)  # quoted

--- a/testdata/precision-suite/tp_alias_idioms.clj
+++ b/testdata/precision-suite/tp_alias_idioms.clj
@@ -1,0 +1,31 @@
+;; True positives for the ordinary Clojure alias idioms.
+;;
+;; The catalog handled aliasing by ENUMERATING the aliases its author expected
+;; -- `shell/sh` beside `clojure.java.shell/sh`, `io/reader`, `jdbc/query`. That
+;; matches only the alias someone anticipated, and the one it anticipated for
+;; clojure.java.shell was `shell`. The canonical alias is `sh` -- it is the one
+;; in that namespace's own docstring -- and it was silently missed:
+;;
+;;   (:require [clojure.java.shell :as shell])   shell/sh   MATCHED
+;;   (:require [clojure.java.shell :as sh])      sh/sh      missed
+;;   (:require [clojure.java.shell :as sh2])     sh2/sh     missed
+;;
+;; The suite had no Clojure sample at all, so it scored 1.00 while the engine
+;; was blind to the dominant spelling of its highest-severity Clojure sink. If a
+;; future change drops `:as` resolution, recall here falls and says so.
+(ns precision.alias-idioms
+  (:require [clojure.java.shell :as sh]
+            [clojure.java.io :as file-io]
+            [clj-http.client :as http-client]))
+
+(defn canonical-alias [req]
+  (let [cmd (:params req)]
+    (sh/sh "sh" "-c" cmd)))          ;; nox-expect: TAINT-002
+
+(defn unanticipated-alias [req]
+  (let [p (:params req)]
+    (file-io/reader p)))             ;; nox-expect: TAINT-004
+
+(defn aliased-http [req]
+  (let [url (:query-string req)]
+    (http-client/get url)))          ;; nox-expect: TAINT-006

--- a/testdata/precision-suite/tp_alias_idioms.cs
+++ b/testdata/precision-suite/tp_alias_idioms.cs
@@ -1,0 +1,20 @@
+// True positives for the C# `using X = Y;` alias.
+//
+// C# sinks are named by TYPE in the catalog (`Process.Start`), which is what
+// code writes after a plain `using System.Diagnostics;`. A using-ALIAS renames
+// the type and made the same call invisible.
+//
+// Known limit, deliberately not papered over: an alias that names a NAMESPACE
+// (`using D = System.Diagnostics;` then `D.Process.Start`) resolves to neither
+// the bare nor the fully-qualified form the catalog carries, and is still
+// missed. Only the type-alias case below is claimed.
+using Proc = System.Diagnostics.Process;
+
+class AliasIdioms
+{
+    void AliasedStart(HttpRequest Request)
+    {
+        var user = Request.QueryString["cmd"];
+        Proc.Start("sh", "-c " + user);  // nox-expect: TAINT-002
+    }
+}

--- a/testdata/precision-suite/tp_alias_idioms.ex
+++ b/testdata/precision-suite/tp_alias_idioms.ex
@@ -1,0 +1,16 @@
+# True positives for the Elixir `alias …, as:` idiom.
+#
+# Elixir sinks are named BARE in the catalog (`System.cmd`, `Repo.query`),
+# which is what unaliased code writes. An `as:` rename made the same call
+# invisible, so this sample resolves to the last segment rather than the whole
+# path -- the form the catalog actually carries.
+#
+# The suite had no Elixir sample, so nothing measured this either way.
+defmodule Precision.AliasIdioms do
+  alias System, as: Sys
+
+  def aliased_cmd(conn) do
+    cmd = conn.params
+    Sys.cmd("sh", ["-c", cmd])  # nox-expect: TAINT-002
+  end
+end

--- a/testdata/precision-suite/tp_import_idioms.js
+++ b/testdata/precision-suite/tp_import_idioms.js
@@ -1,0 +1,18 @@
+// True positives for the ordinary Node import idioms.
+//
+// The corpus tested only `const child_process = require("child_process")` — the
+// one shape where the local name equals the module name. A destructured require
+// and an ESM import are how Node is normally written, and both were silently
+// missed. Four of five idioms produced nothing before import resolution landed.
+const { exec } = require("child_process");
+const cp = require("child_process");
+
+function destructuredRequire(req) {
+  const user = req.query.cmd;
+  exec("sh -c " + user); // nox-expect: TAINT-002
+}
+
+function aliasedRequire(req) {
+  const user = req.query.cmd;
+  cp.exec("sh -c " + user); // nox-expect: TAINT-002
+}

--- a/testdata/precision-suite/tp_import_idioms.py
+++ b/testdata/precision-suite/tp_import_idioms.py
@@ -1,0 +1,32 @@
+# True positives for the ordinary Python import idioms.
+#
+# The corpus tested only `import os` + `os.system(...)` — the ONE shape where
+# the local name happens to equal the module name, which is the shape the
+# catalog matched. `from os import system` and `import os as o` are how Python
+# is normally written, and both were silently missed: the same flow, reported
+# only when the import was written the unusual way.
+#
+# The suite scoring 1.00 recall while the engine missed the common idiom is why
+# these samples exist. If a future change drops import resolution, recall here
+# falls and says so.
+#
+# `request` arrives as a parameter, as in tp_injection.py, so the sample tests
+# the import idiom of the SINK and nothing else.
+from os import system
+import os as operating_system
+import subprocess as sp
+
+
+def from_import(request):
+    cmd = request.args.get("cmd")
+    system("echo " + cmd)  # nox-expect: TAINT-002
+
+
+def aliased_module(request):
+    cmd = request.args.get("cmd")
+    operating_system.system("echo " + cmd)  # nox-expect: TAINT-002
+
+
+def aliased_package(request):
+    cmd = request.args.get("cmd")
+    sp.check_output("echo " + cmd, shell=True)  # nox-expect: TAINT-002

--- a/testdata/precision-suite/tp_shell_argv.js
+++ b/testdata/precision-suite/tp_shell_argv.js
@@ -1,0 +1,8 @@
+// True positives: the program IS a shell, so the argv vector is not a shield.
+// See tp_shell_argv.py for the reasoning; clean_argv_exec.py is the other half.
+const { spawn } = require("child_process");
+
+function run(req) {
+  const user = req.query.cmd;
+  spawn("sh", ["-c", "git log " + user]); // nox-expect: TAINT-002
+}

--- a/testdata/precision-suite/tp_shell_argv.py
+++ b/testdata/precision-suite/tp_shell_argv.py
@@ -1,0 +1,19 @@
+# True positives: the program IS a shell, so the argv vector is not a shield.
+#
+# The arg-vector exemption exists because a tainted value passed as its own argv
+# element is never parsed by a shell — subprocess.run(["ls", user]) is safe. But
+# `run(["sh", "-c", cmd])` runs a shell AS the program, which is the ordinary way
+# a command line is executed through an argv-taking API, and the exemption
+# silenced it. Measured before the fix: five of six such injections across
+# subprocess.* and child_process.spawn produced nothing.
+#
+# clean_argv_exec.py is the other half — the same sinks with a real program,
+# which must stay clean. Together they pin the exemption from both sides.
+import subprocess
+import sys
+
+
+def run():
+    cmd = sys.argv[1]
+    subprocess.run(["sh", "-c", "git log " + cmd])  # nox-expect: TAINT-002
+    subprocess.check_output(["/bin/bash", "-c", "git log " + cmd])  # nox-expect: TAINT-002


### PR DESCRIPTION
Stacked on #561 — base is `fix/taint-resolves-imports`, retarget to `main` once that merges.

#561 fixed import resolution for Python and JS. This is the same defect one layer over, in three more languages.

## The catalog enumerated aliases instead of resolving them

Clojure aliasing was handled by listing the spellings the catalog author expected — `shell/sh` beside `clojure.java.shell/sh`, plus `io/reader`, `jdbc/query`, `client/get`. Enumeration matches only the alias someone guessed. For `clojure.java.shell` the guess was `shell`.

**The canonical alias is `sh`** — it is the one in that namespace's own docstring. Measured, varying nothing but the `:as`:

```
(:require [clojure.java.shell :as shell])   shell/sh   MATCHED      0 -> 1  (already worked)
(:require [clojure.java.shell :as sh])      sh/sh      missed       0 -> 1  <- canonical
(:require [clojure.java.shell :as sh2])     sh2/sh     missed       0 -> 1
(:require [clojure.java.shell :as x])       x/sh       missed       0 -> 1
```

So Clojure's highest-severity sink was blind to its dominant spelling while scoring a match on the unusual one.

## Elixir and C# are the mirror form

Their catalog entries are **bare** module and type names (`System.cmd`, `Repo.query`, `Process.Start`) — what unaliased code writes — so an alias resolves to the **last segment**, not the whole path. Both confirmed end to end:

| | before → after |
|---|---|
| `alias System, as: Sys` → `Sys.cmd(…)` | 0 → 1 |
| `using Proc = System.Diagnostics.Process;` → `Proc.Start(…)` | 0 → 1 |

The plain forms still fire — expansion stays additive, so nothing that matched before can stop matching.

## Probing beat guessing

The blocker on this item was *"18 languages, syntaxes I have not verified."* A three-line sample per language (plain form vs aliased form, count findings) resolved it in minutes:

- **Rust shows no gap** — `use std::process::Command as Cmd` already reaches the sink. Left alone.
- Every other language keeps today's behaviour rather than acquiring a guess at a syntax nobody has checked.

The separator now travels **with** the alias table: a Clojure chain is `sh/sh`, a Python one `os.system`, and expanding either with the other's separator yields a name that matches nothing — silently. There is a test for exactly that.

## Verified

```
precision suite   47 TP / 0 FP / 5 FN  ->  52 / 0 / 0     recall 0.904 -> 1.000
metamorphic       0 violations over 2270 mutations
full suite + golangci-lint   clean
```

The 5 new expectations are **false negatives on a build without the fix**, so the samples are not inert — the check `clean_safe_db.py` once failed. The suite had no Clojure, Elixir or C# sample at all before this, which is why it scored 1.00 throughout.

## Not verified, stated plainly

**The rule-diff corpus reports no change on all 7 repos.** That is not because the fix is inert. `ring` and `reitit` alias `clojure.java.io :as io` and `clojure.java.shell :as shell` — the exact two spellings the catalog had already guessed right. No corpus repo picks an unanticipated alias, so the gate cannot witness this one.

Finding a Clojure repo that does is an open item, same shape as the Python/JS corpus gap #562 closes.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT