### PR TITLE
Real-repo noise review: rule fixes, taint recall across languages, intel E2E

### DIFF
--- a/core/analyzers/data/data_test.go
+++ b/core/analyzers/data/data_test.go
@@ -68,7 +68,7 @@ func TestDataRuleMatches(t *testing.T) {
 		{
 			name:     "DATA-001: Email address in config",
 			ruleID:   "DATA-001",
-			severity: findings.SeverityMedium,
+			severity: findings.SeverityLow,
 			positive: "admin_email = jane.doe@acmecorp.io\n",
 			// example.com is reserved by RFC 2606 for documentation, so an
 			// address there is not PII. See TestDATA001_ReservedDomains.

--- a/core/analyzers/data/rules.go
+++ b/core/analyzers/data/rules.go
@@ -31,7 +31,12 @@ func builtinDataRules() []*rules.Rule {
 		// Personal Identifiable Information (DATA-001 to DATA-012)
 		// -----------------------------------------------------------------
 		{
-			id: "DATA-001", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
+			// Low, not medium: an address in source is contact information far
+			// more often than it is a leak (package authors, maintainers,
+			// notification recipients), and it is the most common DATA hit by
+			// two orders of magnitude. Medium put it on the same line of the
+			// report as a hard-coded password.
+			id: "DATA-001", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
 			pattern:     `(?i)["'=:]\s*[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`,
 			description: "Email address in code or config",
 			cwe:         "CWE-359", keywords: []string{"@"},

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -914,7 +914,11 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-351", severity: findings.SeverityCritical, confidence: findings.ConfidenceMedium,
-			pattern:      `(?im)^[ \t]*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)\s*:\s*['"]?[A-Za-z0-9]`,
+			// `[ \t]*` after the colon, not `\s*`: the rule engine matches the
+			// whole document, so `\s*` crossed the line break and a
+			// workflow_call declaration (`DOCKERHUB_TOKEN:` / `required: true`)
+			// was reported as a hardcoded secret at CRITICAL (certbot).
+			pattern:      `(?im)^[ \t]*(?:PASSWORD|SECRET_KEY|(?:[A-Z0-9_]*_)?TOKEN)[ \t]*:[ \t]*['"]?[A-Za-z0-9]`,
 			description:  "CI variable with hardcoded secret",
 			cwe:          "CWE-798",
 			keywords:     []string{"PASSWORD", "SECRET", "TOKEN"},

--- a/core/analyzers/iac/rules_expanded_test.go
+++ b/core/analyzers/iac/rules_expanded_test.go
@@ -483,6 +483,32 @@ jobs:
 	}
 }
 
+// TestExpandedDetect_IAC351_DoesNotCrossLines: the engine matches the whole
+// document, so `\s*` after the colon spanned the line break and the value
+// class matched the first letter of the NEXT line. A workflow_call secrets
+// declaration -- `DOCKERHUB_TOKEN:` followed by `required: true` -- was
+// reported as a hardcoded secret at CRITICAL (certbot, deploy_docker_images.yml).
+func TestExpandedDetect_IAC351_DoesNotCrossLines(t *testing.T) {
+	a := NewAnalyzer()
+	content := []byte(`on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
+      NPM_TOKEN:
+        description: publish token
+`)
+	results, err := a.ScanFile(".github/workflows/deploy.yml", content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range results {
+		if f.RuleID == "IAC-351" {
+			t.Fatalf("IAC-351 crossed a line break into a secrets declaration: %+v", f.Location)
+		}
+	}
+}
+
 // TestExpandedDetect_IAC351_HardcodedSecret verifies that IAC-351 fires on
 // genuine hardcoded secret variables but does NOT fire on GHA OIDC permission
 // lines (`id-token: write`), which previously triggered a critical false positive

--- a/core/analyzers/secrets/precision_361_test.go
+++ b/core/analyzers/secrets/precision_361_test.go
@@ -218,6 +218,17 @@ func TestConfigFieldRuleNotMatchedInProse(t *testing.T) {
 		}
 	})
 
+	t.Run("terraform password rule spanning two comment lines", func(t *testing.T) {
+		// The pattern's trailing `\s` swallows the newline after the value, so
+		// the match ends on the NEXT comment line. The whitespace between two
+		// comment lines is not code; the match is still prose.
+		src := "#   1. export SYNO_USERNAME=\"adminUser\"\n#   2. export SYNO_PASSWORD=\"adminPassword\"\n# 2. Set optional environment variables\nSYNO_HOSTNAME=localhost\n"
+		got := scanOne(t, "synology_dsm.sh", src)
+		if firedRule(got, "SEC-240") {
+			t.Errorf("SEC-240 fired on a comment run in a shell script (all: %s)", ruleIDs(got))
+		}
+	})
+
 	t.Run("terraform password rule on a real assignment", func(t *testing.T) {
 		src := "resource \"azurerm_mssql_server\" \"x\" {\n  administrator_login_password = \"h7Qz2LmXk9Ta\"\n}\n"
 		got := scanOne(t, "main.tf", src)

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -409,7 +409,11 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-046", severity: findings.SeverityHigh, confidence: findings.ConfidenceHigh,
-			pattern:     `pypi-[A-Za-z0-9\-_]{16,}`,
+			// A PyPI token is a base64url macaroon whose first caveat is the
+			// registry location, so every real one starts with the encoding
+			// of "pypi.org" or "test.pypi.org". `pypi-` plus sixteen
+			// characters matched the job name `pypi-build-and-release`.
+			pattern:     `pypi-(?:AgEIcHlwaS5vcmc|AgENdGVzdC5weXBpLm9yZw)[A-Za-z0-9\-_]{50,}`,
 			description: "PyPI Upload Token detected",
 			cwe:         "CWE-798", keywords: []string{"pypi-"},
 			remediation: "Revoke the token on pypi.org and generate a new one.",

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -33,6 +33,11 @@ type secretRule struct {
 	// every finding an operator accepted under it, because baselines hash the
 	// rule ID and VEX statements and nox:ignore comments name it directly.
 	retires []rules.RetiredRule
+	// validate, when set, vetoes individual matches after the pattern has
+	// accepted them (see rules.Rule.ValidateMatch). It carries the part of a
+	// rule's meaning a regex cannot express in one pass, such as "the
+	// password component is not a template placeholder".
+	validate func(string) bool
 }
 
 // builtinSecretRules returns all built-in secret detection rules.
@@ -638,6 +643,7 @@ func builtinSecretRules() []*rules.Rule {
 		{
 			id: "SEC-073", severity: findings.SeverityCritical, confidence: findings.ConfidenceMedium,
 			pattern:     `(?i)(mysql|postgres(?:ql)?|mssql|sqlserver|oracle|mariadb)://[^:\n]+:[^@\n]+@[^\s'"]+`,
+			validate:    isURLCredentialLiteral,
 			description: "Database Connection String with credentials detected",
 			cwe:         "CWE-798", keywords: []string{"://"},
 			remediation: "Use environment variables or a secrets manager for database connection strings.",
@@ -646,6 +652,7 @@ func builtinSecretRules() []*rules.Rule {
 		{
 			id: "SEC-074", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
 			pattern:     `mongodb\+srv://[^:\n]+:[^@\n]+@[^\s'"]+`,
+			validate:    isURLCredentialLiteral,
 			description: "MongoDB SRV Connection String with credentials detected",
 			cwe:         "CWE-798", keywords: []string{"mongodb+srv://"},
 			remediation: "Use environment variables for MongoDB connection strings. Rotate the database password.",
@@ -662,6 +669,7 @@ func builtinSecretRules() []*rules.Rule {
 		{
 			id: "SEC-076", severity: findings.SeverityCritical, confidence: findings.ConfidenceHigh,
 			pattern:     `rediss?://[^:\n]+:[^@\n]+@[^\s'"]+`,
+			validate:    isURLCredentialLiteral,
 			description: "Redis URL with password detected",
 			cwe:         "CWE-798", keywords: []string{"redis://", "rediss://"},
 			remediation: "Use environment variables for Redis connection strings. Rotate the password.",
@@ -764,6 +772,7 @@ func builtinSecretRules() []*rules.Rule {
 			// userinfo (e.g. https://opensource.org/licenses/MIT) must not
 			// match — see issue #60.
 			pattern:     `https?://[^/\s:@'"<>]+:[^/\s@'"<>]+@[^\s'"<>]+`,
+			validate:    isURLCredentialLiteral,
 			description: "URL with embedded password detected",
 			cwe:         "CWE-798", keywords: []string{"://"},
 			remediation: "Remove credentials from URLs. Use environment variables or a credentials provider.",
@@ -3798,6 +3807,7 @@ func builtinSecretRules() []*rules.Rule {
 			Keywords:               d.keywords,
 			Retires:                d.retires,
 			RequireContextKeywords: requireContext,
+			ValidateMatch:          d.validate,
 			Tags:                   []string{"secrets"},
 			Metadata:               md,
 			Remediation:            d.remediation,

--- a/core/analyzers/secrets/rules.go
+++ b/core/analyzers/secrets/rules.go
@@ -698,7 +698,7 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-079", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?i)(password|passphrase|pass)\s*[=:]\s*['"][^'"]{4,}['"]\s*.*\.(p12|pfx)`,
+			pattern:     `(?i)(password|passphrase|pass)\s*[=:]\s*['"][^'"\n]{4,}['"][ \t]*.*\.(p12|pfx)`,
 			description: "PKCS12/PFX file password reference detected",
 			cwe:         "CWE-321", keywords: []string{".p12", ".pfx"},
 			remediation: "Store PKCS12/PFX passwords in a secrets manager, not in source code.",
@@ -718,7 +718,7 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-080", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:     `(?i)(password|passwd|pwd)\s*[=:]\s*['"][^'"]{8,}['"]`,
+			pattern:     `(?i)(password|passwd|pwd)\s*[=:]\s*['"][^'"\n]{8,}['"]`,
 			description: "Generic password assignment detected",
 			cwe:         "CWE-798", keywords: []string{"password", "passwd", "pwd"},
 			remediation: "Use environment variables or a secrets manager for passwords.",
@@ -771,7 +771,7 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-086", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?i)(db_pass(?:word)?|database_password)\s*[=:]\s*['"][^'"]{4,}['"]`,
+			pattern:     `(?i)(db_pass(?:word)?|database_password)\s*[=:]\s*['"][^'"\n]{4,}['"]`,
 			description: "Hardcoded database password detected",
 			cwe:         "CWE-798", keywords: []string{"db_pass", "database_password"},
 			remediation: "Use environment variables or a secrets manager for database passwords.",
@@ -856,7 +856,7 @@ func builtinSecretRules() []*rules.Rule {
 		},
 		{
 			id: "SEC-095", severity: findings.SeverityHigh, confidence: findings.ConfidenceMedium,
-			pattern:     `(?i)(snowflake[_-]?password|sf[_-]?password)\s*[=:]\s*['"][^'"]{6,}['"]`,
+			pattern:     `(?i)(snowflake[_-]?password|sf[_-]?password)\s*[=:]\s*['"][^'"\n]{6,}['"]`,
 			description: "Snowflake Key Pair password detected",
 			cwe:         "CWE-798", keywords: []string{"snowflake_password", "snowflake-password", "sf_password", "sf-password"},
 			remediation: "Rotate the exposed password immediately. Use environment variables or a secrets manager.",

--- a/core/analyzers/secrets/secrets_test.go
+++ b/core/analyzers/secrets/secrets_test.go
@@ -489,7 +489,7 @@ func TestAllRules_PositiveMatch(t *testing.T) {
 		"SEC-071": "sbp_" + "aabbccddeeff00112233445566778899aabbccdd\n",
 		"SEC-072": "confluent_api_key = \"" + "ABCDEFGHIJKLMNOP\"\n",
 		"SEC-073": "postgres://" + "admin:s3cret@localhost:5432/db\n",
-		"SEC-074": "mongodb+srv://" + "user:pass@cluster0.example.net/mydb\n",
+		"SEC-074": "mongodb+srv://" + "user:Sup3rS3cretPw@cluster0.example.net/mydb\n",
 		"SEC-075": "firebase_api_key = \"" + "AIza" + "SyD-abcdefghijklmnopqrstuvwxyz12345\"\n",
 		"SEC-076": "redis://" + "default:mypassword@redis.example.com:6379\n",
 		"SEC-077": "AGE-SECRET-KEY-" + "1QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L" + "QPZRY9X8GF2TVDW0S3JN54KHCE6M\n",

--- a/core/analyzers/secrets/secrets_test.go
+++ b/core/analyzers/secrets/secrets_test.go
@@ -1030,6 +1030,43 @@ func TestSEC046_StillFiresOnTestPyPIToken(t *testing.T) {
 	t.Fatalf("SEC-046 did not fire on a test.pypi.org token")
 }
 
+// TestSEC080_DoesNotCrossLines: `[^'"]{8,}` admits a newline, and the engine
+// matches whole documents, so an opening quote on one line and a closing quote
+// twelve lines later were reported as one password assignment (pipenv's
+// vendored pip auth.py: a `Password: "` prompt string, then a dozen lines of
+// Python, then the next `ask("`). The value class now stops at the line end.
+func TestSEC080_DoesNotCrossLines(t *testing.T) {
+	a := NewAnalyzer()
+	content := []byte(`        password = ask_password("Password: ")
+        return username, password, True
+
+    def _should_save_password_to_keyring(self) -> bool:
+        if not self.prompting:
+            return False
+        return ask("Save credentials to keyring [y/N]: ", ["y", "n"]) == "y"
+`)
+	results, err := a.ScanFile("auth.py", content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range results {
+		if f.RuleID == "SEC-080" {
+			t.Fatalf("SEC-080 crossed a line break: %+v", f.Location)
+		}
+	}
+	// The same rule on one line is still a finding.
+	hit, err := a.ScanFile("settings.py", []byte("DB_PASSWORD = \"hunter2hunter2\"\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range hit {
+		if f.RuleID == "SEC-080" {
+			return
+		}
+	}
+	t.Fatalf("SEC-080 no longer fires on a one-line password assignment")
+}
+
 func TestSEC085_NoFalsePositiveOnBareURL(t *testing.T) {
 	a := NewAnalyzer()
 	content := []byte(`<script type="application/ld+json">

--- a/core/analyzers/secrets/secrets_test.go
+++ b/core/analyzers/secrets/secrets_test.go
@@ -461,7 +461,7 @@ func TestAllRules_PositiveMatch(t *testing.T) {
 		"SEC-043": "r8_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn\n",
 		"SEC-044": "cohere_api_key= " + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn\n",
 		"SEC-045": "npm_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl\n",
-		"SEC-046": "pypi-" + "ABCDEFGHIJKLMNOPa\n",
+		"SEC-046": "pypi-" + "AgEIcHlwaS5vcmc" + "CJDE4NzUxNTQ2LWFiY2QtNGVmMC05MWZjLTA0YjVjZDQ2ZjFlNAACKlszLCI2ZjBiZDU3Mi1hNzMxLTRlMDktYmY3Yi0zZjFmM2VkYzA2NzAiXQAABiCLrXP7Xh\n",
 		"SEC-047": "rubygems_" + "aabbccddeeff00112233445566778899aabbccddeeff0011\n",
 		"SEC-048": "oy2" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr\n",
 		"SEC-049": "dckr_pat_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZa\n",
@@ -992,6 +992,44 @@ func findMatchingTransition(state State) Transition {
 // TestSEC085_NoFalsePositiveOnBareURL ensures bare https URLs without a
 // userinfo component (user:pass@) do not trigger the rule. Issue #60 reported
 // it firing on JSON-LD license URLs like https://opensource.org/licenses/MIT.
+// TestSEC046_NoFalsePositiveOnJobName: `pypi-` followed by sixteen name-ish
+// characters was the whole pattern, so a GitHub Actions job called
+// `pypi-build-and-release` was reported as a leaked PyPI upload token at
+// HIGH severity and HIGH confidence (httpie, release-pypi.yml). A PyPI token
+// is a base64 macaroon whose location field is the registry host, so every
+// real one begins `pypi-AgEIcHlwaS5vcmc` (pypi.org) or
+// `pypi-AgENdGVzdC5weXBpLm9yZw` (test.pypi.org); the rule now requires that.
+func TestSEC046_NoFalsePositiveOnJobName(t *testing.T) {
+	a := NewAnalyzer()
+	content := []byte("jobs:\n  pypi-build-and-release:\n    name: Build and Release\n    steps:\n      - run: pypi-publish-with-trusted-publisher\n")
+	results, err := a.ScanFile(".github/workflows/release-pypi.yml", content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range results {
+		if f.RuleID == "SEC-046" {
+			t.Fatalf("SEC-046 fired on a job name: %+v", f)
+		}
+	}
+}
+
+// TestSEC046_StillFiresOnTestPyPIToken covers the second registry the
+// tightened prefix admits.
+func TestSEC046_StillFiresOnTestPyPIToken(t *testing.T) {
+	a := NewAnalyzer()
+	content := []byte("TWINE_PASSWORD=" + "pypi-" + "AgENdGVzdC5weXBpLm9yZw" + "IkNGE0YjE3YzYtNzY3Ny00OWM0LWI0MzEtYjA0ZTFkMDgxZDk1AAIqWzMsIjY0ZjNkYjk4LTk3ZTMtNGM3\n")
+	results, err := a.ScanFile("release.env", content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range results {
+		if f.RuleID == "SEC-046" {
+			return
+		}
+	}
+	t.Fatalf("SEC-046 did not fire on a test.pypi.org token")
+}
+
 func TestSEC085_NoFalsePositiveOnBareURL(t *testing.T) {
 	a := NewAnalyzer()
 	content := []byte(`<script type="application/ld+json">

--- a/core/analyzers/secrets/srccontext.go
+++ b/core/analyzers/secrets/srccontext.go
@@ -118,26 +118,9 @@ func dropConfigFieldRuleInComment(lang lexctx.Lang, content []byte, f *findings.
 	if end <= start {
 		end = start + 1
 	}
-	regions := lexctx.Classify(lang, content)
-	if len(regions) == 0 {
-		return false
-	}
-	// EVERY region the match overlaps must be comment. Testing only the two
-	// endpoints would accept a match that begins in one comment, crosses code,
-	// and ends in the next — and a match leaking out of a comment into code is
-	// suspect but not clearly prose, so it is kept.
-	overlapped := false
-	for _, r := range regions {
-		if r.End <= start {
-			continue
-		}
-		if r.Start >= end {
-			break
-		}
-		if r.Kind != lexctx.KindComment {
-			return false
-		}
-		overlapped = true
-	}
-	return overlapped
+	// EVERY non-blank byte the match covers must be comment. A match that
+	// begins in one comment, crosses code, and ends in the next is suspect but
+	// not clearly prose, so it is kept; the whitespace between two comment
+	// lines (a pattern's trailing `\s` swallows the newline) is not code.
+	return lexctx.WithinComments(lang, content, start, end)
 }

--- a/core/analyzers/secrets/urlcred.go
+++ b/core/analyzers/secrets/urlcred.go
@@ -1,0 +1,64 @@
+package secrets
+
+import "strings"
+
+// isURLCredentialLiteral is the ValidateMatch for the connection-string rules
+// (SEC-073/074/076/085). The patterns accept any userinfo of the form
+// user:password@, and the most common way that shape appears in a repository
+// is the templated one -- `postgres://${DB_USER}:${DB_PASSWORD}@db:5432/app`
+// in a compose file, `https://${GIT_USER}:${GIT_TOKEN}@github.com/...` in a
+// Pipfile -- where the password is a placeholder to be filled in at runtime
+// and nothing has leaked. Only a literal password is a finding.
+func isURLCredentialLiteral(match string) bool {
+	password, ok := urlPassword(match)
+	if !ok {
+		return true // shape not recognised; keep the pattern's verdict
+	}
+	return !isPlaceholder(password)
+}
+
+// urlPassword returns the password component of a user:password@host URL.
+func urlPassword(url string) (string, bool) {
+	rest := url
+	if i := strings.Index(rest, "://"); i >= 0 {
+		rest = rest[i+3:]
+	}
+	at := strings.LastIndexByte(rest, '@')
+	if at < 0 {
+		return "", false
+	}
+	userinfo := rest[:at]
+	colon := strings.IndexByte(userinfo, ':')
+	if colon < 0 {
+		return "", false
+	}
+	return userinfo[colon+1:], true
+}
+
+// isPlaceholder reports whether a password component is a template variable
+// or a redaction rather than a value: shell/compose `$VAR` and `${VAR}`,
+// Jinja/Helm/GitHub `{{ … }}`, printf/format `%s` / `%(name)s` / `{}` /
+// `{0}`, `<password>`, and a run of asterisks or the word itself.
+func isPlaceholder(password string) bool {
+	p := strings.TrimSpace(password)
+	if p == "" {
+		return true
+	}
+	switch {
+	case strings.HasPrefix(p, "$"),
+		strings.HasPrefix(p, "{{") || strings.HasPrefix(p, "{%"),
+		strings.HasPrefix(p, "%"),
+		strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}"),
+		strings.HasPrefix(p, "<") && strings.HasSuffix(p, ">"),
+		strings.HasPrefix(p, "[") && strings.HasSuffix(p, "]"),
+		strings.Trim(p, "*") == "",
+		strings.Trim(p, "x") == "" || strings.Trim(p, "X") == "",
+		strings.Trim(p, ".") == "":
+		return true
+	}
+	switch strings.ToLower(p) {
+	case "password", "passwd", "pass", "pwd", "secret", "token", "your_password", "your-password", "yourpassword", "changeme", "redacted", "placeholder":
+		return true
+	}
+	return false
+}

--- a/core/analyzers/secrets/urlcred_test.go
+++ b/core/analyzers/secrets/urlcred_test.go
@@ -1,0 +1,54 @@
+package secrets
+
+import "testing"
+
+// TestURLCredentialRules_TemplatedPasswordIsNotALeak: a placeholder in the
+// password slot of a connection string is configuration, not a credential.
+// A literal password still fires.
+func TestURLCredentialRules_TemplatedPasswordIsNotALeak(t *testing.T) {
+	quiet := []string{
+		`DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/app`,
+		`url = "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/org/repo.git"`,
+		`redis://default:$REDIS_PASSWORD@cache:6379/0`,
+		`mongodb+srv://app:{{ .Values.mongo.password }}@cluster0.example.net/db`,
+		`export DSN="mysql://root:%s@127.0.0.1:3306/test"`,
+		`conn = "postgresql://user:<password>@localhost/db"`,
+		`'git': 'https://${AUTH_USER}:****@github.com/user/myproject.git'`,
+	}
+	loud := map[string]string{
+		`DATABASE_URL=postgres://app:s3cr3t-Pa55@db:5432/app`:              "SEC-073",
+		`url = "https://deploy:ghp_realtokenvalue1234@github.com/o/r.git"`: "SEC-085",
+		`redis://default:hunter2hunter2@cache:6379/0`:                      "SEC-076",
+		`mongodb+srv://app:Qx9!pLm2@cluster0.example.net/db`:               "SEC-074",
+	}
+	a := NewAnalyzer()
+	scan := func(line string) map[string]bool {
+		found, err := a.ScanFile("config.env", []byte(line+"\n"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids := map[string]bool{}
+		for _, f := range found {
+			ids[f.RuleID] = true
+		}
+		return ids
+	}
+	for _, line := range quiet {
+		ids := scan(line)
+		for _, id := range []string{"SEC-073", "SEC-074", "SEC-076", "SEC-085"} {
+			if ids[id] {
+				t.Errorf("%s fired on a templated password: %s", id, line)
+			}
+		}
+	}
+	for line, id := range loud {
+		if !scan(line)[id] {
+			t.Errorf("%s did not fire on a literal password: %s", id, line)
+		}
+	}
+	if !scan(`"https://u:p@h/x"`)["SEC-085"] {
+		// A one-character password is still a literal; this documents that
+		// the validator judges shape, not strength.
+		t.Errorf("SEC-085 should still fire on a literal one-character password")
+	}
+}

--- a/core/analyzers/slop/data/python_stdlib.txt
+++ b/core/analyzers/slop/data/python_stdlib.txt
@@ -202,3 +202,72 @@ zipfile
 zipimport
 zlib
 zoneinfo
+# Present in CPython 3 but absent above: removed in 3.12 (distutils, kept for
+# the decade of code that guards it), added in 3.14 (compression,
+# annotationlib), platform modules, and undocumented but importable internals.
+distutils
+compression
+annotationlib
+nt
+pyexpat
+nturl2path
+ntpath
+genericpath
+opcode
+sre_compile
+sre_constants
+sre_parse
+idlelib
+pydoc_data
+this
+antigravity
+asynchat
+asyncore
+smtpd
+formatter
+parser
+symbol
+binhex
+dummy_threading
+# Python 2 module names. They survive in compatibility shims of the form
+# `try: import queue / except ImportError: import Queue`; the name is a real
+# historical module, not a hallucinated package.
+Queue
+ConfigParser
+StringIO
+cStringIO
+cPickle
+HTMLParser
+httplib
+urllib2
+urlparse
+xmlrpclib
+thread
+Tkinter
+tkMessageBox
+tkFileDialog
+ttk
+commands
+SocketServer
+BaseHTTPServer
+SimpleHTTPServer
+CGIHTTPServer
+Cookie
+cookielib
+anydbm
+dumbdbm
+gdbm
+whichdb
+copy_reg
+sets
+md5
+sha
+exceptions
+htmlentitydefs
+robotparser
+UserDict
+UserList
+UserString
+dummy_thread
+future_builtins
+repr

--- a/core/analyzers/slop/manifests.go
+++ b/core/analyzers/slop/manifests.go
@@ -77,7 +77,7 @@ var importToDist = map[string]string{
 	"pptx":              "python-pptx",
 	"cairo":             "pycairo",
 	"gi":                "pygobject",
-	"OpenSSL":           "pyopenssl",
+	"openssl":           "pyopenssl",
 	"cryptography":      "cryptography",
 	"magic":             "python-magic",
 	"redis":             "redis",
@@ -88,6 +88,39 @@ var importToDist = map[string]string{
 	"multipart":         "python-multipart",
 	"nacl":              "pynacl",
 	"zoneinfo_backport": "backports.zoneinfo",
+	"dns":               "dnspython",
+	"googleapiclient":   "google-api-python-client",
+	"socks":             "pysocks",
+	"pkg_resources":     "setuptools",
+	"crypto":            "pycryptodome",
+	"zmq":               "pyzmq",
+	"mysqldb":           "mysqlclient",
+	"git":               "gitpython",
+	"ldap":              "python-ldap",
+	"websocket":         "websocket-client",
+	"wx":                "wxpython",
+	"ruamel":            "ruamel.yaml",
+	"_pytest":           "pytest",
+	// pywin32 ships a family of extension modules under one distribution.
+	"win32security":    "pywin32",
+	"win32file":        "pywin32",
+	"win32con":         "pywin32",
+	"win32console":     "pywin32",
+	"win32event":       "pywin32",
+	"win32process":     "pywin32",
+	"win32service":     "pywin32",
+	"win32serviceutil": "pywin32",
+	"win32gui":         "pywin32",
+	"win32pipe":        "pywin32",
+	"win32crypt":       "pywin32",
+	"win32net":         "pywin32",
+	"win32clipboard":   "pywin32",
+	"win32profile":     "pywin32",
+	"win32ts":          "pywin32",
+	"pywintypes":       "pywin32",
+	"pythoncom":        "pywin32",
+	"ntsecuritycon":    "pywin32",
+	"winerror":         "pywin32",
 }
 
 // normalizePyPI lowercases and unifies separators per PEP 503 so that
@@ -125,11 +158,18 @@ func (d *declaredSet) addNPM(name string) {
 }
 
 func (d *declaredSet) addPyPI(name string) {
-	name = normalizePyPI(name)
+	raw := strings.TrimSpace(name)
+	name = normalizePyPI(raw)
 	if name == "" {
 		return
 	}
 	d.pypi[name] = struct{}{}
+	// A namespace-package distribution (zope.interface, backports.zoneinfo,
+	// sphinxcontrib.spelling) is imported through its namespace root; the
+	// dotted name is what identifies it as one.
+	if i := strings.IndexByte(raw, '.'); i > 0 {
+		d.pypi[normalizePyPI(raw[:i])] = struct{}{}
+	}
 }
 
 // hasNPM reports whether an npm package (top-level name) is declared.
@@ -146,6 +186,15 @@ func (d *declaredSet) hasPyPI(importRoot string) bool {
 	}
 	if dist, ok := importToDist[strings.ToLower(importRoot)]; ok {
 		if _, ok := d.pypi[normalizePyPI(dist)]; ok {
+			return true
+		}
+	}
+	// The conventional ways a distribution decorates the module it ships:
+	// python-digitalocean, python-augeas, python-dateutil; pyyaml, pyserial,
+	// pyopenssl; kubernetes-python. The explicit table above covers the
+	// names that follow no convention at all.
+	for _, dist := range []string{"python-" + n, "py" + n, "py-" + n, n + "-python"} {
+		if _, ok := d.pypi[dist]; ok {
 			return true
 		}
 	}
@@ -172,6 +221,10 @@ func collectDeclared(files map[string][]byte) *declaredSet {
 			parsePyprojectDeps(content, d)
 		case base == "pipfile":
 			parsePipfile(content, d)
+		case base == "setup.py":
+			parseSetupPy(content, d)
+		case base == "setup.cfg":
+			parseSetupCfg(content, d)
 		}
 	}
 	return d
@@ -287,6 +340,111 @@ func parsePipfile(content []byte, d *declaredSet) {
 			if n := pyReqNameRe.FindStringSubmatch(strings.TrimSpace(trimmed[:i])); n != nil {
 				d.addPyPI(n[1])
 			}
+		}
+	}
+}
+
+// setupPyReqListRe finds the opening bracket of any requirement list in a
+// setup.py: install_requires=[...], tests_require=[...], setup_requires=[...],
+// the lists inside extras_require={...}, and the module-level variables those
+// keyword arguments are commonly assigned from (`install_requires = [...]`).
+var setupPyReqListRe = regexp.MustCompile(`(?i)(?:_requires?|extras_require)\s*=\s*[\[{(]`)
+
+// parseSetupPy extracts requirement names from a setuptools setup.py without
+// executing it. Nox never runs untrusted code, so this reads the literal lists
+// only: from each requirement-list opener it walks to the matching closer and
+// takes every string literal at any nesting depth, which covers extras_require
+// dicts (whose keys are extra names, harmless as declarations) and lists built
+// by concatenation. Requirements computed at runtime are invisible, and a
+// setup.py that delegates everything to setup.cfg or pyproject.toml declares
+// nothing here -- those files are parsed on their own.
+func parseSetupPy(content []byte, d *declaredSet) {
+	text := string(content)
+	for _, loc := range setupPyReqListRe.FindAllStringIndex(text, -1) {
+		for _, lit := range stringLiteralsInBrackets(text[loc[1]-1:]) {
+			if n := pyReqNameRe.FindStringSubmatch(strings.TrimSpace(lit)); n != nil {
+				d.addPyPI(n[1])
+			}
+		}
+	}
+}
+
+// stringLiteralsInBrackets returns the quoted strings inside the bracketed
+// expression that starts at s[0], stopping at the matching closer. Python
+// string prefixes (f, r, u, b) are skipped so an f-string requirement such as
+// f'acme>={version}' still yields its name.
+func stringLiteralsInBrackets(s string) []string {
+	var out []string
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; c {
+		case '[', '{', '(':
+			depth++
+		case ']', '}', ')':
+			depth--
+			if depth <= 0 {
+				return out
+			}
+		case '#':
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case '\'', '"':
+			end := strings.IndexByte(s[i+1:], c)
+			if end < 0 {
+				return out
+			}
+			out = append(out, s[i+1:i+1+end])
+			i += end + 1
+		}
+	}
+	return out
+}
+
+// parseSetupCfg extracts requirement names from a setuptools setup.cfg: the
+// install_requires / tests_require / setup_requires keys under [options] and
+// every list under [options.extras_require]. Values are newline-separated,
+// indented continuation lines; the single-line semicolon form is not
+// supported by setuptools and not read here.
+func parseSetupCfg(content []byte, d *declaredSet) {
+	section := ""
+	inList := false
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			section = strings.ToLower(trimmed)
+			inList = false
+			continue
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		continuation := line != "" && (line[0] == ' ' || line[0] == '\t')
+		if continuation {
+			if inList {
+				if n := pyReqNameRe.FindStringSubmatch(trimmed); n != nil {
+					d.addPyPI(n[1])
+				}
+			}
+			continue
+		}
+		inList = false
+		key, value, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		switch {
+		case section == "[options]" && (key == "install_requires" || key == "tests_require" || key == "setup_requires"):
+			inList = true
+		case section == "[options.extras_require]":
+			inList = true
+		default:
+			continue
+		}
+		// A value on the key line itself is the first requirement.
+		if n := pyReqNameRe.FindStringSubmatch(strings.TrimSpace(value)); n != nil {
+			d.addPyPI(n[1])
 		}
 	}
 }

--- a/core/analyzers/slop/manifests_test.go
+++ b/core/analyzers/slop/manifests_test.go
@@ -65,3 +65,127 @@ func TestHasPyPIImportMapping(t *testing.T) {
 		}
 	}
 }
+
+func TestCollectDeclaredSetupCfg(t *testing.T) {
+	// httpie's layout: setup.py is `setup()` and every requirement lives in
+	// setup.cfg under [options] and [options.extras_require].
+	files := map[string][]byte{
+		"setup.py": []byte("from setuptools import setup\n\nsetup()\n"),
+		"setup.cfg": []byte(`[metadata]
+name = httpie
+
+[options]
+packages = find:
+install_requires =
+    pip
+    charset_normalizer>=2.0.0
+    requests[socks] >=2.22.0
+    Pygments>=2.5.2
+    importlib-metadata>=1.4.0; python_version<"3.8"
+    colorama>=0.2.4; sys_platform=="win32"
+python_requires = >=3.7
+
+[options.extras_require]
+dev =
+    pytest
+    pytest-httpbin>=0.0.6
+    responses
+test = pyyaml
+
+[flake8]
+max-line-length = 120
+`),
+	}
+	d := collectDeclared(files)
+	for _, imp := range []string{"pip", "charset_normalizer", "requests", "pygments", "importlib_metadata", "colorama", "pytest", "pytest_httpbin", "responses", "yaml"} {
+		if !d.hasPyPI(imp) {
+			t.Errorf("setup.cfg: import root %q should be declared", imp)
+		}
+	}
+	for _, imp := range []string{"packages", "find", "python_requires", "max_line_length", "flake8"} {
+		if d.hasPyPI(imp) {
+			t.Errorf("setup.cfg: %q is not a requirement and must not be declared", imp)
+		}
+	}
+}
+
+func TestCollectDeclaredSetupPy(t *testing.T) {
+	// certbot's layout: module-level lists passed to setup(), an f-string
+	// requirement, and an extras_require dict of lists.
+	files := map[string][]byte{
+		"setup.py": []byte(`from setuptools import setup
+
+version = "4.0.0"
+
+install_requires = [
+    # comment with a bracket ] inside
+    f'acme>={version}',
+    'ConfigArgParse>=1.5.3',
+    "cryptography>=43.0.0",
+    'pyopenssl>=25.0.0',
+]
+
+extras_require = {
+    'docs': ['Sphinx>=1.0', 'sphinx_rtd_theme'],
+    'test': ['pytest', 'pytest-xdist'],
+}
+
+setup(
+    name='certbot',
+    install_requires=install_requires,
+    extras_require=extras_require,
+    tests_require=['coverage'],
+)
+`),
+	}
+	d := collectDeclared(files)
+	for _, imp := range []string{"acme", "configargparse", "cryptography", "OpenSSL", "sphinx", "sphinx_rtd_theme", "pytest", "pytest_xdist", "coverage"} {
+		if !d.hasPyPI(imp) {
+			t.Errorf("setup.py: import root %q should be declared", imp)
+		}
+	}
+	for _, imp := range []string{"certbot", "setuptools", "version", "name"} {
+		if d.hasPyPI(imp) {
+			t.Errorf("setup.py: %q is not a requirement and must not be declared", imp)
+		}
+	}
+}
+
+func TestHasPyPINamespaceRoot(t *testing.T) {
+	files := map[string][]byte{
+		"requirements.txt": []byte("zope.interface\nbackports.zoneinfo\nruamel.yaml\n"),
+	}
+	d := collectDeclared(files)
+	for _, imp := range []string{"zope", "backports", "ruamel"} {
+		if !d.hasPyPI(imp) {
+			t.Errorf("namespace root %q should be vouched for by its dotted distribution", imp)
+		}
+	}
+}
+
+func TestHasPyPIMixedCaseImportMapping(t *testing.T) {
+	files := map[string][]byte{
+		"requirements.txt": []byte("pyOpenSSL\npywin32\ndnspython\n"),
+	}
+	d := collectDeclared(files)
+	for _, imp := range []string{"OpenSSL", "win32security", "pywintypes", "dns"} {
+		if !d.hasPyPI(imp) {
+			t.Errorf("hasPyPI(%q) should be true through the import-to-dist mapping", imp)
+		}
+	}
+}
+
+func TestHasPyPIConventionalPrefix(t *testing.T) {
+	files := map[string][]byte{
+		"requirements.txt": []byte("python-digitalocean>=1.15\npython-augeas\npyserial\npy-cpuinfo\n"),
+	}
+	d := collectDeclared(files)
+	for _, imp := range []string{"digitalocean", "augeas", "serial", "cpuinfo"} {
+		if !d.hasPyPI(imp) {
+			t.Errorf("hasPyPI(%q) should resolve through the python-/py- naming convention", imp)
+		}
+	}
+	if d.hasPyPI("thon") { // "py"+"thon" != "python-digitalocean"; no accidental substring match
+		t.Error("prefix convention must be an exact-name check")
+	}
+}

--- a/core/analyzers/slop/slop.go
+++ b/core/analyzers/slop/slop.go
@@ -111,7 +111,7 @@ func predictiveSeverity(tier string) findings.Severity {
 func isManifest(base string) bool {
 	base = strings.ToLower(base)
 	switch base {
-	case "package.json", "package-lock.json", "pyproject.toml", "pipfile":
+	case "package.json", "package-lock.json", "pyproject.toml", "pipfile", "setup.py", "setup.cfg":
 		return true
 	}
 	return base == "requirements.txt" ||
@@ -126,6 +126,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	// the source tree before evaluating any import.
 	manifests := make(map[string][]byte)
 	local := make(map[string]struct{})
+	pkgDirs := make(map[string]struct{})
 	for i := range artifacts {
 		art := artifacts[i]
 		base := filepath.Base(art.Path)
@@ -138,7 +139,13 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			for root := range localModuleRoots(art.Path) {
 				local[root] = struct{}{}
 			}
+			if base == "__init__.py" {
+				pkgDirs[filepath.ToSlash(filepath.Dir(art.Path))] = struct{}{}
+			}
 		}
+	}
+	for root := range topLevelPackages(pkgDirs) {
+		local[root] = struct{}{}
 	}
 	declared := collectDeclared(manifests)
 
@@ -147,7 +154,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 			return nil, err
 		}
 		art := artifacts[i]
-		if art.Type != discovery.Source {
+		if art.Type != discovery.Source || isVendoredPath(art.Path) {
 			continue
 		}
 		eco := ecosystemForExt(filepath.Ext(art.Path))
@@ -176,8 +183,18 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 		if isStdlib(eco, pkg) {
 			continue
 		}
-		if _, isLocal := local[pkg]; isLocal && eco == ecoPyPI {
-			continue // first-party Python module
+		if eco == ecoPyPI {
+			if _, isLocal := local[pkg]; isLocal {
+				continue // first-party Python module
+			}
+			// PEP 508 requires a distribution name to start with a letter or
+			// digit, so an underscore-led import (_ssl, _typeshed, _pytest,
+			// _manylinux) can never resolve to a registry package. It is a
+			// private module of CPython or of an installed package, and there
+			// is nothing here for a squatter to register.
+			if strings.HasPrefix(pkg, "_") {
+				continue
+			}
 		}
 
 		// Predictive dimension (additive, opt-in): when a feed is loaded and the
@@ -278,9 +295,55 @@ func localModuleRoots(path string) map[string]struct{} {
 	}
 	// A directory at the tree root is an importable package root.
 	roots[first] = struct{}{}
-	// Common "src layout": src/<pkg>/... → <pkg> is the package root.
-	if (first == "src" || first == "lib") && len(segs) >= 3 {
-		roots[segs[1]] = struct{}{}
+	// "src layout": src/<pkg>/... → <pkg> is the package root. A monorepo
+	// nests one per subproject (certbot-ci/src/certbot_integration_tests), so
+	// the src segment may sit at any depth.
+	for i := 0; i+1 < len(segs)-1; i++ {
+		if segs[i] == "src" || segs[i] == "lib" {
+			roots[segs[i+1]] = struct{}{}
+		}
 	}
 	return roots
+}
+
+// topLevelPackages returns the names of the Python packages whose directory
+// holds an __init__.py and whose parent does not: the importable roots. A
+// nested subpackage (myapp/plugins) is reachable only through its parent, so
+// admitting it would let `import plugins` pass as first-party.
+func topLevelPackages(pkgDirs map[string]struct{}) map[string]struct{} {
+	roots := make(map[string]struct{})
+	for dir := range pkgDirs {
+		if dir == "." || dir == "" {
+			continue
+		}
+		parent := filepath.ToSlash(filepath.Dir(dir))
+		if _, nested := pkgDirs[parent]; nested {
+			continue
+		}
+		roots[filepath.Base(dir)] = struct{}{}
+	}
+	return roots
+}
+
+// vendoredSegments are the directory names under which a project carries a
+// copy of someone else's code. SLOP-001 asks whether the PROJECT imports a
+// package it never declared; the imports inside a vendored library are that
+// library's, resolved against its own manifest, which is not here. pipenv
+// alone carries pip, urllib3, requests and rich under vendor/ and patched/,
+// and every optional import inside them (keyring, socks, OpenSSL) fired.
+var vendoredSegments = map[string]struct{}{
+	"vendor": {}, "_vendor": {}, "vendored": {}, "patched": {},
+	"node_modules": {}, "third_party": {}, "thirdparty": {}, "3rdparty": {},
+}
+
+// isVendoredPath reports whether any directory segment of path names a
+// vendored tree.
+func isVendoredPath(path string) bool {
+	segs := strings.Split(filepath.ToSlash(path), "/")
+	for _, seg := range segs[:len(segs)-1] {
+		if _, ok := vendoredSegments[strings.ToLower(seg)]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/core/analyzers/slop/slop_test.go
+++ b/core/analyzers/slop/slop_test.go
@@ -140,3 +140,54 @@ func TestScanDeduplicatesPerFile(t *testing.T) {
 		t.Errorf("expected ghostpkg flagged once per file, got %d", count)
 	}
 }
+
+func TestScanPrivateAndLegacyPythonModulesNotFlagged(t *testing.T) {
+	// Underscore-led modules cannot be registry packages (PEP 508 names start
+	// with a letter or digit); Python 2 names live in compatibility shims.
+	pkgs := findingsFor(t, map[string]string{
+		"m.py": "from _typeshed import StrPath\nimport _ssl\nfrom _pytest.fixtures import fixture\n" +
+			"try:\n    import queue\nexcept ImportError:\n    import Queue\n" +
+			"import distutils.util\nfrom compression import zstd\nimport urllib2\n",
+	})
+	if len(pkgs) != 0 {
+		t.Errorf("private and legacy stdlib names must not be flagged; got %v", pkgs)
+	}
+}
+
+func TestScanMonorepoSrcLayoutIsLocal(t *testing.T) {
+	// certbot-ci/src/certbot_integration_tests is first-party even though the
+	// src segment is not at the tree root; myapp/plugins is a subpackage, so a
+	// bare `import plugins` remains external.
+	pkgs := findingsFor(t, map[string]string{
+		"certbot-ci/src/certbot_integration_tests/__init__.py": "",
+		"certbot-ci/src/certbot_integration_tests/utils/x.py":  "import certbot_integration_tests.conftest\n",
+		"tools/pkg/myapp/__init__.py":                          "",
+		"tools/pkg/myapp/plugins/__init__.py":                  "",
+		"tools/pkg/myapp/plugins/a.py":                         "import myapp.plugins\nimport plugins\n",
+	})
+	if hasPkg(pkgs, "certbot_integration_tests") || hasPkg(pkgs, "myapp") {
+		t.Errorf("first-party packages flagged: %v", pkgs)
+	}
+	if !hasPkg(pkgs, "plugins") {
+		t.Errorf("a nested subpackage name must not vouch for a bare import; got %v", pkgs)
+	}
+}
+
+func TestScanSkipsVendoredCode(t *testing.T) {
+	// Imports inside a vendored library are the library's, resolved against a
+	// manifest that is not in this tree. The project's own file still counts.
+	pkgs := findingsFor(t, map[string]string{
+		"pipenv/vendor/rich/live.py":            "import ipywidgets\n",
+		"pipenv/patched/pip/_vendor/socks.py":   "import socks\n",
+		"web/static/node_modules/left-pad/i.js": "const x = require('phantom-left-pad');\n",
+		"pipenv/help.py":                        "import totally_made_up_pkg\n",
+	})
+	for _, p := range []string{"ipywidgets", "socks", "phantom-left-pad"} {
+		if hasPkg(pkgs, p) {
+			t.Errorf("vendored import %q flagged; got %v", p, pkgs)
+		}
+	}
+	if !hasPkg(pkgs, "totally_made_up_pkg") {
+		t.Errorf("project import must still be flagged; got %v", pkgs)
+	}
+}

--- a/core/analyzers/taintflow/taintflow.go
+++ b/core/analyzers/taintflow/taintflow.go
@@ -165,20 +165,26 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, lang lexctx.La
 // source line.
 func (a *Analyzer) toFinding(flow *taint.Flow) findings.Finding {
 	sink := flow.Sink
+	// A source used directly as the sink's argument (`eval "$@"`,
+	// `os.system(request.args.get("c"))`) binds no variable; name the source
+	// expression instead of an empty variable.
+	origin := fmt.Sprintf("%s via %q", flow.Source.Kind, flow.SourceVar)
+	if flow.SourceVar == "" {
+		origin = fmt.Sprintf("%s from %q used directly", flow.Source.Kind, flow.Source.Call)
+	}
 	var msg string
 	if len(flow.Via) > 0 {
 		// Cross-function flow: name the intermediate helper(s) so triage can follow
 		// the path from the caller's source through the summarized helper(s) to the
 		// sink.
 		msg = fmt.Sprintf(
-			"Untrusted input (%s via %q) reaches %s sink %q through %s without sanitization — %s.",
-			flow.Source.Kind, flow.SourceVar, sink.VulnClass, sink.Call,
-			viaPath(flow.Via), sink.CWE,
+			"Untrusted input (%s) reaches %s sink %q through %s without sanitization — %s.",
+			origin, sink.VulnClass, sink.Call, viaPath(flow.Via), sink.CWE,
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Untrusted input (%s via %q) reaches %s sink %q without sanitization — %s.",
-			flow.Source.Kind, flow.SourceVar, sink.VulnClass, sink.Call, sink.CWE,
+			"Untrusted input (%s) reaches %s sink %q without sanitization — %s.",
+			origin, sink.VulnClass, sink.Call, sink.CWE,
 		)
 	}
 	meta := map[string]string{

--- a/core/analyzers/taintflow/taintflow_shell_test.go
+++ b/core/analyzers/taintflow/taintflow_shell_test.go
@@ -1,0 +1,28 @@
+package taintflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/discovery"
+)
+
+// A source used directly as the sink's argument binds no variable. The message
+// used to render that as `via ""`; it now names the source expression.
+func TestAnalyzerShellInlineSourceMessage(t *testing.T) {
+	dir := t.TempDir()
+	art := writeArtifact(t, dir, "run.sh", "#!/bin/sh\neval \"$@\"\n")
+	fs, err := NewAnalyzer().ScanArtifacts(context.Background(), []discovery.Artifact{art})
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+	items := fs.Findings()
+	if len(items) != 1 || items[0].RuleID != "TAINT-005" {
+		t.Fatalf("want one TAINT-005, got %+v", items)
+	}
+	msg := items[0].Message
+	if strings.Contains(msg, `via ""`) || !strings.Contains(msg, `argv from "$@" used directly`) {
+		t.Fatalf("message does not name the inline source: %q", msg)
+	}
+}

--- a/core/config.go
+++ b/core/config.go
@@ -210,6 +210,8 @@ func NonProductionPathGlobs() []string {
 //   - TAINT-*              — dataflow/taint findings
 //   - SLOP-*               — AI-generated-code smells
 //   - VARIANT-*            — variant/anti-pattern matches
+//   - DATA-001             — an email address in docs or vendored code is
+//     contact information, not a leak; the family's other rules stay out.
 //
 // It deliberately EXCLUDES:
 //
@@ -224,7 +226,24 @@ func NonProductionPathGlobs() []string {
 func ContextDowngradeRulePatterns() []string {
 	return []string{
 		"AI-*", "MCP-*", "AGENT-*", "IAC-*", "TAINT-*", "SLOP-*", "VARIANT-*",
+		"DATA-001",
 	}
+}
+
+// NoiseDirDropRulePatterns is the set of rule IDs dropped outright inside
+// test, fixture and example trees and on generated or vendored paths. It is
+// narrower than the downgrade set: a rule belongs here only when a hit in
+// such a tree is noise by construction, not merely less actionable.
+//
+//   - AI-*, MCP-* — tool-wiring and prompt patterns quoted in fixtures
+//   - DATA-001    — an email address. Fixtures are made of them: a registry
+//     mock carries one maintainer address per package version, and one
+//     package manager's test tree produced 184,599 of them on its own. The
+//     other DATA-* rules (card numbers, national IDs, keys) stay out for the
+//     same reason SEC-* is kept out of the downgrade: a real one in a
+//     fixture is a real leak.
+func NoiseDirDropRulePatterns() []string {
+	return []string{"AI-*", "MCP-*", "DATA-001"}
 }
 
 // MatchesNonProductionPath reports whether path matches any of the given globs

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -1,5 +1,7 @@
 package lexctx
 
+import "bytes"
+
 // Kind labels the lexical role of a byte range.
 type Kind int
 
@@ -234,8 +236,13 @@ func SuppressNonCode(lang Lang, content []byte, matchStart, matchEnd int) bool {
 	r := regions[idx]
 	// A match straddling regions (leaking out of a comment/string into code) is
 	// suspect but not clearly noise — keep it so we never hide a real finding.
+	// The one straddle that is clearly noise: a match that runs from one
+	// comment line into the next. The engine matches whole documents, so a
+	// pattern's `\s*` can swallow the newline between two `//` lines; the
+	// match then touches nothing but comment text and whitespace, and is
+	// prose exactly as a single-line comment match is.
 	if r.End < matchEnd {
-		return false
+		return r.Kind == KindComment && onlyCommentsAndBlanks(regions, idx, content, matchEnd)
 	}
 	switch r.Kind {
 	case KindComment:
@@ -245,6 +252,27 @@ func SuppressNonCode(lang Lang, content []byte, matchStart, matchEnd int) bool {
 	default:
 		return false
 	}
+}
+
+// onlyCommentsAndBlanks reports whether every region from regions[from]
+// (a comment) up to matchEnd is either a comment or code that is nothing but
+// whitespace inside the matched span -- the newline and indentation between
+// consecutive comment lines.
+func onlyCommentsAndBlanks(regions []Region, from int, content []byte, matchEnd int) bool {
+	for i := from; i < len(regions) && regions[i].Start < matchEnd; i++ {
+		r := regions[i]
+		if r.Kind == KindComment {
+			continue
+		}
+		if r.Kind != KindCode {
+			return false
+		}
+		end := min(r.End, matchEnd)
+		if len(bytes.TrimSpace(content[r.Start:end])) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // InDataBlob reports whether the match [matchStart,matchEnd) lies entirely

--- a/core/lexctx/lexctx.go
+++ b/core/lexctx/lexctx.go
@@ -254,6 +254,24 @@ func SuppressNonCode(lang Lang, content []byte, matchStart, matchEnd int) bool {
 	}
 }
 
+// WithinComments reports whether the span [start, end) of content is prose: it
+// begins inside a comment and touches nothing but comment text and the
+// whitespace between comment lines. A span that begins outside a comment, or
+// that reaches any non-blank code or string byte, is not. It is the
+// span-level form of the rule SuppressNonCode applies to a straddling match,
+// for callers that already hold a finding's location rather than a match.
+func WithinComments(lang Lang, content []byte, start, end int) bool {
+	if lang == LangUnknown || end <= start || start < 0 || end > len(content) {
+		return false
+	}
+	regions := Classify(lang, content)
+	idx := regionIndexAt(regions, start)
+	if idx < 0 || regions[idx].Kind != KindComment {
+		return false
+	}
+	return onlyCommentsAndBlanks(regions, idx, content, end)
+}
+
 // onlyCommentsAndBlanks reports whether every region from regions[from]
 // (a comment) up to matchEnd is either a comment or code that is nothing but
 // whitespace inside the matched span -- the newline and indentation between

--- a/core/lexctx/lexctx_test.go
+++ b/core/lexctx/lexctx_test.go
@@ -264,3 +264,33 @@ func TestSuppressNonCodeStringPolicy(t *testing.T) {
 		t.Error("token inside a comment must be suppressed")
 	}
 }
+
+// TestSuppressNonCodeSpansConsecutiveComments pins the cross-line case: the
+// engine matches whole documents, so a pattern whose `\s*` swallows a newline
+// can start on one comment line and end on the next. Two `//` lines are two
+// comment regions with a newline between them; a match that never touches
+// anything but comment text and that newline is still prose, and is dropped.
+// One that leaks from the comment into real code on the next line is kept.
+func TestSuppressNonCodeSpansConsecutiveComments(t *testing.T) {
+	prose := "package p\n// innerHTML\n// response as HTML\nfunc f() {}\n"
+	start := indexOf(prose, "innerHTML")
+	end := indexOf(prose, "response") + len("response")
+	if !SuppressNonCode(LangGo, []byte(prose), start, end) {
+		t.Error("a match spanning two consecutive comment lines must be suppressed")
+	}
+
+	leak := "package p\n// innerHTML\nw.Write(response)\n"
+	start = indexOf(leak, "innerHTML")
+	end = indexOf(leak, "response") + len("response")
+	if SuppressNonCode(LangGo, []byte(leak), start, end) {
+		t.Error("a match leaking from a comment into code must be kept")
+	}
+
+	// Python: `#` comments, and a blank line between them is still whitespace.
+	py := "x = 1\n# innerHTML\n\n# response\n"
+	start = indexOf(py, "innerHTML")
+	end = indexOf(py, "response") + len("response")
+	if !SuppressNonCode(LangPython, []byte(py), start, end) {
+		t.Error("comment lines separated by a blank line are still prose")
+	}
+}

--- a/core/lexctx/lexctx_test.go
+++ b/core/lexctx/lexctx_test.go
@@ -294,3 +294,23 @@ func TestSuppressNonCodeSpansConsecutiveComments(t *testing.T) {
 		t.Error("comment lines separated by a blank line are still prose")
 	}
 }
+
+func TestWithinComments(t *testing.T) {
+	src := []byte("# one\n# two\nx=1 # three\n")
+	cases := []struct {
+		name       string
+		start, end int
+		want       bool
+	}{
+		{"single comment", 0, 5, true},
+		{"two comment lines and the newline between", 2, 11, true},
+		{"leaks into code", 6, 15, false},
+		{"begins in code", 12, 22, false},
+		{"empty span", 3, 3, false},
+	}
+	for _, tc := range cases {
+		if got := WithinComments(LangShell, src, tc.start, tc.end); got != tc.want {
+			t.Errorf("%s: WithinComments(%d,%d) = %v, want %v", tc.name, tc.start, tc.end, got, tc.want)
+		}
+	}
+}

--- a/core/rules/engine.go
+++ b/core/rules/engine.go
@@ -95,13 +95,7 @@ func (e *Engine) ScanFile(path string, content []byte) ([]findings.Finding, erro
 				}
 			}
 
-			loc := findings.Location{
-				FilePath:    path,
-				StartLine:   mr.Line,
-				EndLine:     mr.Line,
-				StartColumn: mr.Column,
-				EndColumn:   mr.Column + len(mr.MatchText),
-			}
+			loc := matchLocation(path, mr)
 
 			f := findings.Finding{
 				RuleID:     rule.ID,
@@ -313,4 +307,27 @@ func isBinary(content []byte) bool {
 		}
 	}
 	return false
+}
+
+// matchLocation converts a match into a Location that describes the span the
+// match actually covers. The engine matches whole documents, so a pattern can
+// legitimately span lines (a PEM block, a YAML mapping whose key and value sit
+// on consecutive lines); recording EndLine == StartLine and an EndColumn past
+// the end of the line hid that, and hid the cross-line false positives with
+// it -- a match that had crossed into the next line was indistinguishable in
+// the output from one that had not. The fingerprint reads only the start
+// line, so this changes what a reader sees and nothing a baseline keys on.
+func matchLocation(path string, mr MatchResult) findings.Location {
+	loc := findings.Location{
+		FilePath:    path,
+		StartLine:   mr.Line,
+		EndLine:     mr.Line,
+		StartColumn: mr.Column,
+		EndColumn:   mr.Column + len(mr.MatchText),
+	}
+	if last := strings.LastIndexByte(mr.MatchText, '\n'); last >= 0 {
+		loc.EndLine += strings.Count(mr.MatchText, "\n")
+		loc.EndColumn = len(mr.MatchText) - last
+	}
+	return loc
 }

--- a/core/rules/entropy.go
+++ b/core/rules/entropy.go
@@ -201,7 +201,7 @@ func (m *EntropyMatcher) Match(content []byte, rule *Rule) []MatchResult {
 			// its algorithm (sha256-/sha384-/sha512-) in HTML/JSX/struct tags —
 			// are public integrity values, not credentials. Skip a candidate
 			// whose base64 body is immediately preceded by an SRI prefix.
-			if isSRIIntegrityHash(lineStr, c.col) {
+			if isSRIIntegrityHash(lineStr, c.col) || hasSRIPrefix(c.text) {
 				continue
 			}
 			entropy := ShannonEntropy(c.text)
@@ -490,6 +490,25 @@ func isSRIIntegrityHash(line string, col int) bool {
 			return true
 		}
 		if b := prefixRegion[before-1]; !isAlphaNum(b) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSRIPrefix reports whether the candidate itself begins with an SRI
+// algorithm label — the shape a quoted or assignment candidate takes when the
+// whole `sha512-<base64>` value is the token, as in `"integrity": "sha512-…"`
+// in every npm registry document and package manifest. isSRIIntegrityHash
+// looks at the text before the candidate, which covers the base64 tokenizer
+// (its candidate starts after the prefix) and the HTML attribute form; this
+// covers the other tokenizers, whose candidate starts at the prefix. The label
+// must be at the start of the token, as the SRI grammar defines it — a
+// credential that merely contains "sha256-" is still a candidate.
+func hasSRIPrefix(candidate string) bool {
+	lower := strings.ToLower(candidate)
+	for _, p := range sriPrefixes {
+		if strings.HasPrefix(lower, p) && len(lower) > len(p) {
 			return true
 		}
 	}

--- a/core/rules/entropy_test.go
+++ b/core/rules/entropy_test.go
@@ -284,6 +284,35 @@ func TestEntropyMatcher_SkipsSRIIntegrityHash(t *testing.T) {
 	}
 }
 
+// TestEntropyMatcher_SkipsQuotedSRIIntegrityHash is the same exemption for the
+// shape the previous test does not cover: the prefix INSIDE the quoted
+// candidate. `"integrity": "sha512-…"` is how every npm registry document,
+// package manifest and lockfile-shaped fixture spells an SRI hash, and the
+// quoted-string tokenizer hands the matcher `sha512-…` as one candidate
+// starting at the prefix. isSRIIntegrityHash looked only at the text BEFORE
+// the candidate, so the exemption held for the HTML attribute form and failed
+// for JSON: 42,600 SEC-161 findings on npm/cli, all of them `sha512-`
+// integrity values in test fixtures.
+func TestEntropyMatcher_SkipsQuotedSRIIntegrityHash(t *testing.T) {
+	m := &EntropyMatcher{}
+	rule := Rule{MatcherType: "entropy", Metadata: map[string]string{"entropy_threshold": "5.0", "candidate_kinds": "assignment,quoted"}}
+	for _, line := range []string{
+		"  \"integrity\": \"sha512-1Qs1jdXEMSYwcVooLRfnCc5+e3365pw38v4AVkSsCxsjXRGKDTem5VLCl53SpHSpLnEy8O5DofJHZJELaRiJbg==\",\n",
+		"  \"other\": \"sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\"\n",
+		"integrity = \"sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC\"\n",
+	} {
+		if results := m.Match([]byte(line), &rule); len(results) != 0 {
+			t.Errorf("%q: expected no matches for a quoted SRI hash, got %d: %+v", line, len(results), results)
+		}
+	}
+	// A credential that merely CONTAINS an algorithm name is still a candidate:
+	// the prefix must be at the start of the token, as SRI defines it.
+	notSRI := []byte("token = \"xsha512-1Qs1jdXEMSYwcVooLRfnCc5+e3365pw38v4AVkSsCxsjXRGKDTem5VLCl53SpHSpLnEy8O5DofJHZJELaRiJbg==\"\n")
+	if results := m.Match(notSRI, &rule); len(results) == 0 {
+		t.Fatalf("a token that only contains an algorithm name must still be a candidate")
+	}
+}
+
 // TestIsSRIIntegrityHashLine covers the SRI-prefix recognition helper directly.
 func TestIsSRIIntegrityHashLine(t *testing.T) {
 	tests := []struct {

--- a/core/rules/match_location_test.go
+++ b/core/rules/match_location_test.go
@@ -1,0 +1,29 @@
+package rules
+
+import "testing"
+
+// TestMatchLocation_SpansLines: a match that crosses line breaks reports the
+// line it ends on and a column measured on that line, instead of the start
+// line and a column past its end.
+func TestMatchLocation_SpansLines(t *testing.T) {
+	tests := []struct {
+		name          string
+		mr            MatchResult
+		endLine, endC int
+	}{
+		{"one line", MatchResult{Line: 4, Column: 3, MatchText: "token=abc"}, 4, 12},
+		{"trailing newline", MatchResult{Line: 4, Column: 3, MatchText: "token=abc\n"}, 5, 1},
+		{"pem block", MatchResult{Line: 1, Column: 1, MatchText: "-----BEGIN KEY-----\nMIIB\n-----END KEY-----"}, 3, 18},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loc := matchLocation("f", tt.mr)
+			if loc.StartLine != tt.mr.Line || loc.StartColumn != tt.mr.Column {
+				t.Fatalf("start moved: %+v", loc)
+			}
+			if loc.EndLine != tt.endLine || loc.EndColumn != tt.endC {
+				t.Fatalf("got end %d:%d, want %d:%d", loc.EndLine, loc.EndColumn, tt.endLine, tt.endC)
+			}
+		})
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -1223,12 +1223,12 @@ func refineFindings(allFindings *findings.FindingSet, cfg *ScanConfig, opts Scan
 	// scanning already ran against the same lockfiles, so no real CVE is hidden.
 	if genPaths := cfg.Scan.GeneratedPaths.ResolveGeneratedPaths(); len(genPaths) > 0 {
 		withheld("content rule dropped on a generated or vendored path", func() {
-			allFindings.RemoveByRuleIDsAndPaths([]string{"AI-*", "MCP-*"}, genPaths)
+			allFindings.RemoveByRuleIDsAndPaths(NoiseDirDropRulePatterns(), genPaths)
 		})
 	}
 	if noiseDirs := cfg.Scan.GeneratedPaths.ResolveNoiseDirs(); len(noiseDirs) > 0 {
 		withheld("content rule dropped inside a test, fixture or example tree", func() {
-			allFindings.RemoveByRuleIDsInDirs([]string{"AI-*", "MCP-*"}, noiseDirs)
+			allFindings.RemoveByRuleIDsInDirs(NoiseDirDropRulePatterns(), noiseDirs)
 		})
 	}
 

--- a/core/scan_test.go
+++ b/core/scan_test.go
@@ -2509,3 +2509,49 @@ func TestScan_TrackedOnlyOutsideRepoIsError(t *testing.T) {
 		t.Errorf("expected the error to name --tracked-only, got: %v", err)
 	}
 }
+
+// TestRunScan_EmailInFixtureTreeIsNoise: DATA-001 is dropped inside fixture
+// trees, downgraded in docs, and reported at low in shipping source. Registry
+// mocks carry one maintainer address per package version; one package
+// manager's test tree produced 184,599 of them before this held.
+func TestRunScan_EmailInFixtureTreeIsNoise(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	body := `{"maintainers": [{"email": "maintainer@some-registry-user.io"}]}` + "\n"
+	files := map[string]string{
+		"test/fixtures/registry/pkg.json": body,
+		"docs/contributors.json":          body,
+		"src/notify.json":                 body,
+	}
+	for rel, content := range files {
+		path := filepath.Join(tmpDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := RunScan(tmpDir)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	got := map[string]findings.Severity{}
+	for _, f := range result.Findings.Findings() {
+		if f.RuleID == "DATA-001" {
+			got[filepath.ToSlash(f.Location.FilePath)] = f.Severity
+		}
+	}
+	if _, ok := got["test/fixtures/registry/pkg.json"]; ok {
+		t.Errorf("DATA-001 reported inside a fixture tree: %v", got)
+	}
+	if sev := got["docs/contributors.json"]; sev != findings.SeverityInfo {
+		t.Errorf("DATA-001 in docs: got %q, want info (downgraded)", sev)
+	}
+	if sev := got["src/notify.json"]; sev != findings.SeverityLow {
+		t.Errorf("DATA-001 in source: got %q, want low", sev)
+	}
+}

--- a/core/taint/catalog.go
+++ b/core/taint/catalog.go
@@ -49,6 +49,19 @@ const (
 	VulnOpenRedirect          VulnClass = "open_redirect"          // CWE-601
 )
 
+// knownVulnClass reports whether class is one of the classes above, so a
+// catalog entry naming a class that nothing reports fails to load instead of
+// silently excluding nothing.
+func knownVulnClass(class VulnClass) bool {
+	switch class {
+	case VulnCommandInjection, VulnSQLInjection, VulnCodeInjection, VulnXSS,
+		VulnSSTI, VulnPathTraversal, VulnSSRF, VulnUnsafeDeserialization,
+		VulnPromptInjection, VulnOpenRedirect:
+		return true
+	}
+	return false
+}
+
 // SourceKind describes the provenance of untrusted input. It is informational
 // (it enriches findings and helps triage) rather than part of the taint join;
 // any tainted value can in principle reach any sink.
@@ -78,6 +91,24 @@ type Source struct {
 	Call string `json:"call"`
 	// Kind records the provenance for triage and reporting.
 	Kind SourceKind `json:"kind"`
+	// NotFor lists the vulnerability classes this source can never reach — a
+	// property of what the VALUE is, not of where it came from. A Ring request
+	// `:body` is an InputStream, so `slurp` on it reads the request; it never
+	// opens a path, and reporting it as path traversal is a false positive on
+	// every occurrence. A flow from the source to a sink of a listed class is
+	// not reported. Every other class is untouched: the same body, once read
+	// into a string, still reaches a SQL or command sink.
+	NotFor []VulnClass `json:"not_for,omitempty"`
+}
+
+// Excludes reports whether class is one the source's value can never reach.
+func (s Source) Excludes(class VulnClass) bool {
+	for _, c := range s.NotFor {
+		if c == class {
+			return true
+		}
+	}
+	return false
 }
 
 // Sink is a callable that is dangerous when it receives tainted data. The
@@ -180,6 +211,11 @@ func load(fsys embed.FS) (*Catalog, error) {
 		for _, s := range lc.Sources {
 			if s.Call == "" {
 				return nil, fmt.Errorf("taint: %s: source with empty call", lang)
+			}
+			for _, class := range s.NotFor {
+				if !knownVulnClass(class) {
+					return nil, fmt.Errorf("taint: %s: source %q excludes unknown vuln class %q", lang, s.Call, class)
+				}
 			}
 			srcIdx[s.Call] = s
 		}

--- a/core/taint/catalog_test.go
+++ b/core/taint/catalog_test.go
@@ -179,3 +179,32 @@ func TestSanitizerInvariants(t *testing.T) {
 		}
 	}
 }
+
+// A source's not_for is a claim about the VALUE ("a Ring :body is a stream,
+// never a path"), so it must name classes the engine reports, and it must
+// leave every other class alone.
+func TestSourceExcludes(t *testing.T) {
+	cat := MustDefault()
+	body, ok := cat.Source("clojure", ":body")
+	if !ok {
+		t.Fatal("clojure :body is not a source")
+	}
+	if !body.Excludes(VulnPathTraversal) {
+		t.Error("clojure :body should exclude path_traversal")
+	}
+	if body.Excludes(VulnSQLInjection) || body.Excludes(VulnCommandInjection) {
+		t.Error("clojure :body must still reach sql/command sinks")
+	}
+	for _, lang := range cat.Languages() {
+		for _, s := range cat.Sources(lang) {
+			for _, class := range s.NotFor {
+				if !knownVulnClass(class) {
+					t.Errorf("%s: source %q excludes unknown class %q", lang, s.Call, class)
+				}
+			}
+		}
+	}
+	if knownVulnClass("teleportation") {
+		t.Error("an unknown class must not validate")
+	}
+}

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -5422,7 +5422,8 @@
         {
           "call": ":body",
           "kind": "http_body",
-          "note": "Ring request body stream/string"
+          "not_for": ["path_traversal"],
+          "note": "Ring request body: an InputStream by the Ring spec, so slurp on it reads the request and never opens a path (measured on ring + reitit: every (slurp (:body ...)) was a stream read, request or response). Still a source for every other class once read into a string."
         },
         {
           "call": ":headers",

--- a/core/taint/engine.go
+++ b/core/taint/engine.go
@@ -39,6 +39,13 @@ type Statement struct {
 	// pass can decide whether a parameter flows to a function's return value.
 	// Empty for non-return statements. The intraprocedural engine ignores it.
 	Returns []string
+	// Expr is the code view (string literals blanked) of the expression this
+	// statement assigns to Assigns, or "" when the substrate does not carry it.
+	// The StructuralEngine scans it like a sink argument: a sanitizer wrapping
+	// the source on the binding's own line (`n = int(request.args.get('n'))`)
+	// clears its classes on the assignee. Empty means "unknown", which keeps
+	// the conservative behaviour (the assignee is tainted with nothing cleared).
+	Expr string
 }
 
 // SinkArgInfo is the argument-shape evidence a substrate extracts at a specific

--- a/core/taint/engine/binding_sanitizer_test.go
+++ b/core/taint/engine/binding_sanitizer_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// A sanitizer wrapping the source in the SAME binding it is assigned from —
+// `n = int(request.args.get('n'))` — is the ordinary way to validate input.
+// The engine used to see only "this binding reads a source" and taint n with
+// nothing cleared, so every such validated value fired at its sink. The
+// binding's expression is now scanned the way a sink argument is: the classes
+// of a sanitizer on the path from the expression root to the source are
+// cleared on the assignee.
+func TestBindingSanitizerWrappingSource(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		lang lexctx.Lang
+		src  string
+		want []string
+	}{
+		{
+			name: "python int() around the source clears command injection",
+			path: "t.py", lang: lexctx.LangPython,
+			src:  "import os\nfrom flask import request\ndef f():\n    n = int(request.args.get('n'))\n    os.system('sleep ' + str(n))\n",
+			want: nil,
+		},
+		{
+			name: "python raw source still fires",
+			path: "t.py", lang: lexctx.LangPython,
+			src:  "import os\nfrom flask import request\ndef f():\n    n = request.args.get('n')\n    os.system('sleep ' + n)\n",
+			want: []string{"TAINT-002"},
+		},
+		{
+			name: "python a second, unwrapped source in the same binding keeps the taint",
+			path: "t.py", lang: lexctx.LangPython,
+			src:  "import os\nfrom flask import request\ndef f():\n    n = int(request.args.get('a')) + request.args.get('b')\n    os.system('sleep ' + n)\n",
+			want: []string{"TAINT-002"},
+		},
+		{
+			name: "python the sanitizer clears only its own classes",
+			path: "t.py", lang: lexctx.LangPython,
+			src:  "import os\nfrom flask import request\ndef f():\n    p = html.escape(request.args.get('p'))\n    os.system('cat ' + p)\n",
+			want: []string{"TAINT-002"},
+		},
+		{
+			name: "python a sanitizer beside the source, not around it, clears nothing",
+			path: "t.py", lang: lexctx.LangPython,
+			src:  "import os\nfrom flask import request\ndef f():\n    n = request.args.get('n') + str(int(x))\n    os.system('sleep ' + n)\n",
+			want: []string{"TAINT-002"},
+		},
+		{
+			name: "javascript parseInt around the source",
+			path: "t.js", lang: lexctx.LangJavaScript,
+			src:  "const child_process = require('child_process');\nfunction h(req, res) {\n  const n = parseInt(req.query.n);\n  child_process.execSync('sleep ' + n);\n}\n",
+			want: nil,
+		},
+		{
+			name: "java Integer.parseInt around the source",
+			path: "T.java", lang: lexctx.LangJava,
+			src:  "class A { void f(HttpServletRequest request) throws Exception {\n  int n = Integer.parseInt(request.getParameter(\"n\"));\n  Runtime.getRuntime().exec(\"sleep \" + n);\n}}\n",
+			want: nil,
+		},
+		{
+			name: "php intval around the superglobal",
+			path: "t.php", lang: lexctx.LangPHP,
+			src:  "<?php\n$n = intval($_GET['n']);\nsystem('sleep ' . $n);\n",
+			want: nil,
+		},
+		{
+			name: "ruby Integer() around params",
+			path: "t.rb", lang: lexctx.LangRuby,
+			src:  "def f\n  n = Integer(params[:n])\n  system(\"sleep #{n}\")\nend\n",
+			want: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, c.path, c.lang, c.src)
+			if strings.Join(got, ",") != strings.Join(c.want, ",") {
+				t.Fatalf("got %v, want %v\n%s", got, c.want, c.src)
+			}
+		})
+	}
+}

--- a/core/taint/engine/clojure_hof_test.go
+++ b/core/taint/engine/clojure_hof_test.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// Higher-order CONSTRUCTION: `partial` and `comp` BUILD a function that is
+// invoked through a local name, and `as->` binds the threaded value to a name
+// the author chooses. In all three the sink never appears as a call head under
+// a name the recognizer tracks unless the construction is followed.
+func TestClojureHOFConstruction(t *testing.T) {
+	const ns = `(ns app.t
+  (:require [clojure.java.shell :as shell]
+            [clj-http.client :as client]
+            [clojure.string :as str]))
+`
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"partial bound by let", ns + `
+(defn run [req]
+  (let [cmd (:params req)
+        f   (partial shell/sh "sh" "-c")]
+    (f cmd)))
+`, []string{"TAINT-002"}},
+		{"partial bound by def, invoked in a defn", ns + `
+(def run-it (partial shell/sh "sh" "-c"))
+(defn run [req]
+  (let [cmd (:params req)]
+    (run-it cmd)))
+`, []string{"TAINT-002"}},
+		{"partial of a non-sink", ns + `
+(defn run [req]
+  (let [cmd (:params req)
+        f   (partial str "prefix-")]
+    (f cmd)))
+`, nil},
+		{"partial over a sanitized argument", ns + `
+(defn run [req]
+  (let [raw (:params req)
+        n   (Integer/parseInt raw)
+        f   (partial shell/sh "sleep")]
+    (f n)))
+`, nil},
+		{"partial alias is lexical", ns + `
+(defn run [req]
+  (let [cmd (:params req)]
+    (let [f (partial shell/sh "sh" "-c")]
+      (count f))
+    (let [f (partial str "x")]
+      (f cmd))))
+`, nil},
+		{"comp bound by let", ns + `
+(defn fetch [req]
+  (let [url (:params req)
+        g   (comp client/get str)]
+    (g url)))
+`, []string{"TAINT-006"}},
+		{"comp with a sanitizer inside", ns + `
+(defn fetch [req]
+  (let [n (:params req)
+        g (comp shell/sh Integer/parseInt)]
+    (g n)))
+`, nil},
+		{"comp of non-sinks", ns + `
+(defn fetch [req]
+  (let [url (:params req)
+        g   (comp str/trim str)]
+    (g url)))
+`, nil},
+		{"as-> binds the threaded value", ns + `
+(defn run [req]
+  (as-> (:params req) v
+        (str/trim v)
+        (shell/sh "sh" "-c" v)))
+`, []string{"TAINT-002"}},
+		{"as-> through a sanitizer", ns + `
+(defn run [req]
+  (as-> (:params req) v
+        (Integer/parseInt v)
+        (shell/sh "sleep" v)))
+`, nil},
+		{"as-> from a clean value", ns + `
+(defn run [req]
+  (as-> "ls" v
+        (str/trim v)
+        (shell/sh "sh" "-c" v)))
+`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.clj", lexctx.LangClojure, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/taint/engine/clojure_hof_test.go
+++ b/core/taint/engine/clojure_hof_test.go
@@ -101,3 +101,17 @@ func TestClojureHOFConstruction(t *testing.T) {
 		})
 	}
 }
+
+// A `fn` opened inside a defn body is a unit of the FILE, not of the scope
+// that walked it. The scoped walk introduced for `partial`/`comp` copied the
+// unit list by value, so the nested unit — and the flow inside it — vanished.
+func TestClojureNestedFnKeepsItsUnit(t *testing.T) {
+	src := `(ns app.t (:require [clojure.java.shell :as shell]))
+(defn outer [req]
+  (fn [x] (let [c (:params x)] (shell/sh "sh" "-c" c))))
+`
+	got := analyzeRuleIDs(t, "t.clj", lexctx.LangClojure, src)
+	if want := []string{"TAINT-002"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}

--- a/core/taint/engine/clojure_inline_test.go
+++ b/core/taint/engine/clojure_inline_test.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// A source used INLINE — sanitized on the line that binds it, or passed
+// straight into the sink without a name — is the ordinary Clojure shape.
+// Both needed a Lisp-aware inline scan: the C-like `ident(args)` walk that
+// serves the other languages sees no calls in `(shell/sh "sh" "-c" (:params req))`.
+func TestClojureInlineSource(t *testing.T) {
+	const ns = `(ns app.t
+  (:require [clojure.java.shell :as shell]
+            [clojure.java.jdbc :as jdbc]))
+`
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"parseInt around the source on the binding line", ns + `
+(defn run [req]
+  (let [n (Integer/parseInt (:params req))]
+    (shell/sh "sleep" n)))
+`, nil},
+		{"the raw binding still fires", ns + `
+(defn run [req]
+  (let [n (:params req)]
+    (shell/sh "sleep" n)))
+`, []string{"TAINT-002"}},
+		{"parse-long around a def", ns + `
+(def limit (parse-long (System/getenv "LIMIT")))
+(defn run []
+  (shell/sh "sleep" limit))
+`, nil},
+		{"the raw def fires", ns + `
+(def limit (System/getenv "LIMIT"))
+(defn run []
+  (shell/sh "sleep" limit))
+`, []string{"TAINT-002"}},
+		{"a str wrapping the source is not a sanitizer", ns + `
+(defn run [req]
+  (let [n (str "x" (:params req))]
+    (shell/sh "sleep" n)))
+`, []string{"TAINT-002"}},
+		{"source straight into the sink", ns + `
+(defn run [req]
+  (shell/sh "sh" "-c" (:params req)))
+`, []string{"TAINT-002"}},
+		{"source sanitized straight into the sink", ns + `
+(defn run [req]
+  (shell/sh "sleep" (Integer/parseInt (:params req))))
+`, nil},
+		{"source in a jdbc bind vector is parameterized", ns + `
+(defn run [db req]
+  (jdbc/query db ["select * from t where id = ?" (:params req)]))
+`, nil},
+		// Ring's :body is an InputStream by contract: slurp READS it, it never
+		// opens a path. Measured on ring and reitit, every (slurp (:body …)) —
+		// request or response — was this shape and none was a file read.
+		{"slurp of a request body is request I/O, not a path", ns + `
+(defn read-body [req]
+  (slurp (:body req)))
+`, nil},
+		{"slurp of a bound body is not a path either", ns + `
+(defn read-body [req]
+  (let [body (:body req)]
+    (slurp body)))
+`, nil},
+		{"the body once read still reaches a sql sink", ns + `
+(defn find-user [db req]
+  (let [name (slurp (:body req))]
+    (jdbc/query db (str "select * from users where name = '" name "'"))))
+`, []string{"TAINT-001"}},
+		{"source concatenated into the jdbc query string", ns + `
+(defn run [db req]
+  (jdbc/query db (str "select * from t where id = " (:params req))))
+`, []string{"TAINT-001"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.clj", lexctx.LangClojure, c.src)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("got %v, want %v\n%s", got, c.want, c.src)
+			}
+		})
+	}
+}

--- a/core/taint/engine/dart_shared_test.go
+++ b/core/taint/engine/dart_shared_test.go
@@ -1,0 +1,201 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// Cross-method flow through an INSTANCE FIELD: the source lands in a field in
+// one method and a sink in another reads it. Fields declared in the class body
+// are the syntactically shared names, and they are shared within their class —
+// a same-named field of another class is a different variable.
+func TestDartInstanceFieldJoinsMethods(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"field set in configure, read in run", `import 'dart:io';
+class Fetcher {
+  String target = '';
+
+  void configure() {
+    target = Platform.environment['TARGET'] ?? '';
+  }
+
+  Future<void> run(HttpClient client) async {
+    final req = await client.getUrl(Uri.parse(target));
+    await req.close();
+  }
+}
+`, []string{"TAINT-006"}},
+		{"this. on both sides", `import 'dart:io';
+class Fetcher {
+  late String target;
+
+  void configure() {
+    this.target = Platform.environment['TARGET'] ?? '';
+  }
+
+  Future<void> run(HttpClient client) async {
+    final req = await client.getUrl(Uri.parse(this.target));
+    await req.close();
+  }
+}
+`, []string{"TAINT-006"}},
+		{"top-level variable", `import 'dart:io';
+String target = '';
+
+void configure() {
+  target = Platform.environment['TARGET'] ?? '';
+}
+
+Future<void> run(HttpClient client) async {
+  final req = await client.getUrl(Uri.parse(target));
+  await req.close();
+}
+`, []string{"TAINT-006"}},
+		{"field holds a constant", `import 'dart:io';
+class Fetcher {
+  String target = '';
+
+  void configure() {
+    target = 'https://example.com/';
+  }
+
+  Future<void> run(HttpClient client) async {
+    final req = await client.getUrl(Uri.parse(target));
+    await req.close();
+  }
+}
+`, nil},
+		{"another class's same-named field", `import 'dart:io';
+class Config {
+  String target = '';
+  void load() {
+    target = Platform.environment['TARGET'] ?? '';
+  }
+}
+
+class Fetcher {
+  String target = 'https://example.com/';
+  Future<void> run(HttpClient client) async {
+    final req = await client.getUrl(Uri.parse(target));
+    await req.close();
+  }
+}
+`, nil},
+		{"a local of the same name is not the field", `import 'dart:io';
+class Fetcher {
+  String target = '';
+
+  void configure() {
+    target = Platform.environment['TARGET'] ?? '';
+  }
+
+  Future<void> run(HttpClient client) async {
+    final target = 'https://example.com/';
+    final req = await client.getUrl(Uri.parse(target));
+    await req.close();
+  }
+}
+`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.dart", lexctx.LangDart, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Taint laundered through a CONTAINER: `list.add(tainted)` mutates the list,
+// so a later element read carries the taint (container-level, like an element
+// assignment `list[0] = tainted`).
+func TestDartContainerMutatorBinds(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"list.add then element read", `import 'dart:io';
+Future<void> fetchFirst(HttpClient client) async {
+  final urls = <String>[];
+  urls.add(Platform.environment['TARGET'] ?? '');
+  final req = await client.getUrl(Uri.parse(urls[0]));
+  await req.close();
+}
+`, []string{"TAINT-006"}},
+		{"element assignment", `import 'dart:io';
+Future<void> fetchFirst(HttpClient client) async {
+  final urls = <String, String>{};
+  urls['a'] = Platform.environment['TARGET'] ?? '';
+  final req = await client.getUrl(Uri.parse(urls['a']!));
+  await req.close();
+}
+`, []string{"TAINT-006"}},
+		{"constant added", `import 'dart:io';
+Future<void> fetchFirst(HttpClient client) async {
+  final urls = <String>[];
+  urls.add('https://example.com/');
+  final req = await client.getUrl(Uri.parse(urls[0]));
+  await req.close();
+}
+`, nil},
+		{"tainted value added to an unrelated list", `import 'dart:io';
+Future<void> fetchFirst(HttpClient client) async {
+  final urls = <String>['https://example.com/'];
+  final log = <String>[];
+  log.add(Platform.environment['TARGET'] ?? '');
+  final req = await client.getUrl(Uri.parse(urls[0]));
+  await req.close();
+}
+`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.dart", lexctx.LangDart, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDartDeclaredName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"String target = '';", "target"},
+		{"late String target;", "target"},
+		{"static final List<String> urls = <String>[];", "urls"},
+		{"final Dio dio = Dio();", "dio"},
+		{"Map<String, String> headers = {};", "headers"},
+		{"target = e;", ""},
+		{"Fetcher(this.target);", ""},
+		{"String get target => _target;", ""},
+		{"String f(String x) => x;", ""},
+		{"bool same = a == b;", "same"},
+	}
+	for _, tc := range cases {
+		got, ok := dartDeclaredName(tc.in)
+		if !ok {
+			got = ""
+		}
+		if got != tc.want {
+			t.Errorf("dartDeclaredName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBlankDartThis(t *testing.T) {
+	ll := blankDartThis(logicalLine{code: "this.target = f(this.x, isthis.y)"})
+	if want := "     target = f(     x, isthis.y)"; ll.code != want {
+		t.Fatalf("code = %q, want %q", ll.code, want)
+	}
+}

--- a/core/taint/engine/extract.go
+++ b/core/taint/engine/extract.go
@@ -49,6 +49,11 @@ type stmtDraft struct {
 	// calls.
 	chains   []string
 	sinkArgs map[string]sinkArgDraft
+	// expr is the code view (literals blanked) of the value a binding assigns,
+	// or "" when the extractor has no expression text for it. The engine scans
+	// it for a sanitizer WRAPPING the source, so `n = int(source())` binds n
+	// with command/sql injection cleared instead of tainting it afresh.
+	expr string
 	// returns are the variable names returned by a `return x` / `return a, b`
 	// statement. Empty for non-return statements. The interprocedural summary
 	// pass uses it to decide whether a parameter reaches the function's return.

--- a/core/taint/engine/extract_clojure.go
+++ b/core/taint/engine/extract_clojure.go
@@ -24,12 +24,15 @@ import (
 //
 // HONEST LIMITS (recall is the LOWEST of any supported language, by design — a
 // Lisp is the furthest from the assignment/call model the engine was built for):
-//   - Threading macros (`->`, `->>`, `as->`, `some->`) reorder argument position,
-//     which a positional form recognizer does not follow — a value threaded into a
-//     sink through `->` is missed.
-//   - Higher-order flows (`map`, `apply`, `partial`, `comp`) and destructuring
-//     binds (`{:keys [a b]}`, `[x & xs]`) pass taint through shapes the recognizer
-//     does not model.
+//   - Threading macros (`->`, `->>`, `some->`, `cond->`) are modeled through a
+//     synthetic binding each stage reads and rebinds; `as->` through the name
+//     the author chose. WHAT flows is tracked, not into WHICH argument slot.
+//   - Higher-order DISPATCH (`apply`, `map`) is re-attributed to the dispatched
+//     symbol; higher-order CONSTRUCTION (`partial`, `comp`) is followed through
+//     the `let`/`def` binding that holds the built function (see clojureHOF).
+//     An inline `#(...)`/`fn` literal in either position is not followed.
+//   - Destructuring binds (`{:keys [a b]}`, `[x & xs]`) pass taint through
+//     shapes the recognizer does not model.
 //   - Only a bare-symbol binding target is tracked (`(def x …)`, `(let [x …])`);
 //     a destructuring target is skipped (no field/element sensitivity claimed).
 //
@@ -42,18 +45,127 @@ import (
 func extractClojure(content []byte, regions []lexctx.Region) []unitDraft {
 	code := clojureCodeMask(content, regions)
 	module := &unitDraft{funcName: ""}
-	units := []*unitDraft{module}
+	w := &clojureWalk{units: []*unitDraft{module}, hofs: map[string]clojureHOF{}}
 
 	forms := parseClojureForms(code, 0, len(code))
 	for _, f := range forms {
-		walkClojureForm(code, f, module, &units)
+		walkClojureForm(code, f, module, w)
 	}
 
-	out := make([]unitDraft, 0, len(units))
-	for _, u := range units {
+	out := make([]unitDraft, 0, len(w.units))
+	for _, u := range w.units {
 		out = append(out, *u)
 	}
 	return out
+}
+
+// clojureWalk is the state threaded through the form walk: the units built so
+// far, and the names currently bound to a CONSTRUCTED function (see
+// clojureHOF). hofs is lexically scoped — a `let`/`defn` body works on a copy —
+// so a binding never leaks past the form that made it, while a top-level `def`
+// stays visible to every later form in the file.
+type clojureWalk struct {
+	units []*unitDraft
+	hofs  map[string]clojureHOF
+}
+
+// clojureHOF is a function BUILT by `partial` or `comp` and bound to a name.
+// `apply`/`map` DISPATCH a function and are re-attributed at the dispatch site;
+// `partial` and `comp` instead return a new function that is later invoked
+// through the binding, so the sink never appears as a call head under any name
+// the recognizer tracks. The record keeps what is needed to rewrite the later
+// call `(name args…)` into the calls it actually makes:
+//
+//	(partial f a b)  ⇒  (name x)  ≡  (f a b x)
+//	(comp f g h)     ⇒  (name x)  ≡  (f (g (h x)))
+//
+// Only bare SYMBOLS are recorded — an inline `#(...)`/`fn` literal is left
+// alone — and each symbol still has to BE a catalog sink (or sanitizer) to
+// matter, exactly as at a dispatch site.
+type clojureHOF struct {
+	kind  string        // "partial" or "comp"
+	fns   []clojureForm // partial: the one function; comp: left to right
+	fixed []clojureForm // partial: the pre-supplied leading arguments
+}
+
+// scoped returns a copy of w whose hofs can be extended without affecting the
+// enclosing scope.
+func (w *clojureWalk) scoped() *clojureWalk {
+	inner := &clojureWalk{units: w.units, hofs: make(map[string]clojureHOF, len(w.hofs))}
+	for k, v := range w.hofs {
+		inner.hofs[k] = v
+	}
+	return inner
+}
+
+// clojureHOFConstruction recognizes a `(partial sym fixed…)` / `(comp sym…)`
+// value expression. Every function position must be a bare symbol.
+func clojureHOFConstruction(code []byte, f clojureForm) (clojureHOF, bool) {
+	if f.delim != '(' || len(f.children) < 2 {
+		return clojureHOF{}, false
+	}
+	isSym := func(ch clojureForm) bool {
+		sym := clojureNormalizeCallee(clojureAtomText(code, ch))
+		return ch.delim == 0 && sym != "" && isClojureCalleeStart(sym[0])
+	}
+	switch clojureAtomText(code, f.children[0]) {
+	case "partial":
+		if !isSym(f.children[1]) {
+			return clojureHOF{}, false
+		}
+		return clojureHOF{kind: "partial", fns: f.children[1:2], fixed: f.children[2:]}, true
+	case "comp":
+		for _, ch := range f.children[1:] {
+			if !isSym(ch) {
+				return clojureHOF{}, false
+			}
+		}
+		return clojureHOF{kind: "comp", fns: f.children[1:]}, true
+	}
+	return clojureHOF{}, false
+}
+
+// clojureHOFCall emits the statements a call `(name args…)` to a constructed
+// function actually makes, located at the call site. A partial call is one
+// statement with the fixed arguments prepended; a comp call is a chain
+// applied right to left through a synthetic binding, so a sanitizer in the
+// composition clears the taint before it reaches a sink further left.
+func clojureHOFCall(code []byte, f clojureForm, hof clojureHOF, cur *unitDraft) {
+	line := clojureLine(code, f.children[0].start)
+	args := f.children[1:]
+	if hof.kind == "partial" {
+		kids := append([]clojureForm{hof.fns[0]}, hof.fixed...)
+		if st, ok := clojureCallStatement(code, clojureForm{delim: '(', children: append(kids, args...)}); ok {
+			st.line = line
+			cur.stmts = append(cur.stmts, st)
+		}
+		return
+	}
+	tmp := "__nox_composed_" + strconv.Itoa(line)
+	bind := stmtDraft{line: line, assigns: tmp, sinkArgs: map[string]sinkArgDraft{}}
+	for _, arg := range args {
+		clojureCollectExpr(code, arg, &bind)
+	}
+	clojureFinalizeReads(&bind)
+	cur.stmts = append(cur.stmts, bind)
+	for i := len(hof.fns) - 1; i >= 0; i-- {
+		st, ok := clojureStageStatement(code, hof.fns[i])
+		if !ok {
+			continue
+		}
+		st.line = line
+		st.reads = appendUnique(st.reads, tmp)
+		for _, callee := range st.calls {
+			info := st.sinkArgs[callee]
+			info.taintedArgVars = appendUnique(info.taintedArgVars, tmp)
+			info.positionalVars = append(info.positionalVars, []string{tmp})
+			info.argCount++
+			info.firstArgTainted = true
+			st.sinkArgs[callee] = info
+		}
+		st.assigns = tmp
+		cur.stmts = append(cur.stmts, st)
+	}
 }
 
 // clojureCodeMask returns content with every non-code byte replaced by a space
@@ -157,13 +269,13 @@ func clojureMatchClose(code []byte, open, hi int) int {
 // walkClojureForm dispatches one top-level (or nested body) form to the binding /
 // unit / call recognizers, appending statements to cur (the current unit) and new
 // units to units. Non-list forms carry no statement.
-func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitDraft) {
+func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk) {
 	if f.delim != '(' || len(f.children) == 0 {
 		// A bare vector/map/atom at the top level carries no statement, but a nested
 		// call inside it might — recurse into collection children so a sink buried in
 		// a data literal is still seen.
 		for _, ch := range f.children {
-			walkClojureForm(code, ch, cur, units)
+			walkClojureForm(code, ch, cur, w)
 		}
 		return
 	}
@@ -172,38 +284,52 @@ func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitD
 	case "def", "defonce", "def-":
 		if st, ok := clojureDefStatement(code, f); ok {
 			cur.stmts = append(cur.stmts, st)
+			if len(f.children) >= 3 {
+				if hof, ok := clojureHOFConstruction(code, f.children[2]); ok {
+					w.hofs[st.assigns] = hof
+				}
+			}
 		}
 		// Recurse into the value expression so a call inside it (`(def x (sh …))`)
 		// is also seen as its own statement.
-		walkClojureChildren(code, f, 1, cur, units)
+		walkClojureChildren(code, f, 1, cur, w)
 	case "defn", "defn-", "fn":
 		newUnit := clojureDefnUnit(code, f)
 		if newUnit != nil {
-			*units = append(*units, newUnit)
-			// Walk the body forms into the new unit.
-			walkClojureDefnBody(code, f, newUnit, units)
+			w.units = append(w.units, newUnit)
+			// Walk the body forms into the new unit, in their own scope.
+			walkClojureDefnBody(code, f, newUnit, w.scoped())
 			return
 		}
-		walkClojureChildren(code, f, 1, cur, units)
+		walkClojureChildren(code, f, 1, cur, w)
 	case "let", "let*", "binding", "loop", "when-let", "if-let", "when-some", "if-some", "with-open", "with-local-vars", "for", "doseq":
-		clojureLetForm(code, f, cur, units)
+		clojureLetForm(code, f, cur, w)
 	case "->", "->>", "some->", "some->>", "cond->", "cond->>":
-		clojureThreadingForm(code, f, cur, units)
+		clojureThreadingForm(code, f, cur, w)
+	case "as->":
+		clojureAsThreadForm(code, f, cur, w)
 	default:
+		// A call through a name bound to a constructed function is the calls
+		// that function makes (see clojureHOF).
+		if hof, ok := w.hofs[head]; ok {
+			clojureHOFCall(code, f, hof, cur)
+			walkClojureChildren(code, f, 1, cur, w)
+			return
+		}
 		// An ordinary call `(callee args…)`.
 		if st, ok := clojureCallStatement(code, f); ok {
 			cur.stmts = append(cur.stmts, st)
 		}
 		// Recurse into arguments so nested calls / bindings are also seen.
-		walkClojureChildren(code, f, 1, cur, units)
+		walkClojureChildren(code, f, 1, cur, w)
 	}
 }
 
 // walkClojureChildren recurses into a form's children starting at index from,
 // dispatching each as its own form (so nested calls and bindings surface).
-func walkClojureChildren(code []byte, f clojureForm, from int, cur *unitDraft, units *[]*unitDraft) {
+func walkClojureChildren(code []byte, f clojureForm, from int, cur *unitDraft, w *clojureWalk) {
 	for i := from; i < len(f.children); i++ {
-		walkClojureForm(code, f.children[i], cur, units)
+		walkClojureForm(code, f.children[i], cur, w)
 	}
 }
 
@@ -232,7 +358,7 @@ func clojureDefStatement(code []byte, f clojureForm) (stmtDraft, bool) {
 // form: each name/expr pair in the binding vector becomes a binding statement, and
 // the body forms are walked into cur. A `for`/`doseq` seq-binding vector is handled
 // the same way (the right-hand side of each pair is where a source enters).
-func clojureLetForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitDraft) {
+func clojureLetForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk) {
 	// The binding vector is the first '[' child after the head.
 	var vec *clojureForm
 	bodyStart := len(f.children)
@@ -243,19 +369,20 @@ func clojureLetForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitDr
 			break
 		}
 	}
+	w = w.scoped()
 	if vec != nil {
-		clojureBindingPairs(code, *vec, cur)
+		clojureBindingPairs(code, *vec, cur, w)
 	}
 	// Walk the body forms.
 	for i := bodyStart; i < len(f.children); i++ {
-		walkClojureForm(code, f.children[i], cur, units)
+		walkClojureForm(code, f.children[i], cur, w)
 	}
 }
 
 // clojureBindingPairs walks a binding vector's name/expr pairs (`[a e1 b e2]`) and
 // appends a binding statement per pair whose target is a bare symbol. A pair whose
 // value expression is itself a call/collection has its reads and calls collected.
-func clojureBindingPairs(code []byte, vec clojureForm, cur *unitDraft) {
+func clojureBindingPairs(code []byte, vec clojureForm, cur *unitDraft, w *clojureWalk) {
 	kids := vec.children
 	for i := 0; i+1 < len(kids); i += 2 {
 		name := clojureBindingName(code, kids[i])
@@ -265,6 +392,13 @@ func clojureBindingPairs(code []byte, vec clojureForm, cur *unitDraft) {
 		if name != "" {
 			valStmt.assigns = name
 			cur.stmts = append(cur.stmts, valStmt)
+			// A name bound to a constructed function is remembered for the call
+			// site; a name rebound to anything else shadows an outer record.
+			if hof, ok := clojureHOFConstruction(code, kids[i+1]); ok {
+				w.hofs[name] = hof
+			} else {
+				delete(w.hofs, name)
+			}
 		} else if len(valStmt.calls) > 0 || len(valStmt.reads) > 0 {
 			// Destructuring target we can't name, but the value has a call/read worth
 			// recording (a source-bearing call still matters for a later sink).
@@ -302,7 +436,7 @@ func clojureDefnUnit(code []byte, f clojureForm) *unitDraft {
 
 // walkClojureDefnBody walks the body forms of a defn/fn (everything after the
 // parameter vector) into the unit.
-func walkClojureDefnBody(code []byte, f clojureForm, unit *unitDraft, units *[]*unitDraft) {
+func walkClojureDefnBody(code []byte, f clojureForm, unit *unitDraft, w *clojureWalk) {
 	// Locate the parameter vector, then walk everything after it.
 	vecIdx := -1
 	for i := 1; i < len(f.children); i++ {
@@ -316,7 +450,7 @@ func walkClojureDefnBody(code []byte, f clojureForm, unit *unitDraft, units *[]*
 		from = vecIdx + 1
 	}
 	for i := from; i < len(f.children); i++ {
-		walkClojureForm(code, f.children[i], unit, units)
+		walkClojureForm(code, f.children[i], unit, w)
 	}
 }
 
@@ -782,7 +916,7 @@ var clojureThreadHeads = map[string]bool{
 // argument note (the parameterized-jdbc vector check) therefore does not apply
 // to a threaded stage; that costs precision nowhere in the corpus but is the
 // honest limit of the approximation.
-func clojureThreadingForm(code []byte, f clojureForm, cur *unitDraft, units *[]*unitDraft) {
+func clojureThreadingForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk) {
 	// The threaded value is modeled as a synthetic BINDING that each stage reads
 	// and rebinds. The engine taints a variable at its binding and reports a sink
 	// that READS a tainted variable, so carrying evidence alone was not enough —
@@ -794,25 +928,55 @@ func clojureThreadingForm(code []byte, f clojureForm, cur *unitDraft, units *[]*
 		clojureCollectExpr(code, f.children[1], &bind)
 	}
 	cur.stmts = append(cur.stmts, bind)
-	clojureThreadStages(code, f, 2, tmp, cur, units)
+	clojureThreadStages(code, f, 2, tmp, cur, w)
 	// The initial expression may itself contain calls worth reporting on their
 	// own (`(-> (sh cmd) ...)`), so walk it normally too.
 	if len(f.children) > 1 {
-		walkClojureForm(code, f.children[1], cur, units)
+		walkClojureForm(code, f.children[1], cur, w)
 	}
+}
+
+// clojureAsThreadForm models `(as-> expr name stage…)`: like `->` but the
+// threaded value has the NAME the author chose, and each stage names it
+// explicitly as an ordinary argument. So the value is bound to that name from
+// the initial expression, and every stage rebinds it to the stage's result —
+// the stage's own argument read already carries the name to the sink, and a
+// sanitizing stage clears it for the stages after.
+func clojureAsThreadForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk) {
+	if len(f.children) < 3 {
+		return
+	}
+	name := clojureBindingName(code, f.children[2])
+	if name == "" {
+		walkClojureChildren(code, f, 1, cur, w)
+		return
+	}
+	bind := stmtDraft{line: clojureLine(code, f.start), assigns: name, sinkArgs: map[string]sinkArgDraft{}}
+	clojureCollectExpr(code, f.children[1], &bind)
+	clojureFinalizeReads(&bind)
+	cur.stmts = append(cur.stmts, bind)
+	for _, stage := range f.children[3:] {
+		st, ok := clojureStageStatement(code, stage)
+		if !ok {
+			continue
+		}
+		st.assigns = name
+		cur.stmts = append(cur.stmts, st)
+	}
+	walkClojureForm(code, f.children[1], cur, w)
 }
 
 // clojureThreadStages emits a statement per stage in f.children[from:]. Each
 // stage READS the synthetic threaded variable and REBINDS it to its own result,
 // so the value keeps flowing and a sanitizing stage correctly clears the taint.
-func clojureThreadStages(code []byte, f clojureForm, from int, tmp string, cur *unitDraft, units *[]*unitDraft) {
+func clojureThreadStages(code []byte, f clojureForm, from int, tmp string, cur *unitDraft, w *clojureWalk) {
 	for i := from; i < len(f.children); i++ {
 		stage := f.children[i]
 		if stage.delim == '(' && len(stage.children) > 0 &&
 			clojureThreadHeads[clojureAtomText(code, stage.children[0])] {
 			// A nested threading macro re-threads the same value; all of its
 			// children after the head are stages.
-			clojureThreadStages(code, stage, 1, tmp, cur, units)
+			clojureThreadStages(code, stage, 1, tmp, cur, w)
 			continue
 		}
 		st, ok := clojureStageStatement(code, stage)

--- a/core/taint/engine/extract_clojure.go
+++ b/core/taint/engine/extract_clojure.go
@@ -35,6 +35,14 @@ import (
 //     shapes the recognizer does not model.
 //   - Only a bare-symbol binding target is tracked (`(def x …)`, `(let [x …])`);
 //     a destructuring target is skipped (no field/element sensitivity claimed).
+//   - A `fn` literal used as a let-binding VALUE is not a unit; one in a
+//     `defn` body is (its unit lands in the FILE's list, not the scope's).
+//
+// Closed, and kept closed by the precision suite: a source INSIDE a sink call
+// (`(shell/sh "sh" "-c" (:params req))`) is seen through the call's recorded
+// positional argument text; a sanitizer WRAPPING the source on the binding
+// line clears the binding for its classes (the engine walks `expr` as forms);
+// a top-level `def` is shared state joined into every `defn` that reads it.
 //
 // A miss only weakens RECALL (a false negative), never correctness — an
 // unrecognized form simply yields no statement. Precision is defended: the sinks
@@ -45,18 +53,19 @@ import (
 func extractClojure(content []byte, regions []lexctx.Region) []unitDraft {
 	code := clojureCodeMask(content, regions)
 	module := &unitDraft{funcName: ""}
-	w := &clojureWalk{units: []*unitDraft{module}, hofs: map[string]clojureHOF{}}
+	units := []*unitDraft{module}
+	w := &clojureWalk{units: &units, hofs: map[string]clojureHOF{}, defs: map[string]bool{}}
 
 	forms := parseClojureForms(code, 0, len(code))
 	for _, f := range forms {
 		walkClojureForm(code, f, module, w)
 	}
 
-	out := make([]unitDraft, 0, len(w.units))
-	for _, u := range w.units {
+	out := make([]unitDraft, 0, len(units))
+	for _, u := range units {
 		out = append(out, *u)
 	}
-	return out
+	return joinSharedState(out, w.defs)
 }
 
 // clojureWalk is the state threaded through the form walk: the units built so
@@ -65,8 +74,15 @@ func extractClojure(content []byte, regions []lexctx.Region) []unitDraft {
 // so a binding never leaks past the form that made it, while a top-level `def`
 // stays visible to every later form in the file.
 type clojureWalk struct {
-	units []*unitDraft
+	// units is shared by every scope: a unit opened inside a scoped walk (a
+	// `fn` in a defn body) must land in the file's unit list, not in a copy.
+	units *[]*unitDraft
 	hofs  map[string]clojureHOF
+	// defs are the names bound by a top-level `def`/`defonce`: file-wide shared
+	// state that every defn reading the name joins (see joinSharedState), so
+	// `(def limit (System/getenv "LIMIT"))` reaches `(shell/sh "sleep" limit)`
+	// in a function that never calls anything.
+	defs map[string]bool
 }
 
 // clojureHOF is a function BUILT by `partial` or `comp` and bound to a name.
@@ -91,7 +107,7 @@ type clojureHOF struct {
 // scoped returns a copy of w whose hofs can be extended without affecting the
 // enclosing scope.
 func (w *clojureWalk) scoped() *clojureWalk {
-	inner := &clojureWalk{units: w.units, hofs: make(map[string]clojureHOF, len(w.hofs))}
+	inner := &clojureWalk{units: w.units, hofs: make(map[string]clojureHOF, len(w.hofs)), defs: w.defs}
 	for k, v := range w.hofs {
 		inner.hofs[k] = v
 	}
@@ -284,6 +300,9 @@ func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk)
 	case "def", "defonce", "def-":
 		if st, ok := clojureDefStatement(code, f); ok {
 			cur.stmts = append(cur.stmts, st)
+			if cur == (*w.units)[0] {
+				w.defs[st.assigns] = true
+			}
 			if len(f.children) >= 3 {
 				if hof, ok := clojureHOFConstruction(code, f.children[2]); ok {
 					w.hofs[st.assigns] = hof
@@ -296,7 +315,7 @@ func walkClojureForm(code []byte, f clojureForm, cur *unitDraft, w *clojureWalk)
 	case "defn", "defn-", "fn":
 		newUnit := clojureDefnUnit(code, f)
 		if newUnit != nil {
-			w.units = append(w.units, newUnit)
+			*w.units = append(*w.units, newUnit)
 			// Walk the body forms into the new unit, in their own scope.
 			walkClojureDefnBody(code, f, newUnit, w.scoped())
 			return
@@ -349,6 +368,7 @@ func clojureDefStatement(code []byte, f clojureForm) (stmtDraft, bool) {
 	// The value expression is the third child onward (usually one).
 	if len(f.children) >= 3 {
 		clojureCollectExpr(code, f.children[2], &st)
+		st.expr = clojureFormText(code, f.children[2])
 	}
 	clojureFinalizeReads(&st)
 	return st, true
@@ -391,6 +411,7 @@ func clojureBindingPairs(code []byte, vec clojureForm, cur *unitDraft, w *clojur
 		clojureFinalizeReads(&valStmt)
 		if name != "" {
 			valStmt.assigns = name
+			valStmt.expr = clojureFormText(code, kids[i+1])
 			cur.stmts = append(cur.stmts, valStmt)
 			// A name bound to a constructed function is remembered for the call
 			// site; a name rebound to anything else shadows an outer record.
@@ -496,15 +517,19 @@ func clojureCallStatement(code []byte, f clojureForm) (stmtDraft, bool) {
 	for i := argStart; i < len(f.children); i++ {
 		arg := f.children[i]
 		var vars []string
+		argText := ""
 		if jdbcParam && arg.delim == '[' && clojureVectorIsParamBind(code, arg) {
 			// Parameterized bind vector: its values are safe placeholders, not
 			// interpolated SQL. Record an empty slot so the argument shape still
-			// counts the positional but carries no tainted var.
+			// counts the positional but carries no tainted var — and no argument
+			// text, so an inline source inside the vector is not scanned either.
 			vars = nil
 		} else {
 			vars = clojureExprVars(code, arg)
+			argText = clojureFormText(code, arg)
 		}
 		info.positionalVars = append(info.positionalVars, append([]string(nil), vars...))
+		info.positionalArgs = append(info.positionalArgs, argText)
 		info.argCount++
 		for _, v := range vars {
 			if _, dup := seen[v]; !dup {
@@ -773,6 +798,16 @@ func clojureAtomText(code []byte, f clojureForm) string {
 		return ""
 	}
 	return strings.TrimSpace(string(code[f.start:f.end]))
+}
+
+// clojureFormText returns the masked source text of one form (an atom or a
+// whole bracketed form), the expression view the engine's inline-source scan
+// re-parses. Literals are already blanked in the mask.
+func clojureFormText(code []byte, f clojureForm) string {
+	if f.start < 0 || f.end > len(code) || f.start >= f.end {
+		return ""
+	}
+	return string(code[f.start:f.end])
 }
 
 // clojureNormalizeCallee maps a Clojure symbol head to the catalog call key. A

--- a/core/taint/engine/extract_dart.go
+++ b/core/taint/engine/extract_dart.go
@@ -27,8 +27,10 @@ import "strings"
 //     still captured, but the member is not opened as its own named unit.
 //   - Cascades (`..method()`), null-aware chains (`?.`), and `await`/`Future`
 //     laundering are recognized only as far as their argument reads; a value
-//     laundered through an async callback is not tracked. These gaps are recorded
-//     as honest FNs in testdata/precision-suite-dart/README.md.
+//     laundered through an async callback is not tracked.
+//   - Cross-method flow through a class FIELD or a top-level variable IS joined
+//     (see sharedstate.go): fields are shared per class, top-level names per
+//     file. The join is flow-insensitive across methods.
 //   - A typed function PARAMETER arriving as untrusted input (a shelf `Request`)
 //     is not a source CALL, so it is not tainted from its type — the same
 //     documented gap as the other web extractors.
@@ -39,14 +41,43 @@ func extractDart(lines []logicalLine) []unitDraft {
 
 	// depth is the running brace nesting. funDepth is the depth at which the
 	// current function body lives (-1 when at module scope); when depth falls back
-	// to funDepth the function has closed and scope returns to the module.
+	// to funDepth the function has closed and scope returns to the enclosing
+	// class body or the module.
 	depth := 0
 	funDepth := -1
+
+	// Shared state (see sharedstate.go). A top-level variable is shared by every
+	// unit in the file; an instance/static FIELD is shared by the methods of its
+	// class only, so the same field name in two classes stays two variables.
+	// Each open class carries its own body unit (field initializers) and its
+	// field set; on `}` the class's units are joined and the frame is popped.
+	topShared := map[string]bool{}
+	var classes []*dartClassFrame
+	scopeUnit := func() *unitDraft {
+		if n := len(classes); n > 0 {
+			return classes[n-1].body
+		}
+		return module
+	}
+	closeClasses := func(depth int) {
+		for len(classes) > 0 {
+			fr := classes[len(classes)-1]
+			if depth > fr.depth {
+				return
+			}
+			classes = classes[:len(classes)-1]
+			joinUnitRange(units, fr.start, len(units), fr.fields)
+		}
+	}
 
 	for _, ll := range lines {
 		trimmed := strings.TrimSpace(ll.code)
 		if trimmed == "" {
 			continue
+		}
+		if len(classes) > 0 {
+			ll = blankDartThis(ll)
+			trimmed = strings.TrimSpace(ll.code)
 		}
 
 		// A `return ...` line is a statement, never a header — check it first so a
@@ -56,7 +87,7 @@ func extractDart(lines []logicalLine) []unitDraft {
 			before := depth
 			depth += braceDelta(trimmed)
 			if funDepth >= 0 && before > funDepth && depth <= funDepth {
-				cur = module
+				cur = scopeUnit()
 				funDepth = -1
 			}
 			continue
@@ -74,16 +105,44 @@ func extractDart(lines []logicalLine) []unitDraft {
 			continue
 		}
 
+		// A class-like header opens a frame: its body unit collects the field
+		// initializers, and its methods join through the fields it declares.
+		if funDepth < 0 && isDartClassHead(trimmed) {
+			body := &unitDraft{funcName: ""}
+			classes = append(classes, &dartClassFrame{
+				depth: depth, start: len(units), body: body, fields: map[string]bool{},
+			})
+			units = append(units, body)
+			cur = body
+			depth += braceDelta(trimmed)
+			continue
+		}
+
 		before := depth
 		depth += braceDelta(trimmed)
 		closesFun := funDepth >= 0 && before > funDepth && depth <= funDepth
 
 		if isDartStructuralLine(trimmed) {
 			if closesFun {
-				cur = module
 				funDepth = -1
 			}
+			closeClasses(depth)
+			if funDepth < 0 {
+				cur = scopeUnit()
+			}
 			continue
+		}
+
+		// A declaration directly in a class body (a field) or at the top level
+		// (a global) names shared state.
+		if funDepth < 0 {
+			if name, ok := dartDeclaredName(trimmed); ok {
+				if n := len(classes); n > 0 && before == classes[n-1].depth+1 {
+					classes[n-1].fields[name] = true
+				} else if n == 0 && before == 0 {
+					topShared[name] = true
+				}
+			}
 		}
 
 		if st, ok := recognizeStatement(langDart, ll); ok {
@@ -91,16 +150,105 @@ func extractDart(lines []logicalLine) []unitDraft {
 		}
 
 		if closesFun {
-			cur = module
+			cur = scopeUnit()
 			funDepth = -1
 		}
 	}
+	closeClasses(0)
 
 	out := make([]unitDraft, 0, len(units))
 	for _, u := range units {
 		out = append(out, *u)
 	}
-	return out
+	return joinSharedState(out, topShared)
+}
+
+// dartClassFrame is one open class-like body: the brace depth of its header,
+// the index of its first unit (its body unit), and the fields it declares.
+type dartClassFrame struct {
+	depth  int
+	start  int
+	body   *unitDraft
+	fields map[string]bool
+}
+
+// joinUnitRange runs joinSharedState over units[start:end] in place, so the
+// join is scoped to one class's body and methods.
+func joinUnitRange(units []*unitDraft, start, end int, shared map[string]bool) {
+	if len(shared) == 0 || end-start < 2 {
+		return
+	}
+	drafts := make([]unitDraft, 0, end-start)
+	for _, u := range units[start:end] {
+		drafts = append(drafts, *u)
+	}
+	drafts = joinSharedState(drafts, shared)
+	for i := range drafts {
+		*units[start+i] = drafts[i]
+	}
+}
+
+// isDartClassHead reports whether trimmed opens a class, mixin, enum, or
+// extension body (`[abstract|base|final|sealed|interface] class Name ... {`).
+func isDartClassHead(trimmed string) bool {
+	if !strings.HasSuffix(trimmed, "{") {
+		return false
+	}
+	for _, kw := range []string{
+		"class ", "abstract class ", "base class ", "final class ", "sealed class ",
+		"interface class ", "abstract base class ", "abstract final class ",
+		"abstract interface class ", "mixin ", "mixin class ", "base mixin ",
+		"enum ", "extension ", "extension type ",
+	} {
+		if strings.HasPrefix(trimmed, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// dartDeclaredName returns the variable a declaration line declares:
+// `[static] [late] [final|const|var|Type] name [= expr];`. A member with a
+// parameter list or an arrow body (`String f(x) => ...`, `Fetcher(this.x);`, a
+// getter `String get x => ...`) is not a variable, and a bare reassignment
+// (`x = e;`, no type or keyword) declares nothing.
+func dartDeclaredName(trimmed string) (string, bool) {
+	decl := strings.TrimSuffix(trimmed, ";")
+	if eq := strings.IndexByte(decl, '='); eq >= 0 {
+		// splitAssignment strips the type; require that a type or keyword was
+		// there, and that the target is neither a parameter list nor an arrow
+		// member (`String get x => ...`).
+		lhs, _ := splitAssignment(langDart, decl)
+		head := strings.TrimSpace(decl[:eq])
+		if lhs == "" || head == lhs || strings.ContainsRune(head, '(') || strings.HasPrefix(decl[eq:], "=>") {
+			return "", false
+		}
+		return lhs, true
+	}
+	if strings.ContainsAny(decl, "(=>") {
+		return "", false
+	}
+	name := stripDartDeclType(decl)
+	if name == strings.TrimSpace(decl) || !isBareIdent(name) || isKeyword(name) {
+		return "", false
+	}
+	return name, true
+}
+
+// blankDartThis blanks an explicit `this.` receiver in the code view so
+// `this.target = e` binds and `f(this.target)` reads the same bare field name
+// the implicit form uses. Offsets are preserved (the raw view is untouched).
+func blankDartThis(ll logicalLine) logicalLine {
+	code := []byte(ll.code)
+	for i := 0; i+5 <= len(code); i++ {
+		if string(code[i:i+5]) != "this." || (i > 0 && isIdentPart(code[i-1])) {
+			continue
+		}
+		copy(code[i:i+5], "     ")
+		i += 4
+	}
+	ll.code = string(code)
+	return ll
 }
 
 // dartFuncHeader returns the function/method name and its positional+named

--- a/core/taint/engine/extract_shell.go
+++ b/core/taint/engine/extract_shell.go
@@ -60,23 +60,8 @@ func extractShell(lines []logicalLine) []unitDraft {
 		// recognized normally.
 		if decl, ok := stripShellDeclPrefix(ll); ok {
 			ll = decl
-			trimmed = strings.TrimSpace(ll.code)
 		}
-		if isShellStructuralLine(trimmed) {
-			continue
-		}
-		if sts, ok := shellReadStatements(ll); ok {
-			cur.stmts = append(cur.stmts, sts...)
-			continue
-		}
-		if st, ok := shellAssignment(ll); ok {
-			cur.stmts = append(cur.stmts, st)
-			continue
-		}
-		if st, ok := shellCommand(ll); ok {
-			cur.stmts = append(cur.stmts, st)
-			continue
-		}
+		cur.stmts = append(cur.stmts, shellPipelineStatements(ll)...)
 	}
 
 	out := make([]unitDraft, 0, len(units))
@@ -84,6 +69,173 @@ func extractShell(lines []logicalLine) []unitDraft {
 		out = append(out, *u)
 	}
 	return out
+}
+
+// shellPipelineStatements recognizes one logical line as a PIPELINE: each
+// top-level `|` segment is a command of its own, and the value written by the
+// segments upstream of a command arrives on its stdin. For most commands stdin
+// is mere data, but two shapes turn it into the thing a sink acts on: `xargs`
+// hands it to the command it invokes as ARGUMENTS, and a bare `sh`/`bash`
+// executes it as a SCRIPT. The reads of every upstream segment (variables and
+// inline sources alike) are therefore carried down the pipeline and, at such a
+// consumer, become a tainted argument slot of the sink. A line without a pipe
+// is a single segment and behaves exactly as before.
+func shellPipelineStatements(ll logicalLine) []stmtDraft {
+	var out []stmtDraft
+	var piped *shellPipe
+	for k, seg := range shellPipelineSegments(ll) {
+		sts := shellSegmentStatements(seg, piped)
+		out = append(out, sts...)
+		if k == 0 {
+			piped = &shellPipe{}
+		}
+		piped.absorb(seg, sts)
+	}
+	return out
+}
+
+// shellSegmentStatements recognizes one pipeline segment. piped is nil for the
+// first segment (nothing is upstream of it).
+func shellSegmentStatements(seg logicalLine, piped *shellPipe) []stmtDraft {
+	seg = stripShellLoopReadHeader(seg)
+	trimmed := strings.TrimSpace(seg.code)
+	if trimmed == "" || isShellStructuralLine(trimmed) {
+		return nil
+	}
+	if sts, ok := shellReadStatements(seg); ok {
+		return sts
+	}
+	if st, ok := shellAssignment(seg); ok {
+		return []stmtDraft{st}
+	}
+	if st, ok := shellCommand(seg, piped); ok {
+		return []stmtDraft{st}
+	}
+	return nil
+}
+
+// shellPipe is the value flowing down a pipeline: the named variables read by
+// the segments upstream and the code text of those segments (so an inline
+// source such as `$1` or `$QUERY_STRING` written upstream is found by the
+// inline-source scan exactly as it would be in an argument word). It
+// accumulates across segments rather than resetting at each, because a filter
+// in between (`grep`, `sort`, `tr`, …) passes the data through.
+type shellPipe struct {
+	vars []string
+	code []string
+}
+
+func (p *shellPipe) absorb(seg logicalLine, sts []stmtDraft) {
+	for _, st := range sts {
+		for _, v := range st.reads {
+			p.vars = appendUnique(p.vars, v)
+		}
+	}
+	if strings.TrimSpace(seg.code) != "" {
+		p.code = append(p.code, seg.code)
+	}
+}
+
+// shellPipelineSegments splits a logical line at its top-level pipes. A `|`
+// inside `(...)` or `$(...)` belongs to the subshell, `||` is the OR operator,
+// and `|&` pipes stderr too. Literal contents are blanked in the code view, so
+// a `|` inside a string is never seen. Offsets are preserved: each segment's
+// code and raw views are slices at the same positions, so the alignment the
+// recognizer relies on survives.
+func shellPipelineSegments(ll logicalLine) []logicalLine {
+	code := ll.code
+	aligned := len(code) == len(ll.raw)
+	var segs []logicalLine
+	depth, start := 0, 0
+	cut := func(end, next int) {
+		seg := logicalLine{line: ll.line, code: code[start:end], raw: code[start:end]}
+		if aligned {
+			seg.raw = ll.raw[start:end]
+		}
+		segs = append(segs, seg)
+		start = next
+	}
+	for i := 0; i < len(code); i++ {
+		switch code[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case '|':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < len(code) && code[i+1] == '|' {
+				i++ // the OR operator, not a pipe
+				continue
+			}
+			next := i + 1
+			if next < len(code) && code[next] == '&' {
+				next++
+			}
+			cut(i, next)
+			i = next - 1
+		}
+	}
+	cut(len(code), len(code))
+	return segs
+}
+
+// stripShellLoopReadHeader turns `while read -r line; do` (and `until …`) into
+// the `read -r line` it wraps, blanking the keyword and the trailing `; do` to
+// spaces so offsets hold. A loop header is otherwise structural scaffolding and
+// skipped, which lost the variable the loop reads into — and with it every
+// `cmd | while read -r line; do eval "$line"` flow.
+func stripShellLoopReadHeader(ll logicalLine) logicalLine {
+	code := ll.code
+	i := 0
+	for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+		i++
+	}
+	rest := code[i:]
+	var kw string
+	switch {
+	case strings.HasPrefix(rest, "while "):
+		kw = "while "
+	case strings.HasPrefix(rest, "until "):
+		kw = "until "
+	default:
+		return ll
+	}
+	j := i + len(kw)
+	for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+		j++
+	}
+	// An `IFS=` style prefix is allowed before the read.
+	j += skipShellLeadingAssignments(code[j:])
+	for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+		j++
+	}
+	if !strings.HasPrefix(code[j:], "read ") && strings.TrimSpace(code[j:]) != "read" {
+		return ll
+	}
+	blank := func(s string, from, to int) string {
+		return s[:from] + strings.Repeat(" ", to-from) + s[to:]
+	}
+	code = blank(code, i, j)
+	raw := ll.raw
+	if len(raw) == len(ll.code) {
+		raw = blank(raw, i, j)
+	}
+	// Trailing `; do` / `;do` / ` do`.
+	if end := strings.LastIndex(code, "do"); end >= 0 && strings.TrimSpace(code[end+2:]) == "" {
+		k := end
+		for k > 0 && (code[k-1] == ' ' || code[k-1] == '\t' || code[k-1] == ';') {
+			k--
+		}
+		code = blank(code, k, len(code))
+		if len(raw) == len(code) {
+			raw = blank(raw, k, len(raw))
+		}
+	}
+	return logicalLine{line: ll.line, code: code, raw: raw}
 }
 
 // shellReadStatements recognizes a `read [flags] var1 var2 …` builtin, which
@@ -342,7 +494,7 @@ func splitShellAssignment(code string) (name string, valueStart int, ok bool) {
 // positional slots, whether the first argument carries a tainted value) that the
 // engine's per-sink danger logic consumes. Returns ok=false for a line with no
 // command word.
-func shellCommand(ll logicalLine) (stmtDraft, bool) {
+func shellCommand(ll logicalLine, piped *shellPipe) (stmtDraft, bool) {
 	code := ll.code
 	raw := ll.raw
 	aligned := len(code) == len(raw)
@@ -378,9 +530,21 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 			return stmtDraft{}, false
 		}
 	}
-	// Normalize a leading `command`/`builtin`/`exec` wrapper to its target so
-	// `command eval x` still resolves eval.
-	// (Kept simple: only the bare callee is used.)
+	// A transparent wrapper (`sudo`, `env`, `nohup`, `timeout N`, `command`,
+	// `xargs`, …) runs the command after it: that command is the callee, and
+	// the wrapper's own flags are skipped. `xargs` additionally turns the piped
+	// stdin into arguments of the command it invokes.
+	viaXargs := false
+	for shellWrapperFlags[callee] != nil {
+		inner, next, ok := shellUnwrapWrapper(callee, code, i)
+		if !ok {
+			break
+		}
+		if callee == "xargs" {
+			viaXargs = true
+		}
+		callee, i = inner, next
+	}
 
 	// `exec` with a REDIRECTION and no command word (`exec 200>"$f"`, `exec >log`)
 	// rebinds the shell's own file descriptors — it executes nothing, so a tainted
@@ -394,7 +558,7 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 	// Collect the positional arguments (space-separated words) with quoting info.
 	rawArgsSeg := ""
 	if aligned && i <= len(raw) {
-		rawArgsSeg = raw[i:]
+		rawArgsSeg = shellStripTrailingComment(code[i:], raw[i:])
 	}
 	args := splitShellArgs(code[i:], rawArgsSeg)
 
@@ -431,6 +595,14 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 			skipNext = true
 		}
 		info.positionalVars = append(info.positionalVars, append([]string(nil), vars...))
+		// The slot's code text lets the engine spot a SOURCE used directly as
+		// the argument (`eval "$@"`, `curl "$QUERY_STRING"`), which binds no
+		// variable. A single-quoted word is inert and carries nothing.
+		argCode := ""
+		if !a.singleQuote {
+			argCode = a.code
+		}
+		info.positionalArgs = append(info.positionalArgs, argCode)
 		if len(vars) > 0 {
 			info.argCount++
 		}
@@ -450,6 +622,27 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 	if info.argCount == 0 {
 		info.argCount = len(args)
 	}
+	// The piped-in value becomes an argument of the command when `xargs`
+	// invokes it, and the executed script when a bare `sh`/`bash` reads it.
+	if piped != nil && (viaXargs || shellExecutesStdin(callee, args, hasDashC)) {
+		slot := len(info.positionalVars)
+		info.positionalVars = append(info.positionalVars, append([]string(nil), piped.vars...))
+		info.positionalArgs = append(info.positionalArgs, strings.Join(piped.code, " "))
+		info.argCount++
+		for _, v := range piped.vars {
+			if _, dup := seen[v]; !dup {
+				seen[v] = struct{}{}
+				info.taintedArgVars = append(info.taintedArgVars, v)
+				allReads = append(allReads, v)
+			}
+		}
+		if slot == 0 && len(piped.vars) > 0 {
+			info.firstArgTainted = true
+		}
+		if !viaXargs {
+			hasDashC = true // stdin IS the command line being executed
+		}
+	}
 	sortStrings(info.taintedArgVars)
 	info.shellTrue = hasDashC
 
@@ -462,6 +655,107 @@ func shellCommand(ll logicalLine) (stmtDraft, bool) {
 		return stmtDraft{}, false
 	}
 	return st, true
+}
+
+// shellWrapperFlags lists the transparent wrapper commands and, for each, the
+// flags that take a separate value (so the value is skipped too, not read as
+// the inner command). `xargs -I{}` with the value attached is one word and is
+// skipped as a plain flag. `timeout` takes its duration as a bare word, handled
+// in shellUnwrapWrapper.
+var shellWrapperFlags = map[string]map[string]bool{
+	"xargs": {
+		"-I": true, "-n": true, "-P": true, "-L": true, "-d": true, "-s": true,
+		"-E": true, "-a": true, "--max-args": true, "--max-procs": true,
+		"--max-lines": true, "--replace": true, "--delimiter": true,
+		"--arg-file": true, "--max-chars": true, "--eof": true,
+	},
+	"sudo": {
+		"-u": true, "-g": true, "-U": true, "-h": true, "-p": true, "-C": true,
+		"-r": true, "-t": true, "-T": true, "--user": true, "--group": true,
+	},
+	"env":     {"-u": true, "-C": true, "-S": true, "--unset": true, "--chdir": true},
+	"nice":    {"-n": true, "--adjustment": true},
+	"timeout": {"-s": true, "-k": true, "--signal": true, "--kill-after": true},
+	"nohup":   {},
+	"command": {},
+	"builtin": {},
+	"time":    {},
+}
+
+// shellUnwrapWrapper skips the wrapper's flags (and `NAME=value` environment
+// words) after code[i:] and returns the inner command name and the offset just
+// past it. ok=false when no command word follows (`sudo -v`, a bare `xargs`).
+func shellUnwrapWrapper(wrapper, code string, i int) (inner string, next int, ok bool) {
+	valueFlags := shellWrapperFlags[wrapper]
+	needDuration := wrapper == "timeout"
+	for {
+		for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+			i++
+		}
+		if i >= len(code) {
+			return "", i, false
+		}
+		start := i
+		for i < len(code) && code[i] != ' ' && code[i] != '\t' {
+			i++
+		}
+		word := code[start:i]
+		switch {
+		case word == "--":
+			continue
+		case strings.HasPrefix(word, "-"):
+			if valueFlags[word] {
+				// The value is the next word; skip it.
+				for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+					i++
+				}
+				for i < len(code) && code[i] != ' ' && code[i] != '\t' {
+					i++
+				}
+			}
+			continue
+		case strings.Contains(word, "="):
+			continue // an environment assignment word
+		case needDuration:
+			needDuration = false
+			continue
+		}
+		name := shellCalleeName(word)
+		if name == "" || !isShellIdentStart(name[0]) {
+			return "", i, false
+		}
+		return name, i, true
+	}
+}
+
+// shellExecutesStdin reports whether a shell invoked at the end of a pipe runs
+// what it reads: a bare `sh`/`bash` (optionally `-s`, or other flags) with no
+// script word and no `-c` executes its stdin as a script. `sh script.sh` and
+// `sh -c 'fixed'` do not — stdin is data to them.
+func shellExecutesStdin(callee string, args []shellArg, hasDashC bool) bool {
+	if hasDashC || (callee != "sh" && callee != "bash") {
+		return false
+	}
+	for _, a := range args {
+		if !strings.HasPrefix(strings.TrimSpace(a.raw), "-") {
+			return false
+		}
+	}
+	return true
+}
+
+// shellStripTrailingComment cuts a trailing `# comment` off the raw view of an
+// argument list. The code view already blanks it, but the raw view (which the
+// argument splitter reads for quoting) still carries the words, and they were
+// counted as arguments: `sh # runs stdin` looked like `sh` with three script
+// words. A `#` that the code view keeps (`$#`, `${#x}`) is not a comment.
+func shellStripTrailingComment(code, raw string) string {
+	for i := 0; i < len(raw) && i < len(code); i++ {
+		if raw[i] == '#' && code[i] == ' ' && (i == 0 || raw[i-1] == ' ' || raw[i-1] == '\t') {
+			return raw[:i]
+		}
+	}
+	return raw
 }
 
 // shellFetchCommands are the URL-fetching commands whose SSRF sink is controlled
@@ -761,6 +1055,55 @@ func shellCommandSubCallees(code string) []string {
 			}
 		}
 		i = inner
+	}
+	return out
+}
+
+// shellCommandSub is one `$(cmd …)` command substitution: the text of the
+// whole substitution, the command it runs, and the text inside the parens.
+type shellCommandSub struct {
+	text   string
+	callee string
+	inner  string
+}
+
+// shellCommandSubs returns the top-level `$(...)` substitutions in code, in
+// order. Nested substitutions stay inside their parent's inner text so a
+// caller recursing into it sees them in turn. Backtick substitutions are not
+// nestable and are left to shellCommandSubCallees.
+func shellCommandSubs(code string) []shellCommandSub {
+	var out []shellCommandSub
+	n := len(code)
+	for i := 0; i+1 < n; i++ {
+		if code[i] != '$' || code[i+1] != '(' {
+			continue
+		}
+		depth := 0
+		end := -1
+		for j := i + 1; j < n; j++ {
+			switch code[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end = j
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			break
+		}
+		inner := code[i+2 : end]
+		callee := ""
+		if names := shellCommandSubCallees(code[i : end+1]); len(names) > 0 {
+			callee = names[0]
+		}
+		out = append(out, shellCommandSub{text: code[i : end+1], callee: callee, inner: inner})
+		i = end
 	}
 	return out
 }

--- a/core/taint/engine/imports_test.go
+++ b/core/taint/engine/imports_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/nox-hq/nox/core/lexctx"
@@ -180,6 +181,50 @@ func TestClojureCanonicalShellAliasResolves(t *testing.T) {
 		if got != "clojure.java.shell/sh" {
 			t.Errorf(":as %s → %q, want clojure.java.shell/sh", alias, got)
 		}
+	}
+}
+
+// A call written once is one sink, however many catalog spellings resolve for
+// it. Resolution ADDS the qualified form beside the alias, and the Clojure
+// catalog enumerates `shell/sh` beside `clojure.java.shell/sh`, so before the
+// per-statement key in forwardPass both entries matched and the one command
+// injection was reported twice — measured as a 0.91 precision on a corpus with
+// no false positive in it.
+func TestAliasAndQualifiedFormAreOneFlow(t *testing.T) {
+	cases := []struct {
+		name, path string
+		lang       lexctx.Lang
+		src        string
+		wantCalls  []string
+	}{
+		{"clojure alias enumerated by the catalog", "t.clj", lexctx.LangClojure,
+			"(ns t (:require [clojure.java.shell :as shell]))\n(defn run [req]\n  (let [n (:params req)]\n    (shell/sh \"sleep\" n)))\n",
+			[]string{"shell/sh"}},
+		{"clojure alias only resolution knows", "t.clj", lexctx.LangClojure,
+			"(ns t (:require [clojure.java.shell :as sh2]))\n(defn run [req]\n  (let [n (:params req)]\n    (sh2/sh \"sleep\" n)))\n",
+			[]string{"clojure.java.shell/sh"}},
+		{"python module alias", "t.py", lexctx.LangPython,
+			"import os as o\ndef h():\n    c = request.args.get('c')\n    o.system(c)\n",
+			[]string{"os.system"}},
+		// The key is per (rule, source): two values reaching two sinks of the
+		// same rule on one line are still two flows, one per value.
+		{"two sources into two sinks on one line stay two flows", "t.py", lexctx.LangPython,
+			"import os, subprocess\ndef h():\n    a = request.args.get('a')\n    b = request.args.get('b')\n    os.system(a); subprocess.call(b, shell=True)\n",
+			[]string{"os.system", "subprocess.call"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			eng := NewStructuralEngine(nil)
+			flows := eng.AnalyzeFile(ExtractUnits(c.path, c.lang, []byte(c.src)))
+			var got []string
+			for i := range flows {
+				got = append(got, flows[i].SinkCall)
+			}
+			sortStrings(got)
+			if !reflect.DeepEqual(got, c.wantCalls) {
+				t.Fatalf("sink calls = %v, want %v", got, c.wantCalls)
+			}
+		})
 	}
 }
 

--- a/core/taint/engine/recognize.go
+++ b/core/taint/engine/recognize.go
@@ -84,6 +84,17 @@ func recognizeStatement(lang langKind, ll logicalLine) (st stmtDraft, ok bool) {
 
 	st.chains = dottedChains(exprCode)
 
+	// A mutator call on a container is a store into it (see containerMutators).
+	if st.assigns == "" {
+		if root, ok := containerMutationRoot(lang, code); ok {
+			st.assigns = root
+			if _, seen := reads[root]; !seen {
+				st.reads = append(st.reads, root)
+				sortStrings(st.reads)
+			}
+		}
+	}
+
 	if st.assigns == "" && len(st.calls) == 0 && len(st.reads) == 0 {
 		return stmtDraft{}, false
 	}
@@ -482,6 +493,45 @@ func dottedAssignRoot(left string) (string, bool) {
 // corpus demands it.
 var containerTaintLangs = map[langKind]bool{
 	langPerl: true,
+	langDart: true,
+}
+
+// containerMutators are, per language, the methods that MUTATE their receiver
+// container in place (`urls.add(x)`, `buf.write(x)`). A call to one is a store
+// into the container with no `=` for splitAssignment to see, so before this the
+// taint was lost at the store exactly as it was for `list[0] = x` before
+// containerTaintLangs. The statement is modeled as a rebinding of the receiver
+// that also READS it (`urls = urls.add(x)`): taint already in the container is
+// kept, taint in the arguments is added. Container-level and field-insensitive,
+// like containerTaintLangs, and enabled per language as a corpus demands it.
+var containerMutators = map[langKind]map[string]bool{
+	langDart: {
+		"add": true, "addAll": true, "insert": true, "insertAll": true,
+		"addEntries": true, "write": true, "writeln": true, "writeAll": true,
+	},
+}
+
+// containerMutationRoot returns the receiver of a whole-statement mutator call
+// (`urls.add(x)` -> `urls`). The statement must be exactly `IDENT.method(...)`
+// with the call's parenthesis closing the statement, so a chained or nested
+// call (`urls.add(x).length`, `f(urls.add(x))`) yields ok=false rather than a
+// misattributed binding.
+func containerMutationRoot(lang langKind, code string) (string, bool) {
+	mutators := containerMutators[lang]
+	if mutators == nil {
+		return "", false
+	}
+	code = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(code), ";"))
+	dot := strings.IndexByte(code, '.')
+	open := strings.IndexByte(code, '(')
+	if dot <= 0 || open < dot+2 {
+		return "", false
+	}
+	root, method := code[:dot], code[dot+1:open]
+	if !isBareIdent(root) || isKeyword(root) || !mutators[method] {
+		return "", false
+	}
+	return root, matchParen(code, open) == len(code)-1
 }
 
 // containerAssignRoot returns the container name of an element-assignment target

--- a/core/taint/engine/recognize.go
+++ b/core/taint/engine/recognize.go
@@ -98,6 +98,9 @@ func recognizeStatement(lang langKind, ll logicalLine) (st stmtDraft, ok bool) {
 	if st.assigns == "" && len(st.calls) == 0 && len(st.reads) == 0 {
 		return stmtDraft{}, false
 	}
+	if st.assigns != "" {
+		st.expr = exprCode
+	}
 	return st, true
 }
 

--- a/core/taint/engine/shell_pipeline_test.go
+++ b/core/taint/engine/shell_pipeline_test.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// A positional / CGI source used DIRECTLY as a sink argument, with no
+// intermediate assignment. `eval "$@"` and `bash -c "$*"` are the ordinary
+// wrapper-script idiom; both were invisible because positional parameters were
+// only recognized on the RHS of an assignment.
+func TestShellInlineSourceInSinkArg(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"sh -c $1", "sh -c \"run $1\"\n", []string{"TAINT-002"}},
+		{"eval $@", "eval \"$@\"\n", []string{"TAINT-005"}},
+		{"curl QUERY_STRING", "curl \"$QUERY_STRING\"\n", []string{"TAINT-006"}},
+		{"inside function", "run() {\n  bash -c \"$1\"\n}\nrun \"$2\"\n", []string{"TAINT-002"}},
+		// Single quotes make the expansion inert: the literal text `$1` is run.
+		{"single-quoted is inert", "sh -c 'run $1'\n", nil},
+		// A sanitizer wrapping the source at the call site still clears it.
+		{"basename clears traversal", "source \"$(basename \"$1\")\"\n", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.sh", lexctx.LangShell, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A tainted value that reaches a sink THROUGH A PIPELINE: `xargs` turns stdin
+// into arguments of the command it invokes, and a bare `sh`/`bash` executes
+// stdin as a script. The recognizer used to see only a command's own argument
+// words, so the piped value was invisible.
+func TestShellPipelineFeedsSink(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"xargs curl", "fetch_all() {\n  local urls=\"$1\"\n  echo \"$urls\" | xargs curl -fsSL\n}\nfetch_all \"$1\"\n", []string{"TAINT-006"}},
+		{"xargs -I sh -c with $1", "process_all() {\n  find . -name '*.txt' -print0 | xargs -0 -I{} sh -c \"process {} $1\"\n}\nprocess_all \"$2\"\n", []string{"TAINT-002"}},
+		{"echo | sh", "x=\"$1\"\necho \"$x\" | sh\n", []string{"TAINT-002"}},
+		{"echo | bash -s", "x=\"$1\"\nprintf '%s\\n' \"$x\" | bash -s\n", []string{"TAINT-002"}},
+		{"through a filter", "u=\"$1\"\necho \"$u\" | grep -v x | xargs -n1 curl\n", []string{"TAINT-006"}},
+		{"inline source upstream", "echo \"$1\" | xargs wget\n", []string{"TAINT-006"}},
+		// Negatives: the piped value reaches a non-sink, or the executed string is
+		// fixed and stdin is mere data to it.
+		{"xargs non-sink", "u=\"$1\"\necho \"$u\" | xargs echo\n", nil},
+		{"sh -c fixed script", "u=\"$1\"\necho \"$u\" | sh -c 'cat'\n", nil},
+		{"nothing tainted upstream", "ls | xargs curl\n", nil},
+		{"or is not a pipe", "x=\"$1\"\ntest -n \"$x\" || sh -c 'echo none'\n", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.sh", lexctx.LangShell, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A privilege / environment wrapper in front of the real command is transparent:
+// the sink is the command it runs.
+func TestShellWrapperPrefixIsTransparent(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"sudo sh -c", "cmd=\"$1\"\nsudo sh -c \"$cmd\"\n", []string{"TAINT-002"}},
+		{"sudo -u user bash -c", "cmd=\"$1\"\nsudo -u deploy bash -c \"$cmd\"\n", []string{"TAINT-002"}},
+		{"env VAR= curl", "url=\"$1\"\nenv HTTPS_PROXY=x curl \"$url\"\n", []string{"TAINT-006"}},
+		{"nohup wget", "url=\"$1\"\nnohup wget \"$url\" &\n", []string{"TAINT-006"}},
+		{"timeout N curl", "url=\"$1\"\ntimeout 30 curl \"$url\"\n", []string{"TAINT-006"}},
+		{"sudo of a non-sink", "f=\"$1\"\nsudo chown root \"$f\"\n", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.sh", lexctx.LangShell, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A loop header that reads is a read: `while read -r line; do` binds `line`
+// to untrusted stdin, and a sink in the body is reached. The header used to be
+// skipped as structural scaffolding, which lost the variable.
+func TestShellWhileReadHeaderBindsVariable(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"pipe into while read eval", "cat \"$f\" | while read -r line; do\n  eval \"$line\"\ndone\n", []string{"TAINT-005"}},
+		{"IFS prefix", "while IFS= read -r line; do\n  bash -c \"$line\"\ndone < \"$cfg\"\n", []string{"TAINT-002"}},
+		{"body does not sink", "while read -r line; do\n  echo \"$line\"\ndone\n", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeRuleIDs(t, "t.sh", lexctx.LangShell, tc.src)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rules = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A trailing comment is not an argument list: `sh # runs stdin` is a bare sh.
+func TestShellTrailingCommentIsNotArguments(t *testing.T) {
+	src := "x=\"$1\"\necho \"$x\" | sh # executes what it reads\n"
+	if got := analyzeRuleIDs(t, "t.sh", lexctx.LangShell, src); !reflect.DeepEqual(got, []string{"TAINT-002"}) {
+		t.Fatalf("rules = %v, want [TAINT-002]", got)
+	}
+}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -919,10 +920,36 @@ func (e *StructuralEngine) sinkArgShapeDangerous(sink *taint.Sink, info taint.Si
 		// language discriminator: a quoted/validated shell file invocation leaves
 		// both false and is still suppressed.
 		return info.ShellTrue || info.FirstArgTainted
+	case "setTimeout", "setInterval":
+		// A timer runs its first argument as CODE only when that argument is a
+		// string. A function literal is the ordinary form -- the callback body
+		// reads tainted variables all the time, and the extractor lists them as
+		// arguments of the timer call because textually they are -- and it
+		// compiles nothing. The catalog note says "only when the first argument
+		// is a string, not a function"; this is where that is enforced.
+		return info.FirstArgTainted && !firstArgIsFunctionLiteral(info)
 	default:
 		return true
 	}
 }
+
+// firstArgIsFunctionLiteral reports whether the code view of the first
+// positional argument is a JavaScript function expression: `function (…) {`,
+// `async function`, `async (…) =>`, `(…) =>`, or `x =>`.
+func firstArgIsFunctionLiteral(info taint.SinkArgInfo) bool {
+	if len(info.PositionalArgs) == 0 {
+		return false
+	}
+	arg := strings.TrimSpace(info.PositionalArgs[0])
+	arg = strings.TrimPrefix(arg, "async")
+	arg = strings.TrimSpace(arg)
+	if strings.HasPrefix(arg, "function") {
+		return true
+	}
+	return jsArrowHeadRe.MatchString(arg)
+}
+
+var jsArrowHeadRe = regexp.MustCompile(`^(?:\([^()]*\)|[A-Za-z_$][\w$]*)\s*=>`)
 
 // lookupSinkArg finds the SinkArgInfo for rawCall on st, matching by suffix so
 // the extractor's full-chain key resolves against the canonical sink call.

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -193,6 +193,15 @@ func (e *StructuralEngine) analyzeUnitInterproc(lang string, unit *taint.Unit, s
 	return res.flows
 }
 
+// stmtFlowKey identifies a flow within ONE statement: the rule it violates and
+// the value that reaches it. Two catalog sinks that resolve for the same
+// written call (an alias and its qualified form) share a key and are one flow.
+type stmtFlowKey struct {
+	ruleID     string
+	sourceLine int
+	sourceVar  string
+}
+
 // forwardPass is the single, shared forward-propagation core used by BOTH the
 // intraprocedural Analyze and the interprocedural AnalyzeFile/summarize. Keeping
 // one implementation guarantees summary semantics never diverge from
@@ -232,6 +241,15 @@ func (e *StructuralEngine) forwardPass(
 		// 1) Catalog sink check: for each call that resolves to a catalog sink,
 		//    decide whether a tainted, class-un-sanitized value reaches it in a
 		//    dangerous position.
+		//
+		// One flow per (rule, source) per statement. Import resolution records a
+		// call's qualified form ALONGSIDE the form as written (imports.go), and
+		// for the languages whose catalog enumerates aliases next to the
+		// qualified name (`shell/sh` beside `clojure.java.shell/sh`) both entries
+		// resolve for the one call the author wrote. That is one sink reached by
+		// one value: reporting it twice, once per spelling, doubles the finding.
+		// The first spelling in st.Calls -- the one as written -- names the flow.
+		emitted := map[stmtFlowKey]struct{}{}
 		for _, rawCall := range st.Calls {
 			sink, ok := e.resolveSink(lang, rawCall)
 			if !ok {
@@ -292,6 +310,11 @@ func (e *StructuralEngine) forwardPass(
 						continue // untrusted content confined to the user role (safe pattern)
 					}
 				}
+				fk := stmtFlowKey{sink.RuleID, ti.srcLine, sourceVar}
+				if _, dup := emitted[fk]; dup {
+					break // the same call under another spelling: already reported
+				}
+				emitted[fk] = struct{}{}
 				flows = append(flows, taint.Flow{
 					Source:     ti.src,
 					SourceLine: ti.srcLine,

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -751,6 +751,9 @@ func withInlineOperands(info taint.SinkArgInfo, inline map[string]inlineOperand)
 // call's own arguments, so a source is never matched outside the sanitizer that
 // wraps it.
 func (e *StructuralEngine) scanInlineSource(lang, code string) (taint.Source, map[taint.VulnClass]bool, bool) {
+	if lang == "shell" {
+		return e.scanShellInlineSource(lang, code)
+	}
 	for _, c := range topLevelCalls(code) {
 		// The call itself may be a source (request.args.get(...), r.FormValue(...)).
 		if s, ok := e.sourceForChain(lang, c.callee); ok {
@@ -774,6 +777,35 @@ func (e *StructuralEngine) scanInlineSource(lang, code string) (taint.Source, ma
 	// Bare-identifier source (PHP superglobal read: _GET['c']).
 	for _, id := range freeIdentifiers(langPython, code) {
 		if s, ok := e.sourceForChain(lang, id); ok {
+			return s, map[taint.VulnClass]bool{}, true
+		}
+	}
+	return taint.Source{}, nil, false
+}
+
+// scanShellInlineSource is scanInlineSource for shell, whose sources are not
+// calls but expansions: a positional / special parameter (`$1`, `$@`) or a
+// CGI environment variable (`$QUERY_STRING`) written directly in an argument
+// word. A command substitution `$(sanitizer "$1")` wrapping one clears the
+// sanitizer's classes, mirroring the call-nesting rule of the other languages.
+func (e *StructuralEngine) scanShellInlineSource(lang, code string) (taint.Source, map[taint.VulnClass]bool, bool) {
+	rest := code
+	for _, sub := range shellCommandSubs(code) {
+		if s, cleared, ok := e.scanShellInlineSource(lang, sub.inner); ok {
+			for _, class := range e.sanitizerClasses(lang, sub.callee) {
+				cleared[class] = true
+			}
+			return s, cleared, true
+		}
+		rest = strings.Replace(rest, sub.text, "", 1)
+	}
+	for _, m := range shellPositionalMarkers(rest) {
+		if s, ok := e.cat.Source(lang, m); ok {
+			return s, map[taint.VulnClass]bool{}, true
+		}
+	}
+	for _, v := range shellNamedExpansions(rest) {
+		if s, ok := e.cat.Source(lang, v); ok {
 			return s, map[taint.VulnClass]bool{}, true
 		}
 	}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -52,6 +52,7 @@ func toStatement(d *stmtDraft) taint.Statement {
 		Reads:   append([]string(nil), d.reads...),
 		Chains:  append([]string(nil), d.chains...),
 		Returns: append([]string(nil), d.returns...),
+		Expr:    d.expr,
 	}
 	if len(d.sinkArgs) > 0 {
 		st.SinkArgs = make(map[string]taint.SinkArgInfo, len(d.sinkArgs))
@@ -267,8 +268,8 @@ func (e *StructuralEngine) forwardPass(
 				if !isTainted {
 					continue
 				}
-				if ti.cleared[sink.VulnClass] {
-					continue // sanitized for this exact class (prior assignment / inline wrap)
+				if ti.cleared[sink.VulnClass] || ti.src.Excludes(sink.VulnClass) {
+					continue // sanitized for this exact class (prior assignment / inline wrap), or a class the source's value cannot reach
 				}
 				if inlineCleared[v][sink.VulnClass] {
 					continue // sanitized inline at the sink call
@@ -322,9 +323,10 @@ func (e *StructuralEngine) forwardPass(
 
 		// A source assignment taints the LHS afresh (a re-source overwrites prior
 		// taint/clear state). Sources may be CALLS (request.args.get) or bare
-		// ATTRIBUTE chains (request.args, req.query), so both are consulted.
+		// ATTRIBUTE chains (request.args, req.query), so both are consulted. A
+		// sanitizer wrapping the source on this same line clears its classes.
 		if src, ok := e.resolveSource(lang, st); ok {
-			tainted[st.Assigns] = taintInfo{src: src, srcLine: st.Line, cleared: map[taint.VulnClass]bool{}}
+			tainted[st.Assigns] = taintInfo{src: src, srcLine: st.Line, cleared: e.bindingCleared(lang, st.Expr)}
 			continue
 		}
 
@@ -406,8 +408,8 @@ func (e *StructuralEngine) interprocSinkFlows(lang string, unit *taint.Unit, st 
 			}
 			for _, op := range e.argOperands(lang, info, argIdx, tainted, st.Line) {
 				for _, as := range sinks {
-					if op.ti.cleared[as.sink.VulnClass] {
-						continue // caller already sanitized for this class
+					if op.ti.cleared[as.sink.VulnClass] || op.ti.src.Excludes(as.sink.VulnClass) {
+						continue // caller already sanitized for this class, or the source's value cannot reach it
 					}
 					if cls := sum.sanitizesClass[argIdx]; cls[as.sink.VulnClass] {
 						continue // helper sanitizes this parameter for this class
@@ -754,6 +756,9 @@ func (e *StructuralEngine) scanInlineSource(lang, code string) (taint.Source, ma
 	if lang == "shell" {
 		return e.scanShellInlineSource(lang, code)
 	}
+	if lang == "clojure" {
+		return e.scanClojureInlineSource(lang, code)
+	}
 	for _, c := range topLevelCalls(code) {
 		// The call itself may be a source (request.args.get(...), r.FormValue(...)).
 		if s, ok := e.sourceForChain(lang, c.callee); ok {
@@ -781,6 +786,155 @@ func (e *StructuralEngine) scanInlineSource(lang, code string) (taint.Source, ma
 		}
 	}
 	return taint.Source{}, nil, false
+}
+
+// bindingCleared returns the sanitizer classes cleared on EVERY source in a
+// binding's expression: the intersection over all sources reachable in it of
+// the classes wrapped around each. One unwrapped source is enough to keep the
+// assignee fully tainted (`int(source('a')) + source('b')`), and a sanitizer
+// beside the source rather than around it clears nothing. An expression the
+// extractor could not carry (Expr == "") clears nothing.
+func (e *StructuralEngine) bindingCleared(lang, expr string) map[taint.VulnClass]bool {
+	var out map[taint.VulnClass]bool
+	e.walkInlineSources(lang, expr, func(_ taint.Source, cleared map[taint.VulnClass]bool) {
+		if out == nil {
+			out = make(map[taint.VulnClass]bool, len(cleared))
+			for class := range cleared {
+				out[class] = true
+			}
+			return
+		}
+		for class := range out {
+			if !cleared[class] {
+				delete(out, class)
+			}
+		}
+	})
+	if out == nil {
+		return map[taint.VulnClass]bool{}
+	}
+	return out
+}
+
+// walkInlineSources visits every catalog source reachable in an expression,
+// each with the sanitizer classes cleared on its own path from the expression
+// root. It is scanInlineSource without the first-match cut: a binding needs
+// all of its sources to decide what is cleared, a sink argument needs one.
+// Shell expansions never reach a binding this way (the shell extractor has
+// its own assignment model), so shell is not walked.
+func (e *StructuralEngine) walkInlineSources(lang, code string, visit func(taint.Source, map[taint.VulnClass]bool)) {
+	if lang == "shell" {
+		return
+	}
+	if lang == "clojure" {
+		e.walkClojureInlineSources(lang, code, visit)
+		return
+	}
+	calls, rest := topLevelCallsRest(code)
+	for _, c := range calls {
+		if s, ok := e.sourceForChain(lang, c.callee); ok {
+			visit(s, map[taint.VulnClass]bool{})
+			continue
+		}
+		wrapping := e.sanitizerClasses(lang, c.callee)
+		e.walkInlineSources(lang, c.codeArgs, func(s taint.Source, cleared map[taint.VulnClass]bool) {
+			for _, class := range wrapping {
+				cleared[class] = true
+			}
+			visit(s, cleared)
+		})
+	}
+	// Attribute-source and bare-identifier reads outside the calls: chains
+	// inside a call were already visited on the call's path, with its wrapping.
+	for _, ch := range dottedChains(rest) {
+		if s, ok := e.sourceForChain(lang, ch); ok {
+			visit(s, map[taint.VulnClass]bool{})
+		}
+	}
+	for _, id := range freeIdentifiers(langPython, rest) {
+		if s, ok := e.sourceForChain(lang, id); ok {
+			visit(s, map[taint.VulnClass]bool{})
+		}
+	}
+}
+
+// scanClojureInlineSource is scanInlineSource for Clojure: the first source
+// form reachable in the expression, outermost-first, with the classes of the
+// sanitizer heads wrapping it.
+func (e *StructuralEngine) scanClojureInlineSource(lang, code string) (taint.Source, map[taint.VulnClass]bool, bool) {
+	var (
+		found   taint.Source
+		cleared map[taint.VulnClass]bool
+		ok      bool
+	)
+	e.walkClojureInlineSources(lang, code, func(s taint.Source, cl map[taint.VulnClass]bool) {
+		if !ok {
+			found, cleared, ok = s, cl, true
+		}
+	})
+	return found, cleared, ok
+}
+
+// walkClojureInlineSources is walkInlineSources over Clojure forms. A list
+// form's head is the call: a keyword head `(:params req)` or a source symbol
+// `(System/getenv …)` IS the source; any other head is a call whose arguments
+// are walked with the head's sanitizer classes added to the wrapping, so
+// `(Integer/parseInt (:params req))` reaches the source with command
+// injection cleared and `(str "x" (:params req))` reaches it with nothing
+// cleared. A bare symbol read that is itself a catalog source
+// (`*command-line-args*`) is visited as-is. Keywords inside a vector or map
+// literal are keys, not accesses, and are not visited (see
+// clojureCollectExpr); the forms nested in a literal still are.
+func (e *StructuralEngine) walkClojureInlineSources(lang, code string, visit func(taint.Source, map[taint.VulnClass]bool)) {
+	bytes := []byte(code)
+	for _, f := range parseClojureForms(bytes, 0, len(bytes)) {
+		e.walkClojureInlineForm(lang, bytes, f, nil, visit)
+	}
+}
+
+func (e *StructuralEngine) walkClojureInlineForm(lang string, code []byte, f clojureForm, wrapping []taint.VulnClass, visit func(taint.Source, map[taint.VulnClass]bool)) {
+	emit := func(s taint.Source) {
+		cleared := make(map[taint.VulnClass]bool, len(wrapping))
+		for _, class := range wrapping {
+			cleared[class] = true
+		}
+		visit(s, cleared)
+	}
+	if f.delim == 0 {
+		atom := clojureAtomText(code, f)
+		if atom == "" || strings.HasPrefix(atom, ":") {
+			return
+		}
+		if s, ok := e.sourceForChain(lang, atom); ok {
+			emit(s)
+		}
+		return
+	}
+	if f.delim != '(' || len(f.children) == 0 {
+		for _, ch := range f.children {
+			if ch.delim != 0 {
+				e.walkClojureInlineForm(lang, code, ch, wrapping, visit)
+			}
+		}
+		return
+	}
+	head := clojureAtomText(code, f.children[0])
+	if strings.HasPrefix(head, ":") {
+		if s, ok := e.sourceForChain(lang, head); ok {
+			emit(s)
+		} else if s, ok := e.sourceForChain(lang, strings.TrimPrefix(head, ":")); ok {
+			emit(s)
+		}
+		return
+	}
+	if s, ok := e.sourceForChain(lang, clojureNormalizeCallee(head)); ok {
+		emit(s)
+		return
+	}
+	inner := append(append([]taint.VulnClass(nil), wrapping...), e.sanitizerClasses(lang, clojureNormalizeCallee(head))...)
+	for _, ch := range f.children[1:] {
+		e.walkClojureInlineForm(lang, code, ch, inner, visit)
+	}
 }
 
 // scanShellInlineSource is scanInlineSource for shell, whose sources are not
@@ -819,7 +973,16 @@ func (e *StructuralEngine) scanShellInlineSource(lang, code string) (taint.Sourc
 // a source WRAPPED by a sanitizer from one that is not. Literals are already
 // blanked, so no in-string paren confuses the scan.
 func topLevelCalls(code string) []callChain {
-	var calls []callChain
+	calls, _ := topLevelCallsRest(code)
+	return calls
+}
+
+// topLevelCallsRest is topLevelCalls that also returns the expression with
+// every top-level call (callee and arguments) blanked to spaces, so a caller
+// can look for attribute-chain and bare-identifier sources OUTSIDE the calls
+// without re-matching a chain that sits inside one.
+func topLevelCallsRest(code string) (calls []callChain, rest string) {
+	blanked := []byte(code)
 	i, n := 0, len(code)
 	for i < n {
 		if !isIdentStart(code[i]) {
@@ -842,9 +1005,12 @@ func topLevelCalls(code string) []callChain {
 		if callee := normalizeCallee(chain); callee != "" {
 			calls = append(calls, callChain{callee: callee, codeArgs: codeArgs, rawArgs: codeArgs})
 		}
+		for k := start; k < end; k++ {
+			blanked[k] = ' '
+		}
 		i = end // jump past the whole call: its args are NOT top-level
 	}
-	return calls
+	return calls, string(blanked)
 }
 
 // sanitizerClasses returns every vuln class a call neutralizes (by suffix match).

--- a/core/taint/engine/timer_sink_test.go
+++ b/core/taint/engine/timer_sink_test.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+)
+
+// TestTimerSink_FunctionLiteralIsNotCode: setTimeout compiles its first
+// argument only when it is a string. A callback body that reads argv is the
+// ordinary form and must not be reported as code injection; a string built
+// from argv still must.
+func TestTimerSink_FunctionLiteralIsNotCode(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"function callback", `var args = process.argv.slice(2);
+setTimeout(function() {
+  if (args.length === 1 && args[0] === '--help') {
+    console.log('x');
+  }
+}, 0);
+`, false},
+		{"async arrow callback", `var args = process.argv.slice(2);
+setInterval(async () => { await run(args); }, 100);
+`, false},
+		{"bare-param arrow callback", `var args = process.argv.slice(2);
+setTimeout(x => run(args, x), 0);
+`, false},
+		{"string built from argv", `var args = process.argv.slice(2);
+setTimeout("run(" + args[0] + ")", 10);
+`, true},
+		{"tainted variable as code", `var code = process.argv[2];
+setTimeout(code, 10);
+`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasRule(analyze(t, lexctx.LangJavaScript, tt.src), "TAINT-005")
+			if got != tt.want {
+				t.Fatalf("TAINT-005 fired=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/design/sast-taint.md
+++ b/docs/design/sast-taint.md
@@ -295,6 +295,51 @@ measured to add zero findings across 1072 real Dart files (dart-lang/http,
 cfug/dio, dart-lang/shelf, flutter/samples) while closing the two documented
 `testdata/precision-suite-dart` false negatives (recall 0.667 → 1.0).
 
+## Status update: a sanitizer on the binding line counts
+
+Propagation rule 3 says a statement whose assignee is produced by a sanitizer
+clears taint. The engine applied it on the statement AFTER the source: `raw =
+request.args.get("n")` tainted `raw`, and `n = int(raw)` cleared `n`. Written
+as one statement — `n = int(request.args.get("n"))`, the shape nearly every
+real program uses — the source was recognized, the binding was tainted, and
+the `int(...)` around it was invisible, because the sanitizer pass looked at
+what the statement CALLED, and the statement called the source. Five clean
+fixtures across Python and JS (`clean_inline_sanitizer.py/.js`) fired on
+`origin/main`; every recognizer language (Python, JS/TS, Java, PHP, Ruby) had
+the gap, and only Go — whose AST extractor hoists inline sources into their
+own statements — did not. The Clojure form recognizer had the same gap twice
+over: a source used directly as a sink argument had no binding to taint at
+all.
+
+The fix is a code view of the assigned expression on the `Statement`
+(`Expr`), and a walk over it that visits every source it contains together
+with the sanitizer classes of the calls WRAPPING that source
+(`bindingCleared`). The binding starts out cleared for the intersection over
+all sources — `int(source_a) + source_b` is cleared for nothing, because
+`source_b` is bare — and the sink gate reads that set exactly as it reads a
+later-line sanitizer. The walk blanks each top-level call's span before the
+dotted-chain and free-identifier passes so a chain inside a call is not
+re-visited unwrapped. Clojure walks the same expression as forms, records the
+positional argument text of every call so a source inside a sink argument is
+seen, and joins a top-level `def` into the `defn`s that read it through the
+shared-state join above. Measured: the five fixture false positives are gone,
+Python/JS corpus repositories (certbot, httpie, pipenv, shelljs, node-gyp)
+are unchanged to the finding, and the Clojure suite went 16 → 20 TP at
+precision 1.0.
+
+### A source can be excluded per class: `not_for`
+
+Ring's `:body` is an `InputStream` by the Ring spec, so `(slurp (:body req))`
+reads the request and never opens a path — yet `slurp` is the path-traversal
+sink, and every such read on ring and reitit was reported as TAINT-004 (all
+of them stream reads, request or response). Dropping `:body` as a source
+would lose the real flow where the body is read into a string and reaches
+SQL. A catalog `Source` therefore carries `not_for`: the vuln classes its
+VALUE can never reach by type. The sink gate consults it beside the cleared
+set; the class must be a known one, checked at load. The rule for using it:
+`not_for` states a fact about the value's TYPE, never a judgment that a flow
+is unlikely.
+
 ## Semantics: a partially tainted URL is still reported (SSRF, TAINT-006)
 
 A recurring shape, found in three languages while validating the engine against

--- a/docs/design/sast-taint.md
+++ b/docs/design/sast-taint.md
@@ -262,6 +262,39 @@ F1 0.933** (14 TP, 0 FP, 2 FN). The two recall gaps are honest and documented
 local-summary interprocedural model). Ruby inherits every intraprocedural limit
 above and is module/`def`-scoped like Python.
 
+## Status update: shared state joins units that never call each other
+
+Function summaries join a value that passes through a CALL. They do not join a
+value laundered through state two units SHARE without calling each other — an
+instance variable set in one method and read in another. That was a documented
+recall gap (the Ruby `@ivar` case above) until `core/taint/engine/sharedstate.go`
+closed it narrowly: a binding of a **syntactically shared** name is copied,
+with empty sink evidence, into every other unit that reads that name, and the
+ordinary intra-unit propagation does the rest. The copy is prepended, so a unit
+that assigns the same name locally still shadows it. The join is
+flow-insensitive across units, the standard over-approximation for shared
+state. Only names the language marks as shared participate — a plain local never
+joins, which is what keeps every same-named local in a file from becoming one
+variable.
+
+Per language, "shared" means:
+
+| Language | Shared names | Scope of the join |
+|---|---|---|
+| Ruby | `@ivar`, `@@cvar`, `$global` | file |
+| Perl | `$PKG` globals, `our` | file |
+| Dart | fields declared in a class body (`String target = ...;`, `late`, `static`); top-level variables | **per class** for fields (the same field name in two classes stays two variables); file for top-level variables. `this.field` is normalized to the bare name. |
+
+Dart also opted in to **container binding**: an element assignment
+(`m['k'] = x`) binds the container (as for Perl), and an in-place mutator
+(`add`, `addAll`, `insert`, `insertAll`, `addEntries`, `write`, `writeln`,
+`writeAll`) is modeled as `urls = urls.add(x)` — taint already in the container
+is kept, taint in the argument is added. Both are container-level, not
+per-element, so they can only widen taint; Dart was enabled after the join was
+measured to add zero findings across 1072 real Dart files (dart-lang/http,
+cfug/dio, dart-lang/shelf, flutter/samples) while closing the two documented
+`testdata/precision-suite-dart` false negatives (recall 0.667 → 1.0).
+
 ## Semantics: a partially tainted URL is still reported (SSRF, TAINT-006)
 
 A recurring shape, found in three languages while validating the engine against

--- a/testdata/precision-suite-clojure/README.md
+++ b/testdata/precision-suite-clojure/README.md
@@ -44,31 +44,30 @@ where the honest false negatives live (see below).
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-clojure` scores
-**precision 1.00 / recall 0.81 / F1 0.90** (13 TP, 0 FP, 3 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (16 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits is a true positive, and every clean stressor
 (parameterized jdbc vector, `Integer/parseInt` coercion, placeholder creds,
-data-URI blob, generated banner) fires nothing — while recall is the lowest of any
-language. The last gap — the threading-macro form — is now closed, alongside the
-two higher-order-dispatch gaps (`apply`, `map`).
+data-URI blob, generated banner) fires nothing. The gaps this corpus was built
+to pin — the threading-macro form, higher-order DISPATCH (`apply`, `map`) and
+higher-order CONSTRUCTION (`partial`, `comp`, `as->`) — are all closed.
 
-Recall is deliberately BELOW 1.0 again. It reached 1.0 when the threading model
-landed, at which point the corpus could only catch regressions — so
-`tp_hof_construction.clj` was added, pinning three real misses. `apply` and `map`
-DISPATCH a function and are modeled; `partial` and `comp` instead BUILD one, and
-`as->` renames the threaded value, so in all three the sink is a value rather
-than a call head the recognizer tracks. The drop from 1.00 to 0.81 is the corpus
-getting harder, not the engine getting worse: precision is still 1.000 with zero
-false positives. `clean_threading.clj` was added as the guard: threading
-is THE idiomatic Clojure shape, so modeling it is exactly where an engine risks
-inventing noise, and that sample asserts silence across `->`, `->>`, `some->`
-and `cond->` chains over constants, coerced numbers and pure data transforms.
-It matters more than usual here because no large real-world Clojure corpus was
-available to validate against — the guard is a corpus one.
+The history matters more than the number. Recall reached 1.0 once before, when
+the threading model landed, at which point the corpus could only catch
+regressions — so `tp_hof_construction.clj` was added, pinning three real misses
+and dropping recall to 0.81 on purpose: `partial` and `comp` BUILD a function
+that is invoked through a local name, and `as->` renames the threaded value,
+so in all three the sink was a value rather than a call head the recognizer
+tracked. Closing them (see below) brought recall back to 1.0 with precision
+still 1.000, measured against **78 `partial`, 41 `comp` and 7 `as->` uses in
+ring and reitit** that produced zero new findings. `clean_threading.clj` is the
+guard: threading is THE idiomatic Clojure shape, so modeling it is exactly where
+an engine risks inventing noise, and that sample asserts silence across `->`,
+`->>`, `some->` and `cond->` chains over constants, coerced numbers and pure
+data transforms.
 
-That gap is **honest, not curated**: the FN samples are annotated as the true
-positives a correct scanner should fire, so the number tells the truth. The way to
-raise it is to build the engine (a threading-macro desugarer, HOF modeling), never
-to delete the samples.
+The discipline stands: the next real miss goes in as an annotated true positive
+so the number tells the truth, and the way to raise it is to build the engine,
+never to delete the samples.
 
 ## Sample inventory
 
@@ -117,15 +116,27 @@ Clean stressors (zero annotations — any finding is a false positive):
   slot. `->` prepends and `->>` appends, but for taint the question is whether
   the value reaches the sink at all, and both do. A position-sensitive argument
   note (the parameterized-jdbc vector check) therefore does not apply to a
-  threaded stage. `as->` is not handled: it names its own binding.
+  threaded stage. `as->` is modeled separately: it binds the threaded value
+  to the NAME the author chose, and each stage names it as an ordinary
+  argument, so the value is bound from the initial expression and rebound to
+  each stage's result — a sanitizing stage clears it for the stages after.
 - **Higher-order dispatch — CLOSED for the dispatcher family.** `apply`, `map`,
   `mapv`, `pmap`, `mapcat`, `keep`, `filter`, `remove`, `some`, `every?` and
   `run!` take the function to invoke as their FIRST argument, so a sink reached
   through them was never a literal call head. The statement is now re-attributed
   to the dispatched SYMBOL and the remaining arguments scored against it. Only a
   bare symbol is re-attributed — an inline `#(...)`/`fn` literal has no name to
-  attribute the flow to and leaves the dispatcher as callee. `partial` and `comp`
-  build a function rather than invoking one and are still not modeled.
+  attribute the flow to and leaves the dispatcher as callee.
+- **Higher-order construction — CLOSED.** `partial` and `comp` BUILD a function
+  that is later invoked through a binding, so the sink never appears as a call
+  head under any name. A `let`/`def` binding whose value is `(partial sym
+  fixed…)` or `(comp sym…)` is remembered, lexically scoped, and a later call
+  through that name is rewritten into the calls it makes: `(f x)` ≡
+  `(sym fixed… x)` for partial, and `(sym1 (sym2 x))` for comp — applied
+  right to left through a synthetic binding so a sanitizer inside the
+  composition clears the taint before a sink further left. Only bare symbols
+  are recorded (an inline `#(...)`/`fn` literal is left alone), and each
+  symbol still has to be a catalog sink to report.
 - **Destructuring binds** — `{:keys [a b]}`, `[x & xs]` — are not tracked; only a
   bare-symbol binding target taints. A value bound through destructuring is lost.
 - **`slurp` of a URL** is SSRF, not path traversal, but the recognizer cannot tell
@@ -138,5 +149,5 @@ Clean stressors (zero annotations — any finding is a false positive):
 Precision is defended throughout: the sinks fire only when a tracked binding
 actually carries a source, and the parameterized jdbc vector keeps the value out of
 the SQL-string argument, so `clean_safe_db.clj` stays clean. The `--min-precision
-0.90` CI gate and the committed `baseline.json` ratchet ensure the wide, honest
-recall gap can never be hidden and no new Clojure false positive can creep in.
+0.90` CI gate and the committed `baseline.json` ratchet ensure a closed gap can
+never silently reopen and no new Clojure false positive can creep in.

--- a/testdata/precision-suite-clojure/README.md
+++ b/testdata/precision-suite-clojure/README.md
@@ -44,12 +44,15 @@ where the honest false negatives live (see below).
 ## What this corpus currently reveals
 
 As of writing, `nox bench --precision testdata/precision-suite-clojure` scores
-**precision 1.00 / recall 1.00 / F1 1.00** (16 TP, 0 FP, 0 FN). Precision is
+**precision 1.00 / recall 1.00 / F1 1.00** (20 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits is a true positive, and every clean stressor
-(parameterized jdbc vector, `Integer/parseInt` coercion, placeholder creds,
-data-URI blob, generated banner) fires nothing. The gaps this corpus was built
-to pin — the threading-macro form, higher-order DISPATCH (`apply`, `map`) and
-higher-order CONSTRUCTION (`partial`, `comp`, `as->`) — are all closed.
+(parameterized jdbc vector, `Integer/parseInt` coercion, a sanitizer on the
+binding line or wrapped around the source inside the sink call, placeholder
+creds, data-URI blob, generated banner) fires nothing. The gaps this corpus was
+built to pin — the threading-macro form, higher-order DISPATCH (`apply`, `map`),
+higher-order CONSTRUCTION (`partial`, `comp`, `as->`), the INLINE source
+`(shell/sh "sh" "-c" (:params req))` with no binding at all, and a top-level
+`def` read from inside a `defn` — are all closed.
 
 The history matters more than the number. Recall reached 1.0 once before, when
 the threading model landed, at which point the corpus could only catch
@@ -64,6 +67,20 @@ guard: threading is THE idiomatic Clojure shape, so modeling it is exactly where
 an engine risks inventing noise, and that sample asserts silence across `->`,
 `->>`, `some->` and `cond->` chains over constants, coerced numbers and pure
 data transforms.
+
+The most recent round (`tp_inline_source.clj`, `clean_inline_sanitizer.clj`)
+took recall to 0.80 before the engine caught up. Two of the four misses were
+the same shape every other language shares: the source sat INSIDE the sink
+call (`(shell/sh "sh" "-c" (:params req))`) with no binding for the engine to
+taint, and a `def` at the top of the namespace read from a `defn` below it was
+never joined into that function's flow. The other two were the clean side:
+`(Integer/parseInt (:params req))` on the binding line, and the same form
+placed directly in a sink argument, both fired — the sanitizer and the source
+were in one statement, and the engine only ever saw sanitizers on a LATER
+line. Closing all four was measured on ring and reitit: zero new findings, and
+the two `(slurp (:body req))` reports on ring — a stream read that never
+opens a path — went away, because the catalog now says which classes a
+source's value can never reach (`not_for`), rather than deleting the source.
 
 The discipline stands: the next real miss goes in as an annotated true positive
 so the number tells the truth, and the way to raise it is to build the engine,
@@ -80,6 +97,7 @@ True positives — the idiomatic straight-line flows nox **does** catch:
 | `tp_sqlinjection.clj` | `(jdbc/query db (str "… " id))` string concat | TAINT-001 ×2 | TP ×2 |
 | `tp_pathtraversal.clj` | `(slurp …)` / `(io/reader …)` of a tainted path | TAINT-004 ×2 | TP ×2 |
 | `tp_ssrf.clj` | `(client/get …)` / `(client/post …)` of a tainted URL | TAINT-006 ×2 | TP ×2 |
+| `tp_inline_source.clj` | source INSIDE the sink call, `str`-wrapped source, top-level `def` from `System/getenv` read by a `defn`, jdbc `str` concat | TAINT-002 ×3, TAINT-001 | TP ×4 |
 
 True positives that are honest **false negatives** (annotated ground truth nox is
 expected to MISS — the Lisp recall gap):
@@ -96,6 +114,7 @@ Clean stressors (zero annotations — any finding is a false positive):
 | --- | --- | --- |
 | `clean_safe_db.clj` | parameterized `["… ?" v]` jdbc vector, `Integer/parseInt` coercion, constant command | clean |
 | `clean_validated.clj` | tainted value only logged / in a response map, `parse-long` + arithmetic | clean |
+| `clean_inline_sanitizer.clj` | `Integer/parseInt` on the binding line, in the sink argument itself, `parse-long` around a `def`, source inside a jdbc bind vector | clean |
 | `clean_placeholders.clj` | placeholder creds (`your-api-key-here`, `changeme`, `sk_test_…`), `System/getenv` reads | clean |
 | `clean_datablob.clj` | base64 data-URI SVG, git SHA, UUID, hex color, SRI integrity hash | clean (blob gating) |
 | `clean_prose.clj` | `DO NOT EDIT` banner, sinks quoted in comments, inert opcode data | clean |
@@ -137,6 +156,33 @@ Clean stressors (zero annotations — any finding is a false positive):
   composition clears the taint before a sink further left. Only bare symbols
   are recorded (an inline `#(...)`/`fn` literal is left alone), and each
   symbol still has to be a catalog sink to report.
+- **Inline source and same-line sanitizer — CLOSED.** The engine taints a
+  BINDING and reports a sink that reads one, so `(shell/sh "sh" "-c" (:params
+  req))` — the source as a literal argument of the sink — had nothing to
+  taint, and `(let [n (Integer/parseInt (:params req))] …)` had the sanitizer
+  on the same line as the source, where the engine only ever looked on later
+  lines. Both are now walked as forms: a call's positional argument text is
+  scanned for a source form (keyword head or catalog symbol), and every
+  source found on a binding line or in a sink argument carries the sanitizer
+  classes of the forms WRAPPING it, so `parseInt` around `(:params req)`
+  clears command injection while `str` around it clears nothing. A jdbc bind
+  vector `["… ?" (:params req)]` stays clean: the vector is not the SQL string.
+- **Top-level `def` read from a `defn` — CLOSED.** A `def` at namespace level
+  is shared state, and every `defn` in the file that reads the name sees its
+  binding — the same join every other language uses for module-level
+  assignments — so `(def cmd (System/getenv "CMD"))` reaches a `shell/sh`
+  three functions down, and `(def n (parse-long (System/getenv "N")))` does
+  not.
+- **Ring `:body` is a stream, never a path.** `(slurp (:body req))` reads the
+  request body — an `InputStream` by the Ring spec — so `slurp` on it cannot
+  open a file. The catalog marks `:body` as `not_for: [path_traversal]`; the
+  value is still a source for every other class once read into a string, so
+  a body slurped and concatenated into SQL still reports TAINT-001.
+- **A `fn` nested in a `defn` body keeps its unit.** The scoped walk that
+  carries `partial`/`comp` aliases once copied the unit list by value, so a
+  `fn` opened inside a function body — and the flow inside it — vanished.
+  Pinned by `TestClojureNestedFnKeepsItsUnit`. A `fn` used as a let-binding
+  VALUE is still not a unit (it never was).
 - **Destructuring binds** — `{:keys [a b]}`, `[x & xs]` — are not tracked; only a
   bare-symbol binding target taints. A value bound through destructuring is lost.
 - **`slurp` of a URL** is SSRF, not path traversal, but the recognizer cannot tell

--- a/testdata/precision-suite-clojure/baseline.json
+++ b/testdata/precision-suite-clojure/baseline.json
@@ -3,7 +3,7 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 16,
+  "tp": 20,
   "fn": 0,
   "findings_per_issue": 1,
   "rules": [

--- a/testdata/precision-suite-clojure/baseline.json
+++ b/testdata/precision-suite-clojure/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.8125,
-  "f1": 0.896551724137931,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 13,
-  "fn": 3,
-  "findings_per_issue": 0.8125,
+  "tp": 16,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -15,7 +15,7 @@
     {
       "rule_id": "TAINT-002",
       "precision": 1,
-      "recall": 0.6666666666666666
+      "recall": 1
     },
     {
       "rule_id": "TAINT-004",
@@ -30,7 +30,7 @@
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 0.75
+      "recall": 1
     }
   ]
 }

--- a/testdata/precision-suite-clojure/clean_inline_sanitizer.clj
+++ b/testdata/precision-suite-clojure/clean_inline_sanitizer.clj
@@ -1,0 +1,29 @@
+(ns app.inline-sanitizer
+  "Clean: the sanitizer wraps the source IN the binding — `(Integer/parseInt
+   (:params req))` — or wraps it straight in the sink argument. clean_safe_db.clj
+   binds the raw value first and coerces it on a second line; this file pins the
+   one-line forms, which used to fire because the engine ignored a sanitizer on
+   the same line as its source. A finding on any line here is a false positive."
+  (:require [clojure.java.shell :as shell]
+            [clojure.java.jdbc :as jdbc]))
+
+(def db {:dbtype "postgresql" :dbname "app"})
+
+;; Coerced on the binding line.
+(defn sleep-for [req]
+  (let [n (Integer/parseInt (:params req))]
+    (shell/sh "sleep" n)))
+
+;; Coerced inside the sink argument, no name at all.
+(defn count-to [req]
+  (shell/sh "seq" (Integer/parseInt (:params req))))
+
+;; A top-level def coerced where it is bound.
+(def limit (parse-long (System/getenv "LIMIT")))
+
+(defn head-lines []
+  (shell/sh "head" "-n" limit))
+
+;; An inline source inside a parameterized bind vector is a placeholder value.
+(defn find-user [req]
+  (jdbc/query db ["select * from users where id = ?" (:params req)]))

--- a/testdata/precision-suite-clojure/tp_hof_construction.clj
+++ b/testdata/precision-suite-clojure/tp_hof_construction.clj
@@ -1,35 +1,33 @@
 (ns app.hof-construction
-  "Honest FALSE NEGATIVES: higher-order CONSTRUCTION. `apply` and `map` DISPATCH
-   a function and are modeled — the statement is re-attributed to the dispatched
-   symbol. `partial`, `comp` and `as->` instead BUILD a function (or rename the
-   threaded value) and invoke it through a local binding, so the sink never
-   appears as a call head under any name the recognizer tracks.
-
-   All three are real vulnerabilities a correct scanner reports. They are added
-   deliberately: this suite had reached recall 1.0, at which point it could only
-   catch regressions and could no longer say what a Lisp recognizer still cannot
-   follow. Closing them is the way to raise the number; deleting them is not."
+  "Higher-order CONSTRUCTION. `apply` and `map` DISPATCH a function and are
+   re-attributed at the dispatch site. `partial`, `comp` and `as->` instead
+   BUILD a function (or rename the threaded value) and invoke it through a local
+   binding, so the sink never appears as a call head under any name — until the
+   binding is followed. These three were added as honest false negatives when
+   the suite first reached recall 1.0, and are kept as the regression pin now
+   that each is modeled: a `partial`/`comp` binding is remembered lexically and
+   the later call is rewritten into the calls it makes; `as->` binds and
+   rebinds the author's name per stage."
   (:require [clojure.java.shell :as shell]
             [clj-http.client :as client]
             [clojure.string :as str]))
 
-;; FN: `partial` closes over the sink and returns a new function bound to `f`.
-;; The call head is `f`, a local, so the shell sink is never named at the site.
+;; `partial` closes over the sink and returns a new function bound to `f`. The
+;; call head is `f`, a local; `(f cmd)` is modeled as `(shell/sh "sh" "-c" cmd)`.
 (defn run-partial [req]
   (let [cmd (:params req)
         f   (partial shell/sh "sh" "-c")]
     (f cmd))) ; nox-expect: TAINT-002
 
-;; FN: `comp` composes the sink into a new function bound to `g`. Same shape as
-;; partial — the sink is a value, not a call head.
+;; `comp` composes the sink into a new function bound to `g`. `(g url)` is
+;; modeled as `(client/get (str url))`, right to left.
 (defn fetch-composed [req]
   (let [url (:params req)
         g   (comp client/get str)]
     (g url))) ; nox-expect: TAINT-006
 
-;; FN: `as->` threads like `->`/`->>` but binds the value to a NAME the author
-;; chooses, so the threaded value is a normal local rather than the synthetic
-;; binding the other threading macros are modeled with.
+;; `as->` threads like `->`/`->>` but binds the value to a NAME the author
+;; chooses; `v` is bound from `(:params req)` and rebound to each stage's result.
 (defn run-as-> [req]
   (as-> (:params req) v
         (str/trim v)

--- a/testdata/precision-suite-clojure/tp_inline_source.clj
+++ b/testdata/precision-suite-clojure/tp_inline_source.clj
@@ -1,0 +1,29 @@
+(ns app.inline-source
+  "True positives: the source reaches the sink without ever being bound to a
+   name, or through a top-level def. Both are the ordinary shape and both were
+   invisible: the inline scan was C-like (`ident(args)`) and saw no calls in a
+   Lisp form, and a top-level def was never joined into the functions that read
+   it."
+  (:require [clojure.java.shell :as shell]
+            [clojure.java.jdbc :as jdbc]))
+
+(def db {:dbtype "postgresql" :dbname "app"})
+
+;; Source straight into the sink argument.
+(defn run-inline [req]
+  (shell/sh "sh" "-c" (:params req))) ; nox-expect: TAINT-002
+
+;; `str` is not a sanitizer: wrapping the source in it clears nothing.
+(defn run-wrapped [req]
+  (let [cmd (str "echo " (:params req))]
+    (shell/sh "sh" "-c" cmd))) ; nox-expect: TAINT-002
+
+;; A top-level def bound from the environment reaches a defn that reads it.
+(def target (System/getenv "TARGET"))
+
+(defn ping []
+  (shell/sh "sh" "-c" target)) ; nox-expect: TAINT-002
+
+;; Source concatenated into the SQL string, inline.
+(defn find-user [req]
+  (jdbc/query db (str "select * from users where name = '" (:params req) "'"))) ; nox-expect: TAINT-001

--- a/testdata/precision-suite-dart/README.md
+++ b/testdata/precision-suite-dart/README.md
@@ -22,14 +22,14 @@ RULE       TP  FP  FN  PRECISION  RECALL  F1
 TAINT-001  1   0   0   1.000      1.000   1.000
 TAINT-002  1   0   0   1.000      1.000   1.000
 TAINT-004  1   0   0   1.000      1.000   1.000
-TAINT-006  1   0   1   1.000      0.500   0.667
-OVERALL    4   0   1   1.000      0.800   0.889
+TAINT-006  3   0   0   1.000      1.000   1.000
+OVERALL    6   0   0   1.000      1.000   1.000
 ```
 
-**Precision 1.00 / recall 0.800 / F1 0.889** (4 TP, 0 FP, 1 FN). Precision is
+**Precision 1.00 / recall 1.00 / F1 1.00** (6 TP, 0 FP, 0 FN). Precision is
 perfect — every finding nox emits on this corpus is a true positive, and no
-`clean_*` sample false-positives. Recall is **0.800**, held below 1.0 by one
-honestly-labeled false negative (see the gap below).
+`clean_*` sample false-positives. Recall reached 1.0 when the two former
+false negatives in `tp_known_fns.dart` were closed (see below).
 
 ## Ground-truth philosophy
 
@@ -71,21 +71,27 @@ string.
 | `clean_rawstring_blob.dart` | a base64 `data:` URI and a regex token in `r'...'` raw strings — data blobs, not code |
 | `clean_generated.dart` | `Process.run` / `db.rawQuery` appear only in comments (incl. a nested block comment) — lexctx classifies them as comment, never code |
 
-## The recall gap (honest false negatives)
+## The closed recall gap
 
-`tp_known_fns.dart` carries two real flows nox does not catch. Both are the Dart
-side of a capability the engine HAS but scopes per language, because each is an
-over-approximation that can only widen taint and is enabled where a corpus
-demanded it:
+`tp_known_fns.dart` carries two real flows that were honest false negatives.
+Both are the Dart side of a capability the engine scopes per language, because
+each is an over-approximation that can only widen taint and is enabled where a
+corpus demands it. Dart opted in after the join was measured to add **zero
+findings across 1072 real Dart files** (dart-lang/http, cfug/dio,
+dart-lang/shelf, flutter/samples):
 
-- **cross-method flow through an instance FIELD** — the source lands in a field
-  in one method and the sink reads it in another. Shared state is joined across
-  units for Ruby (`@ivar`) and Perl (`our`); Dart is not in that set.
-- **taint laundered through a LIST ELEMENT** — binding a container from an
-  element assignment is enabled for Perl only.
-
-Closing either is a matter of opting Dart in and measuring, not of new
-machinery.
+- **cross-method flow through an instance FIELD** — a field declared in a class
+  body is shared state for that class's methods (Ruby joins `@ivar`, Perl
+  `our`). The join is per class: the same field name in two classes stays two
+  variables, and a local of the same name still shadows the field in its own
+  method. `this.field` is normalized to the bare name. A top-level variable is
+  shared by every unit in the file.
+- **taint laundered through a LIST ELEMENT** — an element assignment
+  (`m['k'] = x`) binds the container, as for Perl, and an in-place mutator
+  (`add`, `addAll`, `insert`, `insertAll`, `addEntries`, `write`, `writeln`,
+  `writeAll`) is modeled as `urls = urls.add(x)`: taint already in the
+  container is kept, taint in the argument is added. Container-level, not per
+  element — `urls[1]` is tainted when `urls[0]` was the store.
 
 ### Withdrawn: `tp_ssrf_field.dart`
 
@@ -115,5 +121,5 @@ CI enforces `--baseline` (no per-rule precision/recall regression) **and**
 above the floor: the arg-shape check (parameterized `rawQuery`), the `int.parse`
 sanitizer, the raw-string blob heuristic, and lexctx's comment/nested-comment
 classification keep every `clean_*` sample quiet. The gate pins the committed
-snapshot so the known FN cannot be silently hidden and no new Dart false positive
+snapshot so a closed FN cannot silently reopen and no new Dart false positive
 can creep in.

--- a/testdata/precision-suite-dart/baseline.json
+++ b/testdata/precision-suite-dart/baseline.json
@@ -1,11 +1,11 @@
 {
   "precision": 1,
-  "recall": 0.6666666666666666,
-  "f1": 0.8,
+  "recall": 1,
+  "f1": 1,
   "fp": 0,
-  "tp": 4,
-  "fn": 2,
-  "findings_per_issue": 0.6666666666666666,
+  "tp": 6,
+  "fn": 0,
+  "findings_per_issue": 1,
   "rules": [
     {
       "rule_id": "TAINT-001",
@@ -25,7 +25,7 @@
     {
       "rule_id": "TAINT-006",
       "precision": 1,
-      "recall": 0.3333333333333333
+      "recall": 1
     }
   ]
 }

--- a/testdata/precision-suite-dart/tp_known_fns.dart
+++ b/testdata/precision-suite-dart/tp_known_fns.dart
@@ -1,8 +1,9 @@
-// Honest FALSE NEGATIVES for Dart. Both are real flows a correct scanner
-// reports, and both are the Dart side of a capability the engine HAS but scopes
-// per language: receiver taint and container binding are enabled only where a
-// corpus demanded them, because each is an over-approximation that can only
-// widen taint. Dart has not opted in, so these miss.
+// Two flows that were honest FALSE NEGATIVES until Dart opted in to the
+// engine's shared-state join (class-scoped fields, top-level variables) and
+// container binding (element assignment and in-place mutators such as `add`).
+// Both are over-approximations that can only widen taint, so each was enabled
+// only after measuring zero new findings across 1072 real Dart files
+// (dart-lang/http, cfug/dio, dart-lang/shelf, flutter/samples).
 //
 // They replace tp_ssrf_field.dart, which was withdrawn: its comment described a
 // tainted URL stored into `req.url` and fetched by `client.send(req)`, but its
@@ -13,10 +14,10 @@
 // assignment. Correct SSRF coverage lives in tp_ssrf.dart.
 import 'dart:io';
 
-// FN: cross-method flow through an INSTANCE FIELD. The source lands in `target`
-// in one method and the sink reads it in another. The engine joins shared state
-// across units for Ruby (@ivar) and Perl (`our`), but Dart is not in that set,
-// so the two methods are analyzed independently and the flow is not joined.
+// Cross-method flow through an INSTANCE FIELD. The source lands in `target` in
+// one method and the sink reads it in another. A field declared in the class
+// body is shared state for that class's methods only (the same field name in
+// another class is a different variable), and `this.target` is the same name.
 class Fetcher {
   String target = '';
 
@@ -30,9 +31,10 @@ class Fetcher {
   }
 }
 
-// FN: taint laundered through a LIST ELEMENT. Binding a container from an
-// element assignment is enabled for Perl only, so the store is not tracked and
-// the later read of the element looks clean.
+// Taint laundered through a LIST ELEMENT. `urls.add(x)` is a store into the
+// container with no `=` for the assignment recognizer to see; it is modeled as
+// a rebinding of `urls` that keeps what the list already held, so the later
+// element read carries the taint (container-level, not per element).
 Future<void> fetchFirst(HttpClient client) async {
   final urls = <String>[];
   urls.add(Platform.environment['TARGET'] ?? '');

--- a/testdata/precision-suite-shell/clean_pipeline_data.sh
+++ b/testdata/precision-suite-shell/clean_pipeline_data.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Piped data that is DATA to the consumer, not the thing it executes or fetches.
+set -euo pipefail
+
+count_lines() {
+  local input="$1"
+  echo "$input" | wc -l
+}
+
+# `sh -c` with a FIXED script: stdin is read by `cat`, never executed.
+show() {
+  local text="$1"
+  echo "$text" | sh -c 'cat'
+}
+
+# `xargs` invoking a non-sink.
+remove_all() {
+  local names="$1"
+  echo "$names" | xargs echo
+}
+
+# `||` is the OR operator, not a pipe: the fixed script runs on failure.
+ensure() {
+  local path="$1"
+  test -n "$path" || sh -c 'echo missing'
+}
+
+count_lines "$1"
+show "$2"
+remove_all "$3"
+ensure "$4"

--- a/testdata/precision-suite-shell/tp_pipeline_fed.sh
+++ b/testdata/precision-suite-shell/tp_pipeline_fed.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-# Honest FALSE NEGATIVES: a tainted value reaching a sink through a PIPELINE
-# rather than as a literal argument of it. Both are real vulnerabilities a
-# correct scanner reports; nox does not, and they are annotated so the corpus
-# scores the gap rather than staying silent about it.
-#
-# These were added deliberately to give this suite something to indict again: it
-# had reached recall 1.0, at which point it could only detect regressions and
-# could no longer say what the recognizer still cannot do. The way to raise the
-# number is to close these, never to delete them.
+# A tainted value reaching a sink through a PIPELINE rather than as a literal
+# argument of it. These were false negatives: the recognizer modelled only a
+# command's OWN argument words, so a value arriving on stdin was invisible. The
+# pipeline is now modelled — every upstream segment's reads flow down the pipe,
+# and `xargs` hands them to the command it invokes as arguments.
 set -euo pipefail
 
-# FN: the tainted value is piped into `xargs`, which invokes curl with it as an
-# argument. The recognizer models a command's OWN argument words; a value that
-# arrives through the pipe is not one of them, so the curl call looks argument-
-# less. An attacker controls which URLs are fetched.
+# The tainted value is piped into `xargs`, which invokes curl with it as an
+# argument. An attacker controls which URLs are fetched.
 fetch_all() {
   local urls="$1"
   echo "$urls" | xargs curl -fsSL # nox-expect: TAINT-006
 }
 
-# FN: `xargs -I{}` builds a command STRING that interpolates a tainted positional
-# parameter and hands it to `sh -c`. The sink is real command injection, but the
-# string is assembled as an argument of xargs rather than at an `sh -c` call the
-# recognizer can attribute.
+# `xargs -I{}` builds a command STRING that interpolates a tainted positional
+# parameter and hands it to `sh -c`: command injection, with the positional
+# parameter used directly in the sink's argument (no intermediate assignment).
 process_all() {
   find . -name '*.txt' -print0 | xargs -0 -I{} sh -c "process {} $1" # nox-expect: TAINT-002
 }
 
+# A bare `sh` at the end of a pipe executes its stdin as a script.
+run_lines() {
+  local script="$1"
+  printf '%s\n' "$script" | sh # nox-expect: TAINT-002
+}
+
 fetch_all "$1"
 process_all "$2"
+run_lines "$3"

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -209,6 +209,8 @@ Clean stressors (zero annotations — any finding is a false positive):
 | `clean_placeholders.ts` | TS placeholder tokens | clean |
 | `clean_prose_comments.py` | sinks quoted in comments | clean |
 | `clean_safe_db.py` | parameterized / arg-vector / quoted | clean |
+| `clean_inline_sanitizer.py` | `int(request.args.get(…))` / `shlex.quote(…)` / `float(…)` wrapped around the source ON the binding line, then a shell sink | clean (same-statement sanitizer honoured) |
+| `clean_inline_sanitizer.js` | `parseInt(req.query.n)` / `Number(req.body.limit)` on the binding line, then `execSync`/`exec` | clean (same-statement sanitizer honoured) |
 | `clean_hashes.js` | lockfile hashes, git SHA | clean |
 | `clean_svg_blob.ts` | base64 data-URI SVG | clean |
 | `clean_minified_bundle.js` | minified bundle strings | clean |

--- a/testdata/precision-suite/clean_inline_sanitizer.js
+++ b/testdata/precision-suite/clean_inline_sanitizer.js
@@ -1,0 +1,13 @@
+// Clean: the sanitizer wraps the source on the line that binds it. A finding
+// on any line here is a false positive.
+const child_process = require('child_process');
+
+function sleepFor(req, res) {
+  const n = parseInt(req.query.n);
+  child_process.execSync('sleep ' + n);
+}
+
+function countTo(req, res) {
+  const limit = Number(req.body.limit);
+  child_process.exec('seq ' + limit);
+}

--- a/testdata/precision-suite/clean_inline_sanitizer.py
+++ b/testdata/precision-suite/clean_inline_sanitizer.py
@@ -1,0 +1,24 @@
+# Clean: the sanitizer sits on the SAME line as the source it validates —
+# `n = int(request.args.get('n'))` — the ordinary way input is coerced. The
+# engine used to bind n from the source with nothing cleared, so every such
+# validated value fired at its sink; only the two-step idiom in
+# clean_safe_db.py (bind raw, then coerce) was clean. A finding on any line
+# here is a false positive.
+import os
+import shlex
+import subprocess
+
+
+def sleep_for(request):
+    n = int(request.args.get("n"))
+    os.system("sleep " + str(n))          # coerced to a number: no metacharacters survive
+
+
+def grep_for(request):
+    pattern = shlex.quote(request.args.get("q"))
+    subprocess.run("grep " + pattern, shell=True)   # quoted before it is bound
+
+
+def page_size(request):
+    size = float(request.form.get("size"))
+    subprocess.call("head -n " + str(size), shell=True)


### PR DESCRIPTION
## Summary

Real-repo noise review, measured on pinned checkouts rather than self-authored suites, plus the recall gaps those repos and the language suites indicted. Every commit carries its own measured numbers; this body is the roll-up.

Rule-level fixes (each with a corpus before/after in its commit): SEC-161 SRI hashes, SEC-046 PyPI tokens, SEC/IAC password patterns stopping at line end, DATA-001 emails in fixture trees, SLOP-001 Python imports, TAINT-005 `setTimeout` with a function, SEC-073/074/076/085 templated URL passwords, SEC config-field matches ending on a comment line, RULES multi-line match reporting.

Taint engine (language-agnostic, measured per language):
- Shell pipelines carry taint; a wrapper (`xargs`, `sudo`, `env`, …) runs the command after it.
- A flow from an inline source names the source, not an empty variable.
- Dart fields and containers carry taint across methods (shared-state join + container binding; 0 new findings across 1072 real Dart files).
- Clojure follows `partial`, `comp` and `as->` to the sink (0 new findings across 78/41/7 uses in ring + reitit).
- **A sanitizer on the binding line counts** (`n = int(request.args.get("n"))`) — every recognizer language had this gap; Go did not. Source inside a sink call and a top-level `def` are seen in Clojure. Catalog `Source.not_for` marks classes a source's value can never reach by type (Ring `:body` is a stream, so `slurp` on it is not path traversal).

## Measured

| Repo (pinned) | main | this branch |
|---|---|---|
| npm/cli | 238,770 | 11,083 |
| certbot | 199 | 130 |
| httpie | 143 | 61 |
| pipenv | 209 | 113 |
| shelljs | — | 33 |
| node-gyp | — | 42 |
| ring | 4 | 2 (the two `(slurp (:body req))` stream reads) |
| reitit | 487 | 485 |
| shell corpus (acme.sh, nvm, bats-core) | 182 | 180 |

Precision suites: all 20 green; shell 16/16, Clojure 16 → 20 TP at precision 1.0 / recall 1.0, Dart recall 0.667 → 1.0, py/js `clean_inline_sanitizer.*` 5 FPs → 0. `scripts/rule-diff.sh` between consecutive builds shows only the changes each commit explains. `go test ./...`, `golangci-lint` 0 issues, metamorphic selftest + harness OK at every step.

## End-to-end: NOX Intelligence (live, intel.klarlabs.de)

- `nox scan` with OSV direct vs. with intel enabled: identical 22 VULN-001 (+1 TAINT-002) on the same fixture — intel adds no findings and loses none.
- `nox intel preview`: 13 allowlisted observations, no source code, no paths outside the allowlist.
- Anonymous contribution: server logs show 13× `POST /v1/observations` → 202 and 1× `POST /v1/querybatch` → 200.
- `/v1/mirror/status`: 277,545 advisories, `complete: true`.
- Bogus endpoint: scan degrades honestly (intel unavailable is reported) while still emitting all 22 VULN-001 — offline-first holds.
- `nox intel login` was not exercised (device flow needs an interactive browser session).

## Not in this PR (tracked)

- Fixture-tree policy for npm/cli volume (SEC-161 ×325 in fixtures, IAC-* on example manifests, DATA-* on fixture bodies).
- Terraform + TypeScript repos in `scripts/rule-diff-corpus.json`.
- External benchmark scoring (OWASP Benchmark `expectedresults-1.2.csv`).
- Interprocedural taint beyond same-file.
- nox-core `decodeBatchResponse` error labelling (separate PR in Nox-HQ/nox-core, then bump the pin).

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
