### PR TITLE
CONFIG: plugin_policy is a key nox has, not one it does not recognise

### DIFF
--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -737,7 +737,7 @@ func runPluginCall(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: loading config: %v\n", err)
 		return 2
 	}
-	policy := cfg.PluginPolicy.ToPolicy()
+	policy := plugin.ToPolicy(&cfg.PluginPolicy)
 
 	host := plugin.NewHost(plugin.WithPolicy(&policy))
 	defer func() { _ = host.Close() }()

--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -206,8 +206,8 @@ func runPostScanPlugins(ctx context.Context, result *core.ScanResult, target str
 	var overrides plugin.Policy
 	ignoreTrackProfiles := false
 	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(core.ConfigRoot(target), ".nox.yaml")); cfgErr == nil {
-		policy = cfg.PluginPolicy.ToPolicy()
-		overrides = cfg.PluginPolicy.Overrides()
+		policy = plugin.ToPolicy(&cfg.PluginPolicy)
+		overrides = plugin.Overrides(&cfg.PluginPolicy)
 		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
 	}
 
@@ -348,8 +348,8 @@ func runScanPlugins(ctx context.Context, target string, required []string) (*cor
 	var overrides plugin.Policy
 	ignoreTrackProfiles := false
 	if cfg, cfgErr := plugin.LoadConfig(filepath.Join(core.ConfigRoot(target), ".nox.yaml")); cfgErr == nil {
-		policy = cfg.PluginPolicy.ToPolicy()
-		overrides = cfg.PluginPolicy.Overrides()
+		policy = plugin.ToPolicy(&cfg.PluginPolicy)
+		overrides = plugin.Overrides(&cfg.PluginPolicy)
 		ignoreTrackProfiles = cfg.PluginPolicy.IgnoreTrackProfiles
 	}
 	out, err := runPluginBinaries(ctx, target, binaries, &policy, &overrides, ignoreTrackProfiles)

--- a/core/config.go
+++ b/core/config.go
@@ -37,6 +37,58 @@ type ScanConfig struct {
 	Compliance ComplianceSettings `yaml:"compliance"`
 	Cache      CacheSettings      `yaml:"cache"`
 	Plugins    PluginsConfig      `yaml:"plugins"`
+
+	// PluginPolicy is the plugin sandbox policy. The scan engine never reads
+	// it — package plugin does, from this same file — but the schema lives
+	// here because this struct is what UnknownConfigKeys validates .nox.yaml
+	// against, and a key missing from it is reported as one nox does not
+	// recognise.
+	//
+	// That report was wrong for this key, and wrong in the dangerous
+	// direction: `plugin_policy` was in force (it is how an operator widens a
+	// plugin's network or filesystem allowlist) while the scan told them it
+	// was "ignored, so whatever they were meant to configure is not in
+	// effect" and advised checking for a typo. An operator who followed that
+	// advice would delete a sandbox boundary they had deliberately set.
+	//
+	// Declaring it here also means the existing strict decode validates the
+	// keys INSIDE the block, so a misspelt `allowed_network_host` in a
+	// security policy is named rather than silently dropped.
+	//
+	// package plugin aliases this type rather than redeclaring it: core cannot
+	// import plugin (plugin imports core), and two copies of a security
+	// policy's schema would drift.
+	PluginPolicy PluginPolicyConfig `yaml:"plugin_policy"`
+}
+
+// PluginPolicyConfig defines plugin sandbox overrides loaded from .nox.yaml.
+//
+// Overrides are one-directional: an operator can widen an allowlist but cannot
+// empty one, because a zero-length list reads as "not configured". See
+// IgnoreTrackProfiles for the escape hatch that exists because of it.
+type PluginPolicyConfig struct {
+	AllowedNetworkHosts   []string `yaml:"allowed_network_hosts"`
+	AllowedNetworkCIDRs   []string `yaml:"allowed_network_cidrs"`
+	AllowedFilePaths      []string `yaml:"allowed_file_paths"`
+	AllowedEnvVars        []string `yaml:"allowed_env_vars"`
+	MaxRiskClass          string   `yaml:"max_risk_class"`
+	AllowConfirmationReqd bool     `yaml:"allow_confirmation_required"`
+	MaxArtifactMB         int      `yaml:"max_artifact_mb"`
+	MaxConcurrency        int      `yaml:"max_concurrency"`
+	ToolTimeoutSeconds    int      `yaml:"tool_timeout_seconds"`
+	RequestsPerMinute     int      `yaml:"requests_per_minute"`
+	BandwidthMBPerMinute  int      `yaml:"bandwidth_mb_per_minute"`
+
+	// IgnoreTrackProfiles forces every plugin onto the default policy
+	// regardless of its registry track.
+	//
+	// This exists because the override semantics are one-directional: an
+	// operator can widen an allowlist but cannot empty one, since a zero-length
+	// list reads as "not configured". Without this flag there would be no way
+	// to revoke the localhost access the dynamic-runtime profile grants — an
+	// operator could only add to it. Setting this restores the pre-track
+	// behaviour: passive risk class, empty allowlists, opt-in only.
+	IgnoreTrackProfiles bool `yaml:"ignore_track_profiles"`
 }
 
 // PluginsConfig declares the plugins a project requires plus any

--- a/core/config_plugin_policy_test.go
+++ b/core/config_plugin_policy_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// plugin_policy is read from .nox.yaml by the plugin host, not by the scan
+// engine. Until the key was declared on ScanConfig, the strict check reported
+// it as one nox does not recognise, over an impact line reading "they are
+// ignored, so whatever they were meant to configure is not in effect" and
+// advising the operator to check for a typo.
+//
+// The key WAS in effect. It is how an operator widens a plugin's network or
+// filesystem allowlist — the sandbox boundary itself. An operator who believed
+// the message and deleted the block would silently change what a plugin is
+// permitted to reach, in a scan that otherwise reported nothing wrong.
+func TestPluginPolicyIsARecognisedKey(t *testing.T) {
+	dir := t.TempDir()
+	writeCfg(t, dir, `plugin_policy:
+  allowed_network_hosts:
+    - "api.first.org"
+  max_risk_class: passive
+plugins:
+  required:
+    - nox/risk-score
+`)
+
+	if got := UnknownConfigKeys(dir); len(got) != 0 {
+		t.Errorf("UnknownConfigKeys = %v, want none: plugin_policy is in force and must not be reported as ignored", got)
+	}
+}
+
+// Declaring the block's schema rather than accepting it opaquely is the point:
+// a misspelt key inside a security policy is exactly the case the strict check
+// exists for. `allowed_network_host` (singular) grants nothing, and without
+// this the operator would be told nothing while the plugin ran under a
+// narrower sandbox than they wrote.
+func TestTypoInsidePluginPolicyIsReported(t *testing.T) {
+	dir := t.TempDir()
+	writeCfg(t, dir, `plugin_policy:
+  allowed_network_host:
+    - "api.first.org"
+`)
+
+	got := UnknownConfigKeys(dir)
+	if len(got) != 1 || !strings.Contains(got[0], "allowed_network_host") {
+		t.Errorf("UnknownConfigKeys = %v, want the misspelt allowed_network_host named", got)
+	}
+}

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/nox-hq/nox/core"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -14,30 +16,16 @@ type Config struct {
 }
 
 // PolicyConfig defines policy overrides loaded from configuration.
-type PolicyConfig struct {
-	AllowedNetworkHosts   []string `yaml:"allowed_network_hosts"`
-	AllowedNetworkCIDRs   []string `yaml:"allowed_network_cidrs"`
-	AllowedFilePaths      []string `yaml:"allowed_file_paths"`
-	AllowedEnvVars        []string `yaml:"allowed_env_vars"`
-	MaxRiskClass          string   `yaml:"max_risk_class"`
-	AllowConfirmationReqd bool     `yaml:"allow_confirmation_required"`
-	MaxArtifactMB         int      `yaml:"max_artifact_mb"`
-	MaxConcurrency        int      `yaml:"max_concurrency"`
-	ToolTimeoutSeconds    int      `yaml:"tool_timeout_seconds"`
-	RequestsPerMinute     int      `yaml:"requests_per_minute"`
-	BandwidthMBPerMinute  int      `yaml:"bandwidth_mb_per_minute"`
-
-	// IgnoreTrackProfiles forces every plugin onto DefaultPolicy() regardless
-	// of its registry track.
-	//
-	// This exists because the override semantics are one-directional: an
-	// operator can widen an allowlist but cannot empty one, since a zero-length
-	// list reads as "not configured". Without this flag there would be no way
-	// to revoke the localhost access the dynamic-runtime profile grants — an
-	// operator could only add to it. Setting this restores the pre-track
-	// behaviour: passive risk class, empty allowlists, opt-in only.
-	IgnoreTrackProfiles bool `yaml:"ignore_track_profiles"`
-}
+//
+// An alias, not a copy: the schema is declared in core.ScanConfig so the
+// strict-config check validates this block like every other key in .nox.yaml.
+// Before that, `plugin_policy` was reported as a key nox does not recognise —
+// telling an operator that a sandbox override they had deliberately set was
+// "not in effect" when it was.
+//
+// Because it is an alias to a type in another package, its behaviour is
+// expressed as functions (Overrides, ToPolicy) rather than methods.
+type PolicyConfig = core.PluginPolicyConfig
 
 // LoadConfig reads a .nox.yaml configuration file. If the file does not
 // exist, it returns a default Config without error. Returns an error only for
@@ -67,7 +55,7 @@ func LoadConfig(path string) (*Config, error) {
 // deliberate operator choice and would silently override the profile, so
 // applying a profile through it would be a no-op. Merging needs to know what
 // the operator actually wrote, which is what this returns.
-func (c *PolicyConfig) Overrides() Policy {
+func Overrides(c *PolicyConfig) Policy {
 	var p Policy
 
 	p.AllowedNetworkHosts = c.AllowedNetworkHosts
@@ -100,7 +88,7 @@ func (c *PolicyConfig) Overrides() Policy {
 
 // ToPolicy converts PolicyConfig to a runtime Policy, applying unit
 // conversions and falling back to DefaultPolicy() values for zero fields.
-func (c *PolicyConfig) ToPolicy() Policy {
+func ToPolicy(c *PolicyConfig) Policy {
 	p := DefaultPolicy()
 
 	if len(c.AllowedNetworkHosts) > 0 {

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -84,7 +84,7 @@ func TestPolicyConfig_ToPolicy(t *testing.T) {
 		BandwidthMBPerMinute: 10,
 	}
 
-	p := cfg.ToPolicy()
+	p := ToPolicy(&cfg)
 
 	if len(p.AllowedNetworkHosts) != 1 || p.AllowedNetworkHosts[0] != "*.example.com" {
 		t.Errorf("AllowedNetworkHosts = %v", p.AllowedNetworkHosts)
@@ -111,7 +111,7 @@ func TestPolicyConfig_ToPolicy(t *testing.T) {
 
 func TestPolicyConfig_ToPolicy_ZeroValues(t *testing.T) {
 	cfg := PolicyConfig{}
-	p := cfg.ToPolicy()
+	p := ToPolicy(&cfg)
 	def := DefaultPolicy()
 
 	if p.MaxRiskClass != def.MaxRiskClass {

--- a/plugin/host_test.go
+++ b/plugin/host_test.go
@@ -737,7 +737,7 @@ plugin_policy:
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	policy := cfg.PluginPolicy.ToPolicy()
+	policy := ToPolicy(&cfg.PluginPolicy)
 	if policy.MaxRiskClass != RiskClassActive {
 		t.Errorf("MaxRiskClass = %q, want %q", policy.MaxRiskClass, RiskClassActive)
 	}


### PR DESCRIPTION
## The bug

`plugin_policy` in `.nox.yaml` is the plugin sandbox: it is how an operator widens a plugin's network, filesystem or env allowlist. It works. The strict-config check did not know about it, because that check decodes the file against `core.ScanConfig` while the schema lived in package `plugin`.

Every scan of a project using it emitted:

```
[degraded] .nox.yaml has 1 key(s) nox does not recognise: plugin_policy
  impact: they are ignored, so whatever they were meant to configure is not in
  effect; check for a typo against the documented keys
```

Both halves are false, and false in the dangerous direction. The key *was* in effect — the same scan registered a plugin that the default policy had rejected moments earlier, because of it — while the impact line told the operator it was doing nothing and advised deleting it. An operator who followed that advice would silently change a sandbox boundary in a scan that reported nothing wrong.

This inverts the check's own stated purpose: *"A security tool that silently ignores configuration is not merely untidy: it reports on a policy the operator did not ask for, while they believe the one they wrote is in force."*

## How it was found

A/B measuring installed plugins against core 1.33.0. Allowing `api.first.org` and `www.cisa.gov` so an EPSS/KEV plugin could register produced this warning next to the plugin registering successfully.

## The fix

The schema moves to `core.PluginPolicyConfig`; package `plugin` **aliases** it rather than keeping a second copy. `core` cannot import `plugin` (`plugin` imports `core`), and two declarations of a security policy's shape would drift. Because the alias names a type in another package, `PolicyConfig`'s two methods become functions — `plugin.ToPolicy` and `plugin.Overrides` — updated at four call sites and three tests.

Declaring the schema rather than accepting the block opaquely also buys the nested case: a misspelt `allowed_network_host` inside `plugin_policy` is now named instead of silently dropped, which is the whole reason the strict check exists.

## Tests

Two, both failing with the field removed:

- `TestPluginPolicyIsARecognisedKey` — a real `plugin_policy` block reports no unknown keys
- `TestTypoInsidePluginPolicyIsReported` — `allowed_network_host` (singular) is named

Full suite green, `golangci-lint` clean.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT