### PR TITLE
SUPPRESS: a waiver quoted in an inline code span is documentation, like a fenced one

### DIFF
--- a/core/suppress/suppress.go
+++ b/core/suppress/suppress.go
@@ -43,8 +43,9 @@ type Suppression struct {
 	// findings rather than hiding them — and the caller reports it.
 	InvalidExpiry string
 
-	// DocExample marks a directive written inside a fenced code block in a
-	// markdown file — i.e. documentation showing what a nox:ignore looks like,
+	// DocExample marks a directive written inside a fenced code block or an
+	// inline code span in a markdown file — i.e. documentation showing what a
+	// nox:ignore looks like,
 	// not a waiver an operator expects to apply. It changes nothing about
 	// matching: such a directive still suppresses a real finding on its target
 	// line, exactly as before. It only tells the caller not to report it as an
@@ -60,6 +61,29 @@ var markdownExts = map[string]bool{".md": true, ".markdown": true, ".mdx": true}
 // isFence reports whether a trimmed line opens or closes a fenced code block.
 func isFence(trimmed string) bool {
 	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+// inInlineCodeSpan reports whether a directive sits inside a markdown inline
+// code span (`like this`). A fenced block already marks a directive as
+// documentation; a span is the same statement written on one line, and prose
+// quoting a waiver to explain it is not a waiver.
+//
+// docs/design/rule-family-migration.md is the case that found this: it explains
+// that a waiver's own text can cause the finding it waives, and to explain that
+// it quotes one inline. Every scan of this repository then reported that
+// quotation as an unused waiver.
+//
+// The span must CLOSE. An odd number of backticks before the marker with none
+// after it is an unpaired backtick in prose — a real waiver on that line still
+// waives, because failing toward reporting is the safe direction.
+func inInlineCodeSpan(line string, matchStart int) bool {
+	if matchStart <= 0 || matchStart > len(line) {
+		return false
+	}
+	if strings.Count(line[:matchStart], "`")%2 == 0 {
+		return false
+	}
+	return strings.Contains(line[matchStart:], "`")
 }
 
 // suppressionRE matches nox:ignore / nox:disable directives in any
@@ -262,7 +286,7 @@ func ScanForSuppressions(content []byte, filePath string) []Suppression {
 			Reason:        reason,
 			Expires:       expires,
 			InvalidExpiry: invalidExpiry,
-			DocExample:    (isMarkdown && inFence) || nestedInComment(line, loc[0]),
+			DocExample:    (isMarkdown && (inFence || inInlineCodeSpan(line, loc[0]))) || nestedInComment(line, loc[0]),
 		})
 	}
 

--- a/core/suppress/suppress_inline_span_test.go
+++ b/core/suppress/suppress_inline_span_test.go
@@ -1,0 +1,34 @@
+package suppress
+
+import "testing"
+
+// A directive quoted in an INLINE code span of a markdown file is documentation,
+// exactly as one inside a fenced block is. docs/design/rule-family-migration.md
+// explains that a waiver's own text can cause the finding it waives, and to
+// explain it, quotes a waiver inline — which was then read as a live waiver and
+// reported as unused on every scan of this repository.
+func TestInlineCodeSpanInMarkdownIsADocExample(t *testing.T) {
+	md := "Each waiver caused the finding it waived:\n" +
+		"`fmt.Print(bashCompletion) // nox:ignore AI-006 -- shell completion script`.\n"
+	got := ScanForSuppressions([]byte(md), "docs/design/note.md")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 directive, got %d", len(got))
+	}
+	if !got[0].DocExample {
+		t.Error("a directive inside an inline code span must be a DocExample, not a live waiver")
+	}
+}
+
+// The escape must not swallow real waivers: a directive with a backtick
+// elsewhere on the line (an unmatched one, so no span is open at the marker)
+// still waives.
+func TestUnpairedBacktickDoesNotMakeAWaiverDocumentation(t *testing.T) {
+	md := "<!-- nox:ignore SEC-002 -- the `real thing -->\n"
+	got := ScanForSuppressions([]byte(md), "docs/note.md")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 directive, got %d", len(got))
+	}
+	if got[0].DocExample {
+		t.Error("a directive NOT inside a closed span must stay a live waiver")
+	}
+}


### PR DESCRIPTION
`DocExample` already exempts a `nox:ignore` inside a **fenced** markdown block from the unused-waiver report — prose demonstrating the syntax waives nothing by design. An **inline code span** is the same statement written on one line, and was not covered.

## How it was found

Scanning this repository with the released 1.33.0:

```
[degraded] docs/design/rule-family-migration.md:359 waives AI-006 but matched no finding
```

Line 359 is the passage explaining that **a waiver's own text can cause the finding it waives** — and to explain it, it quotes one inline. Deleting the quotation would delete the lesson, so the fix belongs in the parser rather than the doc.

## Safety

The span must **close**. An odd number of backticks before the marker with none after it is an unpaired backtick in prose, not an open span, and a real waiver on that line still waives — failing toward reporting rather than hiding. `TestUnpairedBacktickDoesNotMakeAWaiverDocumentation` pins that direction and passed *before* the change, so it is a guard rather than a restatement.

## Verified

- Falsified: with the wiring reverted, `TestInlineCodeSpanInMarkdownIsADocExample` fails.
- Self-scan unchanged at `2 findings (60 suppressed)` — no waiver stopped applying.
- The degradation is gone.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT