### PR TITLE
IAC-139/140: probes are for containers meant to keep running

### DIFF
--- a/core/analyzers/iac/batch_probes_test.go
+++ b/core/analyzers/iac/batch_probes_test.go
@@ -1,0 +1,77 @@
+package iac
+
+import "testing"
+
+// A CronJob with no probes, no resource constraints and no security context —
+// so every rule that claims to cover batch workloads has something to find.
+const cronJobNoHardening = `apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: dump
+            image: postgres:16
+            command: ["pg_dump"]
+`
+
+// Liveness and readiness probes are for containers that are meant to keep
+// running. A Job container is meant to finish.
+//
+// A liveness probe restarts the container the kubelet judges unhealthy, which
+// for batch work re-runs the job body from the start — worse than the hang it
+// reacts to when the work is a migration or a half-written backup. Kubernetes
+// answers "this Job is stuck" with activeDeadlineSeconds, not liveness.
+//
+// Readiness is more clearly beside the point: it gates a pod's membership in a
+// Service's endpoints, and a Job's pod is behind no Service. There is no
+// traffic to withhold.
+//
+// Both rules were firing on every CronJob in the fleet, recommending a change
+// their own remediation text cannot justify.
+func TestProbeRulesDoNotApplyToBatchWorkloads(t *testing.T) {
+	for _, id := range []string{"IAC-139", "IAC-140"} {
+		if ruleFires(t, "cronjob.yaml", cronJobNoHardening, id) {
+			t.Errorf("%s fired on a CronJob; probes are for long-running containers", id)
+		}
+	}
+}
+
+// The narrowing must not take the rules that are right about batch work with
+// it. Limits and requests govern scheduling and node pressure, and a security
+// context applies to any pod — a backup Job needs all three exactly as much as
+// a Deployment does.
+func TestBatchWorkloadsKeepTheRulesThatDoApply(t *testing.T) {
+	for _, id := range []string{"IAC-137", "IAC-138", "IAC-145"} {
+		if !ruleFires(t, "cronjob.yaml", cronJobNoHardening, id) {
+			t.Errorf("%s stopped firing on an unhardened CronJob", id)
+		}
+	}
+}
+
+// And the probe rules must still work where they belong.
+func TestProbeRulesStillFireOnLongRunningWorkloads(t *testing.T) {
+	deployment := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: web
+        image: nginx:1.25
+`
+	for _, id := range []string{"IAC-139", "IAC-140"} {
+		if !ruleFires(t, "deploy.yaml", deployment, id) {
+			t.Errorf("%s stopped firing on a Deployment with no probes", id)
+		}
+	}
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -1739,11 +1739,18 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-139", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:        `(?i)containers\s*:`,
-			absenceProperty:      `(?i)livenessProbe`,
-			absenceSpan:          "yaml-block",
-			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "Pod"},
-			absencePropertyPath:  []string{"spec.template.spec.containers[].livenessProbe", "spec.containers[].livenessProbe", "spec.jobTemplate.spec.template.spec.containers[].livenessProbe"},
+			absenceAnchor:   `(?i)containers\s*:`,
+			absenceProperty: `(?i)livenessProbe`,
+			absenceSpan:     "yaml-block",
+			// Not Job or CronJob. A liveness probe restarts a container the
+			// kubelet decides is unhealthy — which for batch work re-runs the
+			// job body from the start, and for a non-idempotent migration or a
+			// half-finished backup is worse than the hang it reacts to.
+			// `activeDeadlineSeconds` is the mechanism for a stuck Job. The
+			// rule's own remediation ("detect and restart unhealthy pods")
+			// describes something a batch workload does not want done to it.
+			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod"},
+			absencePropertyPath:  []string{"spec.template.spec.containers[].livenessProbe", "spec.containers[].livenessProbe"},
 			absenceRequireAll:    true,
 			description:          "Kubernetes container without liveness probe",
 			cwe:                  "CWE-693", keywords: []string{"livenessProbe"},
@@ -1754,11 +1761,15 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-140", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:        `(?i)containers\s*:`,
-			absenceProperty:      `(?i)readinessProbe`,
-			absenceSpan:          "yaml-block",
-			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "Pod"},
-			absencePropertyPath:  []string{"spec.template.spec.containers[].readinessProbe", "spec.containers[].readinessProbe", "spec.jobTemplate.spec.template.spec.containers[].readinessProbe"},
+			absenceAnchor:   `(?i)containers\s*:`,
+			absenceProperty: `(?i)readinessProbe`,
+			absenceSpan:     "yaml-block",
+			// Not Job or CronJob. Readiness gates a pod's membership in a
+			// Service's endpoints, and a Job's pod is not behind a Service —
+			// there is no traffic to withhold. The remediation ("only sends
+			// traffic to pods that are ready") has no referent here.
+			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod"},
+			absencePropertyPath:  []string{"spec.template.spec.containers[].readinessProbe", "spec.containers[].readinessProbe"},
 			absenceRequireAll:    true,
 			description:          "Kubernetes container without readiness probe",
 			cwe:                  "CWE-693", keywords: []string{"readinessProbe"},

--- a/scripts/rule-diff-corpus.json
+++ b/scripts/rule-diff-corpus.json
@@ -14,6 +14,12 @@
     "corpus' after an IAC change was a pass by absence of coverage rather than a",
     "verification. A gate that cannot see a family cannot clear it.",
     "",
+    "kubernetes/examples carries no Job and no CronJob, so it could not witness",
+    "IAC-139/140 being narrowed off batch workloads -- the diff came back green on a",
+    "change it was structurally unable to see. podinfo was added for exactly that",
+    "branch: 4 CronJobs and a Job, and it moved IAC-139 13 -> 9 and IAC-140 13 -> 9",
+    "on the commit that narrowed them.",
+    "",
     "Still uncovered: Azure ARM templates (IAC-084/086 and the ARM property rules)",
     "and Terraform. Those families remain verified only by testdata/precision-suite",
     "and the analyzer tests -- a green rule diff says nothing about them. The same",
@@ -76,6 +82,12 @@
       "url": "https://github.com/kubernetes/examples",
       "sha": "d6b8cd27eacb51e651a1aa6f7c190a28713eff6e",
       "why": "Kubernetes manifests -- 75 rules fire, the widest IAC coverage in the corpus, including the structural property-path rules (IAC-137/138/139/140/145). It carries 30 workloads but only ONE PodDisruptionBudget and no ResourceQuota, so it controls the 'no companion declared anywhere' branch of the cross-resource rules and NOT the linkage branch -- aws-cloudformation-templates covers that. Scans in 0.7s, the cheapest entry here, because it is manifests rather than source"
+    },
+    {
+      "name": "podinfo",
+      "url": "https://github.com/stefanprodan/podinfo",
+      "sha": "dd507173b7b75b2312a36cabe0de5f09c1ce69c8",
+      "why": "The only BATCH workload in the corpus: 4 CronJobs and a Job, alongside a Deployment, HPA and Ingress. kubernetes/examples has neither kind, so IAC-139/140 could be narrowed off Job and CronJob with the diff staying green -- a change the gate was structurally unable to see. Measured on that commit: IAC-139 13 -> 9 and IAC-140 13 -> 9, while kubernetes/examples showed no change at all, which is why both are here. 3.4M, 51 rules fire, 1.3s"
     },
     {
       "name": "aws-cloudformation-templates",


### PR DESCRIPTION
IAC-139 ("no liveness probe") and IAC-140 ("no readiness probe") listed `Job` and `CronJob` in `absenceResourceTypes`. Every batch workload in a fleet was told to add probes that cannot do what the findings say they do.

**Liveness.** The probe restarts the container the kubelet judges unhealthy. For batch work that re-runs the job body from the start — worse than the hang it reacts to when the work is a schema migration or a half-written backup. With `restartPolicy: OnFailure` it also burns `backoffLimit`, so a Job can end up marked Failed because of a probe rather than because of the work. Kubernetes answers "this Job is stuck" with `activeDeadlineSeconds`. The rule's own remediation — *"detect and restart unhealthy pods"* — describes something a batch workload does not want done to it.

**Readiness.** More clearly beside the point: readiness gates a pod's membership in a Service's endpoints, and a Job's pod is behind no Service. The remediation, *"only sends traffic to pods that are ready"*, has no referent.

Same shape as #582: a rule firing on a resource kind where its own remediation text cannot be justified.

## What stays

`IAC-137` (limits), `IAC-138` (requests) and `IAC-145` (pod security context) keep `Job` and `CronJob`, and that is deliberate — a backup Job needs all three exactly as much as a Deployment does. A runaway `pg_dump` with no limits starves the node either way.

`TestBatchWorkloadsKeepTheRulesThatDoApply` asserts all three still fire on the same unhardened CronJob fixture, so this narrowing cannot quietly widen later.

The `spec.jobTemplate.spec.template.spec.containers[].*Probe` property paths went with the kinds — a CronJob is the only thing that has a `jobTemplate`, so they were unreachable once the kind was gone. IAC-137/138/145 keep theirs.

## Measured on three real repositories

| repo | total | IAC-139 | IAC-140 |
|---|---|---|---|
| vorhut | 396 → 396 | 15 → 15 | 15 → 15 |
| brotwerk | 347 → 341 | 11 → 8 | 3 → 0 |
| kraftsport-coach | 341 → 333 | 8 → 4 | 4 → 0 |

**14 findings removed, 0 added.** Every one is a `CronJob` — `postgres-backup`, `minio-backup`, `postgres-restore-test`, and MinIO's own backup job.

vorhut is unchanged because its manifests contain no CronJob, which is the control: the rules did not get quieter in general, they stopped firing on one kind.

## Tests

Three, and each was falsified rather than assumed:

- `TestProbeRulesDoNotApplyToBatchWorkloads` — fails on `main` with both rule IDs named.
- `TestBatchWorkloadsKeepTheRulesThatDoApply` — 137/138/145 on the same CronJob.
- `TestProbeRulesStillFireOnLongRunningWorkloads` — 139/140 on a probe-less Deployment.

`go test ./...`, `golangci-lint run ./...` and the self-scan (0 findings, 62 suppressed) all pass.

## The gate could not see this change

The first push of this branch got a green **Rule behaviour diff**. That green was a pass by absence of coverage, not a verification.

`kubernetes/examples` — the corpus entry whose `why` names IAC-137/138/**139/140**/145 as covered — carries 26 Deployments, 56 Pods, 57 Services and **neither a Job nor a CronJob**. It is structurally unable to witness a change that only affects those two kinds.

So this branch also adds **podinfo** to `scripts/rule-diff-corpus.json`: 4 CronJobs and a Job, 3.4M, 51 rules firing, 1.3s. Run against the same two binaries, the real harness now reports

```
── kubernetes-examples @ d6b8cd27
   no change (74 rules fired)
── podinfo @ dd507173
   IAC-139: 13 -> 9
   IAC-140: 13 -> 9
```

kubernetes/examples still shows nothing, which is the point — podinfo covers a branch no existing entry reaches. The corpus comment records the gap next to the ARM and Terraform ones it already tracks.

Worth noting for review: exit 1 from the harness is deliberately a *report*, not a gate, so this check stays green either way. The value is that the delta now appears in the job summary instead of the summary being silent.


---
https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT
