### PR TITLE
PLUGINS: a required plugin nox scan cannot invoke says so

### DIFF
--- a/cli/plugin_scan.go
+++ b/cli/plugin_scan.go
@@ -428,6 +428,8 @@ func runPluginBinaries(ctx context.Context, target string, binaries []installedP
 		return &core.PluginScanOutput{Degradations: regDegradations}, nil
 	}
 
+	regDegradations = append(regDegradations, uninvocableDegradations(host.Plugins())...)
+
 	// Run the analysis `scan` tool across every plugin that declares it.
 	// workspace_root is passed both as the host workspace argument and in the
 	// input map, since plugins read it from req.Input["workspace_root"].
@@ -492,4 +494,59 @@ func runPluginBinaries(ctx context.Context, target string, binaries []installedP
 		"findings this plugin would have produced are missing from this scan; other plugins still ran")...)
 
 	return out, nil
+}
+
+// scanInvokesTool is the name of the analysis-phase tool nox scan calls on
+// every registered plugin. Anything else runs only if it asks for scan context.
+const scanInvokesTool = "scan"
+
+// uninvocableDegradations reports plugins that registered but that `nox scan`
+// has no way to call.
+//
+// A scan reaches exactly two kinds of tool: one named "scan", during the
+// analysis phase, and any tool declaring requires_scan_context, afterwards. A
+// plugin whose tools are neither is loaded, handshaken, counted as registered
+// — and then never invoked. Nothing in the output says so.
+//
+// That is the failure mode degradations exist to prevent, arriving through a
+// door the existing checks do not watch. The plugin degradation covers
+// installed-but-undeclared and declared-but-rejected; this is the third case,
+// declared and accepted and inert, and it is the quietest of the three: the
+// operator wrote the plugin into plugins.required, the scan reported no
+// problem with it, and it contributed nothing.
+//
+// Measured on the installed set: nox/red-team (analyze, validate) and nox/grc
+// (assess, gap_report, evidence) are both unreachable from nox scan today.
+// Their tools are invoked explicitly with `nox plugin call`, which is a
+// legitimate design — the defect is that a scan could not tell you so.
+func uninvocableDegradations(infos []plugin.Info) []core.Degradation {
+	var out []core.Degradation
+	for _, info := range infos {
+		var names []string
+		invocable := false
+		for _, cap := range info.Capabilities {
+			for _, t := range cap.Tools {
+				names = append(names, t.Name)
+				if t.Name == scanInvokesTool || t.RequiresScanContext {
+					invocable = true
+				}
+			}
+		}
+		if invocable {
+			continue
+		}
+		detail := fmt.Sprintf("required plugin %q exposes no tool that nox scan invokes", info.Name)
+		if len(names) > 0 {
+			detail += fmt.Sprintf(" (it provides: %s)", strings.Join(names, ", "))
+		}
+		out = append(out, core.Degradation{
+			Kind:   degrade.Plugin,
+			Detail: detail,
+			Impact: "it registered and then ran nothing: a scan invokes a tool named " +
+				"\"scan\" plus any tool declaring requires_scan_context. Invoke the " +
+				"others explicitly with `nox plugin call`, or drop the plugin from " +
+				"plugins.required so the scan does not imply it contributed",
+		})
+	}
+	return out
 }

--- a/cli/plugin_uninvocable_test.go
+++ b/cli/plugin_uninvocable_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/plugin"
+)
+
+func info(name string, tools ...plugin.ToolInfo) plugin.Info {
+	return plugin.Info{Name: name, Capabilities: []plugin.CapabilityInfo{{Tools: tools}}}
+}
+
+// A plugin listed in plugins.required that exposes neither a "scan" tool nor a
+// post-scan one registers, is counted, and is never invoked. Before this, the
+// scan said nothing at all: the operator declared a detector, the scan reported
+// no problem with it, and it contributed nothing.
+//
+// Two real examples from the published registry: nox/red-team provides
+// analyze/validate, nox/grc provides assess/gap_report/evidence. Both are
+// invoked explicitly with `nox plugin call`, which is a fine design — the
+// defect was that a scan could not tell you that was what you had.
+func TestPluginWithNoInvocableToolIsDegraded(t *testing.T) {
+	got := uninvocableDegradations([]plugin.Info{
+		info("nox/red-team",
+			plugin.ToolInfo{Name: "analyze"},
+			plugin.ToolInfo{Name: "validate"},
+		),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("degradations = %d, want 1", len(got))
+	}
+	if !strings.Contains(got[0].Detail, "nox/red-team") {
+		t.Errorf("detail does not name the plugin: %q", got[0].Detail)
+	}
+	// The operator needs to know which tools it does have, or the report is a
+	// dead end rather than an instruction.
+	for _, want := range []string{"analyze", "validate"} {
+		if !strings.Contains(got[0].Detail, want) {
+			t.Errorf("detail omits tool %q: %q", want, got[0].Detail)
+		}
+	}
+	if !strings.Contains(got[0].Impact, "nox plugin call") {
+		t.Errorf("impact does not say how to invoke it: %q", got[0].Impact)
+	}
+}
+
+// Both invocation paths count. Reporting a plugin that only enriches would be
+// a false alarm on exactly the plugins that work.
+func TestInvocablePluginsAreNotDegraded(t *testing.T) {
+	got := uninvocableDegradations([]plugin.Info{
+		info("nox/api-abuse", plugin.ToolInfo{Name: "scan"}),
+		info("nox/threat-enrich", plugin.ToolInfo{Name: "enrich", RequiresScanContext: true}),
+		info("nox/risk-score",
+			plugin.ToolInfo{Name: "enrich_findings", RequiresScanContext: true},
+			plugin.ToolInfo{Name: "get_epss"},
+			plugin.ToolInfo{Name: "get_kev_status"},
+		),
+	})
+
+	if len(got) != 0 {
+		t.Errorf("degradations = %v, want none", got)
+	}
+}
+
+// A plugin that registers with no tools at all is inert for the same reason
+// and must not produce a detail claiming it provides an empty list.
+func TestPluginWithNoToolsIsDegradedWithoutAToolList(t *testing.T) {
+	got := uninvocableDegradations([]plugin.Info{{Name: "nox/empty"}})
+
+	if len(got) != 1 {
+		t.Fatalf("degradations = %d, want 1", len(got))
+	}
+	if strings.Contains(got[0].Detail, "it provides") {
+		t.Errorf("detail claims a tool list it does not have: %q", got[0].Detail)
+	}
+}

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -41,6 +41,33 @@ Host (nox)                    Plugin (subprocess)
 5. **Invocation**: Host calls `InvokeTool` for each scan operation
 6. **Shutdown**: Host sends SIGTERM, waits 5s, then SIGKILL
 
+### What `nox scan` actually invokes
+
+Registering is not the same as running. A scan calls exactly two kinds of tool:
+
+| when | which tools |
+|---|---|
+| analysis phase | the tool named **`scan`**, on every plugin that declares it |
+| after the scan | every tool declaring **`requires_scan_context`**, given the findings |
+
+A tool that is neither is **never invoked by a scan**. It is reachable only
+through `nox plugin call <plugin> <tool>`, which is a legitimate design for
+tools an operator runs deliberately — compliance assessments, exploit
+validation — but it means listing such a plugin in `plugins.required` gets you
+nothing at scan time.
+
+Two plugins in the published registry are in exactly that position today:
+`nox/red-team` (`analyze`, `validate`) and `nox/grc` (`assess`, `gap_report`,
+`evidence`). Both work when called explicitly. Since nox 1.34.0 a scan says so:
+
+```
+[degraded] required plugin "nox/grc" exposes no tool that nox scan invokes
+           (it provides: assess, gap_report, evidence)
+```
+
+If you want your plugin to contribute to a scan, name its entry point `scan`,
+or set `requires_scan_context` on the tool that reasons over findings.
+
 ## SDK Reference
 
 ### Manifest Builder
@@ -339,3 +366,17 @@ nox plugin install nox/my-scanner@^1.0.0
 - Check that tool names match between manifest and handler registration
 - Verify the workspace_root is accessible
 - Check for context cancellation (timeout)
+
+### The plugin registers but nothing happens during a scan
+
+- Check the tool is named `scan` or declares `requires_scan_context` — see
+  [What `nox scan` actually invokes](#what-nox-scan-actually-invokes). Anything
+  else is only reachable via `nox plugin call`.
+- A read-only tool still inherits the **plugin-level** safety ceiling unless it
+  declares its own `ToolSafety(...)`. A passive `plan`-style tool shipped
+  alongside an active `apply` one is refused with it under a passive policy,
+  which is not what you want: declare the narrower requirements per tool and
+  the host will admit the plugin and refuse only the active tool.
+- Widen a sandbox with `plugin_policy` in `.nox.yaml`. Overrides are
+  one-directional — you can add to an allowlist but not empty one; use
+  `ignore_track_profiles: true` to revoke what a track profile grants.


### PR DESCRIPTION
## The gap

A scan reaches exactly two kinds of plugin tool:

- one named `scan`, during the analysis phase — `host.InvokeAll(ctx, "scan", …)`
- any tool declaring `requires_scan_context`, afterwards — `Host.InvokePostScan`

A plugin whose tools are neither is loaded, handshaken, counted as registered, and then never invoked. `InvokeAll` returns `nil, nil` when nothing has the tool, so the skip is silent and nothing in the output says so.

That is the third case of the failure mode the plugin degradations already cover twice — installed-but-undeclared, and declared-but-rejected — and it is the quietest of the three. The operator wrote the plugin into `plugins.required`, the scan reported no problem with it, and it contributed nothing. That reads exactly like a detector that ran and found nothing.

## Measured, not hypothetical

Dumping `Host.Plugins()` across the published registry, two of sixteen installed plugins are unreachable from `nox scan` today:

| plugin | tools | reachable |
|---|---|---|
| `nox/red-team` | analyze, validate | **no** |
| `nox/grc` | assess, gap_report, evidence | **no** |
| `nox/threat-enrich` | enrich *(post-scan)* | yes |
| `nox/api-abuse` | scan | yes |
| `nox/remediate` | plan_code, apply_code, verify_code *(all post-scan)* | yes |

Both are perfectly functional when called explicitly — `nox plugin call nox/grc assess` returns a real GRC-002 finding. Invoking them that way is a legitimate design. The defect was that a scan could not tell you it was what you had.

## Output

```
[degraded] required plugin "nox/red-team" exposes no tool that nox scan invokes
           (it provides: analyze, validate)
  impact: it registered and then ran nothing: a scan invokes a tool named "scan"
  plus any tool declaring requires_scan_context. Invoke the others explicitly
  with `nox plugin call`, or drop the plugin from plugins.required so the scan
  does not imply it contributed
```

Verified end to end against the installed binaries, with `nox/threat-enrich` in the same run correctly producing no such line.

## Tests

- `TestPluginWithNoInvocableToolIsDegraded` — names the plugin, lists the tools it does have, and says how to invoke them
- `TestInvocablePluginsAreNotDegraded` — both invocation paths count, so enrichment-only plugins are not falsely reported
- `TestPluginWithNoToolsIsDegradedWithoutAToolList` — a plugin with no tools does not get a detail claiming an empty list

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT