### PR TITLE
IAC-464: match the Namespace kind, not the word "namespace"

### DIFF
--- a/core/analyzers/iac/iac464_namespace_kind_test.go
+++ b/core/analyzers/iac/iac464_namespace_kind_test.go
@@ -1,0 +1,77 @@
+package iac
+
+import (
+	"strings"
+	"testing"
+)
+
+// IAC-464 was built on k8sManifestPrefix, which is
+// `(?is)apiVersion:...kind:...` — dotall, so its trailing `.*` spans the whole
+// file, and case-insensitive. Appending the bare word `Namespace` matched that
+// word ANYWHERE after the first kind: line, which includes the `namespace:`
+// field that nearly every namespaced manifest carries.
+//
+// The result: a ConfigMap declaring `namespace: example` was reported as
+// "K8s Namespace defined", at medium severity, in every Kubernetes repository
+// nox has ever scanned.
+func TestIAC464MatchesTheKindNotTheWord(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "an actual Namespace",
+			yaml: "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: example\n",
+			want: true,
+		},
+		{
+			name: "a ConfigMap that merely declares its namespace",
+			yaml: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: example\ndata:\n  k: v\n",
+			want: false,
+		},
+		{
+			name: "a custom resource that declares its namespace",
+			yaml: "apiVersion: example.com/v1\nkind: SomethingElse\nmetadata:\n  name: thing\n  namespace: example\n",
+			want: false,
+		},
+		{
+			name: "the word in a comment",
+			yaml: "# creates a Namespace later\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n",
+			want: false,
+		},
+		{
+			name: "a Namespace declared after another document",
+			yaml: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: example\n",
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ruleFires(t, "manifest.yaml", tc.yaml, "IAC-464")
+			if got != tc.want {
+				t.Errorf("IAC-464 fired = %v, want %v for:\n%s", got, tc.want, tc.yaml)
+			}
+		})
+	}
+}
+
+// The description has always said "(informational)". Reporting it at medium
+// inflated every Kubernetes repository's medium count with a fact rather than
+// a problem.
+func TestIAC464IsInformationalSeverity(t *testing.T) {
+	for _, r := range builtinExpandedIaCRules() {
+		if r.ID != "IAC-464" {
+			continue
+		}
+		if !strings.Contains(r.Description, "informational") {
+			t.Fatalf("description no longer says informational: %q", r.Description)
+		}
+		if string(r.Severity) != "info" {
+			t.Errorf("severity = %q, want info — the description calls it informational", r.Severity)
+		}
+		return
+	}
+	t.Fatal("IAC-464 not found")
+}

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -2166,8 +2166,22 @@ func builtinExpandedIaCRules() []rules.Rule {
 			references:   []string{"https://cwe.mitre.org/data/definitions/400.html"},
 		},
 		{
-			id: "IAC-464", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
-			pattern:      k8sManifestPrefix + `Namespace`,
+			// Anchored to a kind line, and NOT built on k8sManifestPrefix.
+			//
+			// That prefix is `(?is)apiVersion:...kind:...` — dotall, so its
+			// trailing `.*` spans the whole file, and case-insensitive. Appending
+			// the bare word `Namespace` therefore matched that word ANYWHERE
+			// after the first kind: line, which includes the `namespace:` field
+			// that nearly every namespaced manifest carries. A ConfigMap
+			// declaring `namespace: example` was reported as "K8s Namespace
+			// defined".
+			//
+			// Severity drops to Info to match what the description has always
+			// said. A rule whose own message reads "(informational)" has no
+			// business at Medium: it inflated every Kubernetes repository's
+			// medium count with a fact, not a problem.
+			id: "IAC-464", severity: findings.SeverityInfo, confidence: findings.ConfidenceHigh,
+			pattern:      `(?im)^\s*kind:\s*Namespace\s*$`,
 			description:  "K8s Namespace defined (informational)",
 			cwe:          "CWE-693",
 			keywords:     []string{"Namespace"},


### PR DESCRIPTION
## The bug

`IAC-464` was built on `k8sManifestPrefix`:

```go
k8sManifestPrefix := `(?is)apiVersion:\s*[^\n]+.*\n.*kind:\s*[^\n]+.*`
```

`(?is)` is case-insensitive **and dotall**, so the trailing `.*` spans the entire file. Appending the bare word `Namespace` matched that word *anywhere* after the first `kind:` line — including the `namespace:` field that nearly every namespaced Kubernetes manifest carries.

A ConfigMap declaring `namespace: example` was reported as **"K8s Namespace defined"**. So was a custom resource. So was any manifest with the word in a comment.

## Falsified with four minimal fixtures

| fixture | fired |
|---|---|
| `kind: Namespace` | yes ✓ |
| ConfigMap with `namespace: example` | **yes ✗** |
| custom resource with `namespace:` | **yes ✗** |
| custom resource, no such word | no ✓ |

It fired on three of four; the only silent case was the one that never mentions a namespace at all.

## Measured on a real Kubernetes-heavy repository

```
IAC-464 findings       9 -> 1   (the 1 is an actual kind: Namespace)
medium-severity total 57 -> 48
total findings        91 -> 83
```

No other rule changed behaviour — none stopped firing, none started. The arithmetic closes exactly: 8 false positives removed plus 1 reclassified.

## The change

The pattern is anchored to a `kind:` line and no longer uses the dotall prefix.

Severity drops to **Info** to match what the description has always said. A rule whose own message reads *"(informational)"* has no business at Medium, inflating every Kubernetes repository's medium count with a fact rather than a problem.

## How it was found

Dogfooding. nox failed its own gate on a PR whose only Kubernetes content was two RollOps `RolloutConfig` files, neither of which defines a Namespace.

## Tests

Five cases, including a Namespace declared in the *second* document of a multi-document file. The ConfigMap and custom-resource cases fail when the pattern is reverted.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
