### PR TITLE
IAC-132/142: a budget and anti-affinity need more than one replica

### DIFF
--- a/core/analyzers/iac/absence_test.go
+++ b/core/analyzers/iac/absence_test.go
@@ -188,9 +188,13 @@ func TestAbsenceRules_HardenedCleanInsecureFlagged(t *testing.T) {
 		// ---- Kubernetes (file / yaml-block / yaml-doc span) ----
 		{
 			// PodDisruptionBudget is a separate object → whole-file absence.
+			// replicas: 2 because a PodDisruptionBudget only applies above one
+			// replica — at one, minAvailable blocks node drains forever and
+			// maxUnavailable permits the disruption a budget exists to prevent.
+			// The subject here is the absence matcher, not the replica count.
 			id: "IAC-132", path: "deploy.yaml",
-			hardened: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n---\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: web-pdb\n",
-			insecure: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n",
+			hardened: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\nspec:\n  replicas: 2\n---\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: web-pdb\n",
+			insecure: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\nspec:\n  replicas: 2\n",
 		},
 		{
 			id: "IAC-135", path: "pod.yaml",

--- a/core/analyzers/iac/companion_absence_test.go
+++ b/core/analyzers/iac/companion_absence_test.go
@@ -22,6 +22,7 @@ kind: Deployment
 metadata:
   name: api
 spec:
+  replicas: 2
   template:
     metadata:
       labels:
@@ -36,6 +37,7 @@ kind: Deployment
 metadata:
   name: worker
 spec:
+  replicas: 2
   template:
     metadata:
       labels:
@@ -50,6 +52,7 @@ kind: StatefulSet
 metadata:
   name: db
 spec:
+  replicas: 2
   template:
     metadata:
       labels:
@@ -102,6 +105,7 @@ kind: Deployment
 metadata:
   name: api
 spec:
+  replicas: 2
   template:
     metadata:
       labels:

--- a/core/analyzers/iac/crossfile_test.go
+++ b/core/analyzers/iac/crossfile_test.go
@@ -23,6 +23,7 @@ metadata:
   name: api
   namespace: prod
 spec:
+  replicas: 2
   selector:
     matchLabels: {app: api}
   template:

--- a/core/analyzers/iac/replicas_precondition_test.go
+++ b/core/analyzers/iac/replicas_precondition_test.go
@@ -58,4 +58,7 @@ func TestMultiReplicaHardeningStillDiscriminates(t *testing.T) {
 	if ruleFires(t, "deploy.yaml", hardened, "IAC-142") {
 		t.Error("IAC-142 fired on a Deployment that has podAntiAffinity")
 	}
+	if ruleFires(t, "deploy.yaml", hardened, "IAC-132") {
+		t.Error("IAC-132 fired on a Deployment that has a PodDisruptionBudget")
+	}
 }

--- a/core/analyzers/iac/replicas_precondition_test.go
+++ b/core/analyzers/iac/replicas_precondition_test.go
@@ -1,0 +1,61 @@
+package iac
+
+import "testing"
+
+func deployWithReplicas(r string) string {
+	rep := ""
+	if r != "" {
+		rep = "  replicas: " + r + "\n"
+	}
+	return "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\nspec:\n" + rep +
+		"  template:\n    spec:\n      containers:\n      - name: app\n        image: nginx:1.25\n"
+}
+
+// A PodDisruptionBudget on a single-replica workload is not a missing
+// safeguard, it is a hazard: minAvailable:1 means the eviction API may never
+// remove the only pod, so `kubectl drain` blocks forever and the node cannot be
+// patched. maxUnavailable:1 permits exactly the disruption a budget exists to
+// prevent. Either way the advice is wrong — and IAC-132 was giving it for every
+// single-replica workload in a fleet.
+//
+// Anti-affinity has the same shape: with one replica there is nothing to
+// spread, and IAC-142's own remediation says "prevents a single node failure
+// from taking down all replicas".
+func TestPDBAndAntiAffinityNeedMoreThanOneReplica(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas string
+		want     bool
+	}{
+		{"one replica — advice would be harmful", "1", false},
+		{"replicas absent — Kubernetes defaults to one", "", false},
+		{"zero replicas — scaled to nothing", "0", false},
+		{"two replicas", "2", true},
+		{"ten replicas", "10", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			y := deployWithReplicas(tc.replicas)
+			for _, id := range []string{"IAC-132", "IAC-142"} {
+				if got := ruleFires(t, "deploy.yaml", y, id); got != tc.want {
+					t.Errorf("%s fired = %v, want %v for replicas=%q", id, got, tc.want, tc.replicas)
+				}
+			}
+		})
+	}
+}
+
+// The precondition must not silence the rule where it is genuinely right: a
+// multi-replica workload that has neither still gets both findings, and one
+// that has them gets neither.
+func TestMultiReplicaHardeningStillDiscriminates(t *testing.T) {
+	hardened := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\nspec:\n  replicas: 3\n" +
+		"  template:\n    spec:\n      affinity:\n        podAntiAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution: []\n" +
+		"      containers:\n      - name: app\n        image: nginx:1.25\n" +
+		"---\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: app\nspec:\n  minAvailable: 2\n  selector:\n    matchLabels:\n      app: app\n"
+
+	if ruleFires(t, "deploy.yaml", hardened, "IAC-142") {
+		t.Error("IAC-142 fired on a Deployment that has podAntiAffinity")
+	}
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -31,6 +31,10 @@ type iacRule struct {
 	// rules.RetiredRule. Retiring an ID without it un-waives, in every
 	// consuming repo, findings an operator explicitly accepted.
 	retires []rules.RetiredRule
+	// absenceSubjectMinInt restricts the rule to subjects whose property at the
+	// given path is an integer of at least the given value. See
+	// rules.Rule.AbsenceSubjectMinInt.
+	absenceSubjectMinInt map[string]int
 	// absence* fields, when set, switch the rule to the block-scoped absence
 	// matcher (matcher_type "absence") instead of a plain regex. They replace
 	// the RE2-incompatible negative-lookahead patterns that never compiled: the
@@ -1624,8 +1628,26 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceResourceTypes:  []string{"Deployment", "StatefulSet"},
 			absenceCompanionTypes: []string{"PodDisruptionBudget"},
 			absenceCompanionLink:  "selector",
-			description:           "Kubernetes workload without PodDisruptionBudget",
-			cwe:                   "CWE-693", keywords: []string{"PodDisruptionBudget"},
+			// Only when there is more than one replica to protect.
+			//
+			// A PodDisruptionBudget on a single-replica workload is not a
+			// missing safeguard, it is a hazard: `minAvailable: 1` means the
+			// eviction API may never remove the only pod, so `kubectl drain`
+			// blocks forever and the node cannot be patched or replaced.
+			// `maxUnavailable: 1` is the opposite — it permits exactly the
+			// disruption a budget exists to prevent, so it protects nothing.
+			// Either way the advice is wrong, and this rule was giving it for
+			// every single-replica workload in the fleet.
+			//
+			// `replicas` absent means one, by Kubernetes default, so the same
+			// applies and the requirement is not satisfied.
+			//
+			// The rule's own remediation gives the game away: "ensure minimum
+			// availability during voluntary disruptions" presupposes a replica
+			// that can remain available while another goes.
+			absenceSubjectMinInt: map[string]int{"spec.replicas": 2},
+			description:          "Kubernetes workload without PodDisruptionBudget",
+			cwe:                  "CWE-693", keywords: []string{"PodDisruptionBudget"},
 			filePatterns: []string{"*.yaml", "*.yml"},
 			tags:         []string{"iac", "kubernetes", "availability"},
 			remediation:  "Create a PodDisruptionBudget for each Deployment and StatefulSet to ensure minimum availability during voluntary disruptions like node drains.",
@@ -1767,6 +1789,14 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceSpan:          "yaml-doc",
 			absenceResourceTypes: []string{"Deployment"},
 			absencePropertyPath:  []string{"spec.template.spec.affinity.podAntiAffinity"},
+			// Only when there is more than one replica to spread.
+			//
+			// Anti-affinity keeps replicas off the same node. With one replica
+			// there is nothing to spread, and the rule's own remediation says
+			// so: "prevents a single node failure from taking down all
+			// replicas" — with one replica a single node failure takes it down
+			// whatever the affinity says. `replicas` absent means one.
+			absenceSubjectMinInt: map[string]int{"spec.replicas": 2},
 			description:          "Kubernetes Deployment without pod anti-affinity rules",
 			cwe:                  "CWE-693", keywords: []string{"podAntiAffinity"},
 			filePatterns: []string{"*.yaml", "*.yml"},
@@ -2315,6 +2345,7 @@ func (d iacRule) toRule() rules.Rule {
 		r.AbsenceCompanionTypes = d.absenceCompanionTypes
 		r.AbsenceCompanionLink = d.absenceCompanionLink
 		r.AbsenceCompanionPath = d.absenceCompanionPath
+		r.AbsenceSubjectMinInt = d.absenceSubjectMinInt
 		// Absence rules must NOT be keyword-gated. The engine skips a rule
 		// when none of its keywords appear in the file, but these rules'
 		// keywords name the hardening property — which is precisely what is

--- a/core/rules/matcher.go
+++ b/core/rules/matcher.go
@@ -400,15 +400,15 @@ func structuralAbsence(content []byte, rule *Rule) ([]MatchResult, bool) {
 	case len(rule.AbsenceCompanionTypes) > 0:
 		// Cross-resource: the requirement is another object bound to the
 		// subject, not a property on it.
-		v = structural.EvaluateCompanion(content, rule.AbsenceResourceTypes,
+		v = structural.EvaluateCompanionWithSubject(content, rule.AbsenceResourceTypes,
 			structural.Companion{
 				Types: rule.AbsenceCompanionTypes,
 				Link:  structural.Link(rule.AbsenceCompanionLink),
 				Path:  rule.AbsenceCompanionPath,
-			})
+			}, rule.AbsenceSubjectMinInt)
 	case len(rule.AbsencePropertyPath) > 0:
-		v = structural.Evaluate(content, rule.AbsenceResourceTypes,
-			rule.AbsencePropertyPath, rule.AbsenceRequireAll)
+		v = structural.EvaluateWithSubject(content, rule.AbsenceResourceTypes,
+			rule.AbsencePropertyPath, rule.AbsenceRequireAll, rule.AbsenceSubjectMinInt)
 	default:
 		return nil, false
 	}

--- a/core/rules/rules.go
+++ b/core/rules/rules.go
@@ -114,6 +114,26 @@ type Rule struct {
 	AbsenceAnchor   string `yaml:"absence_anchor"`
 	AbsenceProperty string `yaml:"absence_property"`
 	AbsenceRequire  string `yaml:"absence_require"`
+	// AbsenceSubjectMinInt, when set, restricts the rule to subjects whose
+	// property at the given path is an integer of at least the given value.
+	//
+	// It exists because "this workload lacks X" is sometimes only true, or only
+	// worth saying, above a threshold. IAC-132 recommended a
+	// PodDisruptionBudget for every workload including single-replica ones,
+	// where minAvailable:1 blocks node drains forever and maxUnavailable:1
+	// permits the very disruption a budget prevents — advice that is harmful
+	// either way. IAC-142 recommended spreading replicas across nodes for
+	// workloads that have one replica to spread.
+	//
+	// AbsenceRequire cannot express this: it is a regex over the anchor's span,
+	// and the structural path does not evaluate it at all. A precondition on
+	// the SUBJECT has to be read from the parsed resource, which is what this
+	// is.
+	//
+	// A missing path fails the requirement. `spec.replicas` is absent more
+	// often than written and Kubernetes defaults it to 1, so absence must read
+	// as "one", never as "unknown, therefore qualifying".
+	AbsenceSubjectMinInt map[string]int `yaml:"absence_subject_min_int"`
 	// AbsenceSpan selects how the anchor's span is computed: "file" (whole
 	// file), "line" (the anchor's line), "brace-block" (the {...} block that
 	// follows the anchor, e.g. HCL headers), "brace-enclosing" (the {...} object

--- a/core/rules/structural/companion.go
+++ b/core/rules/structural/companion.go
@@ -106,6 +106,12 @@ const (
 // binds elsewhere — because they are different findings to read and the second
 // is the one the text path could never produce.
 func EvaluateCompanion(content []byte, subjectTypes []string, c Companion) Verdict {
+	return EvaluateCompanionWithSubject(content, subjectTypes, c, nil)
+}
+
+// EvaluateCompanionWithSubject is EvaluateCompanion with a precondition on the
+// subject. See EvaluateWithSubject.
+func EvaluateCompanionWithSubject(content []byte, subjectTypes []string, c Companion, subjectMinInt map[string]int) Verdict {
 	if len(subjectTypes) == 0 || len(c.Types) == 0 || c.Link == "" {
 		return Verdict{Reason: "rule carries no companion descriptor"}
 	}
@@ -128,6 +134,9 @@ func EvaluateCompanion(content []byte, subjectTypes []string, c Companion) Verdi
 
 	v := Verdict{Decided: true}
 	for _, s := range subjects {
+		if !subjectQualifies(s, subjectMinInt) {
+			continue
+		}
 		hit := Hit{
 			Type: s.Type, Name: s.Name, Line: s.Line, Family: s.Family,
 			Companion: companionType,

--- a/core/rules/structural/lookup.go
+++ b/core/rules/structural/lookup.go
@@ -1,6 +1,7 @@
 package structural
 
 import (
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -167,4 +168,40 @@ func nodeAt(props *yaml.Node, path string) *yaml.Node {
 		return nil
 	}
 	return n
+}
+
+// IntAtLeast reports whether path admits a value of at least min.
+//
+// Three cases, and the difference between the last two is the whole point:
+//
+//	absent            FALSE. `spec.replicas` is absent far more often than it
+//	                  is written and Kubernetes defaults it to 1, so absence is
+//	                  a KNOWN value, not a missing one. Reading it as "unknown,
+//	                  therefore qualifying" is how IAC-132 came to recommend a
+//	                  PodDisruptionBudget for every single-replica workload in a
+//	                  fleet, which blocks node drains rather than protecting
+//	                  anything.
+//
+//	integer           compared against min, the ordinary case.
+//
+//	unreadable        TRUE. `replicas: {{ .Values.replicas }}` in an unrendered
+//	                  Helm chart is UNKNOWN, and unknown is not one. Silencing
+//	                  the rule there would lose the finding for every chart that
+//	                  renders to three replicas — a document nox cannot read is
+//	                  not a document with nothing in it. So an unreadable value
+//	                  fails toward reporting, which is the direction that costs
+//	                  a false positive rather than a missed one.
+func IntAtLeast(props *yaml.Node, path string, minValue int) bool {
+	n := nodeAt(props, path)
+	if n == nil {
+		return false
+	}
+	if n.Kind != yaml.ScalarNode {
+		return true
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(n.Value))
+	if err != nil {
+		return true
+	}
+	return v >= minValue
 }

--- a/core/rules/structural/verdict.go
+++ b/core/rules/structural/verdict.go
@@ -67,6 +67,15 @@ type Verdict struct {
 // hardened, not any — and getting it wrong hides findings rather than inventing
 // them, so it is an explicit argument at every call site.
 func Evaluate(content []byte, resourceTypes, propertyPaths []string, requireAll bool) Verdict {
+	return EvaluateWithSubject(content, resourceTypes, propertyPaths, requireAll, nil)
+}
+
+// EvaluateWithSubject is Evaluate with a precondition on the subject: a
+// resource is only judged when every path in subjectMinInt holds an integer of
+// at least its value. A resource that fails the precondition is neither Absent
+// nor Present — the rule does not apply to it, which is different from it
+// being configured.
+func EvaluateWithSubject(content []byte, resourceTypes, propertyPaths []string, requireAll bool, subjectMinInt map[string]int) Verdict {
 	if len(resourceTypes) == 0 || len(propertyPaths) == 0 {
 		return Verdict{Reason: "rule carries no structural descriptor"}
 	}
@@ -85,6 +94,9 @@ func Evaluate(content []byte, resourceTypes, propertyPaths []string, requireAll 
 
 	v := Verdict{Decided: true}
 	for _, r := range OfTypes(all, resourceTypes) {
+		if !subjectQualifies(r, subjectMinInt) {
+			continue
+		}
 		hit := Hit{Type: r.Type, Name: r.Name, Line: r.Line, Family: r.Family}
 
 		found := ""
@@ -149,4 +161,15 @@ func (h Hit) companionStatement(name string, absent bool) string {
 	}
 	return fmt.Sprintf("the %s resource %q (%s) was parsed, and the document set declares no %s",
 		h.Family, name, h.Type, h.Companion)
+}
+
+// subjectQualifies reports whether a resource is in scope for a rule carrying a
+// subject precondition. No precondition means every resource qualifies.
+func subjectQualifies(r Resource, minInt map[string]int) bool {
+	for path, min := range minInt {
+		if !IntAtLeast(r.Props, path, min) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
IAC-132 ("no PodDisruptionBudget") and IAC-142 ("no pod anti-affinity") fired on every workload, including single-replica ones, where both pieces of advice are wrong.

A PodDisruptionBudget on a one-replica Deployment is not a missing safeguard, it is a hazard. `minAvailable: 1` means the eviction API may never remove the only pod, so `kubectl drain` blocks forever and the node cannot be patched. `maxUnavailable: 1` permits exactly the disruption a budget exists to prevent. There is no third setting that helps.

Anti-affinity has the same shape: with one pod there is nothing to spread across nodes, and IAC-142's own remediation text gives the game away — "prevents a single node failure from taking down all replicas".

Both rules were telling people to add configuration that cannot do what the finding says it does.

## The mechanism

The rules already carried `absenceRequire`, which reads as if it expressed this precondition. **The structural absence path ignores it entirely** — it is threaded nowhere, so it was inert on both rules. That is the failure this repository keeps finding: a guard that is written down, looks satisfied on inspection, and never executes.

Replaced with a precondition the engine actually evaluates:

- `rules.Rule.AbsenceSubjectMinInt map[string]int` (`absence_subject_min_int` in YAML)
- `structural.IntAtLeast(props, path, min)` and `subjectQualifies`
- threaded through `EvaluateWithSubject` / `EvaluateCompanionWithSubject` and `core/rules/matcher.go`

IAC-132 and IAC-142 declare `spec.replicas: 2`.

`IntAtLeast` is deliberately three-valued, and the third case is the interesting one:

| document says | verdict | why |
|---|---|---|
| `replicas` absent | **does not qualify** | Kubernetes defaults to 1 |
| an integer | compare | |
| unparseable / not a number | **qualifies** | fail toward reporting |

The last row exists because `TestCompanionUnparseableKeepsTheTextPath` states the principle in its own message: *a document nox cannot read is not a document with nothing in it.* Treating unreadable as "does not qualify" would make a malformed manifest silently drop both rules — a scanner reporting an all-clear because it could not parse the file.

## Measured on three real repositories

A/B, `main` vs this branch, by fingerprint:

| repo | findings | IAC-132 | IAC-142 |
|---|---|---|---|
| vorhut | 323 → 297 | 18 → 3 | 14 → 3 |
| brotwerk | 317 → 298 | 12 → 0 | 7 → 0 |
| kraftsport-coach | 310 → 290 | 13 → 0 | 7 → 0 |

**65 findings dropped (40× IAC-132, 25× IAC-142), 0 added.** Every dropped finding is a single-replica workload.

vorhut is the positive control that matters: it keeps 3 of each, because it genuinely runs multi-replica workloads with neither a budget nor anti-affinity. The rules did not go quiet, they got specific.

## Tests

`TestPDBAndAntiAffinityNeedMoreThanOneReplica` covers replicas ∈ {absent, 0, 1, 2, 10} against both rules. `TestMultiReplicaHardeningStillDiscriminates` checks that a hardened three-replica workload gets neither finding — and now asserts the PodDisruptionBudget half, which its comment had claimed and only the anti-affinity half actually checked. Deleting the PDB from that fixture makes the new assertion fail, so it is testing something.

Existing fixtures that relied on the old unconditional behaviour gained an explicit `replicas: 2` rather than being deleted, so the multi-replica path stays covered.

`go test ./...`, `golangci-lint run ./...` and the self-scan all pass.

---
https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
