### PR TITLE
TEST: the auth round-trip test asserted a startup latency the product never requires

### DIFF
--- a/plugin/auth_test.go
+++ b/plugin/auth_test.go
@@ -76,10 +76,21 @@ func TestStartBinary_TokenRoundTrip(t *testing.T) {
 		t.Fatalf("building test plugin: %v\n%s", err, out)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	p, err := StartBinary(ctx, bin, nil, 10*time.Second)
+	// The startup budget matches the fallback RegisterBinaryWithTrack uses in
+	// production. The 10s that stood here was tighter than any value a real
+	// caller passes — every track profile allows 1 to 5 minutes — so the test
+	// was asserting a startup latency the product never requires, and failing
+	// on a busy machine: this binary is compiled by the line above, so its
+	// first execution is a cold start that also has to bind a port.
+	//
+	// Observed failing at load ~20 with "timed out waiting for plugin address:
+	// context deadline exceeded" after 14.5s, blocking an unrelated push. The
+	// subject of this test is the token round-trip, not how fast a cold binary
+	// comes up.
+	p, err := StartBinary(ctx, bin, nil, 30*time.Second)
 	if err != nil {
 		t.Fatalf("StartBinary: %v", err)
 	}


### PR DESCRIPTION
## The failure

`TestStartBinary_TokenRoundTrip` compiles a plugin binary and then gave it **10 seconds** to cold-start and bind a port:

```
--- FAIL: TestStartBinary_TokenRoundTrip (14.56s)
    auth_test.go:84: StartBinary: waiting for plugin address: timed out
    waiting for plugin address: context deadline exceeded
```

## Why the constraint was wrong, not just unlucky

Production is far more generous. `RegisterBinaryWithTrack` passes the track's `ToolInvocationTimeout` and falls back to **30s**, and every track profile allows between one and five minutes:

| track | ToolInvocationTimeout |
|---|---|
| core-analysis | 2m |
| supply-chain | 3m |
| intelligence | 3m |
| policy-governance | 1m |

The test's 10s was tighter than anything a real caller imposes, so it was asserting a startup latency the product never requires — and the binary in question is compiled by the line above it, so its first execution is a cold start that also has to bind a port.

## It hides behind the test cache

`go test ./...` with a warm cache reports the package as `ok`. Only `-count=1` — what the warden pre-push gate runs — sees it. That is how it reached the point of blocking an unrelated push rather than being caught when it was introduced.

## The change

Startup budget 10s → 30s, matching the production fallback exactly; outer context widened to match. The subject of the test is unchanged: that the host passes the token via the environment, attaches it on every RPC, and that the SDK server accepts exactly that token.

## Not included, deliberately

`registry/trust.TestCosignVersion_Parses` also failed once during this work, at exactly its 10s deadline. That timeout lives in **product** code (`cosignVersion`), and re-running the test five times at machine load 19.6 gives 0.11–0.22s each. It fails only inside the full parallel suite on a heavily loaded machine. Loosening a production timeout to accommodate that would be weakening the product to fit the environment, so it is left alone.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT