### PR TITLE
TAINT: resolve aliases, so the canonical spelling is not the missed one

### DIFF
--- a/core/taint/engine/imports.go
+++ b/core/taint/engine/imports.go
@@ -35,6 +35,36 @@ import (
 // Go never had this problem: `extract_go.go` resolves aliases through
 // `core/source.ImportAliases`. This brings the recognizer languages up to that.
 //
+// # The same defect, one layer over: Clojure, Elixir and C#
+//
+// Those three name their sinks by a MODULE or TYPE name that an alias renames,
+// and the catalog handled it by enumerating the aliases its author expected --
+// `shell/sh` beside `clojure.java.shell/sh`, `io/reader`, `jdbc/query`. That
+// works only for the alias someone anticipated. Measured, varying nothing but
+// the `:as`:
+//
+//	(:require [clojure.java.shell :as shell])   shell/sh   MATCHED (enumerated)
+//	(:require [clojure.java.shell :as sh])      sh/sh      missed
+//	(:require [clojure.java.shell :as sh2])     sh2/sh     missed
+//
+// `sh` is the canonical alias -- it is the one in clojure.java.shell's own
+// docstring -- so the command-injection sink was invisible on the dominant
+// spelling while scoring a match on the unusual one. Resolving `:as` replaces
+// the guesswork: any alias reaches the qualified name the catalog already has.
+//
+// Elixir and C# take the mirror form. Their catalog entries are BARE module and
+// type names (`System.cmd`, `Repo.query`, `Process.Start`), which is what
+// unaliased code writes, so the resolution target is the LAST segment of the
+// alias's right-hand side rather than the whole path:
+//
+//	alias MyApp.Repo, as: DB           DB.query    -> Repo.query
+//	using Proc = System.Diagnostics.Process;   Proc.Start -> Process.Start
+//
+// Known limit, stated rather than papered over: a C# alias that names a
+// NAMESPACE (`using D = System.Diagnostics;` then `D.Process.Start`) resolves to
+// neither the bare nor the fully-qualified form the catalog carries, and is
+// still missed. The common type-alias case is what this handles.
+//
 // # Why it adds chains rather than replacing them
 //
 // An expansion is recorded ALONGSIDE the original chain, never instead of it.
@@ -56,23 +86,43 @@ var (
 	jsImport = regexp.MustCompile(`^\s*import\s+(.+?)\s+from\s*['"]([^'"]+)['"]`)
 )
 
+// aliasTable maps a local name to the name it resolves to, together with the
+// separator that joins a call chain in this language. The separator travels
+// WITH the table because it is a property of the same language decision: a
+// Clojure chain is `sh/sh`, a Python one `os.system`, and expanding either with
+// the other's separator would silently produce a name that matches nothing.
+type aliasTable struct {
+	names map[string]string
+	sep   string
+}
+
+func (t aliasTable) empty() bool { return len(t.names) == 0 }
+
 // importAliases maps a local name to the qualified path it refers to.
 //
-// A value may be a module ("os", "child_process") or a fully qualified member
-// ("os.system"), which is why callers must join the remainder of a chain onto
-// it rather than assuming one or the other.
-func importAliases(lang lexctx.Lang, content []byte) map[string]string {
+// A value may be a module ("os", "child_process"), a fully qualified member
+// ("os.system"), or -- for the languages whose catalog entries are bare -- a
+// simple module or type name ("Process"). Callers join the remainder of a chain
+// onto it rather than assuming one or the other.
+func importAliases(lang lexctx.Lang, content []byte) aliasTable {
 	switch lang {
 	case lexctx.LangPython:
-		return pythonAliases(content)
+		return aliasTable{names: pythonAliases(content), sep: "."}
 	case lexctx.LangJavaScript:
-		return javascriptAliases(content)
+		return aliasTable{names: javascriptAliases(content), sep: "."}
+	case lexctx.LangClojure:
+		return aliasTable{names: clojureAliases(content), sep: "/"}
+	case lexctx.LangElixir:
+		return aliasTable{names: elixirAliases(content), sep: "."}
+	case lexctx.LangCSharp:
+		return aliasTable{names: csharpAliases(content), sep: "."}
 	default:
 		// Every other language keeps today's behaviour. Go resolves its own
-		// aliases in the AST extractor; the rest are unmeasured, and adding
-		// guesses for import syntaxes nobody has checked would be the same
-		// mistake in a new place.
-		return nil
+		// aliases in the AST extractor; the rest were probed and either show no
+		// gap (Rust's `use x as y` already reaches the sink) or name their sinks
+		// by a convention no alias renames. Adding guesses for import syntaxes
+		// nobody has checked would be the same mistake in a new place.
+		return aliasTable{}
 	}
 }
 
@@ -189,25 +239,100 @@ func splitJSMember(s string) (name, alias string) {
 	return splitAs(s)
 }
 
-// expandChain returns the qualified form of a dotted chain, or "" when the head
-// is not an imported name.
+// clojureAliases reads `:as` (and `:as-alias`) out of ns/require libspecs.
+//
+// Every alias in Clojure is introduced by the same vector shape --
+// `[some.namespace :as local]` -- whether it appears in an `(ns …)` form, a
+// top-level `(require '[…])`, or a multi-line `:require` block. One pattern
+// covers all three, which is why this is a resolution rather than a list of
+// namespaces someone remembered.
+var cljAlias = regexp.MustCompile(`\[\s*([A-Za-z][\w.$*+!?<>=-]*)\s+:as(?:-alias)?\s+([A-Za-z][\w.$*+!?<>=-]*)`)
+
+func clojureAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, m := range cljAlias.FindAllStringSubmatch(string(content), -1) {
+		ns, local := m[1], m[2]
+		if ns == local {
+			continue // nothing to resolve
+		}
+		out[local] = ns
+	}
+	return out
+}
+
+// elixirAliases reads `alias Some.Module, as: Local`.
+//
+// Plain `alias MyApp.Repo` is deliberately skipped: it binds `Repo`, which is
+// already the bare name the catalog carries, so there is nothing to expand.
+var exAlias = regexp.MustCompile(`^\s*alias\s+([A-Z][\w.]*)\s*,\s*as:\s*([A-Z]\w*)`)
+
+func elixirAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		m := exAlias.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		// The catalog names Elixir sinks bare (`System.cmd`, `Repo.query`), so
+		// the target is the last segment, not the whole path.
+		if target := lastSegment(m[1], "."); target != m[2] {
+			out[m[2]] = target
+		}
+	}
+	return out
+}
+
+// csharpAliases reads `using Local = Some.Qualified.Type;`.
+//
+// The `using var x = …` declaration and `using static …` share the keyword but
+// not the shape: both are excluded by requiring a single identifier before the
+// `=` and a plain dotted name after it.
+var csUsingAlias = regexp.MustCompile(`^\s*(?:global\s+)?using\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_][\w.]*)\s*;`)
+
+func csharpAliases(content []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		m := csUsingAlias.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		// As in Elixir, the catalog names the TYPE (`Process.Start`), so the
+		// alias resolves to the last segment.
+		if target := lastSegment(m[2], "."); target != m[1] {
+			out[m[1]] = target
+		}
+	}
+	return out
+}
+
+// lastSegment returns the final component of a separated path.
+func lastSegment(s, sep string) string {
+	if i := strings.LastIndex(s, sep); i >= 0 {
+		return s[i+len(sep):]
+	}
+	return s
+}
+
+// expandChain returns the resolved form of a chain, or "" when the head is not
+// an imported name.
 //
 // `system` with system→os.system becomes "os.system"; `o.system` with o→os
 // becomes "os.system"; `cp.exec` with cp→child_process becomes
-// "child_process.exec".
-func expandChain(chain string, aliases map[string]string) string {
-	if len(aliases) == 0 || chain == "" {
+// "child_process.exec"; `sh/sh` with sh→clojure.java.shell becomes
+// "clojure.java.shell/sh".
+func expandChain(chain string, t aliasTable) string {
+	if t.empty() || chain == "" {
 		return ""
 	}
-	head, rest, _ := strings.Cut(chain, ".")
-	qualified, ok := aliases[head]
+	head, rest, _ := strings.Cut(chain, t.sep)
+	qualified, ok := t.names[head]
 	if !ok {
 		return ""
 	}
 	if rest == "" {
 		return qualified
 	}
-	return qualified + "." + rest
+	return qualified + t.sep + rest
 }
 
 // applyImportAliases adds the qualified form of every call and chain a statement
@@ -215,22 +340,22 @@ func expandChain(chain string, aliases map[string]string) string {
 // through an alias or a destructured import.
 //
 // Additions only: see the package note on why nothing is replaced.
-func applyImportAliases(drafts []unitDraft, aliases map[string]string) {
-	if len(aliases) == 0 {
+func applyImportAliases(drafts []unitDraft, t aliasTable) {
+	if t.empty() {
 		return
 	}
 	for i := range drafts {
 		for j := range drafts[i].stmts {
 			st := &drafts[i].stmts[j]
-			st.calls = withExpansions(st.calls, aliases)
-			st.chains = withExpansions(st.chains, aliases)
-			expandSinkArgs(st, aliases)
+			st.calls = withExpansions(st.calls, t)
+			st.chains = withExpansions(st.chains, t)
+			expandSinkArgs(st, t)
 		}
 	}
 }
 
 // withExpansions returns the list plus any qualified forms not already present.
-func withExpansions(in []string, aliases map[string]string) []string {
+func withExpansions(in []string, t aliasTable) []string {
 	if len(in) == 0 {
 		return in
 	}
@@ -240,7 +365,7 @@ func withExpansions(in []string, aliases map[string]string) []string {
 	}
 	out := in
 	for _, c := range in {
-		expanded := expandChain(c, aliases)
+		expanded := expandChain(c, t)
 		if expanded == "" {
 			continue
 		}
@@ -257,12 +382,12 @@ func withExpansions(in []string, aliases map[string]string) []string {
 // qualified name, so the argument shape a sink is judged on survives the
 // rewrite. Without it a call would match the catalog by its expanded name and
 // then be judged on no argument evidence at all.
-func expandSinkArgs(st *stmtDraft, aliases map[string]string) {
+func expandSinkArgs(st *stmtDraft, t aliasTable) {
 	if len(st.sinkArgs) == 0 {
 		return
 	}
 	for call, info := range st.sinkArgs {
-		expanded := expandChain(call, aliases)
+		expanded := expandChain(call, t)
 		if expanded == "" {
 			continue
 		}

--- a/core/taint/engine/imports_test.go
+++ b/core/taint/engine/imports_test.go
@@ -15,7 +15,7 @@ from os import system as sys_call
 from subprocess import run, Popen
 from json import *
 `
-	got := importAliases(lexctx.LangPython, []byte(src))
+	got := importAliases(lexctx.LangPython, []byte(src)).names
 	want := map[string]string{
 		"p":        "os.path",
 		"sp":       "subprocess",
@@ -50,7 +50,7 @@ import { readFile } from "fs";
 import { readFile as rf } from "fs";
 import * as path from "path";
 `
-	got := importAliases(lexctx.LangJavaScript, []byte(src))
+	got := importAliases(lexctx.LangJavaScript, []byte(src)).names
 	want := map[string]string{
 		"cp":       "child_process",
 		"exec":     "child_process.exec",
@@ -68,11 +68,11 @@ import * as path from "path";
 }
 
 func TestExpandChain(t *testing.T) {
-	aliases := map[string]string{
+	aliases := aliasTable{sep: ".", names: map[string]string{
 		"system": "os.system",     // from-import of a member
 		"o":      "os",            // aliased module
 		"cp":     "child_process", // aliased module
-	}
+	}}
 	tests := []struct{ in, want string }{
 		{"system", "os.system"},
 		{"o.system", "os.system"},
@@ -92,7 +92,7 @@ func TestExpandChain(t *testing.T) {
 // Expansion ADDS, never replaces. Nothing that matched before can stop
 // matching, so the change cannot remove a finding.
 func TestExpansionIsAdditive(t *testing.T) {
-	aliases := map[string]string{"o": "os"}
+	aliases := aliasTable{sep: ".", names: map[string]string{"o": "os"}}
 	got := withExpansions([]string{"o.system", "print"}, aliases)
 
 	for _, want := range []string{"o.system", "print", "os.system"} {
@@ -114,8 +114,8 @@ func TestUnresolvedLanguagesGetNoAliases(t *testing.T) {
 	for _, lang := range []lexctx.Lang{
 		lexctx.LangGo, lexctx.LangRuby, lexctx.LangJava, lexctx.LangPHP, lexctx.LangRust,
 	} {
-		if got := importAliases(lang, []byte("import os\nfrom os import system\n")); len(got) != 0 {
-			t.Errorf("%v returned aliases from a resolver it does not have: %v", lang, got)
+		if got := importAliases(lang, []byte("import os\nfrom os import system\n")); len(got.names) != 0 {
+			t.Errorf("%v returned aliases from a resolver it does not have: %v", lang, got.names)
 		}
 	}
 }
@@ -127,8 +127,121 @@ func TestImportsInsideStringsAndCommentsAreStillLineMatched(t *testing.T) {
 	// Documenting current behaviour honestly: the resolver is line-based over
 	// raw content, so a commented import DOES bind. The cost is an extra chain
 	// that matches nothing real, never a lost one — expansion is additive.
-	got := importAliases(lexctx.LangPython, []byte("# from os import system\n"))
+	got := importAliases(lexctx.LangPython, []byte("# from os import system\n")).names
 	if len(got) != 0 {
 		t.Logf("known limit: a commented import binds a name (%v); additive expansion makes this harmless", got)
+	}
+}
+
+// Clojure introduces every alias with the same libspec vector, so one pattern
+// has to cover the (ns …) form, a top-level (require '[…]), and a multi-line
+// :require block. `:as-alias` binds a name exactly like `:as` does.
+func TestClojureAliases(t *testing.T) {
+	src := `(ns app.handler
+  (:require [clojure.java.shell :as sh]
+            [clojure.java.io :as io]
+            [clj-http.client :as http :refer [get]]
+            [next.jdbc :as-alias njdbc]
+            [clojure.string]))
+
+(require '[clojure.java.jdbc :as jdbc])
+`
+	got := importAliases(lexctx.LangClojure, []byte(src))
+	if got.sep != "/" {
+		t.Fatalf("clojure chains join with /, got %q", got.sep)
+	}
+	want := map[string]string{
+		"sh":    "clojure.java.shell",
+		"io":    "clojure.java.io",
+		"http":  "clj-http.client",
+		"njdbc": "next.jdbc",
+		"jdbc":  "clojure.java.jdbc",
+	}
+	for local, ns := range want {
+		if got.names[local] != ns {
+			t.Errorf("%s → %q, want %q", local, got.names[local], ns)
+		}
+	}
+	// A require with no :as binds nothing to resolve.
+	if _, ok := got.names["clojure.string"]; ok {
+		t.Error("a plain require created an alias")
+	}
+}
+
+// The gap this closes, stated as the measurement that found it: `sh` is the
+// canonical alias for clojure.java.shell -- it is the one in that namespace's
+// own docstring -- and it resolved to nothing, while the unusual `shell` matched
+// only because the catalog happened to enumerate it.
+func TestClojureCanonicalShellAliasResolves(t *testing.T) {
+	for _, alias := range []string{"sh", "shell", "sh2", "shell-utils"} {
+		src := "(ns p (:require [clojure.java.shell :as " + alias + "]))\n"
+		table := importAliases(lexctx.LangClojure, []byte(src))
+		got := expandChain(alias+"/sh", table)
+		if got != "clojure.java.shell/sh" {
+			t.Errorf(":as %s → %q, want clojure.java.shell/sh", alias, got)
+		}
+	}
+}
+
+// Elixir and C# name their sinks BARE (`System.cmd`, `Process.Start`), so an
+// alias resolves to the last segment, not the whole path. Resolving to the full
+// path would produce a name the catalog does not carry.
+func TestElixirAliases(t *testing.T) {
+	src := `defmodule App do
+  alias MyApp.Repo, as: DB
+  alias System, as: Sys
+  alias MyApp.Repo
+  alias MyApp.{Accounts, Billing}
+end
+`
+	got := importAliases(lexctx.LangElixir, []byte(src)).names
+	if got["DB"] != "Repo" {
+		t.Errorf(`DB → %q, want "Repo"`, got["DB"])
+	}
+	if got["Sys"] != "System" {
+		t.Errorf(`Sys → %q, want "System"`, got["Sys"])
+	}
+	// Plain `alias MyApp.Repo` already binds the bare name the catalog uses, so
+	// there is nothing to expand and inventing an entry would only add noise.
+	if len(got) != 2 {
+		t.Errorf("unexpected aliases: %v", got)
+	}
+}
+
+func TestCSharpUsingAliases(t *testing.T) {
+	src := `using System.Diagnostics;
+using Proc = System.Diagnostics.Process;
+global using Sb = System.Text.StringBuilder;
+using static System.Math;
+using var stream = File.OpenRead(path);
+using (var conn = new SqlConnection(cs)) { }
+`
+	got := importAliases(lexctx.LangCSharp, []byte(src)).names
+	if got["Proc"] != "Process" {
+		t.Errorf(`Proc → %q, want "Process"`, got["Proc"])
+	}
+	if got["Sb"] != "StringBuilder" {
+		t.Errorf(`Sb → %q, want "StringBuilder"`, got["Sb"])
+	}
+	// `using static`, a using DECLARATION and a using STATEMENT share the
+	// keyword but not the shape; binding any of them would invent a chain.
+	if len(got) != 2 {
+		t.Errorf("unexpected aliases: %v", got)
+	}
+}
+
+// The separator belongs to the table because expanding a Clojure chain with a
+// dot -- or a Python one with a slash -- yields a name that matches nothing, and
+// does so silently.
+func TestSeparatorIsPerLanguage(t *testing.T) {
+	clj := aliasTable{sep: "/", names: map[string]string{"sh": "clojure.java.shell"}}
+	if got := expandChain("sh/sh", clj); got != "clojure.java.shell/sh" {
+		t.Errorf("clojure: got %q", got)
+	}
+	// The same chain read with a dot separator finds no head and expands to
+	// nothing, rather than to a plausible-looking wrong answer.
+	dotted := aliasTable{sep: ".", names: map[string]string{"sh": "clojure.java.shell"}}
+	if got := expandChain("sh/sh", dotted); got != "" {
+		t.Errorf("wrong separator should expand to nothing, got %q", got)
 	}
 }

--- a/testdata/precision-suite/README.md
+++ b/testdata/precision-suite/README.md
@@ -6,8 +6,12 @@ ground truth** — what a *correct* scanner should do — so real false positive
 and false negatives surface as a number below 1.0. That is the point: a corpus
 that always scores 1.0 measures nothing.
 
-The corpus spans **Python, JS/TS, and Go** (`clean_*.{py,js,ts,go}` /
-`tp_*.{py,go}`). Go samples were added once `lexctx` began classifying Go
+The corpus spans **Python, JS/TS, Go, Clojure, Elixir and C#**
+(`clean_*.{py,js,ts,go}` / `tp_*.{py,go,clj,ex,cs}`). The last three arrived
+with alias resolution: the suite had NO sample in any of them, so it scored 1.00
+while the engine was blind to the canonical `(:require [clojure.java.shell :as
+sh])` spelling of its highest-severity Clojure sink. A corpus that does not span
+a language cannot report on it. Go samples were added once `lexctx` began classifying Go
 (#197): nox is now measured in its own language for the first time. Adding them
 first *lowered* recall (the six Go taint classes were genuine false negatives
 until a Go taint model existed); the Go taint model has since landed

--- a/testdata/precision-suite/baseline.json
+++ b/testdata/precision-suite/baseline.json
@@ -3,9 +3,9 @@
   "recall": 1,
   "f1": 1,
   "fp": 0,
-  "tp": 47,
+  "tp": 52,
   "fn": 0,
-  "findings_per_issue": 1.0444444444444445,
+  "findings_per_issue": 1.04,
   "rules": [
     {
       "rule_id": "AI-002",

--- a/testdata/precision-suite/tp_alias_idioms.clj
+++ b/testdata/precision-suite/tp_alias_idioms.clj
@@ -1,0 +1,31 @@
+;; True positives for the ordinary Clojure alias idioms.
+;;
+;; The catalog handled aliasing by ENUMERATING the aliases its author expected
+;; -- `shell/sh` beside `clojure.java.shell/sh`, `io/reader`, `jdbc/query`. That
+;; matches only the alias someone anticipated, and the one it anticipated for
+;; clojure.java.shell was `shell`. The canonical alias is `sh` -- it is the one
+;; in that namespace's own docstring -- and it was silently missed:
+;;
+;;   (:require [clojure.java.shell :as shell])   shell/sh   MATCHED
+;;   (:require [clojure.java.shell :as sh])      sh/sh      missed
+;;   (:require [clojure.java.shell :as sh2])     sh2/sh     missed
+;;
+;; The suite had no Clojure sample at all, so it scored 1.00 while the engine
+;; was blind to the dominant spelling of its highest-severity Clojure sink. If a
+;; future change drops `:as` resolution, recall here falls and says so.
+(ns precision.alias-idioms
+  (:require [clojure.java.shell :as sh]
+            [clojure.java.io :as file-io]
+            [clj-http.client :as http-client]))
+
+(defn canonical-alias [req]
+  (let [cmd (:params req)]
+    (sh/sh "sh" "-c" cmd)))          ;; nox-expect: TAINT-002
+
+(defn unanticipated-alias [req]
+  (let [p (:params req)]
+    (file-io/reader p)))             ;; nox-expect: TAINT-004
+
+(defn aliased-http [req]
+  (let [url (:query-string req)]
+    (http-client/get url)))          ;; nox-expect: TAINT-006

--- a/testdata/precision-suite/tp_alias_idioms.cs
+++ b/testdata/precision-suite/tp_alias_idioms.cs
@@ -1,0 +1,20 @@
+// True positives for the C# `using X = Y;` alias.
+//
+// C# sinks are named by TYPE in the catalog (`Process.Start`), which is what
+// code writes after a plain `using System.Diagnostics;`. A using-ALIAS renames
+// the type and made the same call invisible.
+//
+// Known limit, deliberately not papered over: an alias that names a NAMESPACE
+// (`using D = System.Diagnostics;` then `D.Process.Start`) resolves to neither
+// the bare nor the fully-qualified form the catalog carries, and is still
+// missed. Only the type-alias case below is claimed.
+using Proc = System.Diagnostics.Process;
+
+class AliasIdioms
+{
+    void AliasedStart(HttpRequest Request)
+    {
+        var user = Request.QueryString["cmd"];
+        Proc.Start("sh", "-c " + user);  // nox-expect: TAINT-002
+    }
+}

--- a/testdata/precision-suite/tp_alias_idioms.ex
+++ b/testdata/precision-suite/tp_alias_idioms.ex
@@ -1,0 +1,16 @@
+# True positives for the Elixir `alias …, as:` idiom.
+#
+# Elixir sinks are named BARE in the catalog (`System.cmd`, `Repo.query`),
+# which is what unaliased code writes. An `as:` rename made the same call
+# invisible, so this sample resolves to the last segment rather than the whole
+# path -- the form the catalog actually carries.
+#
+# The suite had no Elixir sample, so nothing measured this either way.
+defmodule Precision.AliasIdioms do
+  alias System, as: Sys
+
+  def aliased_cmd(conn) do
+    cmd = conn.params
+    Sys.cmd("sh", ["-c", cmd])  # nox-expect: TAINT-002
+  end
+end


### PR DESCRIPTION
Stacked on #561 — base is `fix/taint-resolves-imports`, retarget to `main` once that merges.

#561 fixed import resolution for Python and JS. This is the same defect one layer over, in three more languages.

## The catalog enumerated aliases instead of resolving them

Clojure aliasing was handled by listing the spellings the catalog author expected — `shell/sh` beside `clojure.java.shell/sh`, plus `io/reader`, `jdbc/query`, `client/get`. Enumeration matches only the alias someone guessed. For `clojure.java.shell` the guess was `shell`.

**The canonical alias is `sh`** — it is the one in that namespace's own docstring. Measured, varying nothing but the `:as`:

```
(:require [clojure.java.shell :as shell])   shell/sh   MATCHED      0 -> 1  (already worked)
(:require [clojure.java.shell :as sh])      sh/sh      missed       0 -> 1  <- canonical
(:require [clojure.java.shell :as sh2])     sh2/sh     missed       0 -> 1
(:require [clojure.java.shell :as x])       x/sh       missed       0 -> 1
```

So Clojure's highest-severity sink was blind to its dominant spelling while scoring a match on the unusual one.

## Elixir and C# are the mirror form

Their catalog entries are **bare** module and type names (`System.cmd`, `Repo.query`, `Process.Start`) — what unaliased code writes — so an alias resolves to the **last segment**, not the whole path. Both confirmed end to end:

| | before → after |
|---|---|
| `alias System, as: Sys` → `Sys.cmd(…)` | 0 → 1 |
| `using Proc = System.Diagnostics.Process;` → `Proc.Start(…)` | 0 → 1 |

The plain forms still fire — expansion stays additive, so nothing that matched before can stop matching.

## Probing beat guessing

The blocker on this item was *"18 languages, syntaxes I have not verified."* A three-line sample per language (plain form vs aliased form, count findings) resolved it in minutes:

- **Rust shows no gap** — `use std::process::Command as Cmd` already reaches the sink. Left alone.
- Every other language keeps today's behaviour rather than acquiring a guess at a syntax nobody has checked.

The separator now travels **with** the alias table: a Clojure chain is `sh/sh`, a Python one `os.system`, and expanding either with the other's separator yields a name that matches nothing — silently. There is a test for exactly that.

## Verified

```
precision suite   47 TP / 0 FP / 5 FN  ->  52 / 0 / 0     recall 0.904 -> 1.000
metamorphic       0 violations over 2270 mutations
full suite + golangci-lint   clean
```

The 5 new expectations are **false negatives on a build without the fix**, so the samples are not inert — the check `clean_safe_db.py` once failed. The suite had no Clojure, Elixir or C# sample at all before this, which is why it scored 1.00 throughout.

## Not verified, stated plainly

**The rule-diff corpus reports no change on all 7 repos.** That is not because the fix is inert. `ring` and `reitit` alias `clojure.java.io :as io` and `clojure.java.shell :as shell` — the exact two spellings the catalog had already guessed right. No corpus repo picks an unanticipated alias, so the gate cannot witness this one.

Finding a Clojure repo that does is an open item, same shape as the Python/JS corpus gap #562 closes.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
