### PR TITLE
INTEL: NOX Intelligence is the default advisory source, verified against OSV.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+NOX Intelligence becomes the default advisory source. Every online `nox scan`
+now asks `https://intel.klarlabs.de` which advisories match each dependency and
+verifies the answer against OSV.dev; a withheld record is restored from OSV and
+reported as a degradation, and an unreachable service degrades to exactly the
+OSV.dev scan nox always ran. What leaves the machine is unchanged — the
+`(ecosystem, package, version)` list OSV.dev always received — and contribution
+stays a separate, opt-in decision. The complete account is `docs/intelligence.md`.
+
+### Added
+
+- `scan.intelligence.disabled: true` asks OSV.dev directly; the service is never
+  contacted. `--offline` still asks nobody.
+- `NOX_INTEL_ENDPOINT` is honoured by `nox scan`, not only by the `nox intel`
+  subcommands, so a self-hosted service is named once. Resolution order is
+  `disabled > scan.intelligence.endpoint > NOX_INTEL_ENDPOINT > compiled-in`.
+- `scan.osv.base_url` names the reference database used for verification, for
+  self-hosted OSV mirrors.
+- Tests that assert the three states from the wire: service and reference,
+  reference only, nobody (`TestScan_IntelligenceIsTheDefaultSource`,
+  `TestScan_IntelligenceDisabledAsksTheReferenceDirectly`,
+  `TestScan_OfflineAsksNobody`).
+- `docs/intelligence.md`: what a scan sends, to whom, and how to turn it off at
+  every level. Roadmap Phase 11 plans the gaps from where the market moves.
+
+### Changed
+
+- `nox intel login/register/add-operator/invite/enroll --endpoint` defaults to
+  the endpoint scans query rather than an empty string.
+- `docs/design/intelligence-service.md` no longer describes the service as
+  proposed.
+
 ## [1.32.0] - 2026-08-31
 
 Two programmes in one release: nox became evidence-native, and its dynamic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,11 @@ network capability.
 
 `core/confirm` is the earlier, narrower version of this loop and stays as-is.
 
-Vulnerability intelligence is deliberately NOT in the CLI. See
-`docs/design/intelligence-service.md` for the boundary and why redaction and the
-private evidence graph stay client-side while aggregation and research do not.
+Vulnerability intelligence is deliberately NOT in the CLI. The CLI consumes it:
+every online scan asks NOX Intelligence by default and verifies the answer
+against OSV.dev (`docs/intelligence.md`; opt-out `scan.intelligence.disabled`).
+See `docs/design/intelligence-service.md` for the boundary and why redaction and
+the private evidence graph stay client-side while aggregation and research do not.
 
 ### MCP Server
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you're shipping LLM features — `chat.completions.create`, RAG ingest into a
 
 Built so you can keep your source local, your CI green, and your CISO answered without paying a per-seat SaaS bill or sending code to a vendor.
 
-> **The MCP scanner that never sees your code.** No API. No token. No telemetry. Deterministic. Run `nox scan --offline` and the scan path makes zero outbound connections — enforced by a test, not a promise (`TestOSVDisabled_NoNetworkEgress`). Unlike scanners that proxy your traffic or phone home to a vendor API, nox runs entirely on your machine.
+> **The MCP scanner that never sees your code.** No token. No telemetry. Deterministic. Run `nox scan --offline` and the scan path makes zero outbound connections — enforced by a test, not a promise (`TestOSVDisabled_NoNetworkEgress`). Online, exactly one thing leaves the machine: the dependency list (ecosystem, package, version), sent to the advisory source — [NOX Intelligence](docs/intelligence.md) by default, every answer verified against OSV.dev, or OSV.dev directly with `scan.intelligence.disabled: true`. Source code never leaves; findings leave only if you turn contribution on.
 
 - **Deterministic** -- same inputs produce same outputs, no hidden state
 - **Offline-first** -- zero required external services
@@ -198,16 +198,17 @@ Detects misconfigurations across **7 IaC categories**:
 
 ### Dependencies & SCA (6 rules)
 
-Parses lockfiles from **8 ecosystems** (Go, npm, PyPI, RubyGems, Cargo, Maven, Gradle, NuGet) and queries the [OSV.dev](https://osv.dev) database for known vulnerabilities:
+Parses lockfiles from **8 ecosystems** (Go, npm, PyPI, RubyGems, Cargo, Maven, Gradle, NuGet) and asks [NOX Intelligence](docs/intelligence.md) — an OSV-compatible advisory source that is verified against [OSV.dev](https://osv.dev) on every lookup — for known vulnerabilities:
 
 | Rule | Description |
 |------|-------------|
 | VULN-001 | Known vulnerability in dependency (severity mapped from CVSS) |
 
-- Batches queries to the OSV.dev API (up to 1000 packages per request)
+- Batches queries (up to 1000 packages per request); the same `/v1/querybatch` wire format as OSV.dev
+- Every intelligence answer is checked against OSV.dev; a withheld advisory is restored from OSV and reported as a degradation, so the service can never cost a scan a finding
 - CVSS scores mapped to nox severity levels (Critical/High/Medium/Low/Info)
-- Graceful degradation on network errors (offline-first)
-- Disable with `--no-osv` flag or `scan.osv.disabled: true` in `.nox.yaml`
+- Graceful degradation on network errors (offline-first): an unreachable service degrades to the OSV.dev scan nox always ran
+- Ask OSV.dev directly with `scan.intelligence.disabled: true`; disable lookups entirely with `--no-osv` / `--offline` / `scan.osv.disabled: true`
 - Vulnerability data enriches CycloneDX and SPDX SBOM output
 
 ### Supply-chain integrity (deterministic, offline)
@@ -279,7 +280,13 @@ scan:
     - "testdata/"
     - "*.test.js"
   osv:
-    disabled: false          # Set true to skip OSV lookups (offline mode)
+    disabled: false          # Set true to skip vulnerability lookups (offline mode)
+    base_url: ""             # OSV-compatible reference database (default api.osv.dev; a self-hosted mirror works)
+  intelligence:
+    disabled: false          # Set true to ask OSV.dev directly instead of NOX Intelligence
+    endpoint: ""             # Self-hosted service (default: NOX_INTEL_ENDPOINT, else https://intel.klarlabs.de)
+    verify_against_osv: true # Check every answer against the reference; a withheld advisory is restored and reported
+    contribute: false        # Send redacted observations back (opt-in; see docs/intelligence.md)
   rules:
     disable:
       - "AI-008"           # Unpinned model refs OK here

--- a/cli/intel_cmd.go
+++ b/cli/intel_cmd.go
@@ -56,8 +56,18 @@ func printIntelUsage() {
 	fmt.Fprintf(os.Stderr, "  add-operator     add someone to your organisation and print their link\n")
 	fmt.Fprintf(os.Stderr, "  invite           re-issue an enrolment link that expired\n")
 	fmt.Fprintf(os.Stderr, "  enroll           bind an authenticator using an enrolment link\n\n")
-	fmt.Fprintf(os.Stderr, "Contribution is off unless scan.intelligence.contribute is set,\n")
-	fmt.Fprintf(os.Stderr, "and is a separate decision from querying an intelligence endpoint.\n")
+	fmt.Fprintf(os.Stderr, "Every scan asks %s for advisories and verifies the\n", core.DefaultIntelligenceEndpoint)
+	fmt.Fprintf(os.Stderr, "answer against OSV.dev; set scan.intelligence.disabled to ask OSV.dev directly,\n")
+	fmt.Fprintf(os.Stderr, "or --offline to ask nobody. Contribution is off unless scan.intelligence.contribute\n")
+	fmt.Fprintf(os.Stderr, "is set, and is a separate decision from querying.\n")
+}
+
+// intelEndpointDefault is the base URL an intel subcommand talks to when
+// --endpoint is not given: NOX_INTEL_ENDPOINT if set, otherwise the service
+// every scan queries by default. The same fallback as scanning, so `nox intel
+// login` signs in to the service `nox scan` is asking.
+func intelEndpointDefault() string {
+	return core.IntelligenceConfig{}.ResolvedEndpoint()
 }
 
 // runIntelAllowlist prints the allowlist. The design requires that "what would

--- a/cli/intel_enroll.go
+++ b/cli/intel_enroll.go
@@ -30,8 +30,8 @@ import (
 func runIntelEnroll(args []string) int {
 	cmdName = "nox intel enroll"
 	fs := flag.NewFlagSet("intel enroll", flag.ContinueOnError)
-	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
-		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	endpoint := fs.String("endpoint", intelEndpointDefault(),
+		"intelligence service base URL (default: NOX_INTEL_ENDPOINT, else the service scans query)")
 	email := fs.String("email", "", "operator address to enrol")
 	yes := fs.Bool("no-confirm", false,
 		"print the URI and exit without confirming (the new factor stays inactive)")
@@ -46,8 +46,8 @@ func runIntelEnroll(args []string) int {
 	// honoured with one: the address comes from the code server-side.
 	if *endpoint == "" || (*email == "" && *invite == "") {
 		fmt.Fprintf(os.Stderr, "Usage:\n")
-		fmt.Fprintf(os.Stderr, "  nox intel enroll --endpoint URL --code CODE          # from an invitation\n")
-		fmt.Fprintf(os.Stderr, "  nox intel enroll --endpoint URL --email you@example.com   # break-glass\n\n")
+		fmt.Fprintf(os.Stderr, "  nox intel enroll --code CODE                 # from an invitation\n")
+		fmt.Fprintf(os.Stderr, "  nox intel enroll --email you@example.com     # break-glass\n\n")
 		fmt.Fprintf(os.Stderr, "An invitation is the ordinary path and needs no operator token.\n")
 		fmt.Fprintf(os.Stderr, "The token (NOX_INTEL_TOKEN) is for the case an invitation cannot cover:\n")
 		fmt.Fprintf(os.Stderr, "an operator who has lost their phone and holds no valid link.\n")

--- a/cli/intel_login.go
+++ b/cli/intel_login.go
@@ -17,15 +17,15 @@ import (
 // and can be revoked for one operator without disturbing anyone else.
 func runIntelLogin(args []string) int {
 	fs := flag.NewFlagSet("intel login", flag.ContinueOnError)
-	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
-		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	endpoint := fs.String("endpoint", intelEndpointDefault(),
+		"intelligence service base URL (default: NOX_INTEL_ENDPOINT, else the service scans query)")
 	noBrowser := fs.Bool("no-browser", false,
 		"print the URL and code instead of opening a browser")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if *endpoint == "" {
-		fmt.Fprintf(os.Stderr, "Usage: nox intel login --endpoint URL\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: nox intel login [--endpoint URL]\n\n")
 		fmt.Fprintf(os.Stderr, "Opens your browser to approve this terminal. Your authenticator\n")
 		fmt.Fprintf(os.Stderr, "code is never typed here — it stays in the browser, where it\n")
 		fmt.Fprintf(os.Stderr, "cannot end up in scrollback or a captured log.\n")
@@ -95,7 +95,7 @@ func runIntelWhoami(args []string) int {
 	}
 	s, ok := loadSession()
 	if !ok {
-		fmt.Println("Not signed in. Run: nox intel login --endpoint URL --email you@example.com")
+		fmt.Println("Not signed in. Run: nox intel login")
 		return 1
 	}
 	fmt.Printf("%s at %s\n", s.Email, s.Endpoint)

--- a/cli/intel_register.go
+++ b/cli/intel_register.go
@@ -16,8 +16,8 @@ import (
 func runIntelRegister(args []string) int {
 	cmdName = "nox intel add-operator"
 	fs := flag.NewFlagSet("intel register", flag.ContinueOnError)
-	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
-		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	endpoint := fs.String("endpoint", intelEndpointDefault(),
+		"intelligence service base URL (default: NOX_INTEL_ENDPOINT, else the service scans query)")
 	email := fs.String("email", "", "address of the operator to register")
 	org := fs.String("org", "", "organisation to register them into")
 	role := fs.String("role", "member", "member or admin")
@@ -96,8 +96,8 @@ func runIntelRegister(args []string) int {
 func runIntelInvite(args []string) int {
 	cmdName = "nox intel invite"
 	fs := flag.NewFlagSet("intel invite", flag.ContinueOnError)
-	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
-		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	endpoint := fs.String("endpoint", intelEndpointDefault(),
+		"intelligence service base URL (default: NOX_INTEL_ENDPOINT, else the service scans query)")
 	email := fs.String("email", "", "address of the operator to re-invite")
 	org := fs.String("org", "",
 		"organisation they belong to (only needed if you administer more than one)")

--- a/cli/intel_signup.go
+++ b/cli/intel_signup.go
@@ -22,14 +22,14 @@ import (
 // technically honest.
 func runIntelSignup(args []string) int {
 	fs := flag.NewFlagSet("intel register", flag.ContinueOnError)
-	endpoint := fs.String("endpoint", os.Getenv("NOX_INTEL_ENDPOINT"),
-		"intelligence service base URL (or NOX_INTEL_ENDPOINT)")
+	endpoint := fs.String("endpoint", intelEndpointDefault(),
+		"intelligence service base URL (default: NOX_INTEL_ENDPOINT, else the service scans query)")
 	noBrowser := fs.Bool("no-browser", false, "print the URL instead of opening a browser")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if *endpoint == "" {
-		fmt.Fprintf(os.Stderr, "Usage: nox intel register --endpoint URL\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: nox intel register [--endpoint URL]\n\n")
 		fmt.Fprintf(os.Stderr, "Opens the page where an organisation is created. Organisations are\n")
 		fmt.Fprintf(os.Stderr, "not created from the command line: that is where terms, billing and\n")
 		fmt.Fprintf(os.Stderr, "address verification live.\n\n")

--- a/core/config.go
+++ b/core/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	osvsource "github.com/nox-hq/nox-core/vulnsource/osv"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -383,6 +385,12 @@ type EntropyConfig struct {
 type OSVConfig struct {
 	Disabled bool `yaml:"disabled"`
 
+	// BaseURL is the OSV-compatible API nox treats as the reference database:
+	// the source asked directly when the intelligence service is disabled, and
+	// the one every intelligence answer is verified against. Empty means
+	// https://api.osv.dev. Set it to a self-hosted OSV mirror.
+	BaseURL string `yaml:"base_url"`
+
 	// CacheDisabled turns off the advisory cache. Default is enabled.
 	//
 	// Only advisory *documents* are ever cached, keyed on the publisher's own
@@ -398,15 +406,34 @@ type OSVConfig struct {
 	CacheDir string `yaml:"cache_dir"`
 }
 
-// IntelligenceConfig points dependency scanning at a NOX Intelligence service
-// instead of OSV.dev directly.
+// DefaultIntelligenceEndpoint is the NOX Intelligence service dependency
+// scanning asks when no endpoint is configured. It is compiled in, so a binary
+// keeps working against it for as long as the binary is in use — moving the
+// service means keeping this host answering, not just updating the constant.
+const DefaultIntelligenceEndpoint = "https://intel.klarlabs.de"
+
+// IntelligenceConfig selects who answers "is this package vulnerable?".
 //
-// Off by default. Enabling it is an explicit act, and it changes who answers
-// "is this package vulnerable?" — which is a trust decision, not a tuning knob.
+// The NOX Intelligence service answers by default, and every answer is
+// verified against OSV.dev (see VerifyAgainstOSV): a record the service
+// withholds is restored from OSV and reported as a degradation, so switching
+// the default source changed WHO is asked, never what a scan can find. What a
+// lookup transmits is exactly what an OSV lookup transmits — (ecosystem,
+// package, version) per dependency — and nothing else; contributing
+// observations back is a separate decision (see Contribute) and stays off
+// until set.
+//
+// Setting Disabled queries OSV.dev directly, as nox did before the default
+// changed. `--offline` (or `scan.osv.disabled`) turns every lookup off.
 type IntelligenceConfig struct {
 	// Endpoint is the intelligence service base URL. Empty (default) means
-	// dependency scanning queries OSV.dev exactly as before.
+	// DefaultIntelligenceEndpoint.
 	Endpoint string `yaml:"endpoint"`
+
+	// Disabled sends dependency lookups to OSV.dev directly instead of the
+	// intelligence service. It is the opt-out for operators who do not want
+	// their dependency list to reach the service at all.
+	Disabled bool `yaml:"disabled"`
 
 	// VerifyAgainstOSV checks every lookup against OSV.dev and reports any
 	// record the intelligence service withheld. Default true.
@@ -430,10 +457,45 @@ type IntelligenceConfig struct {
 	ReporterSaltPath string `yaml:"reporter_salt_path"`
 }
 
+// ReferenceBaseURL is the OSV-compatible API scans use as the reference
+// database: BaseURL when set, otherwise the public OSV.dev endpoint.
+func (c OSVConfig) ReferenceBaseURL() string {
+	if u := strings.TrimSpace(c.BaseURL); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return osvsource.DefaultBaseURL
+}
+
 // VerificationEnabled reports whether lookups are checked against OSV,
 // defaulting to true when unset.
 func (c IntelligenceConfig) VerificationEnabled() bool {
 	return c.VerifyAgainstOSV == nil || *c.VerifyAgainstOSV
+}
+
+// IntelligenceEndpointEnv names the environment variable that selects the
+// intelligence service when .nox.yaml does not. The `nox intel` subcommands
+// read the same variable, so a pipeline pointed at a self-hosted service by
+// environment has every command agreeing on which service that is.
+const IntelligenceEndpointEnv = "NOX_INTEL_ENDPOINT"
+
+// ResolvedEndpoint is the intelligence service base URL lookups and
+// contributions use, resolved as
+//
+//	disabled  >  scan.intelligence.endpoint  >  NOX_INTEL_ENDPOINT  >  DefaultIntelligenceEndpoint
+//
+// and "" when Disabled — the one value that means "ask the reference database
+// directly".
+func (c IntelligenceConfig) ResolvedEndpoint() string {
+	if c.Disabled {
+		return ""
+	}
+	if ep := strings.TrimSpace(c.Endpoint); ep != "" {
+		return strings.TrimRight(ep, "/")
+	}
+	if ep := strings.TrimSpace(os.Getenv(IntelligenceEndpointEnv)); ep != "" {
+		return strings.TrimRight(ep, "/")
+	}
+	return DefaultIntelligenceEndpoint
 }
 
 // SlopConfig enables the SLOP analyzer's predictive slopsquat dimension

--- a/core/config_intel_default_test.go
+++ b/core/config_intel_default_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"testing"
+
+	osvsource "github.com/nox-hq/nox-core/vulnsource/osv"
+)
+
+// Who answers "is this package vulnerable?" is resolved from four places, and
+// the order is the whole contract: an operator who wrote `disabled: true` must
+// win over every URL, a URL in .nox.yaml must win over the environment, and
+// nothing set at all must mean the service every scan asks — not OSV.dev,
+// which the previous default silently was.
+func TestIntelligenceEndpoint_Resolution(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  IntelligenceConfig
+		env  string
+		want string
+	}{
+		{"nothing set is the compiled-in service", IntelligenceConfig{}, "", DefaultIntelligenceEndpoint},
+		{"environment fills in for an absent config", IntelligenceConfig{}, "https://intel.example.test/", "https://intel.example.test"},
+		{"config wins over environment", IntelligenceConfig{Endpoint: "https://a.test"}, "https://b.test", "https://a.test"},
+		{"a trailing slash is not part of the endpoint", IntelligenceConfig{Endpoint: " https://a.test/ "}, "", "https://a.test"},
+		{"disabled wins over a configured endpoint", IntelligenceConfig{Disabled: true, Endpoint: "https://a.test"}, "", ""},
+		{"disabled wins over the environment", IntelligenceConfig{Disabled: true}, "https://b.test", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(IntelligenceEndpointEnv, tc.env)
+			if got := tc.cfg.ResolvedEndpoint(); got != tc.want {
+				t.Fatalf("ResolvedEndpoint() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The reference database defaults to public OSV.dev and can be a self-hosted
+// mirror; it is the one source that is never the intelligence service, because
+// it is what the intelligence service is checked against.
+func TestOSVReferenceBaseURL(t *testing.T) {
+	if got := (OSVConfig{}).ReferenceBaseURL(); got != osvsource.DefaultBaseURL {
+		t.Fatalf("empty base_url = %q, want %q", got, osvsource.DefaultBaseURL)
+	}
+	if got := (OSVConfig{BaseURL: " https://osv.mirror.test/ "}).ReferenceBaseURL(); got != "https://osv.mirror.test" {
+		t.Fatalf("base_url = %q, want the trimmed mirror", got)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -412,7 +412,10 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// two cannot drift into disagreeing about what "offline" means.
 	vulnLookupEnabled := !opts.Offline && !opts.DisableOSV && !cfg.Scan.OSV.Disabled
 
-	depsOpts := []deps.AnalyzerOption{deps.WithDegradations(degradations)}
+	depsOpts := []deps.AnalyzerOption{
+		deps.WithDegradations(degradations),
+		deps.WithOSVBaseURL(cfg.Scan.OSV.ReferenceBaseURL()),
+	}
 	if !vulnLookupEnabled {
 		depsOpts = append(depsOpts, deps.WithOSVDisabled())
 	}
@@ -436,24 +439,24 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			Allow: cfg.License.Allow,
 		}))
 	}
-	// An intelligence endpoint replaces OSV.dev as the source dependency
-	// scanning asks. It is off unless configured, so the default path is
-	// unchanged.
+	// The intelligence service is the source dependency scanning asks, by
+	// default; `scan.intelligence.disabled` asks OSV.dev directly instead.
 	//
 	// When verification is on (the default), the intelligence source is checked
 	// against OSV on every lookup and any record it withheld is restored from
 	// OSV and reported as a degradation. That is what keeps "superset" a
 	// property rather than a promise: a source that starts dropping advisories
 	// costs its operator trust, immediately and visibly, but never costs the
-	// scan a finding.
-	if endpoint := cfg.Scan.Intelligence.Endpoint; endpoint != "" && vulnLookupEnabled {
+	// scan a finding. It is also what makes a compiled-in default defensible:
+	// an unreachable service degrades to exactly the OSV scan nox ran before.
+	if endpoint := cfg.Scan.Intelligence.ResolvedEndpoint(); endpoint != "" && vulnLookupEnabled {
 		intel := osvsource.NewNamed("nox-intelligence", endpoint, intelHTTPClient(), degradations).
 			WithCache(advisoryCache)
 
 		var src vulnsource.Source = intel
 		if cfg.Scan.Intelligence.VerificationEnabled() {
 			src = vulnsource.NewVerifying(intel, func(refDeg *degrade.Degradations) vulnsource.Source {
-				return osvsource.New(osvsource.DefaultBaseURL, intelHTTPClient(), refDeg).
+				return osvsource.New(cfg.Scan.OSV.ReferenceBaseURL(), intelHTTPClient(), refDeg).
 					WithCache(advisoryCache)
 			}, degradations)
 		}
@@ -977,15 +980,16 @@ func parseFeedRefresh(s string) (time.Duration, error) {
 // Querying an endpoint and contributing to it are two decisions, and this is
 // the second one. A lookup already transmits (ecosystem, package, version) for
 // every dependency, so if querying implied contributing then "contribute:
-// false" would be a lie for anyone with an endpoint configured. Both are off by
-// default and both must be set explicitly.
+// false" would be a lie for anyone with an endpoint configured. Querying is on
+// by default; contributing is off until set, in config AND by the caller.
 //
 // Failure is recorded, never propagated. A scan that failed because an upload
 // did would make opting in actively hostile, and would give operators a reason
 // to switch off the thing that makes corroboration possible at all.
 func contributeObservations(ctx context.Context, cfg *ScanConfig, opts ScanOptions, fs []findings.Finding, deg *degrade.Degradations) {
 	ic := cfg.Scan.Intelligence
-	if !opts.ContributeObservations || !ic.Contribute || ic.Endpoint == "" {
+	endpoint := ic.ResolvedEndpoint()
+	if !opts.ContributeObservations || !ic.Contribute || endpoint == "" {
 		return
 	}
 
@@ -1013,7 +1017,7 @@ func contributeObservations(ctx context.Context, cfg *ScanConfig, opts ScanOptio
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	res := intel.NewClient(ic.Endpoint, intelHTTPClient()).Contribute(ctx, obs)
+	res := intel.NewClient(endpoint, intelHTTPClient()).Contribute(ctx, obs)
 	if res.FirstError != nil {
 		deg.Add(degrade.IntelContribution,
 			fmt.Sprintf("%d of %d observations were not accepted: %v",

--- a/core/scan_intel_default_test.go
+++ b/core/scan_intel_default_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// advisoryProbe is an OSV-compatible endpoint that answers every batch query
+// with "no advisories" and counts how many it was asked.
+func advisoryProbe(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var batches atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/querybatch" {
+			batches.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"vulns":[]}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &batches
+}
+
+// lockfileProject is a directory with one npm dependency and the given
+// .nox.yaml, so a scan of it issues exactly one batch query per source asked.
+func lockfileProject(t *testing.T, noxYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	lock := `{"packages":{"node_modules/lodash":{"version":"4.17.15"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox.yaml"), []byte(noxYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A scan with nothing configured asks the intelligence service, and verifies
+// the answer against the reference database. The default is compiled in, so
+// the test reaches it through NOX_INTEL_ENDPOINT — the same fallback a
+// pipeline uses to point every nox command at a self-hosted service.
+func TestScan_IntelligenceIsTheDefaultSource(t *testing.T) {
+	intel, intelBatches := advisoryProbe(t)
+	ref, refBatches := advisoryProbe(t)
+	t.Setenv(IntelligenceEndpointEnv, intel.URL)
+
+	dir := lockfileProject(t, "scan:\n  osv:\n    base_url: "+ref.URL+"\n    cache_disabled: true\n")
+	if _, err := RunScanWithOptions(dir, ScanOptions{}); err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if n := intelBatches.Load(); n != 1 {
+		t.Errorf("intelligence service was asked %d times, want 1", n)
+	}
+	if n := refBatches.Load(); n != 1 {
+		t.Errorf("reference database was asked %d times for verification, want 1", n)
+	}
+}
+
+// `scan.intelligence.disabled` is the opt-out: the reference database is asked
+// directly and the service is never contacted, even with an endpoint in the
+// environment.
+func TestScan_IntelligenceDisabledAsksTheReferenceDirectly(t *testing.T) {
+	intel, intelBatches := advisoryProbe(t)
+	ref, refBatches := advisoryProbe(t)
+	t.Setenv(IntelligenceEndpointEnv, intel.URL)
+
+	dir := lockfileProject(t, "scan:\n  intelligence:\n    disabled: true\n  osv:\n    base_url: "+ref.URL+"\n    cache_disabled: true\n")
+	if _, err := RunScanWithOptions(dir, ScanOptions{}); err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if n := intelBatches.Load(); n != 0 {
+		t.Errorf("intelligence service was asked %d times with intelligence disabled", n)
+	}
+	if n := refBatches.Load(); n != 1 {
+		t.Errorf("reference database was asked %d times, want 1", n)
+	}
+}
+
+// --offline still means nobody is asked. The default source must not have
+// opened a path around the one switch operators rely on to keep a scan local.
+func TestScan_OfflineAsksNobody(t *testing.T) {
+	intel, intelBatches := advisoryProbe(t)
+	ref, refBatches := advisoryProbe(t)
+	t.Setenv(IntelligenceEndpointEnv, intel.URL)
+
+	dir := lockfileProject(t, "scan:\n  osv:\n    base_url: "+ref.URL+"\n    cache_disabled: true\n")
+	if _, err := RunScanWithOptions(dir, ScanOptions{Offline: true}); err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if n := intelBatches.Load() + refBatches.Load(); n != 0 {
+		t.Errorf("an offline scan made %d network lookups", n)
+	}
+}

--- a/docs/design/intelligence-service.md
+++ b/docs/design/intelligence-service.md
@@ -1,7 +1,12 @@
 # Design: NOX Intelligence Service
 
-Status: proposed. Nothing here is implemented. The decision to build this as a
-service rather than a CLI feature is recorded in
+Status: the service runs at `intel.klarlabs.de` (repository `nox-intelligence`)
+and is the source every `nox scan` asks by default, verified against OSV.dev
+on each lookup; contribution stays opt-in. The user-facing account of what a
+scan sends is [docs/intelligence.md](../intelligence.md). Research
+orchestration, coordinated disclosure and early warning are designed below and
+built only as far as the phases in the service repository record. The decision
+to build this as a service rather than a CLI feature is recorded in
 [ADR 0002](../adr/0002-intelligence-layer-is-a-separate-service.md).
 
 ## Purpose
@@ -82,7 +87,7 @@ are. Unattributed observations never count toward independence.
 
 | mode | behaviour |
 |---|---|
-| `disabled` (default) | nothing leaves the environment |
+| `disabled` (default) | nothing beyond the lookup itself leaves the environment |
 | `anonymous` | security facts contribute to aggregate intelligence |
 | `org-private` | observations stay inside the organisation's own instance |
 | `public-intelligence` | eligible validated observations may contribute to the ecosystem, under disclosure policy |

--- a/docs/intelligence.md
+++ b/docs/intelligence.md
@@ -1,0 +1,98 @@
+# NOX Intelligence — what a scan asks, what it sends, and how to turn it off
+
+`nox scan` asks **NOX Intelligence** (`https://intel.klarlabs.de`) which
+advisories match each dependency, and verifies every answer against OSV.dev.
+This page is the complete account of what that means for the machine running
+the scan. If a sentence here is not true of the binary, that is a bug.
+
+## What leaves the machine
+
+| when | what | to whom |
+|---|---|---|
+| every online scan with a lockfile | `(ecosystem, package, version)` per dependency, as one `/v1/querybatch` request — byte-for-byte the request OSV.dev has always received | the intelligence service, then the reference database (verification) |
+| `scan.intelligence.contribute: true` **only** | redacted observations: per finding, the fields in `nox intel allowlist` — fingerprint, rule id, ecosystem/package/version range, verdict — never a path, a line, a snippet, a secret, or a prompt | the intelligence service |
+| never | source code, file paths, file contents, prompts, credentials, customer data | — |
+
+`nox intel preview <path>` prints exactly what a contribution from `<path>`
+would carry, without sending it. `nox intel allowlist` prints every field an
+observation may carry; anything not on that list cannot be sent, by
+construction (`core/intel/allowlist.go` fails closed).
+
+Reporter identity is an HMAC of a private salt kept in
+`$HOME/.nox/reporter-salt`. The salt never leaves the machine; the service
+can count *distinct reporters* without learning who any of them are.
+
+## Why the default is the service, verified
+
+The service answers with the same advisory set OSV.dev does — its mirror is
+complete against OSV — plus, over time, what only a network can know: how many
+independent reporters saw the same issue, how often a finding is dismissed
+across the corpus, and early warning for issues that have not reached the
+public pipeline yet. When the service has something to add beyond the
+advisory itself, it arrives on the finding as `intel_source`,
+`intel_corroboration` (distinct reporters, never observation count) and
+`intel_confidence`; a plain mirrored advisory carries none of them, and `nox why`
+reads them when present.
+
+What makes a compiled-in default defensible is **verification**: every answer
+is checked against the reference database, a record the service withheld is
+restored from the reference, and the discrepancy is reported as a degradation
+on the scan. A service that starts dropping advisories costs its operator
+trust immediately and visibly, and never costs the scan a finding. An
+unreachable service degrades to exactly the OSV.dev scan nox always ran.
+
+## Turning it off, at every level
+
+```yaml
+scan:
+  intelligence:
+    disabled: true       # ask the reference database (OSV.dev) directly; the service is never contacted
+```
+
+```sh
+nox scan --offline       # no lookups at all: zero outbound connections (TestScan_OfflineAsksNobody)
+nox scan --no-osv        # same, for the vulnerability lookup only
+```
+
+Resolution order for the endpoint:
+
+```text
+scan.intelligence.disabled  >  scan.intelligence.endpoint  >  NOX_INTEL_ENDPOINT  >  https://intel.klarlabs.de
+```
+
+`NOX_INTEL_ENDPOINT` is read by `nox scan` and by every `nox intel`
+subcommand, so a pipeline pointed at a self-hosted service has every command
+agreeing on which service that is. `scan.osv.base_url` names the reference
+database (a self-hosted OSV mirror works; the default is `https://api.osv.dev`).
+
+## Contributing back
+
+Contribution is a separate decision from querying, and it is off until
+`scan.intelligence.contribute: true` is set. A lookup already transmits the
+dependency list; it would be a lie to say "contribute: false" meant nothing
+was sent, so the two are named separately and documented separately.
+
+A contribution that fails is recorded as a degradation and never fails the
+scan. Only `nox scan` contributes — `diff`, `bench` and `intel preview` derive
+observations and send nothing.
+
+Why contribute: independence is counted in distinct reporters, not
+observations. One organisation scanning itself a thousand times is one source.
+Every reporter that joins makes corroboration — and everything derived from
+it — possible for everyone else.
+
+## Operator accounts
+
+`nox intel login`, `register`, `add-operator`, `invite` and `enroll` manage
+organisations on the service. None of them are needed to scan or to
+contribute anonymously; they exist for organisation-private intelligence and
+for operating the service. `--endpoint` on each defaults exactly as above.
+
+## The boundary, in one sentence
+
+The CLI decides *what this means here* — reachability, exposure, blast
+radius — on data that never leaves; the service decides *what is emerging
+across the ecosystem* on data that was minimised before it left. See
+[design/intelligence-service.md](design/intelligence-service.md) for the
+service side and [ADR 0002](adr/0002-intelligence-layer-is-a-separate-service.md)
+for why it is a service at all.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -384,8 +384,113 @@ coordinated disclosure, and early warning require multi-tenant state, auth, and 
 operational footprint that has no business in a CLI release cycle. The client-side
 half — privacy redaction, the private evidence graph, and organisation-specific
 blast radius — stays local and auditable, but it is designed against a service
-rather than shipped as a stand-in for one. See
+rather than shipped as a stand-in for one. The CLI *consumes* the service — since
+Phase 11, by default — and the boundary is what keeps both sides honest. See
 `docs/design/intelligence-service.md`.
+
+## Phase 11 — Intelligence by Default
+
+Phase 11 changes one default and then plans against where the market is going,
+not where it is. The default: every online `nox scan` asks NOX Intelligence for
+advisories and verifies the answer against OSV.dev (`docs/intelligence.md`).
+Opting out is one config key; `--offline` still asks nobody. Contribution stays a
+separate, opt-in decision. That is the whole of 11a. Everything after it is
+ordered by five observations about the market, each of which names the gap it
+turns into work.
+
+**What the market is doing.** (1) Finding vulnerabilities is commoditised —
+every scanner, and every LLM, finds the same SQL injection; *triage* is the
+product, and triage is a network property (what did everyone else do with this
+finding?). (2) Buyers are consolidating onto platforms; a primitive survives that
+by being the best-verified *source* those platforms consume, not by growing a
+dashboard. (3) AI is on both sides: agents generate the code that gets scanned
+and agents consume the findings, so the API shape matters more than the CLI
+shape. (4) Regulation — the EU Cyber Resilience Act's reporting duties, VEX as
+the exchange format — turns "is this reachable in *our* deployment?" into a
+document with a deadline. (5) Trust in a shared source is earned in public:
+uptime, a published payload, verified claims, and a visible way to leave.
+
+### 11a. The default, and its opt-out ✓
+
+- `scan.intelligence` resolves `disabled > endpoint > NOX_INTEL_ENDPOINT >
+  compiled-in endpoint`; `scan.osv.base_url` names the reference for
+  verification and for self-hosted mirrors.
+- Every intel subcommand defaults to the same endpoint scans use.
+- Verification is on by default: a withheld advisory is restored from the
+  reference and reported as a degradation; an unreachable service degrades to
+  the OSV.dev scan nox always ran.
+- Tests assert the three states from the wire: service + reference, reference
+  only, nobody.
+
+### 11b. Trust in public — earned before the network is asked for anything
+
+Ordered first because a compiled-in default is a promise the project makes on
+behalf of every user who never reads a config file.
+
+- **Payload page** — `docs/intelligence.md` is the canonical statement of what
+  leaves the machine; the service publishes the same page and a status/uptime
+  page, so the promise is checkable from either side.
+- **Service CI** — the service has none today; its store tests skip without a
+  database. A Postgres service container in CI makes the tenant-isolation test a
+  gate, not an aspiration. Nothing network-derived ships until this is green.
+- **Verified domain claims** — an organisation's `verified: true` is an operator
+  assertion today; DNS TXT verification turns it into a fact the service checked.
+- **The endpoint's name** — the default is compiled in, so the domain is now an
+  API contract. Decide `intel.klarlabs.de` vs `intel.nox-hq.dev` once, keep a
+  permanent redirect from whichever loses, and treat any later change as a
+  breaking release.
+- **Release notes** name the default change as the headline and the one-line
+  opt-out, every release until the next default changes.
+- **Operator credentials** — the founder token is reissued and stored outside a
+  shell history; billing stays postponed until there is more than one reporter
+  to bill.
+
+### 11c. Reporters, not observations — the only number that matters
+
+The evidence spine counts independence in distinct reporters, so the network's
+value is exactly its reporter count, and every feature below is worthless at one.
+The north-star metric is *distinct reporters per ecosystem per week*; the
+service exposes it, and the roadmap re-orders around whatever moves it. Nothing
+that requires corroboration (11d–11f) is promised at a reporter count that
+cannot supply it.
+
+### 11d. Triage is the product — the first network feature
+
+- **Dismissal corpus** — "what did everyone else do with this finding": per
+  fingerprint class, the share of reporters who waived, fixed, or disputed, with
+  the reasons redacted to the allowlist. Arrives on the finding as
+  `intel_corroboration` and in `nox why`; never changes a verdict, because
+  independence and repetition are not evidence at reproduction strength.
+- **KEV / EPSS / reachability as Community triage** — deterministic, public
+  inputs the CLI already has or can fetch; they reorder, they do not confirm.
+- **Early warning stays deferred** until reporters fund the research that
+  produces it; an embargoed disclosure is excluded from early warning by design.
+
+### 11e. Agents are the consumers — the API is the product surface
+
+- **Intelligence API / OEM** — the same advisory + corroboration answer over a
+  documented, versioned HTTP surface for platforms and agents; MCP exposes it
+  through the existing read-only tools so an agent that scans with nox reasons
+  with the network's triage without another integration.
+- The CLI stays a thin, deterministic consumer: the service may add fields, the
+  CLI may ignore them, and neither release blocks the other.
+
+### 11f. Regulation turns exposure into a document — Enterprise
+
+- **Organisation exposure / blast radius** — the private evidence graph answers
+  "which of *our* services carry this, and is it reachable there?" on data that
+  never leaves.
+- **CRA / VEX reporting** — that answer rendered as VEX the way `nox vex`
+  renders it today, with the corroboration that makes a `not_affected`
+  defensible attached as evidence rather than asserted.
+
+### Deliberately not in Phase 11
+
+Research orchestration and autonomous exploit research on the service, advisory
+publication, and coordinated disclosure. All three are designed in
+`docs/design/intelligence-service.md` and all three depend on 11b and 11c being
+true first: a network that cannot show its isolation test or count its reporters
+has no business publishing advisories.
 
 ## Explicitly Out of Scope
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -868,6 +868,35 @@ scan:
 
 This is useful for reducing noise from dependencies in `node_modules/` or test fixtures.
 
+### Vulnerability source (NOX Intelligence, verified against OSV.dev)
+
+Dependency scanning asks **NOX Intelligence** for advisories by default and
+verifies every answer against a reference database (OSV.dev unless
+`scan.osv.base_url` names a mirror). A record the service withholds is restored
+from the reference and reported as a degradation, so the service can add
+findings and can never remove one. What a lookup transmits is what an OSV
+lookup transmits — `(ecosystem, package, version)` per dependency — and nothing
+else. See [docs/intelligence.md](intelligence.md).
+
+```yaml
+scan:
+  intelligence:
+    disabled: false           # true: ask the reference database directly, never the service
+    endpoint: ""              # self-hosted service; empty resolves NOX_INTEL_ENDPOINT, then the public service
+    verify_against_osv: true  # default; set false only for a service you operate and audit yourself
+    contribute: false         # opt-in: send redacted observations back after a `nox scan`
+  osv:
+    base_url: ""              # OSV-compatible reference (default https://api.osv.dev)
+    disabled: false           # true: no vulnerability lookups at all (same as --no-osv)
+```
+
+Resolution order for the endpoint is `disabled` > `scan.intelligence.endpoint`
+> `NOX_INTEL_ENDPOINT` > the compiled-in public service. `--offline` turns off
+every lookup regardless. Contribution is a separate decision from querying and
+is off until `scan.intelligence.contribute: true` is set; only `nox scan`
+contributes (never `diff`, `bench` or `intel preview`), and
+`nox intel preview <path>` shows exactly what would be sent.
+
 ### Predictive Slopsquat Feed (SLOP-002)
 
 The SLOP analyzer can consume a versioned, offline **predictive slopsquat


### PR DESCRIPTION
## What changes

Every online `nox scan` now asks **NOX Intelligence** (`https://intel.klarlabs.de`) which advisories match each dependency and verifies the answer against OSV.dev. A withheld record is restored from the reference and reported as a degradation; an unreachable service degrades to exactly the OSV.dev scan nox always ran. **What leaves the machine is unchanged** — the `(ecosystem, package, version)` list OSV.dev always received — and contribution stays a separate, opt-in decision (`scan.intelligence.contribute`).

- `scan.intelligence` resolves `disabled > endpoint > NOX_INTEL_ENDPOINT > compiled-in`
- `scan.intelligence.disabled: true` → OSV.dev directly, service never contacted; `--offline` → nobody
- `scan.osv.base_url` names the reference (self-hosted mirrors; also the seam that lets tests assert the wire)
- `nox intel login/register/add-operator/invite/enroll --endpoint` default to the endpoint scans use
- `docs/intelligence.md` (new): what a scan sends, to whom, and how to turn it off at every level
- `docs/design/intelligence-service.md` no longer says "proposed, nothing implemented"
- `docs/roadmap.md` Phase 11 plans the remaining gaps from where the market moves
- CHANGELOG `[Unreleased]` entry — this is the headline of the next release

## Verification

Unit (`core/scan_intel_default_test.go`, httptest probes counting `/v1/querybatch`):

| state | intel hits | reference hits |
|---|---|---|
| default (`NOX_INTEL_ENDPOINT` set, `scan.osv.base_url` set) | 1 | 1 |
| `scan.intelligence.disabled: true` | 0 | 1 |
| `--offline` | 0 | 0 |

Falsified: with the old behaviour (empty endpoint = OSV only) the first test fails.

End to end with the built binary on a `package-lock.json` pinning `lodash@4.17.15`:

- live default → 6 `VULN-001` (GHSA-29mw…, 35jh…, f23m…, p6mc…, r5fr…, xxjr…), **no degradation** — the service is a superset of OSV for this query
- `scan.intelligence.disabled: true` → the same 6 fingerprints
- `NOX_INTEL_ENDPOINT` pointed at a local server returning `{"results":[{"vulns":[]}]}` → the wire carried exactly `{"queries":[{"package":{"name":"lodash","ecosystem":"npm"},"version":"4.17.15"}]}`, the scan reported `[degraded] nox-intelligence withheld 6 record(s) published by osv.dev` and **still reported all 6**
- `--offline` → 0, no lookups

`go build ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt` clean.

## Release note

Recommend this ships as **v1.33.0** after #564 and this merge, with the default change and the one-line opt-out as the headline.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
