### PR TITLE
BASELINE: measure before empowering refutation — Milestone 0.1 at 78439de

### DIFF
--- a/core/analyzers/iac/batch_probes_test.go
+++ b/core/analyzers/iac/batch_probes_test.go
@@ -1,0 +1,77 @@
+package iac
+
+import "testing"
+
+// A CronJob with no probes, no resource constraints and no security context —
+// so every rule that claims to cover batch workloads has something to find.
+const cronJobNoHardening = `apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: dump
+            image: postgres:16
+            command: ["pg_dump"]
+`
+
+// Liveness and readiness probes are for containers that are meant to keep
+// running. A Job container is meant to finish.
+//
+// A liveness probe restarts the container the kubelet judges unhealthy, which
+// for batch work re-runs the job body from the start — worse than the hang it
+// reacts to when the work is a migration or a half-written backup. Kubernetes
+// answers "this Job is stuck" with activeDeadlineSeconds, not liveness.
+//
+// Readiness is more clearly beside the point: it gates a pod's membership in a
+// Service's endpoints, and a Job's pod is behind no Service. There is no
+// traffic to withhold.
+//
+// Both rules were firing on every CronJob in the fleet, recommending a change
+// their own remediation text cannot justify.
+func TestProbeRulesDoNotApplyToBatchWorkloads(t *testing.T) {
+	for _, id := range []string{"IAC-139", "IAC-140"} {
+		if ruleFires(t, "cronjob.yaml", cronJobNoHardening, id) {
+			t.Errorf("%s fired on a CronJob; probes are for long-running containers", id)
+		}
+	}
+}
+
+// The narrowing must not take the rules that are right about batch work with
+// it. Limits and requests govern scheduling and node pressure, and a security
+// context applies to any pod — a backup Job needs all three exactly as much as
+// a Deployment does.
+func TestBatchWorkloadsKeepTheRulesThatDoApply(t *testing.T) {
+	for _, id := range []string{"IAC-137", "IAC-138", "IAC-145"} {
+		if !ruleFires(t, "cronjob.yaml", cronJobNoHardening, id) {
+			t.Errorf("%s stopped firing on an unhardened CronJob", id)
+		}
+	}
+}
+
+// And the probe rules must still work where they belong.
+func TestProbeRulesStillFireOnLongRunningWorkloads(t *testing.T) {
+	deployment := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: web
+        image: nginx:1.25
+`
+	for _, id := range []string{"IAC-139", "IAC-140"} {
+		if !ruleFires(t, "deploy.yaml", deployment, id) {
+			t.Errorf("%s stopped firing on a Deployment with no probes", id)
+		}
+	}
+}

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -1739,11 +1739,18 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-139", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:        `(?i)containers\s*:`,
-			absenceProperty:      `(?i)livenessProbe`,
-			absenceSpan:          "yaml-block",
-			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "Pod"},
-			absencePropertyPath:  []string{"spec.template.spec.containers[].livenessProbe", "spec.containers[].livenessProbe", "spec.jobTemplate.spec.template.spec.containers[].livenessProbe"},
+			absenceAnchor:   `(?i)containers\s*:`,
+			absenceProperty: `(?i)livenessProbe`,
+			absenceSpan:     "yaml-block",
+			// Not Job or CronJob. A liveness probe restarts a container the
+			// kubelet decides is unhealthy — which for batch work re-runs the
+			// job body from the start, and for a non-idempotent migration or a
+			// half-finished backup is worse than the hang it reacts to.
+			// `activeDeadlineSeconds` is the mechanism for a stuck Job. The
+			// rule's own remediation ("detect and restart unhealthy pods")
+			// describes something a batch workload does not want done to it.
+			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod"},
+			absencePropertyPath:  []string{"spec.template.spec.containers[].livenessProbe", "spec.containers[].livenessProbe"},
 			absenceRequireAll:    true,
 			description:          "Kubernetes container without liveness probe",
 			cwe:                  "CWE-693", keywords: []string{"livenessProbe"},
@@ -1754,11 +1761,15 @@ func builtinBaseIaCRules() []rules.Rule {
 		},
 		{
 			id: "IAC-140", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:        `(?i)containers\s*:`,
-			absenceProperty:      `(?i)readinessProbe`,
-			absenceSpan:          "yaml-block",
-			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "Pod"},
-			absencePropertyPath:  []string{"spec.template.spec.containers[].readinessProbe", "spec.containers[].readinessProbe", "spec.jobTemplate.spec.template.spec.containers[].readinessProbe"},
+			absenceAnchor:   `(?i)containers\s*:`,
+			absenceProperty: `(?i)readinessProbe`,
+			absenceSpan:     "yaml-block",
+			// Not Job or CronJob. Readiness gates a pod's membership in a
+			// Service's endpoints, and a Job's pod is not behind a Service —
+			// there is no traffic to withhold. The remediation ("only sends
+			// traffic to pods that are ready") has no referent here.
+			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod"},
+			absencePropertyPath:  []string{"spec.template.spec.containers[].readinessProbe", "spec.containers[].readinessProbe"},
 			absenceRequireAll:    true,
 			description:          "Kubernetes container without readiness probe",
 			cwe:                  "CWE-693", keywords: []string{"readinessProbe"},

--- a/core/taint/data/catalog.json
+++ b/core/taint/data/catalog.json
@@ -1656,7 +1656,7 @@
       ]
     },
     "php": {
-      "comment": "PHP source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_php.go). Superglobals ($_GET/$_POST/\u2026) are ARRAY-INDEX source reads, captured as bare chains with the leading `$` stripped (so `$_GET['x']` reads source `_GET`). Method calls on a value ($pdo->query, $mysqli->query) are normalized to a dotted chain (pdo.query, mysqli.query) so the engine's suffixKeys fallback matches the method suffix regardless of the receiver variable name. Rule IDs mirror the shared TAINT-00x space.",
+      "comment": "PHP source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_php.go). Superglobals ($_GET/$_POST/…) are ARRAY-INDEX source reads, captured as bare chains with the leading `$` stripped (so `$_GET['x']` reads source `_GET`). Method calls on a value ($pdo->query, $mysqli->query) are normalized to a dotted chain (pdo.query, mysqli.query) so the engine's suffixKeys fallback matches the method suffix regardless of the receiver variable name. Rule IDs mirror the shared TAINT-00x space.",
       "sources": [
         {
           "call": "_GET",
@@ -1948,7 +1948,7 @@
       ]
     },
     "java": {
-      "comment": "Java source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes, matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (Files.readAllBytes, ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .println, .exec, .start). Method-suffix matching is imprecise on purpose: it is AST-only, so a .executeQuery on a non-JDBC object still matches. This is the same precision trade documented for Go's method sinks; the corpus README records the resulting honest FNs (chained fluent calls the flat recognizer cannot follow). See core/taint/engine/extract_java.go.",
+      "comment": "Java source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes, matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (Files.readAllBytes, ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .println, .exec, .start). Method-suffix matching is imprecise on purpose: it is AST-only, so a .executeQuery on a non-JDBC object still matches. This is the same precision trade documented for Go's method sinks; the corpus README records the resulting honest FNs (chained fluent calls the flat recognizer cannot follow). See core/taint/engine/extract_java.go.",
       "sources": [
         {
           "call": "request.getParameter",
@@ -2013,7 +2013,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command \u2014 matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
+          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command — matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
         },
         {
           "call": "ProcessBuilder",
@@ -2027,7 +2027,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation"
+          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation"
         },
         {
           "call": "executeUpdate",
@@ -2040,7 +2040,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
+          "note": "Statement.execute(sql) — matched on the method suffix"
         },
         {
           "call": "createQuery",
@@ -2054,7 +2054,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) opens a file named by input \u2014 matched on the File constructor name"
+          "note": "new File(path) opens a file named by input — matched on the File constructor name"
         },
         {
           "call": "Files.readAllBytes",
@@ -2086,14 +2086,14 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openConnection() \u2014 matched on the method suffix"
+          "note": "new URL(u).openConnection() — matched on the method suffix"
         },
         {
           "call": "ObjectInputStream.readObject",
@@ -2107,7 +2107,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "ObjectInputStream.readObject() \u2014 matched on the method suffix"
+          "note": "ObjectInputStream.readObject() — matched on the method suffix"
         },
         {
           "call": "ScriptEngine.eval",
@@ -2121,14 +2121,14 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "ScriptEngine.eval(script) \u2014 matched on the method suffix"
+          "note": "ScriptEngine.eval(script) — matched on the method suffix"
         },
         {
           "call": "println",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response.getWriter().println(taintedHtml) reflects unescaped input \u2014 reflected XSS"
+          "note": "response.getWriter().println(taintedHtml) reflects unescaped input — reflected XSS"
         },
         {
           "call": "print",
@@ -2141,7 +2141,7 @@
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .write(taintedHtml) \u2014 reflected XSS"
+          "note": "response writer .write(taintedHtml) — reflected XSS"
         },
         {
           "call": "sendRedirect",
@@ -2196,7 +2196,7 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Encoder.forHtml \u2014 matched on the method suffix"
+          "note": "OWASP Encoder.forHtml — matched on the method suffix"
         },
         {
           "call": "FilenameUtils.getName",
@@ -2215,7 +2215,7 @@
       ]
     },
     "rust": {
-      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser \u2014 only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps. The web-extractor sources (`web.Query`/`web.Form`/`web.Json`/`web.Path` for actix, bare `Query`/`Form`/`Json`/`Path` for axum) are matched not only as constructor calls but also as PARAMETER TYPES: extract_rust.go seeds a function parameter whose type is one of these extractors as tainted-on-entry (via a synthetic `binding = <source>()` statement), because a `web::Query<Params>` handler argument is untrusted input even though it never appears as a source call.",
+      "comment": "Rust source/sink/sanitizer model. Calls are matched in the extractor's NORMALIZED dotted form: the Rust line recognizer rewrites the `::` path separator to `.` and drops the `!` on macro invocations, so `std::env::var` is keyed `env.var`, `Command::new` is `Command.new`, and `sqlx::query!` is `sqlx.query`. Method calls whose receiver varies (`.arg`/`.args` on a Command builder, `.bind` on a query) are matched on the bare method suffix via the engine's suffixKeys fallback. Rust recognition is COARSER than Python/JS/Go (no real parser — only Go gets go/ast): ownership/moves, Result/`?` unwrapping, iterator chains, and macro expansion are invisible to the recognizer, so Rust recall is expected to be the lowest of the supported languages. See testdata/precision-suite-rust/README.md for the measured gaps. The web-extractor sources (`web.Query`/`web.Form`/`web.Json`/`web.Path` for actix, bare `Query`/`Form`/`Json`/`Path` for axum) are matched not only as constructor calls but also as PARAMETER TYPES: extract_rust.go seeds a function parameter whose type is one of these extractors as tainted-on-entry (via a synthetic `binding = <source>()` statement), because a `web::Query<Params>` handler argument is untrusted input even though it never appears as a source call.",
       "sources": [
         {
           "call": "env.args",
@@ -2303,7 +2303,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Command::new(\"sh\").arg(\"-c\").arg(user) \u2014 the tainted value flows through .arg into the shell"
+          "note": "Command::new(\"sh\").arg(\"-c\").arg(user) — the tainted value flows through .arg into the shell"
         },
         {
           "call": "args",
@@ -2435,7 +2435,7 @@
           "neutralizes": [
             "sql_injection"
           ],
-          "note": "sqlx bind parameters ($1/?) \u2014 the value is passed to the driver as data, never concatenated into SQL"
+          "note": "sqlx bind parameters ($1/?) — the value is passed to the driver as data, never concatenated into SQL"
         },
         {
           "call": "file_name",
@@ -2480,7 +2480,7 @@
             "code_injection",
             "ssrf"
           ],
-          "note": "str::parse::<i64>() etc. \u2014 numeric/typed coercion removes injection metacharacters"
+          "note": "str::parse::<i64>() etc. — numeric/typed coercion removes injection metacharacters"
         }
       ]
     },
@@ -2724,7 +2724,7 @@
       ]
     },
     "cpp": {
-      "comment": "C/C++ taint model: INJECTION-CLASS dataflow only (command injection, path traversal, format string, SSRF, SQLi). Memory-safety bugs (buffer overflow strcpy/strcat/sprintf/gets -> CWE-120/787, use-after-free, OOB) are a DIFFERENT analysis than source->sink taint and are OUT OF SCOPE for this engine \u2014 see testdata/precision-suite-cpp/README.md. Call keys are the short/bare form; the extractor normalizes C++ `::` to `.` and the engine suffix-matches, so `system` matches `std::system` and `getenv` matches `std::getenv`.",
+      "comment": "C/C++ taint model: INJECTION-CLASS dataflow only (command injection, path traversal, format string, SSRF, SQLi). Memory-safety bugs (buffer overflow strcpy/strcat/sprintf/gets -> CWE-120/787, use-after-free, OOB) are a DIFFERENT analysis than source->sink taint and are OUT OF SCOPE for this engine — see testdata/precision-suite-cpp/README.md. Call keys are the short/bare form; the extractor normalizes C++ `::` to `.` and the engine suffix-matches, so `system` matches `std::system` and `getenv` matches `std::getenv`.",
       "sources": [
         {
           "call": "getenv",
@@ -2893,7 +2893,7 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-134",
           "rule_id": "TAINT-005",
-          "note": "FORMAT-STRING (CWE-134): mapped to the TAINT-005 code-injection rule id (no dedicated CWE-134 class). The vuln is a TAINTED FORMAT argument \u2014 printf(user) \u2014 which the engine gates on FirstArgTainted; printf(\"%s\", user) with a fixed format is SAFE and does not fire"
+          "note": "FORMAT-STRING (CWE-134): mapped to the TAINT-005 code-injection rule id (no dedicated CWE-134 class). The vuln is a TAINTED FORMAT argument — printf(user) — which the engine gates on FirstArgTainted; printf(\"%s\", user) with a fixed format is SAFE and does not fire"
         },
         {
           "call": "vprintf",
@@ -2933,7 +2933,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "curl_easy_setopt(h, CURLOPT_URL, tainted) fetches an attacker-controlled URL \u2014 SSRF; validate the host against an allow-list first"
+          "note": "curl_easy_setopt(h, CURLOPT_URL, tainted) fetches an attacker-controlled URL — SSRF; validate the host against an allow-list first"
         }
       ],
       "sanitizers": [
@@ -3039,7 +3039,7 @@
       ]
     },
     "scala": {
-      "comment": "Scala source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/object-qualified calls matched on the full dotted chain (Files.readAllBytes, Source.fromFile), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .execute, .openStream, .exec). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (fluent iterator chains and the postfix `.!` process operator the flat recognizer cannot follow). The Slick `sql\"...\"` and Anorm `SQL(\"...\")` string interpolators are recognized as calls named `sql`/`SQL`. See core/taint/engine/extract_scala.go.",
+      "comment": "Scala source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/object-qualified calls matched on the full dotted chain (Files.readAllBytes, Source.fromFile), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .execute, .openStream, .exec). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (fluent iterator chains and the postfix `.!` process operator the flat recognizer cannot follow). The Slick `sql\"...\"` and Anorm `SQL(\"...\")` string interpolators are recognized as calls named `sql`/`SQL`. See core/taint/engine/extract_scala.go.",
       "sources": [
         {
           "call": "request.getQueryString",
@@ -3056,12 +3056,12 @@
         {
           "call": "getQueryString",
           "kind": "http_query",
-          "note": "Play request.getQueryString(\"id\") \u2014 matched on the method suffix"
+          "note": "Play request.getQueryString(\"id\") — matched on the method suffix"
         },
         {
           "call": "queryString",
           "kind": "http_query",
-          "note": "Play request.queryString attribute \u2014 matched on the suffix"
+          "note": "Play request.queryString attribute — matched on the suffix"
         },
         {
           "call": "params",
@@ -3093,7 +3093,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) \u2014 matched on the .exec method suffix"
+          "note": "Runtime.getRuntime().exec(cmd) — matched on the .exec method suffix"
         },
         {
           "call": ".!",
@@ -3107,7 +3107,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation/interpolation"
+          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation/interpolation"
         },
         {
           "call": "executeUpdate",
@@ -3120,7 +3120,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
+          "note": "Statement.execute(sql) — matched on the method suffix"
         },
         {
           "call": "sql",
@@ -3148,14 +3148,14 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "Source.fromFile \u2014 matched on the method suffix"
+          "note": "Source.fromFile — matched on the method suffix"
         },
         {
           "call": "File",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) / File(path) opens a file named by input \u2014 matched on the File constructor name"
+          "note": "new File(path) / File(path) opens a file named by input — matched on the File constructor name"
         },
         {
           "call": "Files.readAllBytes",
@@ -3168,7 +3168,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "Files.readAllBytes(Paths.get(path)) \u2014 matched on the method suffix"
+          "note": "Files.readAllBytes(Paths.get(path)) — matched on the method suffix"
         },
         {
           "call": "Files.readAllLines",
@@ -3181,7 +3181,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is not catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is not catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "fromURL",
@@ -3201,14 +3201,14 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "new ObjectInputStream(bytesFromInput) over attacker-controlled bytes primes a native-serialization RCE; the tainted bytes enter at construction, which is where this is keyed. The trailing .readObject() takes no tainted argument (its receiver is the stream, not the bytes), so keying on the constructor \u2014 not the read method \u2014 reports the flow exactly once per site and avoids double-counting `new ObjectInputStream(blob).readObject()`."
+          "note": "new ObjectInputStream(bytesFromInput) over attacker-controlled bytes primes a native-serialization RCE; the tainted bytes enter at construction, which is where this is keyed. The trailing .readObject() takes no tainted argument (its receiver is the stream, not the bytes), so keying on the constructor — not the read method — reports the flow exactly once per site and avoids double-counting `new ObjectInputStream(blob).readObject()`."
         },
         {
           "call": "Html",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "play.twirl.api.Html(taintedHtml) marks a tainted string as trusted HTML, bypassing Twirl auto-escaping \u2014 reflected XSS. Safe when the value is HTML-escaped first."
+          "note": "play.twirl.api.Html(taintedHtml) marks a tainted string as trusted HTML, bypassing Twirl auto-escaping — reflected XSS. Safe when the value is HTML-escaped first."
         },
         {
           "call": "Html.apply",
@@ -3274,7 +3274,7 @@
       ]
     },
     "kotlin": {
-      "comment": "Kotlin source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Kotlin runs on the JVM, so its dangerous APIs are the Java ones (Runtime.exec, JDBC executeQuery, java.io.File, URL.openStream, ObjectInputStream.readObject) plus the Android idioms (intent.getStringExtra source, SQLiteDatabase.rawQuery sink). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies \u2014 matched by METHOD-NAME suffix (.executeQuery, .exec, .readText, .openStream, .rawQuery). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (scope-function/lambda chains the flat recognizer cannot follow). See core/taint/engine/extract_kotlin.go.",
+      "comment": "Kotlin source/sink/sanitizer model for the lexctx line/statement recognizer (no CGo tree-sitter). Kotlin runs on the JVM, so its dangerous APIs are the Java ones (Runtime.exec, JDBC executeQuery, java.io.File, URL.openStream, ObjectInputStream.readObject) plus the Android idioms (intent.getStringExtra source, SQLiteDatabase.rawQuery sink). Sinks come in two shapes matched via the engine's suffixKeys fallback: (1) package/class-qualified calls matched on the full dotted chain (ObjectInputStream.readObject), and (2) methods on a value whose receiver name varies — matched by METHOD-NAME suffix (.executeQuery, .exec, .readText, .openStream, .rawQuery). Method-suffix matching is imprecise on purpose (AST-only): a .execute on a non-JDBC object still matches. This is the same precision trade documented for Go/Java method sinks; the corpus README records the resulting honest FNs (scope-function/lambda chains the flat recognizer cannot follow). See core/taint/engine/extract_kotlin.go.",
       "sources": [
         {
           "call": "request.getParameter",
@@ -3351,7 +3351,7 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command \u2014 matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
+          "note": "Runtime.getRuntime().exec(cmd) invokes a shell/command — matched on the .exec method suffix (the flat recognizer sees the trailing .exec, not the fluent Runtime.getRuntime() receiver)"
         },
         {
           "call": "ProcessBuilder",
@@ -3365,7 +3365,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.executeQuery(sql) \u2014 safe only when the SQL is a constant/parameterized query, not a tainted concatenation or a template string with a $-interpolated value"
+          "note": "Statement.executeQuery(sql) — safe only when the SQL is a constant/parameterized query, not a tainted concatenation or a template string with a $-interpolated value"
         },
         {
           "call": "executeUpdate",
@@ -3378,7 +3378,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Statement.execute(sql) \u2014 matched on the method suffix"
+          "note": "Statement.execute(sql) — matched on the method suffix"
         },
         {
           "call": "rawQuery",
@@ -3392,7 +3392,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Android SQLiteDatabase.execSQL(sql) \u2014 matched on the method suffix"
+          "note": "Android SQLiteDatabase.execSQL(sql) — matched on the method suffix"
         },
         {
           "call": "createQuery",
@@ -3406,7 +3406,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path) opens a file named by input \u2014 matched on the File constructor name"
+          "note": "File(path) opens a file named by input — matched on the File constructor name"
         },
         {
           "call": "FileInputStream",
@@ -3420,14 +3420,14 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path).readText() reads a file named by tainted input \u2014 matched on the .readText method suffix"
+          "note": "File(path).readText() reads a file named by tainted input — matched on the .readText method suffix"
         },
         {
           "call": "readBytes",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "File(path).readBytes() \u2014 matched on the method suffix"
+          "note": "File(path).readBytes() — matched on the method suffix"
         },
         {
           "call": "readLines",
@@ -3446,14 +3446,14 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "URL(u).openStream() fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
+          "note": "URL(u).openStream() fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor itself is NOT catalogued: constructing a URL does not perform the request, so keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "URL(u).openConnection() \u2014 matched on the method suffix"
+          "note": "URL(u).openConnection() — matched on the method suffix"
         },
         {
           "call": "ObjectInputStream.readObject",
@@ -3467,28 +3467,28 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "ObjectInputStream.readObject() \u2014 matched on the method suffix"
+          "note": "ObjectInputStream.readObject() — matched on the method suffix"
         },
         {
           "call": "write",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .write(taintedHtml) reflects unescaped input \u2014 reflected XSS"
+          "note": "response writer .write(taintedHtml) reflects unescaped input — reflected XSS"
         },
         {
           "call": "print",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response.getWriter().print(taintedHtml) \u2014 reflected XSS"
+          "note": "response.getWriter().print(taintedHtml) — reflected XSS"
         },
         {
           "call": "println",
           "vuln_class": "xss",
           "cwe": "CWE-79",
           "rule_id": "TAINT-003",
-          "note": "response writer .println(taintedHtml) \u2014 reflected XSS"
+          "note": "response writer .println(taintedHtml) — reflected XSS"
         }
       ],
       "sanitizers": [
@@ -3543,14 +3543,14 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "Apache Commons StringEscapeUtils.escapeHtml4 \u2014 matched on the method suffix"
+          "note": "Apache Commons StringEscapeUtils.escapeHtml4 — matched on the method suffix"
         },
         {
           "call": "forHtml",
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Encoder.forHtml \u2014 matched on the method suffix"
+          "note": "OWASP Encoder.forHtml — matched on the method suffix"
         },
         {
           "call": "htmlEscape",
@@ -3564,7 +3564,7 @@
           "neutralizes": [
             "path_traversal"
           ],
-          "note": "File(path).name returns the last path component only, stripping directory traversal \u2014 matched on the .name accessor when used call-shaped"
+          "note": "File(path).name returns the last path component only, stripping directory traversal — matched on the .name accessor when used call-shaped"
         },
         {
           "call": "getName",
@@ -3882,7 +3882,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "session.dataTask(with: tainted URL/request) \u2014 fetching an attacker-controlled URL is SSRF; folded from the with: label so it does not collide with unrelated .with(...) calls"
+          "note": "session.dataTask(with: tainted URL/request) — fetching an attacker-controlled URL is SSRF; folded from the with: label so it does not collide with unrelated .with(...) calls"
         },
         {
           "call": "dataTask",
@@ -3921,7 +3921,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "receiver-varies NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(tainted) \u2014 non-secure unarchiving of attacker bytes is an RCE vector; the secure NSSecureCoding form (unarchivedObject(ofClass:from:) requiring secure coding) is the safe path"
+          "note": "receiver-varies NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(tainted) — non-secure unarchiving of attacker bytes is an RCE vector; the secure NSSecureCoding form (unarchivedObject(ofClass:from:) requiring secure coding) is the safe path"
         },
         {
           "call": "unarchiveObject.with",
@@ -4272,7 +4272,7 @@
         {
           "call": "NSProcessInfo.environment",
           "kind": "environment",
-          "note": "[[NSProcessInfo processInfo] environment] shaped to the NSProcessInfo.environment attribute \u2014 the ObjC environment dictionary"
+          "note": "[[NSProcessInfo processInfo] environment] shaped to the NSProcessInfo.environment attribute — the ObjC environment dictionary"
         },
         {
           "call": "environment",
@@ -4287,7 +4287,7 @@
         {
           "call": "text",
           "kind": "http_body",
-          "note": "receiver-varies textField.text / textView.text \u2014 untrusted UI input"
+          "note": "receiver-varies textField.text / textView.text — untrusted UI input"
         },
         {
           "call": "objectForKey",
@@ -4297,12 +4297,12 @@
         {
           "call": "stringForKey",
           "kind": "user_input",
-          "note": "NSUserDefaults stringForKey: \u2014 user-controlled persisted value"
+          "note": "NSUserDefaults stringForKey: — user-controlled persisted value"
         },
         {
           "call": "valueForKey",
           "kind": "http_query",
-          "note": "receiver-varies request/params valueForKey: \u2014 request parameter access"
+          "note": "receiver-varies request/params valueForKey: — request parameter access"
         },
         {
           "call": "queryParameters",
@@ -4312,7 +4312,7 @@
         {
           "call": "HTTPBody",
           "kind": "http_body",
-          "note": "request.HTTPBody \u2014 the untrusted request body"
+          "note": "request.HTTPBody — the untrusted request body"
         }
       ],
       "sinks": [
@@ -4469,7 +4469,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "[NSURLSession dataTaskWithURL:tainted] fetches an attacker-controlled URL \u2014 SSRF; safe with a host allow-list"
+          "note": "[NSURLSession dataTaskWithURL:tainted] fetches an attacker-controlled URL — SSRF; safe with a host allow-list"
         },
         {
           "call": "dataTaskWithRequest",
@@ -4504,7 +4504,7 @@
           "vuln_class": "unsafe_deserialization",
           "cwe": "CWE-502",
           "rule_id": "TAINT-005",
-          "note": "[NSKeyedUnarchiver unarchiveObjectWithData:tainted] does non-secure unarchiving of attacker bytes \u2014 an RCE vector; the secure NSSecureCoding form (unarchivedObjectOfClass:fromData:error: requiring secure coding) is the safe path"
+          "note": "[NSKeyedUnarchiver unarchiveObjectWithData:tainted] does non-secure unarchiving of attacker bytes — an RCE vector; the secure NSSecureCoding form (unarchivedObjectOfClass:fromData:error: requiring secure coding) is the safe path"
         },
         {
           "call": "unarchiveObjectWithFile",
@@ -4621,7 +4621,7 @@
       ]
     },
     "powershell": {
-      "comment": "PowerShell source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_powershell.go). PowerShell shapes are normalized before recognition: the `$` variable sigil is stripped (like PHP), the static-member `::` becomes `.` with the `[Namespace.Type]` accelerator unwrapped (so `[IO.File]::ReadAllText` keys as `IO.File.ReadAllText`, matched by the `.ReadAllText` suffix), a `[int]`/`[long]` cast becomes an `int(...)`/`long(...)` sanitizer call, the `$env:` provider becomes a bare `env` read, and \u2014 CRUCIALLY \u2014 a cmdlet's `Verb-Noun` hyphen is normalized to an UNDERSCORE (`Invoke-Expression` -> `Invoke_Expression`) because the shared identifier scanner treats `-` as an operator. Every hyphenated cmdlet key below therefore uses the underscore form. Paren-less cmdlet calls (`Get-Content $p`) are wrapped into `Get_Content($p)`, and the call operator `& $cmd` is modeled as the synthetic sink `InvokeOperator`. Rule IDs mirror the shared TAINT-00x space. PowerShell recall is moderate (pipelines, splatting, and paren-less pipeline arguments are only partially modeled) \u2014 see testdata/precision-suite-powershell/README.md.",
+      "comment": "PowerShell source/sink/sanitizer model for the line/statement recognizer (core/taint/engine/extract_powershell.go). PowerShell shapes are normalized before recognition: the `$` variable sigil is stripped (like PHP), the static-member `::` becomes `.` with the `[Namespace.Type]` accelerator unwrapped (so `[IO.File]::ReadAllText` keys as `IO.File.ReadAllText`, matched by the `.ReadAllText` suffix), a `[int]`/`[long]` cast becomes an `int(...)`/`long(...)` sanitizer call, the `$env:` provider becomes a bare `env` read, and — CRUCIALLY — a cmdlet's `Verb-Noun` hyphen is normalized to an UNDERSCORE (`Invoke-Expression` -> `Invoke_Expression`) because the shared identifier scanner treats `-` as an operator. Every hyphenated cmdlet key below therefore uses the underscore form. Paren-less cmdlet calls (`Get-Content $p`) are wrapped into `Get_Content($p)`, and the call operator `& $cmd` is modeled as the synthetic sink `InvokeOperator`. Rule IDs mirror the shared TAINT-00x space. PowerShell recall is moderate (pipelines, splatting, and paren-less pipeline arguments are only partially modeled) — see testdata/precision-suite-powershell/README.md.",
       "sources": [
         {
           "call": "args",
@@ -4668,7 +4668,7 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "Invoke-Expression (iex) evaluates a string as PowerShell code \u2014 the canonical PowerShell code-injection sink"
+          "note": "Invoke-Expression (iex) evaluates a string as PowerShell code — the canonical PowerShell code-injection sink"
         },
         {
           "call": "iex",
@@ -4744,7 +4744,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "[IO.File]::ReadAllText($p) shaped to IO.File.ReadAllText \u2014 matched on the .ReadAllText suffix"
+          "note": "[IO.File]::ReadAllText($p) shaped to IO.File.ReadAllText — matched on the .ReadAllText suffix"
         },
         {
           "call": "ReadAllBytes",
@@ -4848,7 +4848,7 @@
           "neutralizes": [
             "sql_injection"
           ],
-          "note": "receiver-varies $cmd.Parameters.AddWithValue(...) \u2014 matched on the method suffix"
+          "note": "receiver-varies $cmd.Parameters.AddWithValue(...) — matched on the method suffix"
         },
         {
           "call": "Split_Path",
@@ -5026,6 +5026,14 @@
             "path_traversal"
           ],
           "note": "basename strips directory components"
+        },
+        {
+          "call": "jq",
+          "neutralizes": [
+            "command_injection",
+            "code_injection"
+          ],
+          "note": "jq's @sh filter shell-quotes each value, escaping embedded single quotes; the extractor only attaches this call to a `read` whose stdin came from a jq invocation that mentions @sh"
         }
       ]
     },
@@ -5422,7 +5430,9 @@
         {
           "call": ":body",
           "kind": "http_body",
-          "not_for": ["path_traversal"],
+          "not_for": [
+            "path_traversal"
+          ],
           "note": "Ring request body: an InputStream by the Ring spec, so slurp on it reads the request and never opens a path (measured on ring + reitit: every (slurp (:body ...)) was a stream read, request or response). Still a source for every other class once read into a string."
         },
         {
@@ -5539,7 +5549,7 @@
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "slurp of a tainted path reads an attacker-chosen file (slurp of a URL is SSRF instead \u2014 an ambiguity the recognizer cannot resolve; documented FN)"
+          "note": "slurp of a tainted path reads an attacker-chosen file (slurp of a URL is SSRF instead — an ambiguity the recognizer cannot resolve; documented FN)"
         },
         {
           "call": "clojure.java.io/reader",
@@ -5564,7 +5574,7 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "clj-http fetches a tainted URL \u2014 SSRF regardless of validation"
+          "note": "clj-http fetches a tainted URL — SSRF regardless of validation"
         },
         {
           "call": "client/get",
@@ -5676,14 +5686,14 @@
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "\"cmd\".execute() runs an external command via the String.execute() extension \u2014 matched on the .execute method suffix; the idiomatic Groovy shell-out."
+          "note": "\"cmd\".execute() runs an external command via the String.execute() extension — matched on the .execute method suffix; the idiomatic Groovy shell-out."
         },
         {
           "call": "exec",
           "vuln_class": "command_injection",
           "cwe": "CWE-78",
           "rule_id": "TAINT-002",
-          "note": "Runtime.getRuntime().exec(cmd) \u2014 matched on the .exec method suffix."
+          "note": "Runtime.getRuntime().exec(cmd) — matched on the .exec method suffix."
         },
         {
           "call": "ProcessBuilder",
@@ -5711,14 +5721,14 @@
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "groovy.util.Eval.me(script) evaluates arbitrary Groovy \u2014 RCE with a tainted script."
+          "note": "groovy.util.Eval.me(script) evaluates arbitrary Groovy — RCE with a tainted script."
         },
         {
           "call": "evaluate",
           "vuln_class": "code_injection",
           "cwe": "CWE-95",
           "rule_id": "TAINT-005",
-          "note": "GroovyShell.evaluate(script) / script.evaluate(...) executes a tainted Groovy string \u2014 matched on the .evaluate method suffix."
+          "note": "GroovyShell.evaluate(script) / script.evaluate(...) executes a tainted Groovy string — matched on the .evaluate method suffix."
         },
         {
           "call": "GroovyShell.evaluate",
@@ -5732,7 +5742,7 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "groovy.sql.Sql.rows(query) \u2014 safe only when the query is a constant or a parameterized GString/placeholder, not a tainted concatenation. Matched on the .rows suffix."
+          "note": "groovy.sql.Sql.rows(query) — safe only when the query is a constant or a parameterized GString/placeholder, not a tainted concatenation. Matched on the .rows suffix."
         },
         {
           "call": "executeQuery",
@@ -5746,35 +5756,35 @@
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Sql.firstRow(query) \u2014 matched on the .firstRow suffix."
+          "note": "Sql.firstRow(query) — matched on the .firstRow suffix."
         },
         {
           "call": "eachRow",
           "vuln_class": "sql_injection",
           "cwe": "CWE-89",
           "rule_id": "TAINT-001",
-          "note": "Sql.eachRow(query){...} \u2014 matched on the .eachRow suffix."
+          "note": "Sql.eachRow(query){...} — matched on the .eachRow suffix."
         },
         {
           "call": "File",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path) opens a file named by input \u2014 matched on the File constructor name."
+          "note": "new File(path) opens a file named by input — matched on the File constructor name."
         },
         {
           "call": "readLines",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path).readLines() reads an attacker-named file \u2014 matched on the .readLines suffix."
+          "note": "new File(path).readLines() reads an attacker-named file — matched on the .readLines suffix."
         },
         {
           "call": "getText",
           "vuln_class": "path_traversal",
           "cwe": "CWE-22",
           "rule_id": "TAINT-004",
-          "note": "new File(path).getText() / file.text reads an attacker-named file \u2014 matched on the .getText suffix."
+          "note": "new File(path).getText() / file.text reads an attacker-named file — matched on the .getText suffix."
         },
         {
           "call": "FileInputStream",
@@ -5788,21 +5798,21 @@
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openStream() / url.text fetches an attacker-controlled URL \u2014 matched on the .openStream method suffix. The URL constructor is not catalogued (constructing a URL performs no request); keying on the fetch method avoids double-reporting the same flow."
+          "note": "new URL(u).openStream() / url.text fetches an attacker-controlled URL — matched on the .openStream method suffix. The URL constructor is not catalogued (constructing a URL performs no request); keying on the fetch method avoids double-reporting the same flow."
         },
         {
           "call": "openConnection",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "new URL(u).openConnection() \u2014 matched on the method suffix."
+          "note": "new URL(u).openConnection() — matched on the method suffix."
         },
         {
           "call": "toURL",
           "vuln_class": "ssrf",
           "cwe": "CWE-918",
           "rule_id": "TAINT-006",
-          "note": "u.toURL().text / u.toURL().openStream() fetches a tainted URL \u2014 matched on the .toURL suffix."
+          "note": "u.toURL().text / u.toURL().openStream() fetches a tainted URL — matched on the .toURL suffix."
         }
       ],
       "sanitizers": [
@@ -5854,7 +5864,7 @@
           "neutralizes": [
             "xss"
           ],
-          "note": "OWASP Java Encoder.forHtml \u2014 matched on the method suffix."
+          "note": "OWASP Java Encoder.forHtml — matched on the method suffix."
         },
         {
           "call": "getName",

--- a/core/taint/engine/extract_shell.go
+++ b/core/taint/engine/extract_shell.go
@@ -102,7 +102,7 @@ func shellSegmentStatements(seg logicalLine, piped *shellPipe) []stmtDraft {
 	if trimmed == "" || isShellStructuralLine(trimmed) {
 		return nil
 	}
-	if sts, ok := shellReadStatements(seg); ok {
+	if sts, ok := shellReadStatements(seg, piped); ok {
 		return sts
 	}
 	if st, ok := shellAssignment(seg); ok {
@@ -123,6 +123,11 @@ func shellSegmentStatements(seg logicalLine, piped *shellPipe) []stmtDraft {
 type shellPipe struct {
 	vars []string
 	code []string
+	// shellQuoted records that an upstream segment shell-quoted every value it
+	// emitted, so what arrives on stdin can be re-parsed by the shell as data
+	// rather than as syntax. Only `jq` with an `@sh` filter sets it — see
+	// shellQuotingProducer for why the bar is that specific.
+	shellQuoted bool
 }
 
 func (p *shellPipe) absorb(seg logicalLine, sts []stmtDraft) {
@@ -134,6 +139,47 @@ func (p *shellPipe) absorb(seg logicalLine, sts []stmtDraft) {
 	if strings.TrimSpace(seg.code) != "" {
 		p.code = append(p.code, seg.code)
 	}
+	if shellQuotingProducer(seg) {
+		p.shellQuoted = true
+	}
+}
+
+// shellQuotingProducer reports whether seg emits values already quoted for the
+// shell, making `eval` / `set --` on its output a data operation rather than a
+// code one.
+//
+// The bar is deliberately narrow: the callee must be `jq` AND the invocation
+// must mention `@sh`. Two reasons it is not "any sanitizer upstream".
+//
+// First, `printf` is in the shell sanitizer catalog for `printf %q`, but the
+// entry matches the CALL and not the format string. Honouring it here would
+// make `printf '%s\n' "$UNSAFE" | while read x` look sanitized when it quotes
+// nothing at all — turning a coarse entry that currently costs false positives
+// into one that costs false NEGATIVES, which is the direction that hides real
+// injections.
+//
+// Second, @sh is checked against seg.raw rather than seg.code because the code
+// view blanks string literals (that is how pipeline splitting avoids seeing a
+// `|` inside a quoted jq filter). The filter, and therefore the `@sh`, only
+// exists in the raw text.
+func shellQuotingProducer(seg logicalLine) bool {
+	code := seg.code
+	i := skipShellLeadingAssignments(code)
+	for i < len(code) && (code[i] == ' ' || code[i] == '\t') {
+		i++
+	}
+	j := i
+	for j < len(code) && code[j] != ' ' && code[j] != '\t' {
+		j++
+	}
+	callee := code[i:j]
+	if k := strings.LastIndexByte(callee, '/'); k >= 0 {
+		callee = callee[k+1:] // /usr/bin/jq
+	}
+	if callee != "jq" {
+		return false
+	}
+	return strings.Contains(seg.raw, "@sh")
 }
 
 // shellPipelineSegments splits a logical line at its top-level pipes. A `|`
@@ -246,7 +292,7 @@ func stripShellLoopReadHeader(ll logicalLine) logicalLine {
 // `read` with no variable defaults to `$REPLY`, which the catalog also lists as
 // a source. Flags (`-r`, `-p "prompt"`, `-a arr`) are skipped. Returns ok=false
 // for a non-`read` line.
-func shellReadStatements(ll logicalLine) ([]stmtDraft, bool) {
+func shellReadStatements(ll logicalLine, piped *shellPipe) ([]stmtDraft, bool) {
 	code := strings.TrimSpace(ll.code)
 	if code != "read" && !strings.HasPrefix(code, "read ") {
 		return nil, false
@@ -275,12 +321,21 @@ func shellReadStatements(ll logicalLine) ([]stmtDraft, bool) {
 		// Bare `read` populates $REPLY.
 		vars = []string{"REPLY"}
 	}
+	// `read` is a stdin source. When the stdin it consumes was produced by a
+	// shell-quoting stage, the sanitizer call joins this statement's calls, and
+	// the engine's existing rule — a statement carrying a sanitizer clears taint
+	// on its assignee, and that case is evaluated BEFORE sourceAssigned — leaves
+	// the bound variable untainted. No engine change is needed.
+	calls := []string{"read"}
+	if piped != nil && piped.shellQuoted {
+		calls = append(calls, "jq")
+	}
 	out := make([]stmtDraft, 0, len(vars))
 	for _, v := range vars {
 		out = append(out, stmtDraft{
 			line:     ll.line,
 			assigns:  v,
-			calls:    []string{"read"},
+			calls:    calls,
 			sinkArgs: map[string]sinkArgDraft{},
 		})
 	}

--- a/core/taint/engine/shell_atsh_test.go
+++ b/core/taint/engine/shell_atsh_test.go
@@ -1,0 +1,94 @@
+package engine
+
+import "testing"
+
+// jq's @sh filter shell-quotes every value it emits: it wraps the value in
+// single quotes and escapes embedded single quotes as '\”. So the canonical
+// JSON-to-shell idiom below is safe, and nox reported it as TAINT-005 high —
+// twice in one real deployment script.
+//
+// Verified by injection rather than by reading the docs: a payload of
+//
+//	'; touch /tmp/PWNED; echo '
+//
+// arrives at `set --` as a literal string and the command does not run. That
+// matters because Kubernetes NAMES are RFC-1123-restricted, but the label
+// values and annotations these scripts read are not — @sh is doing real work
+// here, not decoration.
+func TestAtShQuotedPipelineDoesNotReachEval(t *testing.T) {
+	src := "kubectl get svc -o json | jq -r '.items[] | \"\\(.metadata.name | @sh)\"' | while read -r row; do\n" +
+		"  eval \"set -- $row\"\n" +
+		"done\n"
+	if flows := analyzeShell(t, src); len(flows) != 0 {
+		t.Errorf("@sh-quoted pipeline should not reach eval; got %v", flows)
+	}
+}
+
+// The bar is `jq` AND `@sh`, never the callee alone. Without the @sh the values
+// are raw and the eval is a real code-injection sink.
+func TestJqWithoutAtShStillReachesEval(t *testing.T) {
+	src := "kubectl get svc -o json | jq -r '.items[].metadata.name' | while read -r row; do\n" +
+		"  eval \"set -- $row\"\n" +
+		"done\n"
+	flows := analyzeShell(t, src)
+	if !shellHasRule(flows, "TAINT-005") {
+		t.Errorf("jq without @sh must still report TAINT-005; got %v", flows)
+	}
+}
+
+// The upstream check must not generalise to "any sanitizer in the pipeline".
+//
+// `printf` is in the shell sanitizer catalog for `printf %q`, but the entry
+// matches the CALL and not the format string. Honouring it in the pipeline
+// position would make this look sanitized while it quotes nothing at all —
+// converting a coarse entry that currently costs false positives into one that
+// costs false NEGATIVES, which is the direction that hides real injections.
+func TestPrintfPipedToReadIsNotTreatedAsQuoting(t *testing.T) {
+	src := "printf '%s\\n' \"$UNSAFE\" | while read -r row; do\n" +
+		"  eval \"set -- $row\"\n" +
+		"done\n"
+	flows := analyzeShell(t, src)
+	if !shellHasRule(flows, "TAINT-005") {
+		t.Errorf("printf upstream must not clear the eval sink; got %v", flows)
+	}
+}
+
+// A read with no quoting producer upstream is unchanged.
+func TestPlainReadStillReachesEval(t *testing.T) {
+	for _, src := range []string{
+		"read -r row\neval \"set -- $row\"\n",
+		"cat /tmp/data | while read -r row; do\n  eval \"set -- $row\"\ndone\n",
+	} {
+		flows := analyzeShell(t, src)
+		if !shellHasRule(flows, "TAINT-005") {
+			t.Errorf("plain read must still report TAINT-005 for %q; got %v", src, flows)
+		}
+	}
+}
+
+// The clearing is CLASS-PRECISE, and this is the test that keeps it honest.
+//
+// @sh makes a value safe to re-parse as shell syntax. It does not make the
+// value trustworthy. A shell-quoted URL is still an attacker's URL, and a
+// shell-quoted path is still an attacker's path — curl's own catalog note says
+// SSRF applies "regardless of quoting". Both must still fire.
+func TestAtShClearsOnlyTheShellParsingClasses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"ssrf survives @sh", "  curl \"$row\"\n", "TAINT-006"},
+		{"path traversal survives @sh", "  source \"$row\"\n", "TAINT-004"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "kubectl get svc -o json | jq -r '.items[] | (.v | @sh)' | while read -r row; do\n" +
+				tc.body + "done\n"
+			flows := analyzeShell(t, src)
+			if !shellHasRule(flows, tc.want) {
+				t.Errorf("%s must still fire; got %v", tc.want, flows)
+			}
+		})
+	}
+}

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -355,7 +355,31 @@ func (e *StructuralEngine) forwardPass(
 		// ATTRIBUTE chains (request.args, req.query), so both are consulted. A
 		// sanitizer wrapping the source on this same line clears its classes.
 		if src, ok := e.resolveSource(lang, st); ok {
-			tainted[st.Assigns] = taintInfo{src: src, srcLine: st.Line, cleared: e.bindingCleared(lang, st.Expr)}
+			cleared := e.bindingCleared(lang, st.Expr)
+			// bindingCleared reasons about the RHS EXPRESSION: it clears only the
+			// classes cleared on every path from the expression root to a source,
+			// which is what distinguishes `int(src())` from `int(src()) + src()`
+			// and from a sanitizer sitting beside the source rather than around it.
+			//
+			// When there is no expression at all it has nothing to reason about,
+			// and its empty answer means "unknown", not "nothing was cleared".
+			// That is the shell `read` case: the statement binds a variable from
+			// stdin with no RHS, while its Calls carry the sanitizer of the
+			// pipeline stage that produced that stdin. Only then fall back to the
+			// statement's calls — a binding that HAS an expression keeps
+			// bindingCleared's precise answer, so no other language is affected.
+			//
+			// Still class-precise: `@sh` neutralizes command_injection and
+			// code_injection only, so a shell-quoted value reaching an SSRF or
+			// path-traversal sink is reported exactly as before.
+			if strings.TrimSpace(st.Expr) == "" {
+				for _, rawCall := range st.Calls {
+					for _, class := range e.sanitizerClasses(lang, rawCall) {
+						cleared[class] = true
+					}
+				}
+			}
+			tainted[st.Assigns] = taintInfo{src: src, srcLine: st.Line, cleared: cleared}
 			continue
 		}
 

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -1,0 +1,149 @@
+# Current-state baseline — 2026-09
+
+Milestone 0.1 of the refutation-safe roadmap
+(`docs/design/roadmap-refutation-safe.md`): *measure the current scanner after
+all recent rule and plugin changes*, so that every later refutation has one
+authoritative set of numbers to be judged against.
+
+Measured on `78439de`, core-only, offline, no plugins in `plugins.required`.
+Supersedes `docs/benchmarks/2026-Q3` (`5848369`, 2026-08-30), which stays as
+the historical record.
+
+## Reproducing
+
+```bash
+go build -o /tmp/nox ./cli
+for d in testdata/precision-corpus testdata/precision-suite testdata/precision-suite-*; do
+  /tmp/nox bench --precision "$d" --json
+done
+/tmp/nox bench --precision testdata/refutation-suite --json
+/tmp/nox analysis-capabilities
+```
+
+Machine-readable: `precision.json`.
+
+## Detection — does nox report too much?
+
+| Corpus | TP | FP | FN | Precision | Recall |
+|---|---:|---:|---:|---:|---:|
+| precision-corpus | 5 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite | 52 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-clojure | 20 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-cpp | 7 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-csharp | 6 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-dart | 6 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-elixir | 14 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-groovy | 7 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-java | 6 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-kotlin | 7 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-lua | 11 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-objc | 7 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-perl | 12 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-php | 9 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-powershell | 8 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-ruby | 17 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-rust | 6 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-scala | 7 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-shell | 16 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite-swift | 7 | 0 | 0 | 1.000 | 1.000 |
+| **Total** | **230** | **0** | **0** | **1.000** | **1.000** |
+
+### The seven false negatives are closed, and they were closed the right way
+
+The Q3 baseline carried seven FNs — TAINT-002 and TAINT-006 in Clojure, Dart
+and Shell — recorded as *"the recall debt the programme must not make worse."*
+This run reports zero.
+
+Recall 1.000 is the number a corpus can most easily fake, so it was checked
+rather than accepted. `git diff 5848369..HEAD` over the three affected corpora
+shows the `nox-expect` annotations **unchanged and still on the same
+statements** — `echo "$urls" | xargs curl -fsSL # nox-expect: TAINT-006` is
+byte-identical across the range. Only the surrounding prose changed, from
+*"honest false negative, the engine cannot follow this"* to a description of
+the shared-state join and pipeline model that now can. The expectations were
+not moved to meet the engine; the engine was moved to meet them (#564).
+
+Three corpora also grew: `precision-suite` 37 → 52, clojure 13 → 20,
+dart 4 → 6, shell 13 → 16. **A total that rises while recall rises is the
+combination that hides a withdrawal**, so the per-corpus columns above matter
+more than the total, and no corpus lost an expectation.
+
+## Refutation — does nox report too little?
+
+This is the half the roadmap adds, and the half nothing else watches.
+
+| Corpus | Cases | Result | Guard | Gate |
+|---|---:|---|---|---|
+| `refutation-suite` | 10 | 10 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` | A |
+| `refutation-hard` | 5 | not precision-scored by design | — | A |
+| `reachability-suite` | 5 | 1 case may suppress, by name | `TestGateB` | B |
+
+`refutation-hard` and `reachability-suite` are deliberately **not** scored for
+fire-rate: a finding in `refutation-hard` is neither a true nor a false
+positive, and `reachability-suite` scores `(reachable, determined)` pairs out
+of each case's `expect.json`. Running `bench --precision` against either
+produces a meaningless FP — one each on this run (CRYPTO-001 and TAINT-002).
+That is an artefact of pointing the wrong harness at them, not a regression;
+it is recorded here so the next person does not rediscover it as a defect.
+
+## Capability coverage
+
+`nox analysis-capabilities` declares nine and provides seven:
+
+```
+call_graph             — not provided
+entry_point            — not provided
+```
+
+Both are prerequisites for the reachability propositions in Phase 7. Neither
+appears in `findings.json`: the scan's `meta` block carries `degradations` and
+`sast_languages`, and nothing about which capabilities were unavailable. A
+consumer reading only the canonical output cannot tell that two of nine
+questions were never asked — which is Milestone 1.2, stated as a measurement
+rather than as an intention.
+
+## Scale and cost
+
+| | |
+|---|---:|
+| Distinct rule IDs | ~1,600 (SEC 913, IAC 500, AI 50, CWE 44, MCP 21, DATA 12, rest ≤6 each, a few of them test fixtures) |
+| `bench --precision` per corpus | 53–101 ms |
+| Full self-scan (`nox scan .`) | 6.1–7.4 s |
+| `go test ./...` | 76 packages ok, 0 failed |
+
+Self-scan of this repo: 62 findings, **55 unique fingerprints — 7 duplicates**,
+60 carrying a `suppressed` status. The duplicate count is the Phase 5.2
+structural-deduplication number; it is not zero today and it is worth watching
+as flow identity spreads beyond `core/attack`.
+
+## What this baseline does not measure
+
+Recorded explicitly, because a baseline whose gaps are unstated reads as
+completeness:
+
+1. **Rule-level narrowing has no refutation corpus.** Every case in
+   `refutation-suite` guards a *refiner* — lexical context, constant analysis,
+   sanitizer recognition, flow identity, wrapper reachability, value semantics.
+   None guards a *rule* being narrowed by its own applicability conditions, and
+   the corpus contains no IaC sample at all. The three refutations merged in
+   the week before this run — #582 replica preconditions (65 findings), #583
+   probes off batch workloads (14), #585 `@sh` as a shell sanitizer (a taint
+   class no pinned repo contains) — **none of them could have been caught by
+   Gate A**, and #583 and #585 could not be witnessed by the rule-diff corpus
+   either at the moment they merged. Milestone 0.3.
+2. **Negative deltas are reported, not accounted for.** `scripts/rule-diff.sh`
+   prints per-rule before/after counts across ten pinned repos and exits 1 as a
+   `::notice`. Nothing requires a reason for a drop, and nothing fails when one
+   is unexplained. Milestone 0.4.
+3. **Plugin matrix not re-run.** The Q3 figure — 0.771 with `api-abuse` 0.2.3,
+   whose API-ABUSE-001 has never scored a true positive on any corpus — stands
+   unremeasured. It should be re-measured, not re-quoted.
+4. **No unevaluated rate.** There is no denominator today for "what fraction of
+   propositions this scan did not evaluate", because the scan output carries no
+   proposition-level evaluation state. Phase 1.
+5. **Path coherence is unguarded but currently clean.** A probe over
+   `builtinBaseIaCRules()` counted 185 rules, 31 reaching the structural
+   absence path, and **0 setting a structural-only field while falling through
+   to the regex path**. Nothing at load time would reject one. Milestone 0.5.
+6. **No wrong-PREVENTED rate.** `PREVENTED` is reachable only through Gate B's
+   single suppressible case; the metric exists but has one observation.

--- a/docs/benchmarks/2026-09/precision.json
+++ b/docs/benchmarks/2026-09/precision.json
@@ -1,0 +1,261 @@
+{
+  "measured_at": "2026-09-06",
+  "nox_ref": "78439de",
+  "note": "core-only run; offline; no plugins in plugins.required; single-run wall clock includes process start",
+  "supersedes": "docs/benchmarks/2026-Q3/precision.json (ref 5848369, measured 2026-08-30)",
+  "detection_corpora": [
+    {
+      "corpus": "precision-corpus",
+      "tp": 5,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite",
+      "tp": 52,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-clojure",
+      "tp": 20,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-cpp",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-csharp",
+      "tp": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-dart",
+      "tp": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-elixir",
+      "tp": 14,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-groovy",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-java",
+      "tp": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-kotlin",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-lua",
+      "tp": 11,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-objc",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-perl",
+      "tp": 12,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-php",
+      "tp": 9,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-powershell",
+      "tp": 8,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-ruby",
+      "tp": 17,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-rust",
+      "tp": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-scala",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-shell",
+      "tp": 16,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    },
+    {
+      "corpus": "precision-suite-swift",
+      "tp": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0
+    }
+  ],
+  "detection_total": {
+    "tp": 230,
+    "fp": 0,
+    "fn": 0,
+    "precision": 1.0,
+    "recall": 1.0
+  },
+  "refutation_corpora": [
+    {
+      "corpus": "refutation-suite",
+      "scored": true,
+      "tp": 10,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "guard": "cli.TestRefutationSuiteRecall",
+      "gate": "A"
+    },
+    {
+      "corpus": "refutation-hard",
+      "scored": false,
+      "cases": 5,
+      "why_unscored": "a finding here is neither a true nor a false positive; what is measured is that nox never states an unearned NEGATIVE",
+      "gate": "A"
+    },
+    {
+      "corpus": "reachability-suite",
+      "scored": false,
+      "cases": 5,
+      "may_suppress_cases": 1,
+      "why_unscored": "scored on (reachable, determined) and may_suppress from each case's expect.json, not on rule fire-rate",
+      "guard": "TestGateB",
+      "gate": "B"
+    }
+  ],
+  "capability_coverage": {
+    "declared": 9,
+    "provided": 7,
+    "unprovided": [
+      "call_graph",
+      "entry_point"
+    ],
+    "reported_by": "nox analysis-capabilities",
+    "in_scan_output": false
+  },
+  "rule_families": {
+    "SEC": 913,
+    "IAC": 500,
+    "AI": 50,
+    "CWE": 44,
+    "MCP": 21,
+    "DATA": 12,
+    "VARIANT": 6,
+    "AGENT": 6,
+    "TAINT": 4,
+    "VULN": 3,
+    "SLOP": 2,
+    "PROV": 2,
+    "PERM": 2,
+    "MULTI": 2,
+    "HARDEN": 2,
+    "CRYPTO": 2,
+    "CONT": 2,
+    "AGENTFLOW": 2,
+    "MEMSAFE": 1,
+    "_total_distinct": 1600,
+    "_note": "grep over core/analyzers and core/rules for quoted IDs; a handful of the small families are test fixtures"
+  },
+  "latency_ms": {
+    "bench_precision_per_corpus": [
+      53,
+      101
+    ],
+    "full_scan_self": [
+      6050,
+      7360
+    ],
+    "note": "single runs, cold-ish cache, macOS arm64; corpora measure quality not throughput"
+  },
+  "self_scan": {
+    "target": "nox repo at 78439de",
+    "findings": 62,
+    "unique_fingerprints": 55,
+    "duplicate_fingerprints": 7,
+    "status_suppressed": 60,
+    "degradations": 1
+  },
+  "test_suite": {
+    "packages_ok": 76,
+    "packages_failed": 0,
+    "packages_without_tests": 3
+  }
+}

--- a/docs/benchmarks/2026-Q3/README.md
+++ b/docs/benchmarks/2026-Q3/README.md
@@ -1,5 +1,9 @@
 # Precision baseline — 2026-Q3
 
+> **Superseded by `docs/benchmarks/2026-09` (ref `78439de`, 2026-09-06).**
+> This page stays as the historical record. Its seven false negatives are
+> closed; the numbers below describe the tree as it stood on `5848369`.
+
 The authoritative baseline for the evidence-native programme
 (`docs/design/evidence-native-nox.md`, Track A / milestone A1). Every later
 milestone is measured against these numbers.

--- a/docs/design/evidence-native-nox.md
+++ b/docs/design/evidence-native-nox.md
@@ -1,5 +1,11 @@
 # Evidence-Native Nox — roadmap evaluation and execution plan
 
+> **Ordering is now set by `docs/design/roadmap-refutation-safe.md`.** That
+> revision moves ground-truth refutation measurement ahead of every further
+> refutation capability. This document stays authoritative for what the
+> evidence-native programme built and what it found; where the two disagree
+> on sequence, the refutation-safe roadmap wins.
+
 Status: in progress. Tracks A, B, C1, C2, D, E1–E3 and F have landed — see
 §2.9 for where the programme stands and what it found. `docs/roadmap.md` records shipped
 phases and stays as the release history.

--- a/docs/design/roadmap-refutation-safe.md
+++ b/docs/design/roadmap-refutation-safe.md
@@ -1,0 +1,264 @@
+# Best-in-class roadmap — refutation-safe revision
+
+**Status: authoritative for roadmap ordering.** Where this document conflicts
+with the sequence in `docs/design/evidence-native-nox.md` or `docs/roadmap.md`,
+this one wins. Those two stay as, respectively, the record of what the
+evidence-native programme built and found, and the release history.
+
+Revision trigger: *The Refutation Gap*, 2026-09-06.
+
+## North star
+
+> Nox is a deterministic, evidence-driven security engine that detects broadly,
+> progressively determines whether a condition actually impacts the
+> application, preserves uncertainty, and can reproduce why every conclusion
+> was reached.
+
+Operating principle:
+
+> **Analyzers observe. Evidence supports or refutes. Core adjudicates. Findings
+> explain.**
+
+Safety principle added by this revision:
+
+> **Measure refutation before empowering refutation.**
+
+## Why the ordering changed
+
+The revision does not overturn the evidence-driven thesis. It supplies
+production evidence for two failure modes the thesis predicted:
+
+1. **Proposition confusion** — evidence about one fact silently establishes a
+   broader conclusion.
+2. **Absence reported as success** — an evaluation that never ran appears
+   identical to a clean result.
+
+Both were found repeatedly in nox and adjacent code: IaC rule applicability,
+taint sanitization semantics, structurally ignored rule fields, matcher types
+that loaded and matched nothing, corpus branches claimed but not exercised,
+disabled CI whose checks stayed required, and empty-set success conditions.
+
+The correction:
+
+> **Ground-truth refutation measurement moves from a later validation
+> investment to Investment 0.**
+
+Before nox expands machine refutation through typed propositions, reachability,
+negative evidence or automated `PREVENTED`, it must have instrumentation
+capable of detecting a deliberately wrong negative conclusion.
+
+A second north-star question joins the first:
+
+> **How often did nox conclude that a security condition did not matter here —
+> and was that negative conclusion correct?**
+
+---
+
+## Phase 0 — Refutation observability and benchmark safety
+
+| Milestone | Exit criterion | State on 2026-09-06 |
+|---|---|---|
+| **0.1** Current-state baseline | one authoritative baseline exists | **done** — `docs/benchmarks/2026-09` |
+| **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **partly done** — Gate A covers refiners, not rule narrowing |
+| **0.3** Semantic corpus coverage | removing the only fixture for a branch fails coverage | open |
+| **0.4** Negative-delta accountability | unexplained narrowing is rejected or reviewed | open |
+| **0.5** Path-coherence validation | no rule loads with behaviourally inert mandatory fields | open |
+
+### 0.1 — Current-state baseline
+
+Precision, recall, findings added, findings removed, removals by reason,
+duplicate findings, false-negative rate, rule-family coverage, scan latency.
+
+Measured at `78439de`: **230 TP / 0 FP / 0 FN** across twenty detection
+corpora, **10 TP / 0 FP / 0 FN** on the refutation suite, seven duplicate
+fingerprints on a self-scan, seven of nine analysis capabilities provided.
+The Q3 baseline's seven false negatives are closed, and the corpus annotations
+that scored them are unchanged — the engine moved, not the ground truth.
+
+### 0.2 — Refutation corpus
+
+`testdata/refutation-suite` (10 cases, `TestRefutationSuiteRecall`),
+`testdata/refutation-hard` (5 cases that must never reach `PREVENTED`), and
+`testdata/reachability-suite` (Gate B, exactly one suppressible case).
+
+**The gap.** Every case guards a *refiner*. None guards a *rule* narrowed by
+its own applicability conditions, and there is no IaC case at all. Three rule
+narrowings merged in the week before the baseline; Gate A could not have caught
+any of them, and the rule-diff corpus could not witness two of them. Rule-level
+narrowing is where refutation actually ships today, and it is the branch with
+no instrumentation.
+
+### 0.3 — Semantic corpus coverage
+
+Corpus metadata asserts what is exercised: resource kind, language, rule
+family, matcher path, proposition, refutation branch. Removing the only fixture
+for a branch makes coverage fail rather than pass silently.
+
+### 0.4 — Negative-delta accountability
+
+`scripts/rule-diff.sh` already reports per-rule before/after counts across ten
+pinned repos. It exits 1 as a `::notice` — a report, not a gate. Every removed
+finding gains a recorded reason; unexplained narrowing is rejected or
+explicitly reviewed.
+
+### 0.5 — Path-coherence validation
+
+At rule load time, reject declared semantics the chosen matcher or evaluation
+path cannot consume. `jsonpath`, `yamlpath` and `heuristic` were removed from
+`ValidMatcherTypes` for exactly this reason: they validated at load and matched
+nothing at runtime.
+
+`validateRule` (`core/rules/loader.go:79`) checks three things: a non-empty ID,
+a known matcher type, a known severity. It cannot see the asymmetry that
+matters. `structuralAbsence` reads `AbsenceResourceTypes`,
+`AbsencePropertyPath`, `AbsenceRequireAll`, `AbsenceCompanion*` and
+`AbsenceSubjectMinInt`, and returns `(nil, false)` unless resource types are
+set *and* one of companion types or property path is; everything else falls
+through to the regex path, which reads `AbsenceAnchor`, `AbsenceProperty`,
+`AbsenceSpan` and `AbsenceRequire` and ignores the first group entirely. A rule
+declaring `absence_subject_min_int` without a property path therefore loads,
+lists, and applies no precondition at all.
+
+**Measured 2026-09-06: 185 built-in IaC rules, 31 on the structural path, 0
+incoherent.** This is a latent hazard, not a live defect — which is the right
+time to close it, and the reason 0.5 is a gate rather than a bug fix.
+
+---
+
+## Phase 1 — Explicit evaluation state
+
+- **1.1** Results become at least `MATCH` / `CLEAN` / `UNEVALUATED`, with a
+  reason: `parse_error`, `unsupported_construct`, `capability_unavailable`,
+  `timeout`, `path_incomplete`, `not_applicable`. Malformed input must not look
+  identical to a hardened result.
+- **1.2** That state reaches canonical scan output. Today `findings.json` meta
+  carries `degradations` and `sast_languages` and says nothing about the two
+  unprovided capabilities; two scans differing only by analyzer availability
+  are byte-identical.
+- **1.3** Default CI policy must not treat unevaluated as safe. Uninstalling an
+  analyzer cannot turn a failing scan green.
+
+## Phase 2 — Competence moves into core
+
+- **2.1** Degradation, baseline drift, baseline-absent-vs-zero-match, capability
+  loss and scan competence move out of workflow YAML into core, so CLI, MCP and
+  LSP inherit identical semantics.
+- **2.2** Per-claim competence: capability used, scope, limitations, unmodelled
+  constructs, budget state. One scan may hold different competence states for
+  different findings.
+- **2.3** A negative claim that met relevant unmodelled behaviour is never
+  presented unqualified.
+
+## Phase 3 — Typed propositions, earned incrementally
+
+- **3.1** Minimal subject vocabulary: `package_version`, `symbol`, `flow`,
+  `call_path`, `input`, `trigger_condition`, `exploit_hypothesis`. No subject
+  enters without a fixture distinguishing it from adjacent propositions.
+- **3.2** Subject-bound evidence: an advisory about a package cannot become the
+  strongest evidence for exploitability.
+- **3.3** Polarity `SUPPORTS` / `REFUTES` / `UNKNOWN`, behind the refutation
+  benchmark. Missing evidence is never `REFUTES`.
+- **3.4** Lifecycle: supersession, retraction, invalidation.
+
+## Phase 4 — Central adjudication
+
+- **4.1** One adjudicator composes `POTENTIAL`, `PLAUSIBLE`, `PREVENTED`,
+  `INCONCLUSIVE`, `CONFIRMED`.
+- **4.2** `PREVENTED` requires positive, deterministic, scope-sound refuting
+  evidence. Absence of evidence cannot produce it.
+- **4.3** CI gates on adjudicated state. A scan cannot become greener by losing
+  capability.
+
+## Phase 5 — Graph and flow identity
+
+Bind findings and claims to symbols, nodes, edges, flows, source/sink and call
+paths; recognise several observations as one security condition. TRIAGE-002 is
+solved through flow identity, never by deleting a detector.
+
+## Phase 6 — Progressive semantic refinement
+
+Noisy regex families become candidate generators; cheap semantic refutation
+(lexer context, constants, AST node type, value semantics) decides survival.
+Stage accounting measures candidates in, refuted, promoted, unknown, latency.
+Precision improves without refutation-caused recall loss.
+
+## Phase 7 — Reachability and applicability
+
+Core owns what reachability means and distinguishes dependency reachability,
+symbol usage, call reachability, attacker-entry reachability,
+attacker-controlled flow and runtime observed path. Every negative claim
+records entry-point scope and model limitations. The ladder runs `PRESENT` →
+`APPLICABLE` → `REACHABLE` → `ATTACKER-REACHABLE` → `PREVENTED` → `CONFIRMED`.
+
+## Phase 8 — Verification hypothesis and reproduction semantics
+
+`ExploitHypothesis` as an emitted artifact; a reproduction hierarchy from
+trigger through invariant violation, crash, security effect and exploit; a
+controlled-reproduction contract requiring real execution, a deterministic
+oracle, repeatability, a benign control and a completed run. Removing any
+condition prevents a `CONFIRMED` transition.
+
+## Phase 9 — Directed verification R&D
+
+Lightweight trigger solving first (input-to-state correspondence, taint-guided
+search), then property-based typed generation, and SMT only if a meaningful
+residual class survives. SMT must demonstrate measurable value over simpler
+techniques before becoming architecture.
+
+## Phase 10 — Active verification
+
+`nox scan` stays read-only; `nox attack` stays explicit and authorized. The
+handoff is a typed hypothesis, and verification evidence enters the same
+ledger — no separate attack truth system.
+
+## Phase 11 — Replay and explainability
+
+Adjudication replay is exact: ledger plus adjudicator version reproduces the
+verdict. Execution replay is best-effort with stated environment assumptions.
+Every important result answers what was observed, what supports it, what
+refutes it, what was not evaluated, what it means here, and what evidence would
+change the conclusion.
+
+## Phase 12 — Nox Intel evidence network
+
+A shared proposition and evidence model; structured research artifacts
+(affected symbols, trigger conditions, configurations, PoV metadata,
+reproduction evidence, refutations, maintainer and advisory evidence); and a
+publication rule that no quantity of heuristic or community observation
+substitutes for deterministic evidence.
+
+---
+
+## Hard gates
+
+| | |
+|---|---|
+| **A — Refutation instrumentation** | No new high-impact refuting capability ships until a deliberately wrong refutation is caught by CI |
+| **B — Unevaluated honesty** | Loss of capability must be visible and policy-relevant |
+| **C — Proposition distinction** | No new proposition without a benchmark case distinguishing it from adjacent ones |
+| **D — `PREVENTED` safety** | No `PREVENTED` without deterministic, positive, scope-sound refutation |
+| **E — Active consent** | No runtime or network attack behaviour in `nox scan` |
+| **F — Agent trust boundary** | Agent output may create hypotheses, never authoritative verdicts without deterministic evidence |
+
+## Primary success metrics
+
+```
+precision                         duplicate/security-condition rate
+recall                            % explicit unknown / not_evaluated
+false-negative rate from refutation   % evidence with provenance
+wrong PREVENTED rate              deterministic replay equality
+unexplained finding removals      stage-attributed latency
+                                  hypotheses resolved per unit compute
+```
+
+The metric that must never disappear:
+
+> **How often did nox conclude something did not matter, and was it right?**
+
+## What to avoid
+
+Replacing all regex; moving every plugin into core; inventing another
+confidence model; making AI authoritative; equating reachability with impact;
+equating a PoV with exploitability; letting "not evaluated" mean safe; adopting
+SMT because a paper used SMT; and measuring best-in-class by number of
+findings.

--- a/scripts/rule-diff-corpus.json
+++ b/scripts/rule-diff-corpus.json
@@ -14,6 +14,12 @@
     "corpus' after an IAC change was a pass by absence of coverage rather than a",
     "verification. A gate that cannot see a family cannot clear it.",
     "",
+    "kubernetes/examples carries no Job and no CronJob, so it could not witness",
+    "IAC-139/140 being narrowed off batch workloads -- the diff came back green on a",
+    "change it was structurally unable to see. podinfo was added for exactly that",
+    "branch: 4 CronJobs and a Job, and it moved IAC-139 13 -> 9 and IAC-140 13 -> 9",
+    "on the commit that narrowed them.",
+    "",
     "Still uncovered: Azure ARM templates (IAC-084/086 and the ARM property rules)",
     "and Terraform. Those families remain verified only by testdata/precision-suite",
     "and the analyzer tests -- a green rule diff says nothing about them. The same",
@@ -76,6 +82,12 @@
       "url": "https://github.com/kubernetes/examples",
       "sha": "d6b8cd27eacb51e651a1aa6f7c190a28713eff6e",
       "why": "Kubernetes manifests -- 75 rules fire, the widest IAC coverage in the corpus, including the structural property-path rules (IAC-137/138/139/140/145). It carries 30 workloads but only ONE PodDisruptionBudget and no ResourceQuota, so it controls the 'no companion declared anywhere' branch of the cross-resource rules and NOT the linkage branch -- aws-cloudformation-templates covers that. Scans in 0.7s, the cheapest entry here, because it is manifests rather than source"
+    },
+    {
+      "name": "podinfo",
+      "url": "https://github.com/stefanprodan/podinfo",
+      "sha": "dd507173b7b75b2312a36cabe0de5f09c1ce69c8",
+      "why": "The only BATCH workload in the corpus: 4 CronJobs and a Job, alongside a Deployment, HPA and Ingress. kubernetes/examples has neither kind, so IAC-139/140 could be narrowed off Job and CronJob with the diff staying green -- a change the gate was structurally unable to see. Measured on that commit: IAC-139 13 -> 9 and IAC-140 13 -> 9, while kubernetes/examples showed no change at all, which is why both are here. 3.4M, 51 rules fire, 1.3s"
     },
     {
       "name": "aws-cloudformation-templates",


### PR DESCRIPTION
The refutation-safe roadmap revision moves ground-truth refutation measurement
from a later validation investment to **Investment 0**: nox must be able to
detect a deliberately wrong negative conclusion *before* it builds more
machinery that produces negative conclusions.

This PR is that measurement, plus the roadmap ordering it serves. **Docs only —
no code, no rule, no test changes.**

## Measured at `78439de`, core-only, offline

| | |
|---|---|
| Detection | **230 TP / 0 FP / 0 FN** across twenty corpora |
| Refutation (Gate A) | **10 TP / 0 FP / 0 FN**, recall 1.000 |
| Capabilities | 7 of 9 provided — `call_graph` and `entry_point` are not |
| Self-scan | 62 findings, 55 unique fingerprints, **7 duplicates** |
| Tests | 76 packages ok, 0 failed |

## The seven false negatives are closed, and I checked how

Q3 recorded seven FNs (TAINT-002/006 in Clojure, Dart, Shell) as *"the recall
debt the programme must not make worse."* This run reports zero.

Recall 1.000 is the easiest number for a corpus to fake, so it was falsified
rather than accepted. `git diff 5848369..HEAD` over the three affected corpora
shows every `nox-expect` annotation **unchanged and still on the same
statement** — `echo "$urls" | xargs curl -fsSL # nox-expect: TAINT-006` is
byte-identical across the range. Only the surrounding prose changed, from *"the
engine cannot follow this"* to a description of the shared-state join and
pipeline model that now can (#564).

Three corpora also grew (`precision-suite` 37→52, clojure 13→20, dart 4→6,
shell 13→16). A rising total alongside rising recall is exactly the shape that
hides a withdrawal, so the per-corpus columns are what matter: no corpus lost
an expectation.

## What the baseline records that no number shows

**Gate A guards refiners, not rules.** Every case in `refutation-suite` guards
a *refiner* — lexical context, constants, sanitizer recognition, flow identity,
wrapper reachability, value semantics — and there is no IaC case at all. The
three rule narrowings merged the week before this run (#582 replica
preconditions, 65 findings; #583 probes off batch workloads, 14; #585 `@sh` as
a shell sanitizer) removed real findings and **none of them could have been
caught by it**; #583 and #585 could not be witnessed by the rule-diff corpus
either at the moment they merged. Rule narrowing is where refutation actually
ships today, and it is the branch with no instrumentation. → Milestone 0.3.

**Path coherence is unguarded and currently clean.** `validateRule`
(`core/rules/loader.go:79`) checks three things: non-empty ID, known matcher
type, known severity. `structuralAbsence` reads `AbsenceResourceTypes`,
`AbsencePropertyPath`, `AbsenceRequireAll`, `AbsenceCompanion*` and
`AbsenceSubjectMinInt`, and falls through to the regex path — which ignores all
five — unless resource types are set *and* one of companion types or property
path is. A rule declaring `absence_subject_min_int` without a property path
would load, list, and apply no precondition at all. A probe over the 185
built-in IaC rules found 31 on the structural path and **0 incoherent**. Latent
hazard, not a live defect, which is the right time to close it. → Milestone 0.5.

**Two corpora are not precision-scored, by design.** Running
`bench --precision` against `refutation-hard` or `reachability-suite` produces
one meaningless FP each (CRYPTO-001, TAINT-002). They are scored by `TestGateB`
and by their own ground truth. Recorded so the next person does not rediscover
it as a defect.

Also unmeasured and stated as such: negative deltas are reported but not
accounted for (0.4); the plugin matrix has not been re-run, so Q3's 0.771 with
`api-abuse` 0.2.3 stands unremeasured and should be re-measured rather than
re-quoted; there is no unevaluated rate because the scan output carries no
proposition-level evaluation state (Phase 1.2); and the wrong-PREVENTED rate
has exactly one observation.

## Files

- `docs/benchmarks/2026-09/` — the baseline (README + `precision.json`)
- `docs/design/roadmap-refutation-safe.md` — authoritative for roadmap ordering
- `docs/benchmarks/2026-Q3/README.md` — marked superseded, otherwise untouched
- `docs/design/evidence-native-nox.md` — points at the new ordering; stays
  authoritative for what the evidence-native programme built and found

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT