### PR TITLE
METAMORPHIC: embedding a manifest in a block scalar must not change the findings

### DIFF
--- a/scripts/metamorphic/README.md
+++ b/scripts/metamorphic/README.md
@@ -11,6 +11,20 @@ This is the same technique that found three nox rule bugs by hand (a blank
 line before a Dockerfile `COPY` → false positive; a comment mentioning
 `HEALTHCHECK` → false negative).
 
+Most mutations are whitespace and comment edits. `embed_in_block_scalar` is
+different in kind: it wraps a Kubernetes manifest in a YAML block scalar, the
+shape every wrapper tool uses — RollOps `RolloutConfig`, Argo CD `Application`
+with inline manifests, a Helm template rendered into a ConfigMap, a Flux patch.
+The workload described is identical, so every rule that fired on it standing
+alone must still fire on it embedded.
+
+That relation was violated seven ways at once (#576). Absence rules bounded to
+a YAML document never looked inside the string — the block's contents are a
+*value* of the outer document, not a document — while pattern rules, being
+plain regexes over the file, carried on matching. Half the ruleset evaluated,
+and nothing in the output said the other half had not: an absence rule that
+never runs produces exactly what a clean result produces.
+
 There are **two modes**, sharing one engine:
 
 | | Per-PR gate | Corpus audit (oracle) |

--- a/scripts/metamorphic/harness.py
+++ b/scripts/metamorphic/harness.py
@@ -313,6 +313,50 @@ def mut_keyword_comments(lines, filename):
     return variants
 
 
+
+# Wrapper that embeds a Kubernetes manifest as a block scalar, in the shape
+# every tool of this kind uses: RollOps RolloutConfig, Argo CD Application with
+# inline manifests, a Helm template rendered into a ConfigMap, a Flux patch.
+EMBED_WRAPPER = [
+    "apiVersion: metamorphic.test/v1",
+    "kind: EmbeddedManifest",
+    "metadata:",
+    "  name: embedded",
+    "spec:",
+    "  manifest: |",
+]
+EMBED_INDENT = "    "
+
+
+def _is_k8s_manifest(lines, filename):
+    _, ext = os.path.splitext(filename)
+    if ext not in (".yaml", ".yml"):
+        return False
+    text = "\n".join(lines)
+    return "apiVersion:" in text and "kind:" in text
+
+
+def mut_embed_in_block_scalar(lines, filename):
+    """Wrap a Kubernetes manifest in a YAML block scalar.
+
+    Semantics-preserving for the purposes of this relation: the workload being
+    described is identical, so every rule that fired on it standing alone must
+    still fire on it embedded.
+
+    This is the relation that would have caught the block-scalar blind spot
+    (#576), where absence rules bounded to a YAML document never looked inside
+    the string and silently reported nothing — while pattern rules, being plain
+    regexes over the file, carried on matching. Half the ruleset evaluated, and
+    no signal that the other half had not.
+    """
+    if not _is_k8s_manifest(lines, filename):
+        return []
+    edits = [{"op": "insert", "pos": 0, "text": w} for w in EMBED_WRAPPER]
+    edits += [{"op": "replace", "idx": i, "text": EMBED_INDENT + ln if ln.strip() else ln}
+              for i, ln in enumerate(lines)]
+    return [("embed_in_block_scalar", edits)]
+
+
 MUTATIONS = [
     mut_blank_line_top,
     mut_blank_line_bottom,
@@ -322,6 +366,7 @@ MUTATIONS = [
     mut_crlf,
     mut_pad_before_trailing_comment,
     mut_keyword_comments,
+    mut_embed_in_block_scalar,
 ]
 
 

--- a/scripts/metamorphic/seeds/k8s_deployment.yaml
+++ b/scripts/metamorphic/seeds/k8s_deployment.yaml
@@ -1,0 +1,27 @@
+# Seed for the embed_in_block_scalar mutation: a plain Kubernetes workload.
+#
+# Wrapping this in a block scalar must not change which rules fire on it. Before
+# #576 that relation was violated seven ways at once — every absence rule
+# bounded to a YAML document stopped looking, while the pattern rules carried on
+# matching, so half the ruleset evaluated with no signal that the other half
+# had not.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seed-app
+  namespace: seed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seed-app
+  template:
+    metadata:
+      labels:
+        app: seed-app
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
Refs #576. Adds the relation that would have caught that bug before it shipped.

## Why a mutation and not a test

`testdata/metamorphic-corpus` and `harness.py` already encode the relation:

> A *semantics-preserving* edit to a file must not change nox's finding set.

Wrapping a Kubernetes manifest in a YAML block scalar is exactly such an edit — the workload described is identical — so this belongs as a mutation rather than a bespoke test. As a mutation it runs on **every PR** and in the **weekly corpus audit**, against **every rule**, not just the seven that happened to break.

`embed_in_block_scalar` wraps the manifest in the shape every wrapper tool uses: RollOps `RolloutConfig`, Argo CD `Application` with inline manifests, a Helm template rendered into a ConfigMap, a Flux patch.

## It is discriminating

The only property that makes a regression test worth having:

```
nox 1.33.0 (pre-fix):  9 verified violations
current main (fixed):  0
```

IAC-132, 137, 138, 139, 140, 142 and 145 all **disappear** under the wrap, plus IAC-464 moving. Absence rules bounded to a YAML document stopped looking inside the string, while pattern rules — plain regexes over the file — carried on matching. Half the ruleset evaluated, and nothing in the output said the other half had not.

## The seed matters as much as the mutation

The mutation is a no-op on anything that is not a YAML file containing both `apiVersion:` and `kind:`. The corpus had **no plain Kubernetes workload**, so without a seed the relation would have been declared, committed, and never once exercised — green forever, proving nothing.

That is the same failure this whole thread has been about: a check that never runs, reporting identically to a check that passed. So `seeds/k8s_deployment.yaml` is added, and the seed is verified to trigger the relation — the 9 violations above are reported via that exact seed path.

## Blast radius

- existing seeds: still clean
- `selftest.py` positive controls PC6/PC7/PC8: still pass
- the mutation returns `[]` for every non-Kubernetes file, so the rest of the corpus is untouched

## Note on the branch

Cut fresh from `main` after #579 squash-merged. The original branch still carried #579's pre-squash commit as "unique", which would have re-applied the whole IaC change on top of itself — `git diff --stat origin/main...HEAD` is what catches that.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
