### PR TITLE
DEPS: dependency applicability answers for five more ecosystems, not Go alone

### DIFF
--- a/core/analyzers/deps/applicability_multilang_test.go
+++ b/core/analyzers/deps/applicability_multilang_test.go
@@ -1,0 +1,97 @@
+package deps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/applicability"
+)
+
+// tree writes files and returns a sourceImports over them.
+func tree(t *testing.T, files map[string]string) *sourceImports {
+	t.Helper()
+	dir := t.TempDir()
+	s := &sourceImports{}
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		s.paths = append(s.paths, p)
+	}
+	return s
+}
+
+// The gap this closes: applicability was implemented for Go alone, so every
+// npm, PyPI, Cargo, pub and RubyGems finding reported the same "unexamined"
+// verdict however plainly the project used the package.
+func TestApplicabilityClimbsForNonGoEcosystems(t *testing.T) {
+	cases := []struct {
+		name, eco, pkg, file, src string
+	}{
+		{"npm", "npm", "lodash", "a.js", `const _ = require("lodash");`},
+		{"pypi", "PyPI", "requests", "a.py", "import requests\n"},
+		{"cargo", "crates.io", "serde-json", "a.rs", "use serde_json::Value;\n"},
+		{"pub", "pub", "http", "a.dart", `import 'package:http/http.dart';`},
+		{"rubygems", "rubygems", "nokogiri", "a.rb", `require "nokogiri"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := tree(t, map[string]string{c.file: c.src})
+			v := applicabilityFor(Package{Name: c.pkg, Ecosystem: c.eco},
+				goAdvisory(c.pkg), nil, false, src)
+
+			if v.Reached != applicability.SymbolUsed {
+				t.Errorf("reached %q, want %q — the project imports the package by name",
+					v.Reached, applicability.SymbolUsed)
+			}
+			// Climbing must never turn into a refutation.
+			if v.Outcome == applicability.NotImpacting {
+				t.Error("a direct import must never produce NotImpacting")
+			}
+		})
+	}
+}
+
+// The property the whole design rests on: a package the source does not import
+// is NOT refuted. goImportedPackages uses the toolchain precisely because a
+// vulnerable package is usually reached THROUGH a dependency, which parsing the
+// repository's own imports cannot see. So absence here is not evidence.
+func TestNotImportedIsNeverARefutation(t *testing.T) {
+	src := tree(t, map[string]string{"a.js": `const x = require("express");`})
+	v := applicabilityFor(Package{Name: "lodash", Ecosystem: "npm"},
+		goAdvisory("lodash"), nil, false, src)
+
+	if v.Outcome == applicability.NotImpacting {
+		t.Fatal("a package absent from the source may be reached through a dependency; refuting it would hide a real vulnerability")
+	}
+	if v.Reached != applicability.AffectedVersion {
+		t.Errorf("reached %q, want %q — nothing above was established", v.Reached, applicability.AffectedVersion)
+	}
+}
+
+// An ecosystem whose import names a namespace rather than the distribution is
+// left alone rather than guessed at.
+func TestUnsupportedEcosystemIsUnchanged(t *testing.T) {
+	src := tree(t, map[string]string{"A.java": "import com.fasterxml.jackson.databind.ObjectMapper;\n"})
+	v := applicabilityFor(Package{Name: "jackson-databind", Ecosystem: "maven"},
+		goAdvisory("jackson-databind"), nil, false, src)
+
+	if v.Reached != applicability.AffectedVersion {
+		t.Errorf("reached %q, want %q", v.Reached, applicability.AffectedVersion)
+	}
+}
+
+// Nothing is read until a finding asks: the index costs a read of every source
+// file, and most scans have no dependency finding this can answer for.
+func TestSourceIsNotReadUntilAsked(t *testing.T) {
+	src := tree(t, map[string]string{"a.js": `require("lodash")`})
+	if src.index != nil {
+		t.Fatal("index built before any finding asked")
+	}
+	_ = applicabilityFor(Package{Name: "lodash", Ecosystem: "npm"}, goAdvisory("lodash"), nil, false, src)
+	if src.index == nil {
+		t.Error("index should have been built on first use")
+	}
+}

--- a/core/analyzers/deps/applicability_test.go
+++ b/core/analyzers/deps/applicability_test.go
@@ -91,7 +91,7 @@ func TestApplicabilityClimbsAsFarAsTheEvidenceGoes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			v := applicabilityFor(tc.pkg, tc.adv, tc.linked, tc.linkedKnown)
+			v := applicabilityFor(tc.pkg, tc.adv, tc.linked, tc.linkedKnown, &sourceImports{})
 			if v.Outcome != tc.wantOutcome {
 				t.Errorf("outcome = %q, want %q", v.Outcome, tc.wantOutcome)
 			}
@@ -131,7 +131,7 @@ func TestOnlyTheUnlinkedCaseIsNotImpacting(t *testing.T) {
 		{goAdvisory(module, "golang.org/x/crypto/ssh"), nil, false, "go"},
 		{goAdvisory("left-pad"), nil, false, "npm"},
 	} {
-		v := applicabilityFor(Package{Name: module, Ecosystem: tc.eco}, tc.adv, tc.linked, tc.linkedKnown)
+		v := applicabilityFor(Package{Name: module, Ecosystem: tc.eco}, tc.adv, tc.linked, tc.linkedKnown, &sourceImports{})
 		if v.Outcome == applicability.NotImpacting {
 			notImpacting++
 		}
@@ -150,7 +150,7 @@ func TestTheMessageSaysWhatWasEstablished(t *testing.T) {
 	linked := map[string]struct{}{"golang.org/x/crypto/openpgp": {}}
 
 	unlinked := applicabilityFor(Package{Name: module, Ecosystem: "go"},
-		goAdvisory(module, "golang.org/x/crypto/ssh"), linked, true)
+		goAdvisory(module, "golang.org/x/crypto/ssh"), linked, true, &sourceImports{})
 	got := unlinked.Describe()
 	if !strings.Contains(got, "not currently impacting") {
 		t.Errorf("%q does not state the conclusion in a developer's terms", got)
@@ -160,7 +160,7 @@ func TestTheMessageSaysWhatWasEstablished(t *testing.T) {
 	}
 
 	stalled := applicabilityFor(Package{Name: module, Ecosystem: "go"},
-		goAdvisory(module, "golang.org/x/crypto/openpgp"), linked, true)
+		goAdvisory(module, "golang.org/x/crypto/openpgp"), linked, true, &sourceImports{})
 	got = stalled.Describe()
 	if strings.Contains(got, "not currently impacting") {
 		t.Errorf("%q claims non-impact for a linked package", got)

--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -404,6 +404,15 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 	// the build actually links so advisories can be scoped by import path.
 	var goModDir string
 
+	// Source files whose imports can answer applicability for the ecosystems
+	// the toolchain cannot. Paths only: nothing is read unless a finding asks.
+	srcImports := &sourceImports{}
+	for _, art := range artifacts {
+		if art.Type == discovery.Source {
+			srcImports.paths = append(srcImports.paths, art.AbsPath)
+		}
+	}
+
 	for _, art := range artifacts {
 		if art.Type != discovery.Lockfile {
 			continue
@@ -727,7 +736,7 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 					// including — especially — the ones where it got nowhere,
 					// because "we could not tell" and "we did not look" are the
 					// answers a reader most needs and least often gets.
-					verdict := applicabilityFor(pkg, &ov, linkedGoPkgs, linkedGoKnown)
+					verdict := applicabilityFor(pkg, &ov, linkedGoPkgs, linkedGoKnown, srcImports)
 					meta["applicability"] = string(verdict.Outcome)
 					meta["applicability_reached"] = string(verdict.Reached)
 					if verdict.StoppedAt != "" {
@@ -795,14 +804,22 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 // the point. A scanner that stops climbing and stays silent leaves the reader
 // to assume it stopped because there was nothing above; this says it stopped
 // because nobody has built the thing that would look.
-func applicabilityFor(pkg Package, ov *osvVuln, linked map[string]struct{}, linkedKnown bool) applicability.Verdict {
+func applicabilityFor(pkg Package, ov *osvVuln, linked map[string]struct{}, linkedKnown bool, src *sourceImports) applicability.Verdict {
 	// Present and AffectedVersion are established by the fact of the finding:
 	// the package is in the lockfile, and OSV matched its version.
 	const reached = applicability.AffectedVersion
 
 	if pkg.Ecosystem != "go" {
-		// Dependency reachability is implemented for Go only. An npm package is
-		// not unreachable; it is unexamined, and nothing here could examine it.
+		// Go is answered by the toolchain, which sees the transitive link set.
+		// Everything else is answered by this project's own imports, which can
+		// only ever CLIMB — see importApplicability for why absence there
+		// refutes nothing.
+		if v, ok := importApplicability(pkg, reached, src); ok {
+			return v
+		}
+		// Not unreachable: unexamined, or examined and not directly imported,
+		// which are the same answer because nothing here can see through a
+		// dependency.
 		return applicability.Undeterminable(reached, applicability.SymbolUsed, capability.Unsupported)
 	}
 

--- a/core/analyzers/deps/reachability.go
+++ b/core/analyzers/deps/reachability.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/applicability"
 	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/depimports"
 	"github.com/nox-hq/nox/core/reach"
 )
 
@@ -182,4 +184,68 @@ func goSymbolReferenced(affectedImports []string, linked map[string]struct{}, li
 	}
 	r, ok := reach.Refute(subject, reach.SymbolReferenced, scope)
 	return r, ok
+}
+
+// maxImportScanBytes bounds a single file read when indexing imports. A source
+// file larger than this is a bundle or a generated blob, and its import list is
+// not evidence about what this project uses.
+const maxImportScanBytes = 1 << 20
+
+// sourceImports lazily indexes the imports of a scan's source files.
+//
+// Lazily, because most scans have no vulnerable dependency in an ecosystem this
+// can answer for, and the index costs a read of every source file. Nothing is
+// read until the first finding actually asks.
+type sourceImports struct {
+	paths []string
+	index *depimports.Index
+}
+
+// get builds the index on first use and returns it.
+func (s *sourceImports) get() *depimports.Index {
+	if s.index != nil {
+		return s.index
+	}
+	ix := depimports.New()
+	for _, p := range s.paths {
+		info, err := os.Stat(p)
+		if err != nil || info.Size() > maxImportScanBytes {
+			continue
+		}
+		content, err := os.ReadFile(p) // #nosec G304 -- path came from the scan's own discovery walk
+		if err != nil {
+			continue
+		}
+		ix.Add(p, content)
+	}
+	s.index = ix
+	return ix
+}
+
+// importApplicability answers the SymbolUsed rung for the ecosystems whose
+// import statement names the distribution.
+//
+// It ONLY CLIMBS. goImportedPackages deliberately asks the toolchain rather
+// than parsing the repository's own imports, because a vulnerable package is
+// usually reached THROUGH a dependency and static parsing cannot see that —
+// getting it wrong in that direction would hide real vulnerabilities. That
+// reasoning is why this never returns a refutation: a direct import is positive
+// evidence that the package is used, and its absence is not evidence of
+// anything. Every miss degrades to the undetermined verdict callers already got.
+func importApplicability(pkg Package, reached applicability.Rung, src *sourceImports) (applicability.Verdict, bool) {
+	if !depimports.Supported(pkg.Ecosystem) {
+		return applicability.Verdict{}, false
+	}
+	ix := src.get()
+	if !ix.Known(pkg.Ecosystem) {
+		// No source of that language was read, so the question was never put.
+		return applicability.Verdict{}, false
+	}
+	if !ix.Imports(pkg.Ecosystem, pkg.Name) {
+		return applicability.Verdict{}, false
+	}
+	// The project imports the package by name. That establishes SymbolUsed;
+	// whether anything calls it is the rung nox cannot climb at all.
+	return applicability.Undeterminable(applicability.SymbolUsed,
+		applicability.CallReachable, capability.Unsupported), true
 }

--- a/core/depimports/depimports.go
+++ b/core/depimports/depimports.go
@@ -1,0 +1,234 @@
+// Package depimports answers one question for a dependency finding, in every
+// language nox can answer it soundly: does this project's own source import the
+// package the advisory names?
+//
+// It exists because dependency applicability was implemented for Go alone.
+// nox is a language-agnostic scanner, so "is this dependency used?" answered
+// only for Go is a Go feature wearing a general name — and it left every npm,
+// PyPI, Cargo, pub and RubyGems finding reported as unexamined.
+//
+// # Only ever climbing
+//
+// A positive answer here establishes the SymbolUsed rung. A negative answer
+// establishes NOTHING and must never refute one.
+//
+// The reason is that a distribution's name and its import name are different
+// strings in most ecosystems — PyPI ships PyYAML as `yaml` and beautifulsoup4
+// as `bs4` — and a package this project never imports directly may still be
+// used by a package it does import. Reading either miss as "not impacting"
+// would turn an unknown into an all-clear, which is the one error a
+// vulnerability scanner must not make. Every failure mode here therefore
+// degrades to exactly today's behaviour: no climb.
+//
+// # Which ecosystems, and why not the rest
+//
+// Covered: npm, PyPI, Cargo, pub and RubyGems — the ecosystems whose import
+// statement names the distribution, so a match means what it appears to mean.
+//
+// Not covered: Maven, NuGet, Packagist and Hex, whose imports name a namespace
+// (`com.fasterxml.jackson.databind`, `System.Text.Json`) that the manifest does
+// not carry. Resolving those needs the package's own metadata, not its name.
+// Guessing would produce matches nobody has checked, in the direction that
+// silently promotes a finding's priority.
+package depimports
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// Index records which module identifiers a source tree imports, per ecosystem,
+// and — separately — whether any source for that ecosystem was seen at all.
+//
+// The two are not the same fact. "No Python file imports requests" and "there
+// is no Python here" both produce an empty set, and only the first is evidence.
+type Index struct {
+	imports map[string]map[string]struct{}
+	seen    map[string]bool
+}
+
+// New returns an empty Index. A zero tree answers Known(false) for everything,
+// which is the honest answer when nothing was read.
+func New() *Index {
+	return &Index{imports: map[string]map[string]struct{}{}, seen: map[string]bool{}}
+}
+
+// ecosystemFor maps a file extension to the dependency ecosystem its imports
+// name. Extensions absent here contribute nothing.
+var ecosystemFor = map[string]string{
+	".js": "npm", ".jsx": "npm", ".mjs": "npm", ".cjs": "npm",
+	".ts": "npm", ".tsx": "npm",
+	".py":   "pypi",
+	".rs":   "cargo",
+	".dart": "pub",
+	".rb":   "rubygems",
+}
+
+// Add reads one file's imports into the index. Unknown extensions are ignored.
+func (ix *Index) Add(filePath string, content []byte) {
+	eco, ok := ecosystemFor[strings.ToLower(path.Ext(filePath))]
+	if !ok {
+		return
+	}
+	// Seeing the file is what makes a later absence meaningful, so record it
+	// before extraction and regardless of whether anything was found.
+	ix.seen[eco] = true
+	set := ix.imports[eco]
+	if set == nil {
+		set = map[string]struct{}{}
+		ix.imports[eco] = set
+	}
+	for _, m := range extract(eco, string(content)) {
+		if m != "" {
+			set[m] = struct{}{}
+		}
+	}
+}
+
+// Known reports whether any source file of this ecosystem's languages was read.
+func (ix *Index) Known(ecosystem string) bool { return ix.seen[normalizeEco(ecosystem)] }
+
+// Imports reports whether the source imports the given distribution.
+//
+// Matching is on the normalised name, which is what makes `serde-json` in a
+// Cargo manifest match `use serde_json` in source. A false answer means only
+// that no import matched — never that the package is unused.
+func (ix *Index) Imports(ecosystem, pkg string) bool {
+	eco := normalizeEco(ecosystem)
+	set := ix.imports[eco]
+	if set == nil {
+		return false
+	}
+	_, ok := set[normalizeName(eco, pkg)]
+	return ok
+}
+
+// Supported reports whether this ecosystem's import statements name the
+// distribution closely enough for a match to mean anything.
+func Supported(ecosystem string) bool {
+	switch normalizeEco(ecosystem) {
+	case "npm", "pypi", "cargo", "pub", "rubygems":
+		return true
+	}
+	return false
+}
+
+// normalizeEco folds the spellings OSV, lockfiles and nox's own analyzers use
+// for the same ecosystem onto one key.
+func normalizeEco(e string) string {
+	switch strings.ToLower(strings.TrimSpace(e)) {
+	case "npm":
+		return "npm"
+	case "pypi", "pip", "python":
+		return "pypi"
+	case "cargo", "crates.io", "crates":
+		return "cargo"
+	case "pub", "dart":
+		return "pub"
+	case "rubygems", "gem", "ruby":
+		return "rubygems"
+	}
+	return strings.ToLower(strings.TrimSpace(e))
+}
+
+// normalizeName folds a distribution name and an import identifier onto one
+// spelling. Cargo and PyPI both treat `-` and `_` as the same character in this
+// position; npm scopes are case-sensitive only in theory and lowercase in
+// practice.
+func normalizeName(eco, name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	switch eco {
+	case "cargo", "pypi":
+		n = strings.ReplaceAll(n, "-", "_")
+	}
+	return n
+}
+
+var (
+	// require("x") / require('x')
+	jsRequireRE = regexp.MustCompile(`require\s*\(\s*['"]([^'"]+)['"]\s*\)`)
+	// import ... from "x" / import "x" / export ... from "x"
+	jsFromRE = regexp.MustCompile(`(?m)(?:^|\s)(?:import|export)\b[^;'"]*?from\s*['"]([^'"]+)['"]`)
+	jsBareRE = regexp.MustCompile(`(?m)^\s*import\s*['"]([^'"]+)['"]`)
+	// import x / import x.y as z
+	pyImportRE = regexp.MustCompile(`(?m)^\s*import\s+([A-Za-z_][\w.]*)`)
+	pyFromRE   = regexp.MustCompile(`(?m)^\s*from\s+([A-Za-z_][\w.]*)\s+import\b`)
+	// use crate::x is internal; use foo::bar names crate foo
+	rsUseRE    = regexp.MustCompile(`(?m)^\s*(?:pub\s+)?use\s+([A-Za-z_]\w*)\s*(?:::|;)`)
+	rsExternRE = regexp.MustCompile(`(?m)^\s*extern\s+crate\s+([A-Za-z_]\w*)`)
+	// import 'package:foo/bar.dart'
+	dartRE = regexp.MustCompile(`(?m)^\s*(?:import|export)\s+['"]package:([^/'"]+)`)
+	// require 'foo' / require "foo/bar"
+	rbRequireRE = regexp.MustCompile(`(?m)^\s*require(?:_relative)?\s*\(?\s*['"]([^'"]+)['"]`)
+)
+
+// extract returns the distribution names an ecosystem's source imports.
+func extract(eco, src string) []string {
+	var out []string
+	add := func(ms [][]string, f func(string) string) {
+		for _, m := range ms {
+			if len(m) > 1 {
+				out = append(out, normalizeName(eco, f(m[1])))
+			}
+		}
+	}
+	switch eco {
+	case "npm":
+		add(jsRequireRE.FindAllStringSubmatch(src, -1), npmPackage)
+		add(jsFromRE.FindAllStringSubmatch(src, -1), npmPackage)
+		add(jsBareRE.FindAllStringSubmatch(src, -1), npmPackage)
+	case "pypi":
+		add(pyImportRE.FindAllStringSubmatch(src, -1), topSegment)
+		add(pyFromRE.FindAllStringSubmatch(src, -1), topSegment)
+	case "cargo":
+		add(rsUseRE.FindAllStringSubmatch(src, -1), rustCrate)
+		add(rsExternRE.FindAllStringSubmatch(src, -1), rustCrate)
+	case "pub":
+		add(dartRE.FindAllStringSubmatch(src, -1), func(s string) string { return s })
+	case "rubygems":
+		add(rbRequireRE.FindAllStringSubmatch(src, -1), topSegment)
+	}
+	return out
+}
+
+// npmPackage reduces a module specifier to the installed package: `lodash/fp`
+// is lodash, `@babel/core/lib` is @babel/core. A relative or absolute path is
+// this project's own file and names no package.
+func npmPackage(spec string) string {
+	if strings.HasPrefix(spec, ".") || strings.HasPrefix(spec, "/") {
+		return ""
+	}
+	// `node:fs` explicitly names the builtin. Mapping it to the npm package
+	// `fs` — which exists — would climb a rung on a module that was never
+	// installed, and climbing wrongly is the only direction that misleads.
+	if strings.HasPrefix(spec, "node:") {
+		return ""
+	}
+	parts := strings.Split(spec, "/")
+	if strings.HasPrefix(spec, "@") {
+		if len(parts) < 2 {
+			return ""
+		}
+		return parts[0] + "/" + parts[1]
+	}
+	return parts[0]
+}
+
+// topSegment takes the first dotted or slashed segment: `os.path` is os,
+// `active_support/core_ext` is active_support.
+func topSegment(s string) string {
+	if i := strings.IndexAny(s, "./"); i > 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// rustCrate drops the paths that name this crate rather than a dependency.
+func rustCrate(name string) string {
+	switch name {
+	case "crate", "self", "super", "std", "core", "alloc":
+		return ""
+	}
+	return name
+}

--- a/core/depimports/depimports_test.go
+++ b/core/depimports/depimports_test.go
@@ -1,0 +1,86 @@
+package depimports
+
+import "testing"
+
+// The ordinary import idiom of each covered ecosystem must name its
+// distribution. These are the shapes real code is written in, not the one shape
+// that happens to work — the same measure that exposed the taint engine's
+// import gap.
+func TestOrdinaryIdiomsNameTheDistribution(t *testing.T) {
+	cases := []struct {
+		name, file, src, eco, pkg string
+		want                      bool
+	}{
+		{"npm require", "a.js", `const _ = require("lodash");`, "npm", "lodash", true},
+		{"npm subpath", "a.js", `const fp = require("lodash/fp");`, "npm", "lodash", true},
+		{"npm esm from", "a.ts", `import { z } from "zod";`, "npm", "zod", true},
+		{"npm bare import", "a.js", `import "core-js";`, "npm", "core-js", true},
+		{"npm scoped", "a.ts", `import x from "@babel/core";`, "npm", "@babel/core", true},
+		{"npm node: prefix names the builtin, not the fs package", "a.js", `import fs from "node:fs";`, "npm", "fs", false},
+		{"npm relative names nothing", "a.js", `const x = require("./util");`, "npm", "util", false},
+		{"pypi import", "a.py", "import requests\n", "PyPI", "requests", true},
+		{"pypi from", "a.py", "from requests.adapters import x\n", "PyPI", "requests", true},
+		{"pypi dash normalises", "a.py", "import ruamel_yaml\n", "PyPI", "ruamel-yaml", true},
+		{"cargo use", "a.rs", "use serde_json::Value;\n", "cargo", "serde-json", true},
+		{"cargo extern", "a.rs", "extern crate rand;\n", "crates.io", "rand", true},
+		{"cargo crate:: is local", "a.rs", "use crate::thing;\n", "cargo", "crate", false},
+		{"pub package uri", "a.dart", `import 'package:http/http.dart';`, "pub", "http", true},
+		{"rubygems require", "a.rb", `require "nokogiri"`, "rubygems", "nokogiri", true},
+		{"rubygems subpath", "a.rb", `require "active_support/core_ext"`, "gem", "active_support", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ix := New()
+			ix.Add(c.file, []byte(c.src))
+			if got := ix.Imports(c.eco, c.pkg); got != c.want {
+				t.Errorf("Imports(%q, %q) = %v, want %v", c.eco, c.pkg, got, c.want)
+			}
+		})
+	}
+}
+
+// The distinction the whole package rests on: an empty set because nothing
+// imported the package, versus an empty set because there is no source of that
+// language here. Only the first is evidence, and neither may refute.
+func TestUnseenLanguageIsNotAnAbsence(t *testing.T) {
+	ix := New()
+	ix.Add("a.py", []byte("import requests\n"))
+
+	if !ix.Known("PyPI") {
+		t.Error("a Python file was read; PyPI must be Known")
+	}
+	if ix.Known("npm") {
+		t.Error("no JavaScript was read, so npm must NOT be Known")
+	}
+	if ix.Imports("npm", "lodash") {
+		t.Error("nothing may be reported as imported from a language never read")
+	}
+}
+
+// A file with no imports still makes its ecosystem Known: that is precisely the
+// case where "not imported" is a real observation rather than a blind spot.
+func TestFileWithoutImportsStillMakesEcosystemKnown(t *testing.T) {
+	ix := New()
+	ix.Add("a.py", []byte("x = 1\n"))
+	if !ix.Known("pypi") {
+		t.Error("the file was read; the ecosystem is Known even with no imports")
+	}
+	if ix.Imports("pypi", "requests") {
+		t.Error("no import must not report as imported")
+	}
+}
+
+// Ecosystems whose import names a namespace the manifest does not carry are
+// declared unsupported rather than guessed at.
+func TestUnsupportedEcosystemsSaySo(t *testing.T) {
+	for _, e := range []string{"npm", "PyPI", "cargo", "pub", "rubygems"} {
+		if !Supported(e) {
+			t.Errorf("%s should be supported", e)
+		}
+	}
+	for _, e := range []string{"maven", "nuget", "packagist", "hex", "go"} {
+		if Supported(e) {
+			t.Errorf("%s must not claim support: its import names a namespace, not the distribution", e)
+		}
+	}
+}


### PR DESCRIPTION
`applicabilityFor` returned `Unsupported` for every ecosystem but Go, so an npm, PyPI, Cargo, pub or RubyGems advisory reported the same **"unexamined"** verdict however plainly the project used the package. nox is a language-agnostic scanner; reachability answered only for Go is a Go feature wearing a general name.

## What it adds

`core/depimports` indexes what a source tree imports and answers whether the distribution an advisory names is among them.

**Covered:** npm, PyPI, Cargo, pub, RubyGems — the ecosystems whose import statement names the distribution.

**Deliberately not covered:** Maven, NuGet, Packagist, Hex. Their imports name a namespace (`com.fasterxml.jackson.databind`, `System.Text.Json`) that the manifest does not carry; resolving those needs the package's own metadata, not its name. Guessing would produce matches nobody has checked, in the direction that silently promotes a finding.

## It only ever CLIMBS

This is the part worth reviewing hardest.

`goImportedPackages` deliberately asks the toolchain rather than parsing the repository's own imports, because a vulnerable package is usually reached **through** a dependency and static parsing cannot see that — and getting it wrong that way hides real vulnerabilities.

That reasoning is exactly why this never refutes. A direct import is positive evidence the package is used; its absence is evidence of nothing. Every miss — a dist name differing from its import name (`PyYAML`/`yaml`), a transitively-reached package, a language with no source in the tree — degrades to the undetermined verdict callers already got.

- `TestNotImportedIsNeverARefutation` pins it.
- The existing "exactly 1 branch may produce `NotImpacting`" invariant still holds unchanged.
- `node:fs` maps to the builtin, not to the npm package `fs`, so it cannot climb on a module that was never installed.

## Measured end to end

A lockfile with `lodash` (imported by `app.js`) and `minimist` (never imported):

```
lodash    GHSA-35jh-r3h4-6jhm  applicability=undetermined  reached=symbol_used
minimist  GHSA-xvch-5gv4-984h  applicability=undetermined  reached=affected_version
```

Both stay `undetermined` — neither is refuted — but the climb feeds `--sort priority`, so a dependency the code actually imports now sorts above one it merely ships.

## Cost

Nothing is read until a finding asks: most scans have no dependency finding this can answer for, and the index costs a read of every source file (`TestSourceIsNotReadUntilAsked`). Files over 1 MiB are skipped as bundles or generated blobs.

## Verified

- Falsified: with the climb disabled, `TestApplicabilityClimbsForNonGoEcosystems` fails for all five ecosystems.
- `go test ./core/analyzers/deps/ ./core/depimports/` green; `golangci-lint` 0 issues.

## Follow-up

This closes the recall half. The refutation half for these ecosystems needs the lockfile dependency **graph** (npm/pnpm/yarn, Cargo.lock and poetry.lock all carry per-package dependency edges), which would let "nothing in the graph reaches it" be established rather than assumed. Not attempted here.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT