### PR TITLE
GATE A: a refutation branch with no fixture is now a failure, not a silence

### DIFF
--- a/cli/bench_coverage_test.go
+++ b/cli/bench_coverage_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/bench"
+)
+
+// TestRefutationBranchCoverage is Gate A's second half.
+//
+// TestRefutationSuiteRecall answers "does every fixture still fire?". It
+// cannot answer "is there still a fixture?" — deleting the last sample for a
+// refutation branch takes its expectations with it, so recall stays 1.000 over
+// whatever remains and the branch quietly stops being guarded. That is the
+// empty-set success this programme exists to remove: a check over nothing
+// passes, and passes identically to a check that found nothing wrong.
+//
+// The fix is to declare the universe somewhere a testdata deletion cannot
+// reach. bench.RefutationBranches lists every way nox can decide a candidate
+// is not a finding; each fixture claims one with a `nox-cover` annotation.
+// Removing the only fixture for a branch leaves the branch registered and
+// unwitnessed, and this test fails naming it.
+//
+// Adding the branch before the fixture is the intended order: the failing test
+// is the specification for the sample that has to be written.
+func TestRefutationBranchCoverage(t *testing.T) {
+	root := filepath.Join("..", "testdata")
+
+	report, err := bench.CheckCoverage(root, bench.RefutationBranches)
+	if err != nil {
+		t.Fatalf("CheckCoverage: %v", err)
+	}
+
+	for _, b := range report.Uncovered {
+		t.Errorf("GATE A COVERAGE: refutation branch %q has no fixture in testdata/%s.\n"+
+			"  proposition: %s\n"+
+			"  wrong reasoning it must catch: %s\n"+
+			"Either write the sample, or delete the branch from bench.RefutationBranches "+
+			"and say in the commit why nox no longer refutes this way.",
+			b.ID, b.Corpus, b.Proposition, b.Wrong)
+	}
+	for _, c := range report.Unknown {
+		t.Errorf("%s:%d claims unregistered branch %q; register it in bench.RefutationBranches "+
+			"or fix the typo — an unregistered claim guards nothing",
+			c.FilePath, c.Line, c.BranchID)
+	}
+	for _, c := range report.Misfiled {
+		t.Errorf("%s:%d claims branch %q, which declares a different corpus; a fixture in the "+
+			"wrong corpus is scored by the wrong guard", c.FilePath, c.Line, c.BranchID)
+	}
+}
+
+// TestRefutationBranchesAreWellFormed pins the registry's own invariants.
+//
+// A registry entry with an empty proposition or an empty Wrong is a branch
+// nobody can review: the coverage failure it produces would name an ID and say
+// nothing about what deleting the fixture would cost.
+func TestRefutationBranchesAreWellFormed(t *testing.T) {
+	if len(bench.RefutationBranches) == 0 {
+		t.Fatal("the branch registry is empty; every coverage check over it passes vacuously")
+	}
+	seen := map[string]bool{}
+	for _, b := range bench.RefutationBranches {
+		switch {
+		case b.ID == "":
+			t.Errorf("branch %+v has no ID", b)
+		case seen[b.ID]:
+			t.Errorf("duplicate branch ID %q", b.ID)
+		}
+		seen[b.ID] = true
+		if strings.TrimSpace(b.Wrong) == "" {
+			t.Errorf("branch %q does not say what wrong reasoning it catches", b.ID)
+		}
+		if strings.TrimSpace(b.Proposition) == "" {
+			t.Errorf("branch %q does not say what its refutation establishes", b.ID)
+		}
+		if strings.TrimSpace(b.Family) == "" || strings.TrimSpace(b.Matcher) == "" {
+			t.Errorf("branch %q must name a rule family and an evaluation path", b.ID)
+		}
+	}
+}
+
+// TestCoverageCheckFailsWhenAFixtureIsRemoved is the falsification.
+//
+// Every guard in this repo has been written correctly against the wrong input
+// at least once, so the coverage check is asked to fail on demand: a registry
+// naming a branch no fixture claims must be reported, by name. Without this,
+// a CheckCoverage that silently returned an empty report would pass every
+// assertion above forever.
+func TestCoverageCheckFailsWhenAFixtureIsRemoved(t *testing.T) {
+	root := filepath.Join("..", "testdata")
+
+	phantom := append([]bench.Branch{}, bench.RefutationBranches...)
+	phantom = append(phantom, bench.Branch{
+		ID: "branch-with-no-fixture", Corpus: "refutation-suite",
+		Wrong:  "stands in for the branch whose last sample was deleted",
+		Family: "TAINT", Matcher: "none", Proposition: "nothing",
+	})
+
+	report, err := bench.CheckCoverage(root, phantom)
+	if err != nil {
+		t.Fatalf("CheckCoverage: %v", err)
+	}
+	if report.OK() {
+		t.Fatal("coverage reported OK for a branch with no fixture; the check cannot fail and guards nothing")
+	}
+	var named bool
+	for _, b := range report.Uncovered {
+		if b.ID == "branch-with-no-fixture" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("uncovered branch was not named in the report: %+v", report.Uncovered)
+	}
+
+	// And the empty registry must be an error, not a pass.
+	if _, err := bench.CheckCoverage(root, nil); err == nil {
+		t.Error("CheckCoverage over an empty registry returned no error; a vacuous pass is the failure mode")
+	}
+}

--- a/core/bench/coverage.go
+++ b/core/bench/coverage.go
@@ -1,0 +1,324 @@
+package bench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// A Branch is one way nox can decide that a candidate is NOT a finding.
+//
+// Every branch here is a place where the scanner concludes something did not
+// matter. That conclusion is the product's value and its most dangerous
+// failure: a refutation that is slightly wrong removes a real vulnerability
+// while every metric anyone watches improves. Precision rises, counts fall,
+// and nothing goes red.
+//
+// The registry exists so that the corpus cannot silently stop covering one of
+// them. A coverage check that only walked the fixtures would pass trivially
+// once the last fixture for a branch was deleted — the branch would vanish
+// along with its evidence, which is the empty-set success this whole programme
+// is written against. Declaring the universe in code and the witnesses in
+// testdata means deleting a fixture leaves a registered branch with nothing
+// covering it, and the check fails naming it.
+//
+// Adding a branch before its fixture is the intended order: the failing check
+// is the specification.
+type Branch struct {
+	// ID is the stable slug a fixture names in its `nox-cover:` annotation.
+	ID string
+	// Corpus is the corpus directory, relative to testdata/, that must hold at
+	// least one fixture covering this branch.
+	Corpus string
+	// Wrong is the tempting-but-incorrect reasoning this branch's fixture
+	// exists to catch. It is the sentence a reviewer must disagree with before
+	// deleting the fixture.
+	Wrong string
+	// Family is the rule family the branch removes findings from.
+	Family string
+	// Matcher names the evaluation path the refutation runs on, because the
+	// same declared semantics behave differently on different paths — the
+	// reason Milestone 0.5 exists.
+	Matcher string
+	// Proposition is what the refutation actually establishes. Keeping it
+	// explicit is what stops evidence about one fact from settling another.
+	Proposition string
+}
+
+// RefutationBranches is the declared universe of refutation branches.
+//
+// Ordered by corpus, then by the milestone that introduced the branch.
+var RefutationBranches = []Branch{
+	{
+		ID: "lexical-context", Corpus: "refutation-suite",
+		Wrong:  "a lexer that starts a comment at the first bare # rather than tracking string state swallows a sink whose argument holds a \"#\" literal",
+		Family: "TAINT", Matcher: "lexctx",
+		Proposition: "this text is a comment, not code",
+	},
+	{
+		ID: "generated-code", Corpus: "refutation-suite",
+		Wrong:  "greping the whole file for a generated-code banner rather than requiring it in the leading comment block, which skips hand-written code most reliably in code that writes code",
+		Family: "TAINT", Matcher: "file-prefilter",
+		Proposition: "this file is machine-generated, so its contents are not authored risk",
+	},
+	{
+		ID: "constant-evaluation", Corpus: "refutation-suite",
+		Wrong:  "resolving one operand of a concatenation to a literal and stopping",
+		Family: "TAINT", Matcher: "consteval",
+		Proposition: "this value is a compile-time constant",
+	},
+	{
+		ID: "sanitizer-recognition", Corpus: "refutation-suite",
+		Wrong:  "proximity is not dataflow: a sanitizer running one line above the sink, on a different variable",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the value reaching this sink was neutralized for this vulnerability class",
+	},
+	{
+		ID: "flow-identity", Corpus: "refutation-suite",
+		Wrong:  "one tainted value reaching two sinks on consecutive lines shares every cheap merge signal but is two vulnerabilities with two fixes",
+		Family: "TAINT", Matcher: "dedup",
+		Proposition: "these two observations are one security condition",
+	},
+	{
+		ID: "interprocedural-scope", Corpus: "refutation-suite",
+		Wrong:  "an intraprocedural check finds no source-to-sink flow in either function and concludes the code is safe, while the sink sits behind a one-line wrapper",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "no flow connects a source to a sink",
+	},
+	{
+		ID: "value-semantics", Corpus: "refutation-suite",
+		Wrong:  "an identifier that says EXAMPLE or SAMPLE describes the value bound to it",
+		Family: "SEC", Matcher: "secrets/refiner",
+		Proposition: "this literal is a placeholder, not a credential",
+	},
+	{
+		ID: "absence-subject-precondition", Corpus: "refutation-suite",
+		Wrong:  "a precondition that correctly exempts one subject is widened until it exempts subjects the rule was written for",
+		Family: "IAC", Matcher: "absence/structural",
+		Proposition: "this rule does not apply to this subject",
+	},
+	{
+		ID: "absence-resource-kind", Corpus: "refutation-suite",
+		Wrong:  "a rule narrowed off one workload kind is narrowed off the kinds it was written for",
+		Family: "IAC", Matcher: "absence/structural",
+		Proposition: "this rule does not apply to this resource kind",
+	},
+	{
+		ID: "absence-kind-still-governed", Corpus: "refutation-suite",
+		Wrong:  "narrowing SOME rules off a resource kind is generalized into that kind being exempt from hardening",
+		Family: "IAC", Matcher: "absence/structural",
+		Proposition: "the rules that do apply to this kind still apply",
+	},
+	{
+		ID: "sanitizer-pipeline-producer", Corpus: "refutation-suite",
+		Wrong:  "a quoting producer upstream in a pipeline is generalized from the exact call that quotes to any call by the same name",
+		Family: "TAINT", Matcher: "taint/shell-extractor",
+		Proposition: "an upstream pipeline segment quoted this value for the downstream parser",
+	},
+	{
+		ID: "unmodelled-reflection", Corpus: "refutation-hard",
+		Wrong:  "no flow found through MethodByName is reported as no flow exists",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the callee is undetermined, so the search was not exhaustive",
+	},
+	{
+		ID: "unmodelled-dynamic-dispatch", Corpus: "refutation-hard",
+		Wrong:  "the concrete type behind an interface is assumed to be the only one the analysis saw",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the concrete callee is chosen from data, not from the text",
+	},
+	{
+		ID: "unmodelled-bounded-loop", Corpus: "refutation-hard",
+		Wrong:  "a bounded unrolling that did not reach the flow is reported as the flow not existing",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the analysis budget, not the program, ended the search",
+	},
+	{
+		ID: "unmodelled-indirection", Corpus: "refutation-hard",
+		Wrong:  "a value leaving through a pointer the analysis cannot model is treated as a value that did not leave",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the value escaped through an unmodelled construct",
+	},
+	{
+		ID: "unmodelled-dynamic-loading", Corpus: "refutation-hard",
+		Wrong:  "code that does not exist at analysis time is treated as code that does not exist",
+		Family: "TAINT", Matcher: "taint/structural",
+		Proposition: "the callee is not present in the analyzed program",
+	},
+}
+
+// coverMarker matches `nox-cover: <branch-id>[, <branch-id>...]`, the fixture
+// side of the registry above. It is deliberately the same shape as
+// expectMarker: an inline annotation, in the file, next to what it describes,
+// so the ground truth cannot drift away from the sample the way a separate
+// manifest can.
+var coverMarker = regexp.MustCompile(`(?i)nox-cover\s*:\s*(.*)$`)
+
+// CoverageClaim is one fixture's declaration that it covers a branch.
+type CoverageClaim struct {
+	BranchID string
+	Corpus   string
+	FilePath string
+	Line     int
+}
+
+// ParseCoverage walks a corpus directory and returns every `nox-cover` claim.
+// Documentation files and harness artifacts are skipped for the same reason
+// ParseCorpus skips them: a README explaining the annotation must not be able
+// to satisfy the coverage it documents.
+func ParseCoverage(dir string) ([]CoverageClaim, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("bench: coverage dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("bench: coverage path %q is not a directory", dir)
+	}
+
+	corpus := filepath.Base(dir)
+	var claims []CoverageClaim
+	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if IsNonSample(rel) {
+			return nil
+		}
+		lines, readErr := readLines(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range lines {
+			for _, id := range parseCoverIDs(line) {
+				claims = append(claims, CoverageClaim{
+					BranchID: id, Corpus: corpus, FilePath: rel, Line: i + 1,
+				})
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("bench: walking coverage: %w", walkErr)
+	}
+	return claims, nil
+}
+
+// parseCoverIDs returns the branch IDs declared on a line, or nil.
+func parseCoverIDs(line string) []string {
+	m := coverMarker.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+	fields := strings.FieldsFunc(m[1], func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+	var ids []string
+	for _, f := range fields {
+		if f = strings.TrimSpace(f); f != "" {
+			ids = append(ids, f)
+		}
+	}
+	return ids
+}
+
+// CoverageReport is the result of checking a branch registry against the
+// fixtures that claim to cover it.
+type CoverageReport struct {
+	// Uncovered lists registered branches no fixture claims. This is the
+	// failure the registry exists to produce: deleting the last fixture for a
+	// branch leaves the branch declared and unwitnessed.
+	Uncovered []Branch
+	// Unknown lists claims naming a branch that is not registered — a typo, or
+	// a fixture left behind by a branch that was renamed or removed.
+	Unknown []CoverageClaim
+	// Misfiled lists claims made in a corpus other than the one the branch
+	// declares. A fixture in the wrong corpus is scored by the wrong guard.
+	Misfiled []CoverageClaim
+	// Covered maps branch ID to the fixtures covering it.
+	Covered map[string][]CoverageClaim
+}
+
+// OK reports whether coverage is complete and consistent.
+func (r CoverageReport) OK() bool {
+	return len(r.Uncovered) == 0 && len(r.Unknown) == 0 && len(r.Misfiled) == 0
+}
+
+// CheckCoverage verifies a branch registry against the fixtures under root
+// (typically "testdata"). It reads each corpus named by the registry exactly
+// once, so a branch pointing at a corpus that does not exist is an error rather
+// than a silent pass.
+func CheckCoverage(root string, branches []Branch) (CoverageReport, error) {
+	report := CoverageReport{Covered: map[string][]CoverageClaim{}}
+	if len(branches) == 0 {
+		return report, fmt.Errorf("bench: empty branch registry; a coverage check over no branches passes vacuously")
+	}
+
+	registry := make(map[string]Branch, len(branches))
+	corpora := map[string]bool{}
+	for _, b := range branches {
+		if b.ID == "" || b.Corpus == "" {
+			return report, fmt.Errorf("bench: branch %+v must declare an ID and a corpus", b)
+		}
+		if _, dup := registry[b.ID]; dup {
+			return report, fmt.Errorf("bench: duplicate branch ID %q", b.ID)
+		}
+		registry[b.ID] = b
+		corpora[b.Corpus] = true
+	}
+
+	var allClaims []CoverageClaim
+	for corpus := range corpora {
+		claims, err := ParseCoverage(filepath.Join(root, corpus))
+		if err != nil {
+			return report, err
+		}
+		allClaims = append(allClaims, claims...)
+	}
+
+	for _, c := range allClaims {
+		b, known := registry[c.BranchID]
+		switch {
+		case !known:
+			report.Unknown = append(report.Unknown, c)
+		case b.Corpus != c.Corpus:
+			report.Misfiled = append(report.Misfiled, c)
+		default:
+			report.Covered[c.BranchID] = append(report.Covered[c.BranchID], c)
+		}
+	}
+
+	for _, b := range branches {
+		if len(report.Covered[b.ID]) == 0 {
+			report.Uncovered = append(report.Uncovered, b)
+		}
+	}
+
+	sort.Slice(report.Unknown, func(i, j int) bool {
+		return report.Unknown[i].FilePath < report.Unknown[j].FilePath
+	})
+	sort.Slice(report.Misfiled, func(i, j int) bool {
+		return report.Misfiled[i].FilePath < report.Misfiled[j].FilePath
+	})
+	return report, nil
+}
+
+// readLines reads a file into lines, tolerating the long lines corpus samples
+// carry (minified bundles, base64 blobs).
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // corpus paths are operator-supplied, not user input
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n"), nil
+}

--- a/core/bench/coverage_test.go
+++ b/core/bench/coverage_test.go
@@ -1,0 +1,165 @@
+package bench
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCorpus(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestParseCoverageFindsClaims(t *testing.T) {
+	root := writeCorpus(t, map[string]string{
+		"suite/a.py": "# nox-cover: alpha\nx = 1\n",
+		"suite/b.go": "// nox-cover: beta, gamma\npackage p\n",
+	})
+
+	claims, err := ParseCoverage(filepath.Join(root, "suite"))
+	if err != nil {
+		t.Fatalf("ParseCoverage: %v", err)
+	}
+	got := map[string]string{}
+	for _, c := range claims {
+		got[c.BranchID] = c.FilePath
+	}
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("claim %q not parsed; got %v", want, got)
+		}
+	}
+	if len(claims) != 3 {
+		t.Errorf("got %d claims, want 3: %+v", len(claims), claims)
+	}
+}
+
+// A README explaining the annotation format must not be able to satisfy the
+// coverage it documents — the same rule ParseCorpus applies to expectations.
+// Without this, every branch could be "covered" by prose describing it.
+func TestParseCoverageIgnoresDocsAndArtifacts(t *testing.T) {
+	root := writeCorpus(t, map[string]string{
+		"suite/README.md":     "Annotate a sample with `nox-cover: alpha` to claim a branch.\n",
+		"suite/baseline.json": `{"note": "nox-cover: beta"}`,
+		"suite/real.py":       "# nox-cover: gamma\n",
+	})
+
+	claims, err := ParseCoverage(filepath.Join(root, "suite"))
+	if err != nil {
+		t.Fatalf("ParseCoverage: %v", err)
+	}
+	if len(claims) != 1 || claims[0].BranchID != "gamma" {
+		t.Errorf("docs or harness artifacts satisfied coverage: %+v", claims)
+	}
+}
+
+func TestCheckCoverageReportsUncovered(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"suite/a.py": "# nox-cover: alpha\n"})
+
+	report, err := CheckCoverage(root, []Branch{
+		{ID: "alpha", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+		{ID: "orphan", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+	})
+	if err != nil {
+		t.Fatalf("CheckCoverage: %v", err)
+	}
+	if report.OK() {
+		t.Fatal("report OK with an uncovered branch")
+	}
+	if len(report.Uncovered) != 1 || report.Uncovered[0].ID != "orphan" {
+		t.Errorf("uncovered = %+v, want just orphan", report.Uncovered)
+	}
+	if len(report.Covered["alpha"]) != 1 {
+		t.Errorf("alpha should have one witness, got %+v", report.Covered["alpha"])
+	}
+}
+
+// A claim naming a branch nobody registered guards nothing, and it is the
+// shape a rename leaves behind: the branch moves, the fixture keeps the old
+// slug, and coverage would otherwise report the new branch uncovered without
+// saying that a fixture for it is sitting right there under the old name.
+func TestCheckCoverageReportsUnknownClaims(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"suite/a.py": "# nox-cover: typo\n"})
+
+	report, err := CheckCoverage(root, []Branch{
+		{ID: "alpha", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+	})
+	if err != nil {
+		t.Fatalf("CheckCoverage: %v", err)
+	}
+	if len(report.Unknown) != 1 || report.Unknown[0].BranchID != "typo" {
+		t.Errorf("unknown = %+v, want the typo claim", report.Unknown)
+	}
+	if len(report.Uncovered) != 1 {
+		t.Errorf("alpha should still be uncovered; got %+v", report.Uncovered)
+	}
+}
+
+// A fixture filed under the wrong corpus is scored by the wrong guard: a case
+// that belongs in refutation-hard, dropped into refutation-suite, is scored
+// for precision, and a case that must produce no verdict becomes a false
+// positive nobody can explain.
+func TestCheckCoverageReportsMisfiledClaims(t *testing.T) {
+	root := writeCorpus(t, map[string]string{
+		"suite/a.py": "# nox-cover: alpha\n",
+		"hard/b.go":  "// nox-cover: alpha\n",
+	})
+
+	report, err := CheckCoverage(root, []Branch{
+		{ID: "alpha", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+		{ID: "beta", Corpus: "hard", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+	})
+	if err != nil {
+		t.Fatalf("CheckCoverage: %v", err)
+	}
+	if len(report.Misfiled) != 1 || report.Misfiled[0].Corpus != "hard" {
+		t.Errorf("misfiled = %+v, want the hard/ claim", report.Misfiled)
+	}
+}
+
+// An empty registry is the vacuous pass this whole mechanism exists to
+// prevent: coverage over no branches is complete by definition.
+func TestCheckCoverageRejectsAnEmptyRegistry(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"suite/a.py": "# nox-cover: alpha\n"})
+	if _, err := CheckCoverage(root, nil); err == nil {
+		t.Error("empty registry accepted; a coverage check over nothing passes vacuously")
+	}
+}
+
+func TestCheckCoverageRejectsDuplicateAndMalformedBranches(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"suite/a.py": "# nox-cover: alpha\n"})
+	dup := []Branch{
+		{ID: "alpha", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+		{ID: "alpha", Corpus: "suite", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+	}
+	if _, err := CheckCoverage(root, dup); err == nil {
+		t.Error("duplicate branch IDs accepted; the second entry would be invisible")
+	}
+	if _, err := CheckCoverage(root, []Branch{{ID: "alpha"}}); err == nil {
+		t.Error("branch with no corpus accepted; nothing would be read for it")
+	}
+}
+
+// A corpus a branch names but that does not exist must be an error. Returning
+// "no claims found" for a missing directory turns a moved corpus into a silent
+// coverage failure with a misleading cause.
+func TestCheckCoverageRejectsAMissingCorpus(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"suite/a.py": "# nox-cover: alpha\n"})
+	_, err := CheckCoverage(root, []Branch{
+		{ID: "alpha", Corpus: "not-there", Wrong: "w", Family: "F", Matcher: "m", Proposition: "p"},
+	})
+	if err == nil {
+		t.Error("missing corpus directory accepted")
+	}
+}

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -74,9 +74,15 @@ This is the half the roadmap adds, and the half nothing else watches.
 
 | Corpus | Cases | Result | Guard | Gate |
 |---|---:|---|---|---|
-| `refutation-suite` | 10 | 10 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` | A |
-| `refutation-hard` | 5 | not precision-scored by design | — | A |
+| `refutation-suite` | 27 | 27 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
+| `refutation-hard` | 5 | not precision-scored by design | `TestRefutationBranchCoverage` | A |
 | `reachability-suite` | 5 | 1 case may suppress, by name | `TestGateB` | B |
+
+**Branch coverage: 16 of 16 registered refutation branches witnessed**
+(`core/bench.RefutationBranches`). Milestone 0.3 added the registry, four
+rule-level fixtures, and a gate that fails when the last fixture for a branch
+is deleted — a deletion recall alone cannot see, because it removes the
+expectations along with the sample.
 
 `refutation-hard` and `reachability-suite` are deliberately **not** scored for
 fire-rate: a finding in `refutation-hard` is neither a true nor a false
@@ -121,7 +127,11 @@ as flow identity spreads beyond `core/attack`.
 Recorded explicitly, because a baseline whose gaps are unstated reads as
 completeness:
 
-1. **Rule-level narrowing has no refutation corpus.** Every case in
+1. ~~**Rule-level narrowing has no refutation corpus.**~~ **Closed by
+   Milestone 0.3** — `absence-subject-precondition`, `absence-resource-kind`,
+   `absence-kind-still-governed` and `sanitizer-pipeline-producer` are now
+   registered branches with fixtures. The original text follows, because it is
+   the argument that produced them. Every case in
    `refutation-suite` guards a *refiner* — lexical context, constant analysis,
    sanitizer recognition, flow identity, wrapper reachability, value semantics.
    None guards a *rule* being narrowed by its own applicability conditions, and

--- a/docs/benchmarks/2026-09/precision.json
+++ b/docs/benchmarks/2026-09/precision.json
@@ -176,20 +176,23 @@
     {
       "corpus": "refutation-suite",
       "scored": true,
-      "tp": 10,
+      "tp": 27,
       "fp": 0,
       "fn": 0,
       "precision": 1.0,
       "recall": 1.0,
-      "guard": "cli.TestRefutationSuiteRecall",
-      "gate": "A"
+      "guard": "cli.TestRefutationSuiteRecall + cli.TestRefutationBranchCoverage",
+      "gate": "A",
+      "branches": 11
     },
     {
       "corpus": "refutation-hard",
       "scored": false,
       "cases": 5,
       "why_unscored": "a finding here is neither a true nor a false positive; what is measured is that nox never states an unearned NEGATIVE",
-      "gate": "A"
+      "gate": "A",
+      "guard": "cli.TestRefutationBranchCoverage",
+      "branches": 5
     },
     {
       "corpus": "reachability-suite",
@@ -257,5 +260,14 @@
     "packages_ok": 76,
     "packages_failed": 0,
     "packages_without_tests": 3
-  }
+  },
+  "branch_coverage": {
+    "registry": "core/bench.RefutationBranches",
+    "branches": 16,
+    "covered": 16,
+    "uncovered": 0,
+    "gate": "cli.TestRefutationBranchCoverage",
+    "note": "removing the only fixture for a branch fails coverage while recall stays 1.000"
+  },
+  "revised_at": "2026-09-06 (Milestone 0.3)"
 }

--- a/docs/design/roadmap-refutation-safe.md
+++ b/docs/design/roadmap-refutation-safe.md
@@ -59,8 +59,8 @@ A second north-star question joins the first:
 | Milestone | Exit criterion | State on 2026-09-06 |
 |---|---|---|
 | **0.1** Current-state baseline | one authoritative baseline exists | **done** — `docs/benchmarks/2026-09` |
-| **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **partly done** — Gate A covers refiners, not rule narrowing |
-| **0.3** Semantic corpus coverage | removing the only fixture for a branch fails coverage | open |
+| **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **done** — 27 cases over 11 branches, refiners *and* rule narrowing |
+| **0.3** Semantic corpus coverage | removing the only fixture for a branch fails coverage | **done** — `bench.RefutationBranches`, 16 branches, `TestRefutationBranchCoverage` |
 | **0.4** Negative-delta accountability | unexplained narrowing is rejected or reviewed | open |
 | **0.5** Path-coherence validation | no rule loads with behaviourally inert mandatory fields | open |
 
@@ -81,18 +81,29 @@ that scored them are unchanged — the engine moved, not the ground truth.
 `testdata/refutation-hard` (5 cases that must never reach `PREVENTED`), and
 `testdata/reachability-suite` (Gate B, exactly one suppressible case).
 
-**The gap.** Every case guards a *refiner*. None guards a *rule* narrowed by
-its own applicability conditions, and there is no IaC case at all. Three rule
-narrowings merged in the week before the baseline; Gate A could not have caught
-any of them, and the rule-diff corpus could not witness two of them. Rule-level
-narrowing is where refutation actually ships today, and it is the branch with
-no instrumentation.
+**The gap, and its closure.** Every case used to guard a *refiner*. None
+guarded a *rule* narrowed by its own applicability conditions, and there was no
+IaC case at all — so #582, #583 and #585 each removed real findings with
+nothing able to catch an over-narrowing. Milestone 0.3 added four rule-level
+fixtures (`r8`–`r11`) covering the replica precondition, the workload-kind
+narrowing, the kinds that stay governed, and the pipeline quoting producer.
+The suite is 27 cases over 11 branches; `refutation-hard` contributes 5 more.
 
 ### 0.3 — Semantic corpus coverage
 
-Corpus metadata asserts what is exercised: resource kind, language, rule
-family, matcher path, proposition, refutation branch. Removing the only fixture
-for a branch makes coverage fail rather than pass silently.
+Corpus metadata asserts what is exercised: rule family, matcher path,
+proposition, refutation branch, and the wrong reasoning the fixture catches.
+
+The universe of branches lives in `core/bench.RefutationBranches` — in code,
+where deleting a testdata file cannot reach it — and each fixture claims one
+with a `nox-cover:` annotation. `TestRefutationBranchCoverage` fails when a
+registered branch has no witness, when a claim names an unregistered branch,
+and when a fixture sits in a corpus other than the one its branch declares. An
+empty registry is an error rather than a pass.
+
+**Falsified, not asserted:** deleting `r11_pipeline_unquoted.sh` leaves
+`TestRefutationSuiteRecall` passing at 1.000 and fails coverage naming
+`sanitizer-pipeline-producer`. That difference is the whole milestone.
 
 ### 0.4 — Negative-delta accountability
 

--- a/testdata/refutation-hard/README.md
+++ b/testdata/refutation-hard/README.md
@@ -29,3 +29,9 @@ enforces at construction.
 These are not scored for precision. A finding here is neither a true nor a false
 positive; what is being measured is whether nox ever states a NEGATIVE it has
 not earned.
+
+Each case carries a `nox-cover:` annotation naming the branch it witnesses, and
+`bench.RefutationBranches` registers all five. Deleting one of these files
+leaves its branch registered and unwitnessed, and
+`TestRefutationBranchCoverage` fails naming it — which matters more here than
+anywhere else, because this corpus has no recall number to drop.

--- a/testdata/refutation-hard/h1_reflection.go
+++ b/testdata/refutation-hard/h1_reflection.go
@@ -1,3 +1,4 @@
+// nox-cover: unmodelled-reflection
 // Reflection. The same source and sink as a case nox detects, with the call
 // made through reflect so nothing static resolves the callee.
 //

--- a/testdata/refutation-hard/h2_dynamic_dispatch.go
+++ b/testdata/refutation-hard/h2_dynamic_dispatch.go
@@ -1,3 +1,4 @@
+// nox-cover: unmodelled-dynamic-dispatch
 // Dynamic dispatch. One implementation sanitizes, one does not, and the choice
 // comes from data. Following only the statically-visible implementation sees a
 // clean path that is not necessarily the one that runs.

--- a/testdata/refutation-hard/h3_bounded_loop.go
+++ b/testdata/refutation-hard/h3_bounded_loop.go
@@ -1,3 +1,4 @@
+// nox-cover: unmodelled-bounded-loop
 // Bounded analysis. The tainted value only reaches the sink after the eighth
 // iteration, so an analysis that unrolls to a small bound sees a clean pass.
 package hard

--- a/testdata/refutation-hard/h4_indirection.go
+++ b/testdata/refutation-hard/h4_indirection.go
@@ -1,3 +1,4 @@
+// nox-cover: unmodelled-indirection
 // Unsupported semantics. The value passes through a map and a closure stored in
 // it, so the callee is a value rather than a name.
 package hard

--- a/testdata/refutation-hard/h5_dynamic_loading.go
+++ b/testdata/refutation-hard/h5_dynamic_loading.go
@@ -1,3 +1,4 @@
+// nox-cover: unmodelled-dynamic-loading
 // Dynamic loading. The callee does not exist at analysis time, so "no sink
 // found" is a statement about the code that was present.
 package hard

--- a/testdata/refutation-suite/README.md
+++ b/testdata/refutation-suite/README.md
@@ -28,11 +28,22 @@ is wrong.
 nox bench --precision testdata/refutation-suite
 ```
 
-Today: **10 TP, 0 FP, 0 FN — precision 1.000, recall 1.000.**
+Today: **27 TP, 0 FP, 0 FN — precision 1.000, recall 1.000.**
 
-The guard is `TestRefutationSuiteRecall` in `cli/bench_refutation_test.go`. It
-asserts recall is exactly 1.000, and its threshold is not negotiable. Nothing
-that changes scan output ships while it is failing.
+There are two guards, and they answer different questions.
+
+`TestRefutationSuiteRecall` (`cli/bench_refutation_test.go`) asserts recall is
+exactly 1.000. Its threshold is not negotiable, and nothing that changes scan
+output ships while it is failing.
+
+`TestRefutationBranchCoverage` (`cli/bench_coverage_test.go`) asserts that
+every refutation branch still has a fixture. Recall cannot answer this:
+deleting the last sample for a branch deletes its expectations too, so recall
+stays 1.000 over whatever remains and the branch quietly stops being guarded.
+The universe of branches therefore lives in `bench.RefutationBranches`, in
+code, where a testdata deletion cannot reach it; each sample claims one with a
+`nox-cover:` annotation. Remove `r11_pipeline_unquoted.sh` and the recall test
+still passes while coverage fails naming `sanitizer-pipeline-producer`.
 
 ## The cases
 
@@ -48,8 +59,44 @@ that would drop it. The header comment in each file carries the full argument.
 | `r5_two_distinct.py` | Flow identity, dedup (F) | One tainted value reaching two sinks on consecutive lines shares a source, a variable and a line neighbourhood — every cheap merge signal — but is two vulnerabilities with two fixes |
 | `r6_wrapper_reach.py` | Reachability (G) | An intraprocedural check finds no source-to-sink flow in *either* function and concludes the code is safe. The sink sits behind a one-line private wrapper |
 | `r7_placeholder_named_secret.py` | Value semantics (E3) | Two live-format credentials bound to identifiers that say `EXAMPLE` and `SAMPLE`. The value is the evidence; the name is not. `clean_placeholders.py` pins the other half of this rule |
+| `r8_replicated_no_pdb.yaml` | Absence subject preconditions (#582) | A precondition that correctly exempts a single-replica workload keeps widening until it exempts the replicated ones the rule was written for |
+| `r9_longrunning_no_probes.yaml` | Absence resource kinds (#583) | Probe rules narrowed off batch workloads generalize from the workload KIND to the container's command line, which is a guess |
+| `r10_batch_still_governed.yaml` | Absence resource kinds (#583) | "Some rules do not apply to CronJobs" becomes "CronJobs are exempt", removing limits, requests and security context from every scheduled job |
+| `r11_pipeline_unquoted.sh` | Pipeline sanitizer producers (#585) | `jq \| @sh` quoting is generalized from the exact call that quotes to any call named `jq` — the direction that turns false positives into false negatives |
+
+The last four are the rule-level half of the corpus and they were added because
+Gate A could not see it. Every case above them guards a *refiner*. Nothing
+guarded a *rule narrowed by its own applicability conditions* — so #582, #583
+and #585 each removed real findings with no fixture anywhere able to catch an
+over-narrowing, and two of the three were invisible to the rule-diff corpus as
+well at the moment they merged.
 
 The credentials in `r7` are synthetic and match no issued credential.
+
+## What the rule-level cases found on their first run
+
+Writing `r8` surfaced two defects that no existing guard could see. Both are
+filed; neither is fixed here, because the instrument has to exist before the
+narrowing that answers it.
+
+**IAC-183 re-reports what IAC-132 refutes.** The two rules carry a
+byte-identical absence configuration — same anchor, same property,
+`absence_span: file`. #582 gave IAC-132 a subject precondition and the
+structural path; IAC-183 kept neither and describes itself as a Helm rule while
+matching every `*.yaml`. On a single-replica Deployment with no budget,
+IAC-132 is correctly silent and IAC-183 fires. So #582's 65 removed findings
+were removed under one ID and are still reported under another, and the
+rule-diff report showed `IAC-132: 29 -> 16` against an IAC-183 that never
+moved. It is annotated in `r8` deliberately: the corpus records what nox does
+today so that removing it can be measured rather than asserted.
+
+**IaC rules match inside YAML comments.** A file containing only
+`# ... PodDisruptionBudget ...` in a comment reports IAC-395. `core/lexctx`
+classifies YAML comment regions and `core/rules/matcher.go` consults it, but
+the IaC path does not reach that refinement — which is the same class `r1`
+guards for Python, one file format over. `r8`'s header is worded around the
+trigger rather than annotating it, because annotating it would make this corpus
+assert that the behaviour is correct.
 
 ## Rules for changing this corpus
 
@@ -62,6 +109,13 @@ The credentials in `r7` are synthetic and match no issued credential.
 3. **Add a case before you build a refiner.** Milestones E1, E2, E3, F and G
    each remove findings. Each should arrive with the case that proves it
    removes only what it should.
+4. **Add the branch before the case.** Register it in
+   `bench.RefutationBranches` first and let `TestRefutationBranchCoverage`
+   fail: the failing test names the proposition and the wrong reasoning, which
+   is the specification for the sample that has to be written.
+5. **Never delete a branch to make coverage pass.** Removing an entry from the
+   registry is a claim that nox no longer refutes that way. Say so in the
+   commit.
 
 ## Known gap
 

--- a/testdata/refutation-suite/r10_batch_still_governed.yaml
+++ b/testdata/refutation-suite/r10_batch_still_governed.yaml
@@ -1,0 +1,32 @@
+# Guards: absence-kind-still-governed (IAC-137, IAC-138, IAC-145; PR #583).
+# nox-cover: absence-kind-still-governed
+#
+# The companion to r9. #583 narrowed IAC-139 and IAC-140 off batch workloads,
+# and deliberately left IAC-137, IAC-138 and IAC-145 applying to them: resource
+# limits, resource requests and a security context are as necessary on a
+# CronJob as on a Deployment. A job that runs unbounded can exhaust a node, and
+# one that runs as root has root for as long as it runs.
+#
+# The wrong reasoning it catches is the step from "some rules do not apply to
+# this kind" to "this kind is exempt". That step is cheap to take — the
+# resource-type list is one shared field, and dropping a kind from it once
+# looks like a tidy-up — and it silently removes every hardening check from
+# every scheduled job in a cluster.
+#
+# This CronJob declares no limits, no requests and no security context. It also
+# declares no timeZone, which IAC-379 reports separately and correctly.
+apiVersion: batch/v1
+kind: CronJob  # nox-expect: IAC-137, IAC-138, IAC-145
+metadata:
+  name: ledger-reconcile
+  namespace: prod
+spec:
+  schedule: "*/15 * * * *"  # nox-expect: IAC-379
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: reconcile
+              image: registry.internal/ledger-reconcile@sha256:2222222222222222222222222222222222222222222222222222222222222222

--- a/testdata/refutation-suite/r11_pipeline_unquoted.sh
+++ b/testdata/refutation-suite/r11_pipeline_unquoted.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Guards: sanitizer-pipeline-producer (TAINT-005; PR #585).
+# nox-cover: sanitizer-pipeline-producer
+#
+# #585 taught the shell extractor that `jq`'s @sh filter shell-quotes what it
+# emits, so a value read from such a pipeline is data by the time an `eval`
+# re-parses it. That refutation is correct and it is class-precise: @sh clears
+# the shell-parsing classes and leaves SSRF and path traversal alone.
+#
+# The bar is `jq` AND `@sh`, never the callee alone. This pipeline runs jq
+# WITHOUT the filter, so every name arrives raw and the eval below is real code
+# injection: a service named `; rm -rf /; echo ` runs.
+#
+# The wrong reasoning it catches is the generalization from the exact call that
+# quotes to any call by the same name — the same step that would make `printf`
+# a sanitizer because `printf %q` is one. That direction converts an entry that
+# costs false positives into one that costs false NEGATIVES, which is the
+# direction that hides real injections.
+set -euo pipefail
+
+kubectl get svc -o json | jq -r '.items[].metadata.name' | while read -r row; do
+  eval "set -- $row"  # nox-expect: TAINT-005
+done

--- a/testdata/refutation-suite/r1_comment_adjacent.py
+++ b/testdata/refutation-suite/r1_comment_adjacent.py
@@ -1,4 +1,5 @@
 # Guards: lexical-context refinement (Track E1).
+# nox-cover: lexical-context
 #
 # nox already drops rule matches that land inside comments — core/lexctx
 # classifies comment and string regions, and secrets/srccontext.go uses it to

--- a/testdata/refutation-suite/r2_generated_banner.go
+++ b/testdata/refutation-suite/r2_generated_banner.go
@@ -1,4 +1,5 @@
 // Guards: generated-code suppression (Track E1).
+// nox-cover: generated-code
 //
 // nox skips machine-generated files — clean_generated.go in the precision
 // suite pins that behaviour, and it is worth keeping: generated code is not

--- a/testdata/refutation-suite/r3_constant_looking.py
+++ b/testdata/refutation-suite/r3_constant_looking.py
@@ -1,4 +1,5 @@
 # Guards: constant-argument refutation (Track E2).
+# nox-cover: constant-evaluation
 #
 # Milestone E2 re-expresses the AI-006 fix as evidence: a regex match is
 # refuted when every argument to the matched call is deterministically

--- a/testdata/refutation-suite/r4_sanitizer_other_var.go
+++ b/testdata/refutation-suite/r4_sanitizer_other_var.go
@@ -1,4 +1,5 @@
 // Guards: same-line and nearby sanitizer recognition (Track E / taint).
+// nox-cover: sanitizer-recognition
 //
 // Recognising a sanitizer is how a taint engine avoids reporting code that is
 // already safe, and the triage-agent history shows why it is tempting to do it

--- a/testdata/refutation-suite/r5_two_distinct.py
+++ b/testdata/refutation-suite/r5_two_distinct.py
@@ -1,4 +1,5 @@
 # Guards: flow identity and structural deduplication (Track F).
+# nox-cover: flow-identity
 #
 # Track F merges observations that describe one underlying condition: a source,
 # its propagation and its sink are one security hypothesis, not three

--- a/testdata/refutation-suite/r6_wrapper_reach.py
+++ b/testdata/refutation-suite/r6_wrapper_reach.py
@@ -1,4 +1,5 @@
 # Guards: reachability (Track G).
+# nox-cover: interprocedural-scope
 #
 # Gate B is the rule that deterministic unreachability may suppress a finding
 # and unknown reachability may not. This sample is the shape that makes a naive

--- a/testdata/refutation-suite/r7_placeholder_named_secret.py
+++ b/testdata/refutation-suite/r7_placeholder_named_secret.py
@@ -1,4 +1,5 @@
 # Guards: value-semantics refutation (Track E3).
+# nox-cover: value-semantics
 #
 # ENRICH-004 matched the NAME of an assignment (`api_key = "`) and never looked
 # at the value, so every documentation placeholder scored as a hardcoded

--- a/testdata/refutation-suite/r8_replicated_no_pdb.yaml
+++ b/testdata/refutation-suite/r8_replicated_no_pdb.yaml
@@ -1,0 +1,61 @@
+# Guards: absence-subject-precondition (IAC-132, IAC-142; PR #582).
+# nox-cover: absence-subject-precondition
+#
+# #582 gave IAC-132 and IAC-142 a subject precondition: a disruption budget and
+# pod anti-affinity are meaningless on a workload that runs one replica,
+# because a single-replica Deployment has no availability to preserve. That
+# narrowing was correct and removed 65 findings.
+#
+# This is the other side of it. THREE replicas is exactly the shape the rules
+# were written for: a node drain can take every pod at once, and this workload
+# declares neither a budget nor anti-affinity.
+#
+# The wrong reasoning it catches is a precondition that keeps widening. Read
+# spec.replicas from the wrong nesting level, raise the floor from 2 to some
+# larger number, or answer "unreadable" as "exempt" rather than "report", and a
+# genuinely replicated production workload silently stops being checked — while
+# the rule-diff report shows a pleasing drop and the precision suite improves.
+#
+# The remaining annotated rules are advisories that fire on any workload of
+# this shape and are unrelated to the precondition; they are listed so the file
+# scores zero false positives. IAC-183 is NOT a second condition: it is a
+# duplicate of IAC-132 that never received the precondition, and it is pinned
+# here deliberately so that removing it can be measured rather than asserted.
+# See the suite README.
+#
+# This header says "budget" rather than spelling the resource kind, because an
+# IaC rule currently matches its keyword inside a YAML comment. That is a real
+# gap in lexical refinement on the IaC path and it is filed; it is not what
+# this fixture is for, and encoding it here would make the corpus assert it.
+apiVersion: apps/v1
+kind: Deployment  # nox-expect: IAC-132, IAC-142, IAC-131, IAC-183, IAC-286
+metadata:
+  name: payments-api
+  namespace: prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+    spec:
+      containers:
+        - name: api
+          image: registry.internal/payments-api@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          resources:
+            limits: { cpu: "1", memory: 512Mi }
+            requests: { cpu: 100m, memory: 128Mi }
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]

--- a/testdata/refutation-suite/r9_longrunning_no_probes.yaml
+++ b/testdata/refutation-suite/r9_longrunning_no_probes.yaml
@@ -1,0 +1,48 @@
+# Guards: absence-resource-kind (IAC-139, IAC-140; PR #583).
+# nox-cover: absence-resource-kind
+#
+# #583 took the liveness and readiness probe rules off batch workloads. A Job
+# or CronJob container is meant to run to completion and exit; a liveness probe
+# on one restarts work that finished correctly, and a readiness probe gates
+# traffic that never arrives. Narrowing those two rules to long-running kinds
+# was right.
+#
+# A Deployment is a long-running kind. This one declares no probes at all,
+# which is the condition IAC-139 and IAC-140 exist to report: the kubelet has
+# no way to tell a wedged process from a healthy one, and the service will keep
+# routing to a container that stopped serving.
+#
+# The wrong reasoning it catches is the narrowing generalizing from the kind to
+# the shape. The container below runs a command that LOOKS one-shot — a
+# `--once` flag, no server subcommand — and a refiner reading intent out of the
+# command line rather than the workload kind would exempt it. The workload kind
+# is the fact; the command line is a guess.
+apiVersion: apps/v1
+kind: Deployment  # nox-expect: IAC-139, IAC-140, IAC-131, IAC-183, IAC-286, IAC-132, IAC-142
+metadata:
+  name: session-gateway
+  namespace: prod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: session-gateway
+  template:
+    metadata:
+      labels:
+        app: session-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: registry.internal/session-gateway@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          command: ["/bin/gateway", "--once"]
+          resources:
+            limits: { cpu: "1", memory: 512Mi }
+            requests: { cpu: 100m, memory: 128Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]


### PR DESCRIPTION
Milestone 0.3 of the refutation-safe roadmap.

## The gap

`TestRefutationSuiteRecall` answers *"does every fixture still fire?"*. It
cannot answer *"is there still a fixture?"* — deleting the last sample for a
refutation branch deletes its expectations too, so recall stays 1.000 over
whatever remains and the branch quietly stops being guarded.

That is the empty-set success this programme exists to remove: a check over
nothing passes, and passes identically to a check that found nothing wrong.

## The fix

The universe of branches now lives in `core/bench.RefutationBranches` — in
code, where a testdata deletion cannot reach it. Sixteen branches, each naming
its rule family, evaluation path, the proposition its refutation establishes,
and the tempting-but-wrong reasoning its fixture catches. Every sample claims
one with a `nox-cover:` annotation.

`TestRefutationBranchCoverage` fails when a registered branch has no witness,
when a claim names an unregistered branch, and when a fixture sits in a corpus
other than the one its branch declares. An empty registry is an error, not a
pass.

**Falsified, not asserted:**

```
$ mv testdata/refutation-suite/r11_pipeline_unquoted.sh /tmp/
$ go test ./cli/ -run "TestRefutationBranchCoverage|TestRefutationSuiteRecall"
--- FAIL: TestRefutationBranchCoverage
    GATE A COVERAGE: refutation branch "sanitizer-pipeline-producer"
    has no fixture in testdata/refutation-suite.
```

`TestRefutationSuiteRecall` passed. That difference is the whole milestone.

## Gate A guarded refiners, not rules

Every existing case protected lexical context, constants, sanitizer
recognition, flow identity, wrapper reachability or value semantics. None
protected a rule narrowed by its own applicability conditions, and there was no
IaC case at all — so #582, #583 and #585 each removed real findings with
nothing anywhere able to catch an over-narrowing.

| | |
|---|---|
| `r8_replicated_no_pdb.yaml` | three replicas, no budget, no anti-affinity — #582's precondition |
| `r9_longrunning_no_probes.yaml` | a long-running Deployment with no probes — #583's workload kinds |
| `r10_batch_still_governed.yaml` | a CronJob with no limits/requests/context — the kinds that stay governed |
| `r11_pipeline_unquoted.sh` | `jq` **without** `@sh` piped into `eval` — #585's quoting producer |

`r9` in particular gives the container a `--once` flag and no server
subcommand: a refiner reading intent from the command line rather than the
workload kind would exempt it. The kind is the fact; the command line is a
guess.

## Measurements

| | before | after |
|---|---:|---:|
| Refutation suite | 10 TP / 0 FP / 0 FN | **27 TP / 0 FP / 0 FN** |
| Detection (20 corpora) | 230 / 0 / 0 | **230 / 0 / 0** — unchanged |
| Branches covered | — | **16 of 16** |
| `go test ./...` | 76 ok | 76 ok |

## Two defects found writing the first fixture

Both filed, **neither fixed here** — the instrument has to exist before the
narrowing that answers it.

**#587 — IAC-183 re-reports what IAC-132 refutes.** Byte-identical absence
configuration: same anchor, same property, `absence_span: file`. #582 gave
IAC-132 a subject precondition and the structural path; IAC-183 kept neither
and calls itself a Helm rule while matching every `*.yaml`. On a single-replica
Deployment with no budget, IAC-132 is correctly silent and IAC-183 fires. So
#582's 65 removed findings were removed under one ID and are still reported
under another — and rule-diff showed `IAC-132: 29 -> 16` against an IAC-183
that never moved.

**#588 — IaC rules match inside YAML comments.** A file whose only content is a
comment mentioning the keyword reports IAC-395. `core/lexctx` classifies YAML
comment regions and `core/rules/matcher.go` consults it; the IaC path does not
reach that refinement. Same class `r1` guards for Python, one file format over.

`r8`'s header is worded *around* the second one rather than annotating it —
annotating it would make the corpus assert the behaviour is correct. IAC-183
**is** annotated, deliberately, so that removing it flips a corpus expectation
rather than passing silently.

## Files

- `core/bench/coverage.go` + tests — registry, `nox-cover` parser, checker
- `cli/bench_coverage_test.go` — the gate, plus its own falsification
- four new fixtures; `nox-cover` annotations on the twelve existing ones
- corpus READMEs, `docs/benchmarks/2026-09`, roadmap Phase 0 table

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT