### PR TITLE
CLI: `plugin call` can pass a flag after the positionals, and a value that is not a string

### DIFF
--- a/cli/plugin_call_args_test.go
+++ b/cli/plugin_call_args_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// flag.FlagSet.Parse stops at the first non-flag argument, so with the order
+// the usage string documents — `nox plugin call <name> <tool> --input f` — the
+// flag was never parsed. It fell through to the key=value loop, where
+// SplitN(kv, "=", 2) accepted "--input=f" as a key named "--input", and the
+// tool ran with NO input at all while reporting success.
+func TestInputFlagIsFoundAfterThePositionalArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"before positionals, separate", []string{"--input", "in.json", "p", "t"}, "in.json"},
+		{"after positionals, separate", []string{"p", "t", "--input", "in.json"}, "in.json"},
+		{"after positionals, joined", []string{"p", "t", "--input=in.json"}, "in.json"},
+		{"single dash", []string{"p", "t", "-input=in.json"}, "in.json"},
+		{"absent", []string{"p", "t", "k=v"}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := extractInputFlag(tc.args)
+			if err != nil {
+				t.Fatalf("extractInputFlag: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("inputFile = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A flag typo must not be swallowed as a key=value pair and become silent input.
+func TestUnknownFlagIsRejectedRatherThanBecomingAnArgument(t *testing.T) {
+	if _, _, err := extractInputFlag([]string{"p", "t", "--inpt=in.json"}); err == nil {
+		t.Error("a misspelt flag was accepted; it would have become a tool argument named --inpt")
+	}
+	if _, _, err := extractInputFlag([]string{"p", "t", "--input"}); err == nil {
+		t.Error("--input with no value was accepted")
+	}
+}
+
+func TestPositionalsSurviveFlagExtraction(t *testing.T) {
+	_, pos, err := extractInputFlag([]string{"nox/ai-eval", "ai_eval", "--input=in.json", "k=v"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"nox/ai-eval", "ai_eval", "k=v"}; !reflect.DeepEqual(pos, want) {
+		t.Errorf("positional = %v, want %v", pos, want)
+	}
+}
+
+// Every value used to be a string, so a tool input declared as a bool could not
+// be satisfied from the command line at all. nox/ai-eval gates its attack
+// corpus behind `authorize: true` and asserts req.Input["authorize"].(bool):
+// authorize=true sent the string "true", the assertion failed, and the operator
+// got a lecture about authorisation rather than a word about types.
+func TestTypedArgumentsSendJSON(t *testing.T) {
+	tests := []struct {
+		arg  string
+		key  string
+		want any
+	}{
+		{"authorize:=true", "authorize", true},
+		{"authorize:=false", "authorize", false},
+		{"count:=42", "count", float64(42)},
+		{"ratio:=1.5", "ratio", 1.5},
+		{"opt:=null", "opt", nil},
+		{`tags:=["a","b"]`, "tags", []any{"a", "b"}},
+		{`cfg:={"k":1}`, "cfg", map[string]any{"k": float64(1)}},
+		{`name:="literal"`, "name", "literal"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.arg, func(t *testing.T) {
+			k, v, err := parseToolArg(tc.arg)
+			if err != nil {
+				t.Fatalf("parseToolArg(%q): %v", tc.arg, err)
+			}
+			if k != tc.key || !reflect.DeepEqual(v, tc.want) {
+				t.Errorf("= (%q, %#v), want (%q, %#v)", k, v, tc.key, tc.want)
+			}
+		})
+	}
+}
+
+// key= must keep sending a string unconditionally: inferring would make a tool
+// that takes the literal string "true" impossible to call, and would change the
+// meaning of arguments that work today.
+func TestPlainArgumentsStayStrings(t *testing.T) {
+	for _, arg := range []string{"authorize=true", "count=42", "opt=null", "name=hello"} {
+		_, v, err := parseToolArg(arg)
+		if err != nil {
+			t.Fatalf("parseToolArg(%q): %v", arg, err)
+		}
+		if _, ok := v.(string); !ok {
+			t.Errorf("%q produced %T, want string", arg, v)
+		}
+	}
+}
+
+func TestMalformedArgumentsAreRejected(t *testing.T) {
+	for _, arg := range []string{"novalue", "=novalue", ":=true", "bad:=not-json"} {
+		if _, _, err := parseToolArg(arg); err == nil {
+			t.Errorf("parseToolArg(%q) accepted a malformed argument", arg)
+		}
+	}
+}

--- a/cli/plugin_cmd.go
+++ b/cli/plugin_cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -677,18 +678,109 @@ func runPluginRemove(args []string) int {
 }
 
 // runPluginCall invokes a tool on an installed plugin.
-func runPluginCall(args []string) int {
-	fs := flag.NewFlagSet("plugin call", flag.ContinueOnError)
-	var inputFile string
-	fs.StringVar(&inputFile, "input", "", "JSON file with tool input")
+// extractInputFlag pulls --input out of args wherever it appears and returns
+// the remaining positional arguments.
+//
+// flag.FlagSet.Parse stops at the first non-flag argument, so with the
+// documented order — `nox plugin call <name> <tool> [--input f]` — the flag was
+// never parsed. It fell through to the key=value loop, where SplitN(kv, "=", 2)
+// accepted "--input=f" as a key named "--input", and the tool ran with no input
+// at all. A silently empty input is the worst outcome available: the plugin
+// reports whatever it reports when asked nothing, which reads as a result.
+//
+// Both spellings are accepted anywhere in the argument list.
+func extractInputFlag(args []string) (inputFile string, positional []string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--input" || a == "-input":
+			if i+1 >= len(args) {
+				return "", nil, fmt.Errorf("%s needs a file path", a)
+			}
+			inputFile = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--input=") || strings.HasPrefix(a, "-input="):
+			inputFile = a[strings.IndexByte(a, '=')+1:]
+			if inputFile == "" {
+				return "", nil, fmt.Errorf("%s needs a file path", a)
+			}
+		case strings.HasPrefix(a, "-"):
+			return "", nil, fmt.Errorf("unknown flag %q (only --input is accepted here)", a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+	return inputFile, positional, nil
+}
 
-	if err := fs.Parse(args); err != nil {
+// jsonScalarRE matches the values an operator most likely meant as a JSON
+// scalar rather than a string: booleans, null, and plain numbers.
+var jsonScalarRE = regexp.MustCompile(`^(true|false|null|-?\d+(\.\d+)?)$`)
+
+// parseToolArg parses one tool argument.
+//
+//	key=value    value is always a string
+//	key:=value   value is parsed as JSON — bool, number, null, array, object
+//
+// The typed form exists because every value used to be a string, so a tool
+// input declared as a bool could not be satisfied from the command line at all.
+// nox/ai-eval gates its attack corpus behind `authorize: true` and asserts
+// req.Input["authorize"].(bool); passing authorize=true sent the STRING "true",
+// the assertion failed, and the operator got a lecture about authorisation
+// rather than a word about types.
+//
+// key= stays a string unconditionally, so nothing that works today changes
+// meaning. Where the value looks like a scalar the caller probably meant, the
+// mismatch is called out on stderr rather than guessed at: guessing would make
+// a tool taking the literal string "true" impossible to call.
+func parseToolArg(arg string) (key string, value any, err error) {
+	if k, raw, ok := strings.Cut(arg, ":="); ok {
+		if k == "" {
+			return "", nil, fmt.Errorf("invalid argument %q: empty key", arg)
+		}
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			return "", nil, fmt.Errorf("invalid JSON in %q: %v (use %s=%s to send it as a string)", arg, err, k, raw)
+		}
+		return k, v, nil
+	}
+
+	k, raw, ok := strings.Cut(arg, "=")
+	if !ok || k == "" {
+		return "", nil, fmt.Errorf("invalid argument %q: expected key=value (string) or key:=value (JSON)", arg)
+	}
+	if jsonScalarRE.MatchString(raw) {
+		fmt.Fprintf(os.Stderr,
+			"[note] %s was sent as the string %q. If the tool expects a JSON %s, write %s:=%s\n",
+			k, raw, scalarKindOf(raw), k, raw)
+	}
+	return k, raw, nil
+}
+
+// scalarKindOf names the JSON type a bare value would have parsed as, for the
+// hint in parseToolArg.
+func scalarKindOf(raw string) string {
+	switch raw {
+	case "true", "false":
+		return "boolean"
+	case "null":
+		return "null"
+	default:
+		return "number"
+	}
+}
+
+func runPluginCall(args []string) int {
+	inputFile, remaining, err := extractInputFlag(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 
-	remaining := fs.Args()
 	if len(remaining) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: nox plugin call <name> <tool> [--input <file.json>] [key=value ...]")
+		fmt.Fprintln(os.Stderr, "Usage: nox plugin call <name> <tool> [--input <file.json>] [key=value ...] [key:=<json> ...]")
+		fmt.Fprintln(os.Stderr, "  key=value    sends a string")
+		fmt.Fprintln(os.Stderr, "  key:=value   sends JSON — true, 42, null, [\"a\"], {\"k\":1}")
 		return 2
 	}
 
@@ -722,12 +814,12 @@ func runPluginCall(args []string) int {
 		}
 	}
 	for _, kv := range kvArgs {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			fmt.Fprintf(os.Stderr, "error: invalid key=value argument: %q\n", kv)
+		key, value, err := parseToolArg(kv)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 2
 		}
-		input[parts[0]] = parts[1]
+		input[key] = value
 	}
 
 	// Load policy from .nox.yaml if present.


### PR DESCRIPTION
Two defects in `nox plugin call`, both ending the same way: a tool running on input the operator did not give it.

## 1. `--input` was silently ignored where the usage string says to put it

`flag.FlagSet.Parse` stops at the first non-flag argument. In the documented order — `nox plugin call <name> <tool> --input f` — the flag was never parsed. It fell through to the key=value loop, where `SplitN(kv, "=", 2)` accepted `"--input=f"` as a key named `--input`, and the tool ran with **no input at all**, reporting whatever it reports when asked nothing.

Only `--input f` placed *before* the plugin name ever worked.

`--input` is now extracted from anywhere in the argument list, both spellings, and an argument starting with `-` that is not it is an error rather than a tool argument:

```
$ nox plugin call nox/ai-eval ai_eval --inpt=in.json
error: unknown flag "--inpt=in.json" (only --input is accepted here)
```

A misspelt flag can no longer become silent input.

## 2. Every value was a string

A tool input declared as a bool, number or list could not be satisfied from the command line at all.

`nox/ai-eval` gates its attack corpus behind `authorize: true` and asserts `req.Input["authorize"].(bool)`. Passing `authorize=true` sent the **string** `"true"`, the assertion failed, and the operator got a lecture about authorisation rather than a word about types — an error pointing at entirely the wrong problem.

`key:=<json>` now sends a parsed JSON value — bool, number, null, array, object. `key=<value>` still sends a string **unconditionally**, so nothing that works today changes meaning: inferring would make a tool taking the literal string `"true"` impossible to call.

Where a `key=` value looks like a scalar the caller probably meant, the mismatch is named rather than guessed at:

```
[note] authorize was sent as the string "true". If the tool expects a JSON boolean, write authorize:=true
```

## Verified against the installed plugin

| invocation | before | after |
|---|---|---|
| `authorize=true` | authorisation lecture | `[note]` naming the type mismatch |
| `authorize:=true` | n/a | corpus runs, 12/16 |
| `--input=f` after positionals | silently empty input | honoured |
| `--inpt=f` | became a tool argument | rejected |

## Tests

`extractInputFlag` across five placements plus a misspelt flag and a valueless one; `parseToolArg` across eight typed forms, four plain forms that must stay strings, and four malformed ones.

Found while measuring `nox/ai-eval` — both had to be worked around before the plugin could be invoked at all, and neither said what was wrong.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
