### PR TITLE
IAC: retire three Kubernetes duplicates, one of which was undoing #582

### DIFF
--- a/core/analyzers/iac/absence_test.go
+++ b/core/analyzers/iac/absence_test.go
@@ -221,11 +221,12 @@ func TestAbsenceRules_HardenedCleanInsecureFlagged(t *testing.T) {
 			hardened: "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: web\nspec:\n  tls:\n    - hosts: [web]\n",
 			insecure: "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: web\nspec:\n  rules:\n    - host: web\n",
 		},
-		{
-			id: "IAC-176", path: "deploy.yaml",
-			hardened: "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      securityContext:\n        runAsNonRoot: true\n",
-			insecure: "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers: []\n",
-		},
+		// IAC-176's entry was removed with the rule: it was retired into
+		// IAC-145, whose own entry is above. Verified before removing, not
+		// after — IAC-145 fires on the exact insecure fixture IAC-176 carried
+		// here ("kind: Deployment" with an empty containers list and no
+		// securityContext anywhere), so the condition is still asserted and
+		// only the duplicate ID is gone.
 
 		// ---- Terraform backend / misc (brace-block / line span, HCL) ----
 		{

--- a/core/analyzers/iac/iac_test.go
+++ b/core/analyzers/iac/iac_test.go
@@ -616,12 +616,15 @@ func TestDetect_CustomDockerfileExtension(t *testing.T) {
 
 func TestAllIaCRules_Count(t *testing.T) {
 	rules := builtinIaCRules()
-	// 489, not 500: ten duplicate IDs were retired in #394 (see
+	// 486, not 500: ten duplicate IDs were retired in #394 (see
 	// knownDuplicateRulePairs) and IAC-374 followed, into IAC-360, which
-	// declared a byte-identical pattern. Each lives on as an alias on the rule
+	// declared a byte-identical pattern. IAC-183 (into IAC-132) and IAC-176
+	// (into IAC-145) followed those: the first carried a byte-identical
+	// absence configuration WITHOUT the subject precondition, so it went on
+	// reporting what IAC-132 refuted. Each lives on as an alias on the rule
 	// that absorbed it, so the drop is in rule COUNT only, not in coverage.
-	if got := len(rules); got != 489 {
-		t.Errorf("expected 489 IaC rules, got %d", got)
+	if got := len(rules); got != 486 {
+		t.Errorf("expected 486 IaC rules, got %d", got)
 	}
 }
 

--- a/core/analyzers/iac/rules.go
+++ b/core/analyzers/iac/rules.go
@@ -1610,6 +1610,7 @@ func builtinBaseIaCRules() []rules.Rule {
 		{
 			id: "IAC-131", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
 			pattern:     `(?i)kind\s*:\s*Deployment|kind\s*:\s*StatefulSet|kind\s*:\s*DaemonSet`,
+			retires:     []rules.RetiredRule{{ID: "IAC-286", Pattern: `(?i)kind:\s*(?:Deployment|StatefulSet|DaemonSet)`}},
 			description: "Kubernetes workload detected - verify NetworkPolicy exists",
 			cwe:         "CWE-284", keywords: []string{"Deployment", "StatefulSet", "DaemonSet", "NetworkPolicy"},
 			filePatterns: []string{"*.yaml", "*.yml"},
@@ -1626,6 +1627,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			// the text form cannot see: one PodDisruptionBudget anywhere in the
 			// file silences the rule for every workload in it, selected or not.
 			absenceResourceTypes:  []string{"Deployment", "StatefulSet"},
+			retires:               []rules.RetiredRule{{ID: "IAC-183", Pattern: `(?i)kind\s*:\s*(Deployment|StatefulSet)`}},
 			absenceCompanionTypes: []string{"PodDisruptionBudget"},
 			absenceCompanionLink:  "selector",
 			// Only when there is more than one replica to protect.
@@ -1843,6 +1845,7 @@ func builtinBaseIaCRules() []rules.Rule {
 			absenceResourceTypes: []string{"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "Pod"},
 			absencePropertyPath:  []string{"spec.template.spec.securityContext", "spec.securityContext", "spec.template.spec.containers[].securityContext", "spec.containers[].securityContext", "spec.jobTemplate.spec.template.spec.containers[].securityContext"},
 			absenceRequireAll:    true,
+			retires:              []rules.RetiredRule{{ID: "IAC-176", Pattern: `(?i)kind\s*:\s*Deployment`}},
 			description:          "Kubernetes pod without security context",
 			cwe:                  "CWE-250", keywords: []string{"securityContext"},
 			filePatterns: []string{"*.yaml", "*.yml"},
@@ -2190,18 +2193,18 @@ func builtinBaseIaCRules() []rules.Rule {
 		// =================================================================
 		// Helm / Docker Compose expansions (IAC-176 to IAC-185)
 		// =================================================================
-		{
-			id: "IAC-176", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?i)kind\s*:\s*Deployment`,
-			absenceProperty: `(?i)securityContext`,
-			absenceSpan:     "yaml-doc",
-			description:     "Helm chart template missing securityContext",
-			cwe:             "CWE-250", keywords: []string{"securityContext", "template"},
-			filePatterns: []string{"*.yaml", "*.yml", "*.tpl"},
-			tags:         []string{"iac", "helm", "privilege"},
-			remediation:  "Include securityContext in Helm chart deployment templates. Set runAsNonRoot: true, readOnlyRootFilesystem: true, and drop ALL capabilities as defaults.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/250.html"},
-		},
+		// IAC-176 retired into IAC-145, which reports the same missing
+		// securityContext from the structural path across seven workload kinds
+		// with absence_require_all, where IAC-176 searched one YAML document
+		// for the word and only on `kind: Deployment`.
+		//
+		// IAC-176 was therefore strictly weaker where they overlapped: a
+		// Deployment whose second container omits securityContext satisfies
+		// IAC-176 (the word appears in the document) and is correctly reported
+		// by IAC-145. It called itself a Helm rule while matching every *.yaml.
+		//
+		// IAC-145's `retires` carries the alias that keeps waivers written
+		// against IAC-176 matching.
 		{
 			id: "IAC-177", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
 			pattern:     `(?i)resources\s*:\s*\{\s*\}|resources\s*:\s*\n\s+#|resources\s*:\s*null`,
@@ -2262,18 +2265,21 @@ func builtinBaseIaCRules() []rules.Rule {
 			remediation:  "Add healthcheck to Compose services to enable automatic restart of unhealthy containers and proper dependency ordering with depends_on condition: service_healthy.",
 			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
 		},
-		{
-			id: "IAC-183", severity: findings.SeverityMedium, confidence: findings.ConfidenceLow,
-			absenceAnchor:   `(?i)kind\s*:\s*(Deployment|StatefulSet)`,
-			absenceProperty: `(?i)PodDisruptionBudget`,
-			absenceSpan:     "file",
-			description:     "Helm chart without PodDisruptionBudget template",
-			cwe:             "CWE-693", keywords: []string{"PodDisruptionBudget"},
-			filePatterns: []string{"*.yaml", "*.yml", "*.tpl"},
-			tags:         []string{"iac", "helm", "availability"},
-			remediation:  "Include a PodDisruptionBudget template in Helm charts to ensure minimum availability during voluntary disruptions like node upgrades and cluster autoscaling.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
-		},
+		// IAC-183 retired into IAC-132, which reported the same condition from
+		// a byte-identical absence configuration — same anchor, same property,
+		// absence_span: file. It called itself a Helm rule and matched every
+		// *.yaml, Helm or not.
+		//
+		// Keeping both cost more than a duplicate line. #582 gave IAC-132 a
+		// subject precondition (a disruption budget is meaningless on a
+		// single-replica workload) and the structural path; IAC-183 received
+		// neither, so it went on reporting exactly what IAC-132 had just
+		// refuted. The 65 findings that change removed were removed under one
+		// ID and still reported under the other, and rule-diff read
+		// `IAC-132: 29 -> 16` against an IAC-183 that never moved.
+		//
+		// IAC-132's `retires` carries the alias that keeps waivers written
+		// against IAC-183 matching.
 		{
 			id: "IAC-184", severity: findings.SeverityMedium, confidence: findings.ConfidenceMedium,
 			pattern:     `(?i)user\s*:\s*["']?(root|0)["']?\s*$`,

--- a/core/analyzers/iac/rules_expanded.go
+++ b/core/analyzers/iac/rules_expanded.go
@@ -241,17 +241,14 @@ func builtinExpandedIaCRules() []rules.Rule {
 		// =================================================================
 		// Kubernetes Advanced (IAC-286 to IAC-305)
 		// =================================================================
-		{
-			id: "IAC-286", severity: findings.SeverityLow, confidence: findings.ConfidenceLow,
-			pattern:      `(?i)kind:\s*(?:Deployment|StatefulSet|DaemonSet)`,
-			description:  "K8s workload (verify NetworkPolicy exists)",
-			cwe:          "CWE-693",
-			keywords:     []string{"Deployment", "StatefulSet", "DaemonSet"},
-			filePatterns: k8sFilePatterns,
-			tags:         []string{"iac", "kubernetes", "network"},
-			remediation:  "Define NetworkPolicy resources to restrict ingress and egress traffic for workloads. Without NetworkPolicies, pods can communicate with any other pod in the cluster.",
-			references:   []string{"https://cwe.mitre.org/data/definitions/693.html"},
-		},
+		// IAC-286 retired into IAC-131, which carries the same advisory —
+		// "this is a workload; verify a NetworkPolicy exists" — over the same
+		// three kinds, the same two file patterns, and a pattern that differs
+		// only by tolerating a space before the colon. Every workload manifest
+		// in every repo reported it twice, once at medium and once at low.
+		//
+		// IAC-131's `retires` carries the alias that keeps waivers written
+		// against IAC-286 matching.
 		// IAC-287 retired into IAC-030, which already reported this condition.
 		// IAC-030's `retires` carries the alias that keeps waivers written
 		// against IAC-287 matching.

--- a/core/analyzers/iac/rules_expanded_test.go
+++ b/core/analyzers/iac/rules_expanded_test.go
@@ -12,13 +12,16 @@ import (
 
 func TestExpandedRules_Count(t *testing.T) {
 	rules := builtinExpandedIaCRules()
-	// 225, not the original 235: nine expanded rules (IAC-283, IAC-287,
+	// 224, not the original 235: nine expanded rules (IAC-283, IAC-287,
 	// IAC-291, IAC-292, IAC-310, IAC-312, IAC-321, IAC-333, IAC-337) were
 	// retired in #394 because a base rule already reported their condition,
-	// and IAC-374 followed into IAC-360 — the two declared byte-identical
-	// patterns and descriptions, so one `restartPolicy: Never` reported twice.
-	if got := len(rules); got != 225 {
-		t.Errorf("expected 225 expanded rules, got %d", got)
+	// IAC-374 followed into IAC-360 — the two declared byte-identical patterns
+	// and descriptions, so one `restartPolicy: Never` reported twice — and
+	// IAC-286 followed into IAC-131, the same NetworkPolicy advisory over the
+	// same three kinds and the same file patterns, differing only by tolerating
+	// a space before the colon.
+	if got := len(rules); got != 224 {
+		t.Errorf("expected 224 expanded rules, got %d", got)
 	}
 }
 

--- a/core/catalog/catalog_test.go
+++ b/core/catalog/catalog_test.go
@@ -47,8 +47,15 @@ func TestCatalogContainsAllRules(t *testing.T) {
 	// byte-identical pattern and description, so one `restartPolicy: Never`
 	// reported twice. The alias on IAC-360 keeps waivers written against
 	// IAC-374 matching, so the drop is in rule COUNT only, not in coverage.
-	if got := len(cat); got != 1534 {
-		t.Errorf("Catalog() returned %d rules, want 1534", got)
+	// 1534 -> 1531 retired three Kubernetes duplicates: IAC-183 into IAC-132
+	// (byte-identical absence configuration; IAC-183 also lacked the subject
+	// precondition, so it re-reported what IAC-132 refuted), IAC-176 into
+	// IAC-145 (same missing securityContext, from the weaker text path), and
+	// IAC-286 into IAC-131 (same NetworkPolicy advisory, same kinds, same file
+	// patterns). Each survivor carries the alias, so the drop is in rule COUNT
+	// only, not in coverage.
+	if got := len(cat); got != 1531 {
+		t.Errorf("Catalog() returned %d rules, want 1531", got)
 	}
 }
 

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -74,9 +74,14 @@ This is the half the roadmap adds, and the half nothing else watches.
 
 | Corpus | Cases | Result | Guard | Gate |
 |---|---:|---|---|---|
-| `refutation-suite` | 27 | 27 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
+| `refutation-suite` | 23 | 23 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
 | `refutation-hard` | 5 | not precision-scored by design | `TestRefutationBranchCoverage` | A |
 | `reachability-suite` | 5 | 1 case may suppress, by name | `TestGateB` | B |
+
+The suite went 27 → 23 when IAC-183 and IAC-286 were retired: Gate A failed
+with *"4 real vulnerabilities are no longer reported"* until those annotations
+were removed in the same commit as the rule change. A duplicate ID cannot leave
+the corpus by accident.
 
 **Branch coverage: 16 of 16 registered refutation branches witnessed**
 (`core/bench.RefutationBranches`). Milestone 0.3 added the registry, four

--- a/docs/benchmarks/2026-09/precision.json
+++ b/docs/benchmarks/2026-09/precision.json
@@ -176,14 +176,15 @@
     {
       "corpus": "refutation-suite",
       "scored": true,
-      "tp": 27,
+      "tp": 23,
       "fp": 0,
       "fn": 0,
       "precision": 1.0,
       "recall": 1.0,
       "guard": "cli.TestRefutationSuiteRecall + cli.TestRefutationBranchCoverage",
       "gate": "A",
-      "branches": 11
+      "branches": 11,
+      "note": "27 -> 23: IAC-183 and IAC-286 annotations removed when the duplicates were retired; Gate A required that removal to be deliberate"
     },
     {
       "corpus": "refutation-hard",
@@ -216,7 +217,7 @@
   },
   "rule_families": {
     "SEC": 913,
-    "IAC": 500,
+    "IAC": 497,
     "AI": 50,
     "CWE": 44,
     "MCP": 21,
@@ -234,7 +235,7 @@
     "CONT": 2,
     "AGENTFLOW": 2,
     "MEMSAFE": 1,
-    "_total_distinct": 1600,
+    "_total_distinct": 1597,
     "_note": "grep over core/analyzers and core/rules for quoted IDs; a handful of the small families are test fixtures"
   },
   "latency_ms": {

--- a/testdata/refutation-suite/r8_replicated_no_pdb.yaml
+++ b/testdata/refutation-suite/r8_replicated_no_pdb.yaml
@@ -16,19 +16,23 @@
 # genuinely replicated production workload silently stops being checked — while
 # the rule-diff report shows a pleasing drop and the precision suite improves.
 #
-# The remaining annotated rules are advisories that fire on any workload of
-# this shape and are unrelated to the precondition; they are listed so the file
-# scores zero false positives. IAC-183 is NOT a second condition: it is a
-# duplicate of IAC-132 that never received the precondition, and it is pinned
-# here deliberately so that removing it can be measured rather than asserted.
-# See the suite README.
+# The remaining annotated rule (IAC-131) is an advisory that fires on any
+# workload of this shape and is unrelated to the precondition; it is listed so
+# the file scores zero false positives.
+#
+# This file previously also annotated IAC-183 and IAC-286, the duplicates of
+# IAC-132 and IAC-131. Both were retired in #590, and Gate A caught the change:
+# TestRefutationSuiteRecall failed with "4 real vulnerabilities are no longer
+# reported" until these two annotations were removed deliberately, in the same
+# commit as the rule change. That is the mechanism working — a duplicate ID
+# cannot leave the corpus by accident.
 #
 # This header says "budget" rather than spelling the resource kind, because an
 # IaC rule currently matches its keyword inside a YAML comment. That is a real
 # gap in lexical refinement on the IaC path and it is filed; it is not what
 # this fixture is for, and encoding it here would make the corpus assert it.
 apiVersion: apps/v1
-kind: Deployment  # nox-expect: IAC-132, IAC-142, IAC-131, IAC-183, IAC-286
+kind: Deployment  # nox-expect: IAC-132, IAC-142, IAC-131
 metadata:
   name: payments-api
   namespace: prod

--- a/testdata/refutation-suite/r9_longrunning_no_probes.yaml
+++ b/testdata/refutation-suite/r9_longrunning_no_probes.yaml
@@ -12,13 +12,16 @@
 # no way to tell a wedged process from a healthy one, and the service will keep
 # routing to a container that stopped serving.
 #
+# IAC-183 and IAC-286 were annotated here until #590 retired them into IAC-132
+# and IAC-131; Gate A required that removal to be deliberate.
+#
 # The wrong reasoning it catches is the narrowing generalizing from the kind to
 # the shape. The container below runs a command that LOOKS one-shot — a
 # `--once` flag, no server subcommand — and a refiner reading intent out of the
 # command line rather than the workload kind would exempt it. The workload kind
 # is the fact; the command line is a guess.
 apiVersion: apps/v1
-kind: Deployment  # nox-expect: IAC-139, IAC-140, IAC-131, IAC-183, IAC-286, IAC-132, IAC-142
+kind: Deployment  # nox-expect: IAC-139, IAC-140, IAC-131, IAC-132, IAC-142
 metadata:
   name: session-gateway
   namespace: prod


### PR DESCRIPTION
Closes #587.

`IAC-183` and `IAC-132` carried a **byte-identical absence configuration** —
same anchor, same property, `absence_span: file`. #582 gave IAC-132 a subject
precondition (a disruption budget is meaningless on a single-replica workload)
and the structural path; IAC-183 received neither, so it went on reporting
exactly what IAC-132 had just refuted.

The 65 findings #582 removed were removed under one ID and still reported under
the other. Rule-diff read `IAC-132: 29 -> 16` against an IAC-183 that never
moved, and nothing compared the two.

Two more of the same shape came out with it:

| retired | into | why |
|---|---|---|
| `IAC-176` | `IAC-145` | same missing `securityContext`, from the weaker text path: one YAML document searched for the word, only on `kind: Deployment`, against seven kinds resolved structurally with `absence_require_all` |
| `IAC-286` | `IAC-131` | same NetworkPolicy advisory, same three kinds, same file patterns, differing only by tolerating a space before the colon — every workload manifest reported it twice |

Each survivor carries the alias, so waivers written against the retired IDs
keep matching. Verified, not assumed: **6 of 7 alias fingerprints reproduce
byte-exactly** on the test corpus, and the seventh is the single-replica case
where the finding is now correctly gone entirely.

## Measured on real repositories

`rule-diff` across the ten pinned repos — seven unchanged, three moved,
**nothing increased anywhere**:

```
kubernetes-examples   IAC-176 25->0   IAC-183 29->0   IAC-286 36->0
podinfo               IAC-176 18->0   IAC-183 21->0   IAC-286 21->0
aws-cloudformation    IAC-176  1->0   IAC-183  1->0   IAC-286  1->0
```

IAC-132, IAC-145 and IAC-131 did not move on any repo, so the survivors still
report everything they did.

podinfo, per file, **271 findings → 211**:

| retired → survivor | files fired | already duplicated | removed |
|---|---:|---:|---:|
| IAC-286 → IAC-131 | 21 | 21 | **0** |
| IAC-176 → IAC-145 | 18 | 9 | 9 |
| IAC-183 → IAC-132 | 21 | 3 | 18 |

No file lost coverage entirely, and every removal was checked by hand:

- **17 were HorizontalPodAutoscaler documents.** `spec.scaleTargetRef.kind:
  Deployment` is a *reference* to the workload being scaled — no pod template,
  no containers, no `securityContext` to be missing. Both retired rules
  anchored on a bare `kind\s*:\s*Deployment` regex and reported against it. The
  survivors resolve the document's own kind structurally and were always
  correct here. **IAC-131 still has this bug — filed as #590.**
- **10 were single-replica Deployments and StatefulSets** — `replicas: 1`, or
  absent and therefore 1 by Kubernetes default, which is what `IntAtLeast`
  models. These are #582's exemption finally taking effect.

**Zero real findings lost.**

## Gate A caught this change, which is the point

`TestRefutationSuiteRecall` failed with *"4 real vulnerabilities in the
refutation suite are no longer reported"* — the IAC-183 and IAC-286
annotations on `r8` and `r9`, pinned there one PR earlier (#589) precisely so
this removal could not happen quietly. They are removed here, in the same
commit as the rule change, which is what the corpus README asks for. The suite
is 23 TP / 0 FP / 0 FN.

This is the first time the instrument built in #589 has been used on the
narrowing it was built for, and it behaved as specified.

## What I withdrew

A clean HorizontalPodAutoscaler fixture for `precision-suite`. It cannot score
clean while **#590** (IAC-131 on `scaleTargetRef`) and **#588** (IaC rules
matching inside YAML comments) are open, and annotating either would make the
corpus assert the behaviour is correct. It should land with whichever is fixed
first — the fixture text is preserved in #590.

## Rule counts

1534 → 1531 catalog, 489 → 486 IaC, 225 → 224 expanded. Drop is in rule
**count** only, not coverage.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT