### PR TITLE
IAC: absence rules see manifests embedded in YAML block scalars

### DIFF
--- a/core/analyzers/iac/embedded.go
+++ b/core/analyzers/iac/embedded.go
@@ -1,0 +1,196 @@
+package iac
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/rules"
+)
+
+// embeddedManifest is a Kubernetes manifest found inside a YAML block scalar,
+// together with the line in the outer file where its first line sits.
+type embeddedManifest struct {
+	content    []byte
+	lineOffset int // outer-file line number of content's line 1
+}
+
+// blockScalarRE matches a mapping key introducing a literal or folded block
+// scalar: `manifest: |`, `template: >-`, `content: |2+` and so on.
+var blockScalarRE = regexp.MustCompile(`^(\s*)[\w.\-/]+\s*:\s*[|>][-+0-9]*\s*$`)
+
+// looksLikeK8sManifest reports whether s carries both of the keys that make a
+// Kubernetes document. Deliberately cheap and textual: this decides whether to
+// spend a second scan on a string, not whether a finding is real.
+func looksLikeK8sManifest(s string) bool {
+	return strings.Contains(s, "apiVersion:") && strings.Contains(s, "kind:")
+}
+
+// extractEmbeddedManifests returns the Kubernetes manifests embedded in YAML
+// block scalars within content.
+//
+// Absence rules and pattern rules disagreed about these. A pattern rule is a
+// regex over the whole file, so it matches inside a block scalar without
+// knowing the string is there. An absence rule bounds itself to a YAML
+// document, and the block scalar's contents are a string VALUE of the outer
+// document rather than a document of their own — so it never looked inside,
+// and reported nothing.
+//
+// Reporting nothing is the problem. A pattern rule that misses says nothing and
+// claims nothing; an absence rule that never evaluates produces the same output
+// as a clean result. Every workload deployed through a wrapper that embeds its
+// manifest — RollOps RolloutConfig, Argo CD Application, a Helm template
+// rendered into a ConfigMap, a Flux patch — had its hardening checks silently
+// skipped while the scan reported clean.
+//
+// Only the absence rules are re-run over what this returns. Pattern rules
+// already match inside the block, so running them again would report every
+// pattern finding twice — the double-report that retiring IAC-374 just removed.
+func extractEmbeddedManifests(content []byte) []embeddedManifest {
+	if !bytes.Contains(content, []byte("apiVersion:")) {
+		return nil
+	}
+
+	var out []embeddedManifest
+	sc := bufio.NewScanner(bytes.NewReader(content))
+	sc.Buffer(make([]byte, 0, 64*1024), maxEmbeddedBytes)
+
+	var (
+		lineNo      int
+		inBlock     bool
+		blockIndent int
+		bodyIndent  int
+		startLine   int
+		body        []string
+	)
+
+	flush := func() {
+		if inBlock && len(body) > 0 {
+			joined := strings.Join(body, "\n") + "\n"
+			if looksLikeK8sManifest(joined) {
+				out = append(out, embeddedManifest{content: []byte(joined), lineOffset: startLine})
+			}
+		}
+		inBlock, body = false, nil
+	}
+
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+
+		if inBlock {
+			trimmed := strings.TrimLeft(line, " \t")
+			indent := len(line) - len(trimmed)
+			// A blank line belongs to the block; it carries no indentation to
+			// judge and dropping it would corrupt the reconstructed document.
+			if trimmed == "" {
+				body = append(body, "")
+				continue
+			}
+			if bodyIndent < 0 {
+				bodyIndent = indent
+				startLine = lineNo
+			}
+			if indent < bodyIndent || indent <= blockIndent {
+				flush()
+				// fall through: this line may itself open a new block
+			} else {
+				body = append(body, line[bodyIndent:])
+				continue
+			}
+		}
+
+		if m := blockScalarRE.FindStringSubmatch(line); m != nil {
+			inBlock = true
+			blockIndent = len(m[1])
+			bodyIndent = -1
+			body = nil
+		}
+	}
+	flush()
+	return out
+}
+
+// maxEmbeddedBytes bounds a single embedded document. A block scalar is
+// operator-authored config, not input, but an unbounded scanner buffer on a
+// pathological file is a denial of service with extra steps.
+const maxEmbeddedBytes = 1 << 20
+
+// scanEmbedded runs the absence rules over each manifest embedded in content
+// and rewrites the reported lines back into the outer file.
+// already keys a finding by the fact it asserts: the same rule, at the same
+// line of the same file, is the same fact however it was reached.
+type seenKey struct {
+	rule string
+	line int
+}
+
+func (a *Analyzer) scanEmbedded(path string, content []byte, outer []findings.Finding) ([]findings.Finding, error) {
+	if a.absence == nil {
+		return nil, nil
+	}
+
+	// Some absence rules already fire on the outer file: their anchor is raw
+	// text, so `kind: Deployment` inside a block scalar matches, and a
+	// span of "file" (or a yaml-doc span that swallows the block) then looks
+	// for the hardening property across the whole thing. IAC-176 and IAC-183
+	// both do this. Re-reporting them from the extracted document would double
+	// every one of those — the defect retiring IAC-374 just removed, reintroduced
+	// by the fix for the opposite problem.
+	seen := make(map[seenKey]struct{}, len(outer))
+	for i := range outer {
+		seen[seenKey{outer[i].RuleID, outer[i].Location.StartLine}] = struct{}{}
+	}
+
+	var out []findings.Finding
+	for _, em := range extractEmbeddedManifests(content) {
+		got, err := a.absence.ScanFile(path, em.content)
+		if err != nil {
+			return nil, err
+		}
+		for i := range got {
+			// The finding's line is relative to the extracted document. Shift
+			// it so an operator opening the file at that line sees the
+			// resource the rule is talking about, not an unrelated one.
+			got[i].Location.StartLine += em.lineOffset - 1
+			if got[i].Location.EndLine > 0 {
+				got[i].Location.EndLine += em.lineOffset - 1
+			}
+			// Column offsets do not survive the re-indent, and a wrong column
+			// is worse than none.
+			got[i].Location.StartColumn = 0
+			got[i].Location.EndColumn = 0
+			if got[i].Metadata == nil {
+				got[i].Metadata = map[string]string{}
+			}
+			got[i].Metadata["embedded_manifest"] = "true"
+
+			k := seenKey{got[i].RuleID, got[i].Location.StartLine}
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			out = append(out, got[i])
+		}
+	}
+	return out, nil
+}
+
+// absenceRuleSet returns the absence-matcher rules from rs.
+func absenceRuleSet(rs []rules.Rule) *rules.RuleSet {
+	out := rules.NewRuleSet()
+	var n int
+	for i := range rs {
+		if rs[i].MatcherType != "absence" {
+			continue
+		}
+		out.Add(&rs[i])
+		n++
+	}
+	if n == 0 {
+		return nil
+	}
+	return out
+}

--- a/core/analyzers/iac/embedded_test.go
+++ b/core/analyzers/iac/embedded_test.go
@@ -1,0 +1,154 @@
+package iac
+
+import (
+	"strings"
+	"testing"
+)
+
+const hardenedPod = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: app
+        image: nginx:1.25
+        livenessProbe:
+          httpGet: {path: /, port: 80}
+        readinessProbe:
+          httpGet: {path: /, port: 80}
+        resources:
+          limits: {cpu: 100m, memory: 128Mi}
+          requests: {cpu: 10m, memory: 64Mi}
+`
+
+const barePod = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+`
+
+func wrap(inner string) string {
+	var b strings.Builder
+	b.WriteString("apiVersion: rollops.klarlabs.de/v1\nkind: RolloutConfig\nmetadata:\n  name: x\nspec:\n  target:\n    spec:\n      manifest: |\n")
+	for _, l := range strings.Split(strings.TrimRight(inner, "\n"), "\n") {
+		b.WriteString("        " + l + "\n")
+	}
+	return b.String()
+}
+
+func embeddedRuleIDs(t *testing.T, path, content string) map[string]int {
+	t.Helper()
+	got, err := NewAnalyzer().ScanFile(path, []byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]int{}
+	for i := range got {
+		out[got[i].RuleID]++
+	}
+	return out
+}
+
+// A manifest embedded in a block scalar must be checked exactly like the same
+// manifest standing alone. Absence rules used to skip it entirely: the block's
+// contents are a string VALUE of the outer document, not a document, so a rule
+// bounded to a YAML document never looked inside — and reported nothing, which
+// is indistinguishable from a clean result.
+func TestEmbeddedManifestGetsTheSameRulesAsAPlainOne(t *testing.T) {
+	plain := embeddedRuleIDs(t, "deploy.yaml", barePod)
+	nested := embeddedRuleIDs(t, "rollout.yaml", wrap(barePod))
+
+	for id := range plain {
+		if nested[id] == 0 {
+			t.Errorf("%s fires on the plain manifest but not the embedded one", id)
+		}
+	}
+	if len(nested) < len(plain) {
+		t.Errorf("embedded saw %d rules, plain saw %d", len(nested), len(plain))
+	}
+}
+
+// Some absence rules DO already fire on the outer file — their anchor is raw
+// text, so `kind: Deployment` inside the block matches, and a span of "file"
+// then searches the whole thing. Re-reporting those from the extracted document
+// would double them, which is the defect retiring IAC-374 just removed.
+func TestEmbeddedScanDoesNotDoubleReport(t *testing.T) {
+	for id, n := range embeddedRuleIDs(t, "rollout.yaml", wrap(barePod)) {
+		if n > 1 {
+			t.Errorf("%s reported %d times for one embedded manifest", id, n)
+		}
+	}
+}
+
+// The extraction must not invent findings: a hardened manifest stays clean
+// whether or not it is embedded.
+func TestHardenedEmbeddedManifestStaysClean(t *testing.T) {
+	plain := embeddedRuleIDs(t, "deploy.yaml", hardenedPod)
+	nested := embeddedRuleIDs(t, "rollout.yaml", wrap(hardenedPod))
+
+	for id := range nested {
+		if plain[id] == 0 {
+			t.Errorf("%s fires only when the manifest is embedded — the extraction invented it", id)
+		}
+	}
+}
+
+// A block scalar that is not a Kubernetes manifest must be left alone. Scanning
+// a shell script or a licence text as though it were a workload is how a
+// precision fix becomes a false-positive generator.
+func TestNonManifestBlockScalarsAreIgnored(t *testing.T) {
+	cases := map[string]string{
+		"a shell script":  "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\ndata:\n  run.sh: |\n    #!/bin/sh\n    echo hello\n",
+		"prose":           "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\ndata:\n  notes: |\n    kind of a long note\n    apiVersion of the API we use\n",
+		"no block scalar": barePod,
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			for i, em := range extractEmbeddedManifests([]byte(content)) {
+				t.Errorf("extracted %d: %q", i, string(em.content))
+			}
+		})
+	}
+}
+
+// A finding's line must point at the resource inside the outer file, or the
+// operator opens the file and sees something unrelated.
+func TestEmbeddedFindingsPointAtTheOuterFileLine(t *testing.T) {
+	content := wrap(barePod)
+	got, err := NewAnalyzer().ScanFile("rollout.yaml", []byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(content, "\n")
+
+	var checked int
+	for i := range got {
+		if got[i].Metadata["embedded_manifest"] != "true" {
+			continue
+		}
+		checked++
+		ln := got[i].Location.StartLine
+		if ln < 1 || ln > len(lines) {
+			t.Fatalf("%s reported line %d, file has %d lines", got[i].RuleID, ln, len(lines))
+		}
+		// Every absence rule here anchors on the workload, so the line it
+		// names must sit inside the embedded document, not in the wrapper.
+		if ln < 9 {
+			t.Errorf("%s reported line %d, which is the wrapper, not the manifest", got[i].RuleID, ln)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no embedded findings produced, so the line assertion proves nothing")
+	}
+}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -21,6 +21,11 @@ import (
 // Analyzer wraps a rules.Engine pre-loaded with IaC security rules.
 type Analyzer struct {
 	engine *rules.Engine
+	// absence holds only the absence-matcher rules, and is run separately over
+	// Kubernetes manifests embedded in YAML block scalars. Pattern rules match
+	// inside a block scalar already, so they are deliberately excluded: running
+	// them twice would double-report. See extractEmbeddedManifests.
+	absence *rules.Engine
 	// reasoning receives a claim for every finding this analyzer decided by
 	// parsing the document rather than by matching text. Nil unless a caller
 	// asked for evidence, which keeps recording free when nobody did.
@@ -35,9 +40,14 @@ func NewAnalyzer() *Analyzer {
 	for i := range iacRules {
 		rs.Add(&iacRules[i])
 	}
-	return &Analyzer{
-		engine: rules.NewEngine(rs),
+	a := &Analyzer{engine: rules.NewEngine(rs)}
+	// A second engine holding only the absence rules, for manifests embedded
+	// in YAML block scalars. See extractEmbeddedManifests for why the pattern
+	// rules must not be re-run over them.
+	if ars := absenceRuleSet(iacRules); ars != nil {
+		a.absence = rules.NewEngine(ars)
 	}
+	return a
 }
 
 // Rules returns the analyzer's RuleSet for catalog aggregation.
@@ -91,6 +101,11 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 		return nil, err
 	}
 	out := dropArtifactsWhenAlways(results, content)
+	embedded, err := a.scanEmbedded(path, content, out)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, embedded...)
 	a.recordStructuralClaims(path, out)
 	return out, nil
 }


### PR DESCRIPTION
Closes #576.

## The blind spot

A Kubernetes manifest inside a `manifest: |` block was scanned by **half** the ruleset. Pattern rules matched it — a regex over the file does not know the string is there. Absence rules bounded to a YAML document did not, because the block's contents are a string **value** of the outer document rather than a document of their own.

Reporting nothing is what makes this dangerous. A pattern rule that misses says nothing and claims nothing; an absence rule that never evaluates produces **the same output as a clean result** — no finding, no degradation, nothing separating *"this workload sets resource limits"* from *"nox never looked"*.

## Measured

Same Deployment, plain and embedded:

```
plain    13 rules
before    6 rules
after    13 rules, identical set, no duplicates
```

Real repositories deploying through RollOps:

| repo | findings newly visible |
|---|---|
| `vorhut/.rollops` | **32** |
| `brotwerk/.rollops` | **14** |
| `kraftsport-coach/.rollops` | **11** |

Missing PodDisruptionBudgets (IAC-132), absent pod anti-affinity (IAC-142), missing liveness and readiness probes (IAC-139, IAC-140) — on production workloads, none of which any scan had ever reported.

## Only absence rules are re-run

Pattern rules already match inside the block, so running them again would report every pattern finding twice — the double-report that retiring IAC-374 just removed, reintroduced by the fix for the opposite problem.

**That was not sufficient on its own.** Some absence rules *do* already fire on the outer file: their anchor is raw text, so `kind: Deployment` inside the block matches, and a span of `"file"` then searches the whole thing for the hardening property. `IAC-176` and `IAC-183` both do this, and both duplicated until a dedupe keyed on `(rule, line)` was added — the same rule at the same line of the same file is the same fact however it was reached.

So the precise statement is narrower than #576 claimed: absence rules **bounded to a document** could not see inside; those **anchored on raw text with a file-wide span** already could.

## Guarding the obvious failure mode

A recall fix is exactly how false positives get generated, so two of the five tests assert this invents nothing:

- a **hardened** manifest stays clean when embedded
- non-manifest block scalars — a shell script, prose in a ConfigMap — extract nothing

Extraction is conservative: a block scalar is treated as a manifest only when it contains **both** `apiVersion:` and `kind:`. Documents are bounded at 1 MiB.

## Line numbers

Shifted back into the outer file, so an operator opening at that line sees the resource the rule is talking about. A test asserts every embedded finding lands inside the embedded document rather than in the wrapper.

Columns are **cleared rather than guessed** — the re-indent invalidates them, and a wrong column is worse than none.

## Not addressed

Suggestion 2 from #576 (emit a degradation when nested manifests are skipped) is moot now that they are scanned. Suggestion 3 (a metamorphic-corpus invariant asserting that wrapping a manifest does not change which rules fire) is still worth adding and is not in this change.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
