### PR TITLE
IAC-374 retires into IAC-360, and both rule files share one conversion

### DIFF
--- a/core/analyzers/iac/iac374_retirement_test.go
+++ b/core/analyzers/iac/iac374_retirement_test.go
@@ -1,0 +1,72 @@
+package iac
+
+import "testing"
+
+// IAC-374 declared a pattern and description byte-identical to IAC-360, so a
+// single `restartPolicy: Never` produced two findings a triager had to dismiss
+// separately.
+func TestIAC374RetiredIntoIAC360(t *testing.T) {
+	const pod = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: p\nspec:\n  restartPolicy: Never\n  containers:\n  - name: c\n    image: nginx:1.25\n"
+
+	a := NewAnalyzer()
+	got, err := a.ScanFile("pod.yaml", []byte(pod))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var n int
+	var retired []string
+	for i := range got {
+		switch got[i].RuleID {
+		case "IAC-374":
+			t.Error("IAC-374 still reports; it was retired into IAC-360")
+		case "IAC-360":
+			n++
+			retired = got[i].RetiredRuleIDs
+		}
+	}
+	if n != 1 {
+		t.Errorf("IAC-360 fired %d times, want exactly 1", n)
+	}
+
+	// The alias is the whole point of the retirement. Without it, every
+	// baseline entry, VEX statement and nox:ignore comment written against
+	// IAC-374 silently stops matching.
+	var found bool
+	for _, id := range retired {
+		if id == "IAC-374" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("RetiredRuleIDs = %v, want IAC-374 — waivers written against the retired ID would un-waive", retired)
+	}
+}
+
+// rules.go and rules_expanded.go used to convert their definitions with two
+// separate loops, and the second omitted `retires`, `extraMetadata` and the
+// whole absence block. A retirement declared in rules_expanded.go compiled,
+// passed the dedup test's validation, and was then dropped on the way to the
+// engine — un-waiving in every consuming repository. Both files now share one
+// conversion; this asserts the field that was being lost survives it.
+func TestExpandedRulesCarryTheirRetirements(t *testing.T) {
+	var checked int
+	for _, r := range builtinExpandedIaCRules() {
+		if r.ID != "IAC-360" {
+			continue
+		}
+		checked++
+		if len(r.Retires) == 0 {
+			t.Fatal("IAC-360 lost its Retires through the conversion")
+		}
+		if r.Retires[0].ID != "IAC-374" {
+			t.Errorf("retires %q, want IAC-374", r.Retires[0].ID)
+		}
+		if r.Retires[0].Pattern == "" {
+			t.Error("retirement carries no pattern, so the alias cannot be bounded to what IAC-374 actually matched")
+		}
+	}
+	if checked == 0 {
+		t.Fatal("IAC-360 not found in the expanded rules")
+	}
+}

--- a/core/analyzers/iac/iac_test.go
+++ b/core/analyzers/iac/iac_test.go
@@ -616,11 +616,12 @@ func TestDetect_CustomDockerfileExtension(t *testing.T) {
 
 func TestAllIaCRules_Count(t *testing.T) {
 	rules := builtinIaCRules()
-	// 490, not 500: ten duplicate IDs were retired in #394 (see
-	// knownDuplicateRulePairs). Each lives on as an alias on the rule that
-	// absorbed it, so the drop is in rule COUNT only, not in coverage.
-	if got := len(rules); got != 490 {
-		t.Errorf("expected 490 IaC rules, got %d", got)
+	// 489, not 500: ten duplicate IDs were retired in #394 (see
+	// knownDuplicateRulePairs) and IAC-374 followed, into IAC-360, which
+	// declared a byte-identical pattern. Each lives on as an alias on the rule
+	// that absorbed it, so the drop is in rule COUNT only, not in coverage.
+	if got := len(rules); got != 489 {
+		t.Errorf("expected 489 IaC rules, got %d", got)
 	}
 }
 

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -2266,47 +2266,63 @@ func builtinBaseIaCRules() []rules.Rule {
 func convertIaCRules(defs []iacRule) []rules.Rule {
 	out := make([]rules.Rule, len(defs))
 	for i := range defs {
-		md := map[string]string{"cwe": defs[i].cwe}
-		maps.Copy(md, defs[i].extraMetadata)
-		r := rules.Rule{
-			ID:           defs[i].id,
-			Version:      "1.0",
-			Description:  defs[i].description,
-			Severity:     defs[i].severity,
-			Confidence:   defs[i].confidence,
-			MatcherType:  "regex",
-			Pattern:      defs[i].pattern,
-			FilePatterns: defs[i].filePatterns,
-			Keywords:     defs[i].keywords,
-			Tags:         defs[i].tags,
-			Metadata:     md,
-			Remediation:  defs[i].remediation,
-			References:   defs[i].references,
-			Retires:      defs[i].retires,
-		}
-		if defs[i].absenceAnchor != "" {
-			r.MatcherType = "absence"
-			r.Pattern = ""
-			r.AbsenceAnchor = defs[i].absenceAnchor
-			r.AbsenceProperty = defs[i].absenceProperty
-			r.AbsenceRequire = defs[i].absenceRequire
-			r.AbsenceSpan = defs[i].absenceSpan
-			r.AbsenceResourceTypes = defs[i].absenceResourceTypes
-			r.AbsencePropertyPath = defs[i].absencePropertyPath
-			r.AbsenceRequireAll = defs[i].absenceRequireAll
-			r.AbsenceCompanionTypes = defs[i].absenceCompanionTypes
-			r.AbsenceCompanionLink = defs[i].absenceCompanionLink
-			r.AbsenceCompanionPath = defs[i].absenceCompanionPath
-			// Absence rules must NOT be keyword-gated. The engine skips a rule
-			// when none of its keywords appear in the file, but these rules'
-			// keywords name the hardening property — which is precisely what is
-			// absent when the rule should fire. Keyword-gating them would skip
-			// the file exactly when it is misconfigured. The anchor regex is the
-			// gate instead: the matcher returns nothing when no resource anchor
-			// is present, so clearing keywords costs only a cheap no-op scan.
-			r.Keywords = nil
-		}
-		out[i] = r
+		out[i] = defs[i].toRule()
 	}
 	return out
+}
+
+// toRule converts a rule definition into the engine's rules.Rule.
+//
+// One conversion, shared by both definition files. There used to be two —
+// rules.go and rules_expanded.go each had their own loop — and the second
+// silently omitted `retires`, `extraMetadata` and the whole absence block. A
+// rule in rules_expanded.go could therefore declare a retirement that compiled,
+// passed the dedup test's validation of its ID and pattern, and was then
+// dropped on the way to the engine: the surviving rule would report the
+// finding with no RetiredRuleIDs, so every baseline entry, VEX statement and
+// nox:ignore comment written against the retired ID would silently stop
+// matching. That is the exact outcome RetiredRule exists to prevent, reachable
+// by putting a retirement in the wrong file.
+func (d iacRule) toRule() rules.Rule {
+	md := map[string]string{"cwe": d.cwe}
+	maps.Copy(md, d.extraMetadata)
+	r := rules.Rule{
+		ID:           d.id,
+		Version:      "1.0",
+		Description:  d.description,
+		Severity:     d.severity,
+		Confidence:   d.confidence,
+		MatcherType:  "regex",
+		Pattern:      d.pattern,
+		FilePatterns: d.filePatterns,
+		Keywords:     d.keywords,
+		Tags:         d.tags,
+		Metadata:     md,
+		Remediation:  d.remediation,
+		References:   d.references,
+		Retires:      d.retires,
+	}
+	if d.absenceAnchor != "" {
+		r.MatcherType = "absence"
+		r.Pattern = ""
+		r.AbsenceAnchor = d.absenceAnchor
+		r.AbsenceProperty = d.absenceProperty
+		r.AbsenceRequire = d.absenceRequire
+		r.AbsenceSpan = d.absenceSpan
+		r.AbsenceResourceTypes = d.absenceResourceTypes
+		r.AbsencePropertyPath = d.absencePropertyPath
+		r.AbsenceRequireAll = d.absenceRequireAll
+		r.AbsenceCompanionTypes = d.absenceCompanionTypes
+		r.AbsenceCompanionLink = d.absenceCompanionLink
+		r.AbsenceCompanionPath = d.absenceCompanionPath
+		// Absence rules must NOT be keyword-gated. The engine skips a rule
+		// when none of its keywords appear in the file, but these rules'
+		// keywords name the hardening property — which is precisely what is
+		// absent when the rule should fire. Keyword-gating them would skip
+		// the file exactly when it is misconfigured. The anchor regex is the
+		// gate instead: the matcher returns nothing when no resource anchor
+		// is present, so clearing keywords costs only a cheap no-op scan.
+		r.Keywords = nil
+	}
+	return r
 }

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -1021,9 +1021,20 @@ func builtinExpandedIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-360", severity: findings.SeverityLow, confidence: findings.ConfidenceHigh,
-			pattern:      `(?i)restartPolicy:\s*['"]?Never`,
-			description:  "K8s pod restart policy set to Never",
-			cwe:          "CWE-693",
+			pattern:     `(?i)restartPolicy:\s*['"]?Never`,
+			description: "K8s pod restart policy set to Never",
+			cwe:         "CWE-693",
+			// IAC-374 declared a byte-identical pattern and description, so a
+			// single `restartPolicy: Never` produced two findings that a
+			// triager had to dismiss separately. IAC-360 survives: it is the
+			// earlier ID and graded the condition at high confidence, which is
+			// right for a deterministic literal match.
+			//
+			// The alias keeps waivers written against IAC-374 matching. It
+			// carries IAC-374's own pattern so it never reaches a location
+			// IAC-374 would not have reported — an ID-level waiver still covers
+			// exactly what it used to.
+			retires:      []rules.RetiredRule{{ID: "IAC-374", Pattern: `(?i)restartPolicy:\s*['"]?Never`}},
 			keywords:     []string{"restartPolicy", "Never"},
 			filePatterns: k8sFilePatterns,
 			tags:         []string{"iac", "kubernetes", "availability"},
@@ -1174,17 +1185,9 @@ func builtinExpandedIaCRules() []rules.Rule {
 			remediation:  "Ensure preStop hooks complete within terminationGracePeriodSeconds to allow graceful shutdown without forced termination.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-374", severity: findings.SeverityLow, confidence: findings.ConfidenceMedium,
-			pattern:      `(?i)restartPolicy:\s*['"]?Never`,
-			description:  "K8s pod restart policy set to Never",
-			cwe:          "CWE-693",
-			keywords:     []string{"restartPolicy", "Never"},
-			filePatterns: k8sFilePatterns,
-			tags:         []string{"iac", "kubernetes", "availability"},
-			remediation:  "Consider using restartPolicy: OnFailure for workloads that should retry on error. Never means failed pods stay failed.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
-		},
+		// IAC-374 retired into IAC-360, which reported the identical condition
+		// with the identical pattern. IAC-360's `retires` carries the alias that
+		// keeps waivers written against IAC-374 matching.
 		{
 			id: "IAC-375", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
 			pattern:      `(?i)activeDeadlineSeconds:\s*\d+`,
@@ -2576,21 +2579,7 @@ func builtinExpandedIaCRules() []rules.Rule {
 
 	out := make([]rules.Rule, len(defs))
 	for i := range defs {
-		out[i] = rules.Rule{
-			ID:           defs[i].id,
-			Version:      "1.0",
-			Description:  defs[i].description,
-			Severity:     defs[i].severity,
-			Confidence:   defs[i].confidence,
-			MatcherType:  "regex",
-			Pattern:      defs[i].pattern,
-			FilePatterns: defs[i].filePatterns,
-			Keywords:     defs[i].keywords,
-			Tags:         defs[i].tags,
-			Metadata:     map[string]string{"cwe": defs[i].cwe},
-			Remediation:  defs[i].remediation,
-			References:   defs[i].references,
-		}
+		out[i] = defs[i].toRule()
 	}
 	return out
 }

--- a/core/analyzers/iac/rules_expanded_test.go
+++ b/core/analyzers/iac/rules_expanded_test.go
@@ -12,11 +12,13 @@ import (
 
 func TestExpandedRules_Count(t *testing.T) {
 	rules := builtinExpandedIaCRules()
-	// 226, not the original 235: nine expanded rules (IAC-283, IAC-287,
+	// 225, not the original 235: nine expanded rules (IAC-283, IAC-287,
 	// IAC-291, IAC-292, IAC-310, IAC-312, IAC-321, IAC-333, IAC-337) were
-	// retired in #394 because a base rule already reported their condition.
-	if got := len(rules); got != 226 {
-		t.Errorf("expected 226 expanded rules, got %d", got)
+	// retired in #394 because a base rule already reported their condition,
+	// and IAC-374 followed into IAC-360 — the two declared byte-identical
+	// patterns and descriptions, so one `restartPolicy: Never` reported twice.
+	if got := len(rules); got != 225 {
+		t.Errorf("expected 225 expanded rules, got %d", got)
 	}
 }
 

--- a/core/catalog/catalog_test.go
+++ b/core/catalog/catalog_test.go
@@ -43,8 +43,12 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	// character class plus a file-level keyword: SEC-542 (retired into
 	// SEC-087, which detects the same credential by requiring the assignment)
 	// and SEC-524 (an Azure subscription ID is not a credential).
-	if got := len(cat); got != 1535 {
-		t.Errorf("Catalog() returned %d rules, want 1535", got)
+	// 1535 -> 1534 retired IAC-374 into IAC-360: the two declared a
+	// byte-identical pattern and description, so one `restartPolicy: Never`
+	// reported twice. The alias on IAC-360 keeps waivers written against
+	// IAC-374 matching, so the drop is in rule COUNT only, not in coverage.
+	if got := len(cat); got != 1534 {
+		t.Errorf("Catalog() returned %d rules, want 1534", got)
 	}
 }
 


### PR DESCRIPTION
## The duplicate

`IAC-360` and `IAC-374` declared a **byte-identical** pattern and description:

```go
pattern:     `(?i)restartPolicy:\s*['"]?Never`
description: "K8s pod restart policy set to Never"
```

One `restartPolicy: Never` produced two findings a triager had to dismiss separately.

`IAC-360` survives — it is the earlier ID and grades the condition at **high** confidence, which is right for a deterministic literal match.

The retirement follows the established pattern: `IAC-360`'s `retires` carries `IAC-374`'s own pattern, so the alias never reaches a location `IAC-374` would not have reported. Verified end to end — a pod carrying `# nox:ignore IAC-374` still comes back **suppressed** under `IAC-360`.

## The alias didn't work at first, which found a worse defect

`rules.go` and `rules_expanded.go` each had their **own loop** converting definitions into `rules.Rule`, and the one in `rules_expanded.go` omitted `retires`, `extraMetadata` and the entire absence block.

So a retirement declared in that file:

1. **compiles**
2. **passes** `rules_dedup_test`'s validation of its ID and pattern
3. is then **silently dropped** on the way to the engine

The surviving rule reports with no `RetiredRuleIDs` — so every baseline entry, VEX statement and `nox:ignore` comment written against the retired ID stops matching, **in every consuming repository**. That is the exact outcome `RetiredRule` exists to prevent, reachable purely by putting a retirement in the wrong file.

Both files now share one `iacRule.toRule()`. The duplication was the bug generator, so removing it is the fix rather than copying the missing lines across.

No expanded rule currently declares `absence*` fields, so that half of the omission had no live effect — but it was the same trap waiting.

## Counts

490→489 IaC, 226→225 expanded, 1535→1534 catalog. Coverage is unchanged: the condition is still reported, once, by `IAC-360`.

## Tests

- `TestIAC374RetiredIntoIAC360` — exactly one finding, and `RetiredRuleIDs` contains `IAC-374`
- `TestExpandedRulesCarryTheirRetirements` — the field survives the conversion

Both fail when the alias is dropped.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
