### PR TITLE
CLI: `nox scan --no-cache` is accepted again, as its help text promises

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -97,7 +97,10 @@ func extractInterspersedArgs(args []string) []string {
 
 func isTopLevelBoolFlag(name string) bool {
 	switch name {
-	case "quiet", "q", "verbose", "v", "version", "no-cache":
+	// no-cache is a scan flag, not a top-level one: hoisting it here handed
+	// it to a flagset that never registered it, and the documented
+	// `nox scan --no-cache` exited 2 with "flag provided but not defined".
+	case "quiet", "q", "verbose", "v", "version":
 		return true
 	}
 	return false

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -214,6 +214,24 @@ func TestRun_ScanInterspersedFlags(t *testing.T) {
 	}
 }
 
+// --no-cache is registered on the scan flagset only. Hoisting it to the top
+// level handed it to a flagset that never defined it, so the documented
+// compatibility flag exited 2 instead of being ignored.
+func TestRun_ScanNoCacheIsAccepted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("clean\n"), 0o644); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	for _, args := range [][]string{
+		{"scan", "--no-cache", "--offline", "--output", filepath.Join(dir, "a"), dir},
+		{"scan", dir, "--no-cache", "--offline", "--output", filepath.Join(dir, "b")},
+	} {
+		if code := run(args); code == 2 {
+			t.Fatalf("%v: exit 2 — --no-cache was rejected instead of accepted", args)
+		}
+	}
+}
+
 func TestParseFormats(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
Found during the release E2E: `nox scan --no-cache` exited 2 with `flag provided but not defined: -no-cache`. The flag was hoisted to the top-level flagset by `extractInterspersedArgs` but only registered on the scan flagset. Removed from the hoist list; regression test covers both argument orderings and was falsified against the old code.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT