### PR TITLE
0.4: a rule that reports less now has to say why

### DIFF
--- a/.github/workflows/rule-diff.yml
+++ b/.github/workflows/rule-diff.yml
@@ -23,6 +23,9 @@ on:
       - 'core/lexctx/**'
       - 'scripts/rule-diff.sh'
       - 'scripts/rule-diff-corpus.json'
+      # The ledger decides whether a negative delta passes, so a PR that only
+      # edits it still has to prove the entries match reality.
+      - 'scripts/rule-deltas.json'
       - '.github/workflows/rule-diff.yml'
 
 permissions:
@@ -58,6 +61,11 @@ jobs:
           tar xzf "$tmp/nox.tar.gz" -C "$tmp"
           mv "$tmp/nox" /tmp/nox-baseline
           /tmp/nox-baseline version
+          # The ledger declares which release its entries are written against.
+          # Handing the tag over lets the harness reject a ledger left behind by
+          # a release, instead of matching entries against a comparison nobody
+          # is making.
+          echo "RULE_DIFF_BASELINE_TAG=$tag" >> "$GITHUB_ENV"
 
       - name: Diff rule behaviour
         id: diff
@@ -73,12 +81,18 @@ jobs:
       - name: Report
         # Exit 2 means a scan did not RUN -- unambiguous, so it fails the job.
         #
-        # Exit 1 means rule behaviour changed. That is deliberately NOT a
+        # Exit 1 means rule behaviour changed AND every negative delta is
+        # accounted for in scripts/rule-deltas.json. That is deliberately NOT a
         # failure: most rule PRs change behaviour on purpose, and a check that
         # goes red every time it works correctly is one people learn to ignore.
-        # It is a report, and it says so -- unlike a gate that was accidentally
-        # neutered into always-green, which is the failure mode this repo has
-        # been bitten by. The delta lands in the job summary for the reviewer.
+        # The delta lands in the job summary for the reviewer.
+        #
+        # Exit 3 is new, and it IS a failure: a rule removed findings from a
+        # real repository with nothing saying why, or the ledger describes a
+        # drop that no longer happens. Reporting alone could not tell a fix
+        # from a hidden vulnerability -- both print as a smaller number -- so
+        # the direction that can hide a vulnerability now has to be argued in
+        # writing before it merges. Milestone 0.4.
         if: always()
         run: |
           code="${{ steps.diff.outputs.code }}"
@@ -92,7 +106,9 @@ jobs:
 
           case "$code" in
             0) echo "No rule-level change on the corpus." ;;
-            1) echo "::notice title=Rule behaviour changed::Review the delta in the job summary and confirm each change is intended. This is a report, not a gate." ;;
+            1) echo "::notice title=Rule behaviour changed::Every negative delta is accounted for in scripts/rule-deltas.json. Review the summary and confirm each reason is the real one." ;;
+            3) echo "::error title=Unexplained narrowing::A rule removed findings from a real repository with no entry in scripts/rule-deltas.json, or an entry no longer describes a real drop. See the job summary."
+               exit 1 ;;
             *) echo "::error title=Rule diff could not run::The harness failed (exit $code) -- a scan produced no findings.json, or the corpus is unusable. This check verified nothing."
                exit 1 ;;
           esac

--- a/core/catalog/rule_deltas_test.go
+++ b/core/catalog/rule_deltas_test.go
@@ -1,0 +1,115 @@
+package catalog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type ruleDelta struct {
+	Rule           string `json:"rule"`
+	Classification string `json:"classification"`
+	PR             int    `json:"pr"`
+	Reason         string `json:"reason"`
+}
+
+type deltaLedger struct {
+	NoxRelease      string            `json:"nox_release"`
+	Classifications map[string]string `json:"classifications"`
+	Entries         []ruleDelta       `json:"entries"`
+}
+
+func loadLedger(t *testing.T) deltaLedger {
+	t.Helper()
+	path := filepath.Join("..", "..", "scripts", "rule-deltas.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var l deltaLedger
+	if err := json.Unmarshal(data, &l); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return l
+}
+
+// TestRuleDeltaLedgerIsWellFormed checks here what rule-diff.sh checks in CI,
+// so a malformed ledger fails in seconds rather than after a four-minute
+// harness run that needs the network and ten clones.
+//
+// Shape matters as much as content. An entry with an empty reason, or naming a
+// classification nobody defined, satisfies the harness's "is this rule
+// accounted for?" lookup while explaining nothing — the failure the ledger
+// exists to prevent, one indirection over.
+func TestRuleDeltaLedgerIsWellFormed(t *testing.T) {
+	l := loadLedger(t)
+
+	if l.NoxRelease == "" {
+		t.Error("ledger declares no nox_release; entries cannot be checked against the baseline they describe")
+	}
+	if len(l.Classifications) == 0 {
+		t.Fatal("ledger defines no classifications; every classification would then validate vacuously")
+	}
+
+	seen := map[string]bool{}
+	for _, e := range l.Entries {
+		if e.Rule == "" {
+			t.Errorf("entry %+v has no rule", e)
+			continue
+		}
+		if seen[e.Rule] {
+			t.Errorf("duplicate entry for %s; the second explanation is unreachable", e.Rule)
+		}
+		seen[e.Rule] = true
+
+		if strings.TrimSpace(e.Reason) == "" {
+			t.Errorf("%s has an empty reason; it satisfies the lookup and explains nothing", e.Rule)
+		}
+		if _, ok := l.Classifications[e.Classification]; !ok {
+			t.Errorf("%s names classification %q, which is not defined in .classifications", e.Rule, e.Classification)
+		}
+		if e.PR <= 0 {
+			t.Errorf("%s does not name the PR that made the change", e.Rule)
+		}
+	}
+}
+
+// TestRuleDeltaLedgerNamesRealRules is the typo guard.
+//
+// The harness matches observed drops against entries by rule ID. An ID
+// belonging to no rule can never match a drop, so it is invisible to the
+// unexplained-narrowing check and surfaces only as a STALE entry — with a
+// message blaming a reverted change rather than the typo it is. Every entry
+// must name a rule that still exists, or one a surviving rule retired.
+func TestRuleDeltaLedgerNamesRealRules(t *testing.T) {
+	l := loadLedger(t)
+
+	live := Catalog()
+	retired := map[string]bool{}
+	for _, rs := range allRuleSets() {
+		for _, r := range rs.Rules() {
+			for _, ret := range r.Retires {
+				retired[ret.ID] = true
+			}
+		}
+	}
+	if len(live) == 0 || len(retired) == 0 {
+		t.Fatal("no live or no retired rules found; the check below would pass vacuously")
+	}
+
+	for _, e := range l.Entries {
+		if e.Rule == "" {
+			continue
+		}
+		if _, ok := live[e.Rule]; ok {
+			continue
+		}
+		if retired[e.Rule] {
+			continue
+		}
+		t.Errorf("%s names no live rule and no retired ID; a drop can never match it, so the entry "+
+			"explains nothing and will surface as a stale entry rather than as the typo it is", e.Rule)
+	}
+}

--- a/docs/design/roadmap-refutation-safe.md
+++ b/docs/design/roadmap-refutation-safe.md
@@ -59,9 +59,9 @@ A second north-star question joins the first:
 | Milestone | Exit criterion | State on 2026-09-06 |
 |---|---|---|
 | **0.1** Current-state baseline | one authoritative baseline exists | **done** — `docs/benchmarks/2026-09` |
-| **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **done** — 27 cases over 11 branches, refiners *and* rule narrowing |
+| **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **done** — 23 cases over 11 branches, refiners *and* rule narrowing |
 | **0.3** Semantic corpus coverage | removing the only fixture for a branch fails coverage | **done** — `bench.RefutationBranches`, 16 branches, `TestRefutationBranchCoverage` |
-| **0.4** Negative-delta accountability | unexplained narrowing is rejected or reviewed | open |
+| **0.4** Negative-delta accountability | unexplained narrowing is rejected or reviewed | **done** — `scripts/rule-deltas.json`; rule-diff exits 3 and fails the job |
 | **0.5** Path-coherence validation | no rule loads with behaviourally inert mandatory fields | open |
 
 ### 0.1 — Current-state baseline
@@ -107,10 +107,36 @@ empty registry is an error rather than a pass.
 
 ### 0.4 — Negative-delta accountability
 
-`scripts/rule-diff.sh` already reports per-rule before/after counts across ten
-pinned repos. It exits 1 as a `::notice` — a report, not a gate. Every removed
-finding gains a recorded reason; unexplained narrowing is rejected or
-explicitly reviewed.
+`scripts/rule-diff.sh` reported per-rule before/after counts across ten pinned
+repos and exited 1 as a `::notice`. Reporting is not accountability: a drop and
+a correct narrowing print identically, so the answer to "is that right?" was
+whatever the reader assumed.
+
+`scripts/rule-deltas.json` is the other half. Every rule whose count **falls**
+needs an entry with a classification from a fixed vocabulary and a reason.
+Rising counts stay reported and ungated — a new false positive is visible in
+the output and costs nobody a vulnerability.
+
+Four ways the harness now fails (exit 3, and the job goes red):
+
+1. a rule dropped findings with no entry;
+2. an entry describes a drop that no longer happens — checked only on a full
+   run of the committed corpus, because a reduced corpus or a skipped repo is
+   missing evidence rather than a stale reason;
+3. an entry has no reason, or names a classification nobody defined;
+4. the ledger's `nox_release` disagrees with the baseline the harness resolved,
+   which means a release was cut and the entries it explained were never
+   cleared.
+
+**Falsified, not asserted.** All five paths were exercised against the real
+`v1.34.0` baseline: the committed ledger passes at exit 1 with seven accounted
+deltas, and deleting an entry, corrupting one, mis-declaring the release, and
+adding a phantom each produce exit 3 naming the rule.
+
+One flaw surfaced while testing and was fixed rather than lived with. The
+stale-entry check is corpus-dependent, so on a reduced corpus every entry whose
+witnessing repo was left out looked stale. It is an error only on a full
+committed-corpus run with nothing skipped, and a warning otherwise.
 
 ### 0.5 — Path-coherence validation
 

--- a/scripts/rule-deltas.json
+++ b/scripts/rule-deltas.json
@@ -1,0 +1,70 @@
+{
+  "_why": [
+    "Milestone 0.4. rule-diff.sh reports every per-rule count change between the",
+    "last release and this build. Reporting is not accountability: a drop and a",
+    "correct narrowing look identical in that output, and the only thing telling",
+    "them apart was whoever happened to read the job summary.",
+    "",
+    "This file is the other half. Every rule whose count DROPS must have an entry",
+    "here saying why. An unexplained drop fails the job; so does an entry that no",
+    "longer describes a real drop, because a ledger nothing validates rots into",
+    "decoration.",
+    "",
+    "The baseline is the last released nox, so entries accumulate between releases",
+    "and are cleared when one is cut. `nox_release` records which release they are",
+    "written against: if it does not match the tag rule-diff resolved, the ledger",
+    "is stale as a whole and says so rather than silently passing."
+  ],
+  "nox_release": "v1.34.0",
+  "classifications": {
+    "duplicate-retired": "a second rule reported the same condition; one ID was retired into the other, which carries the alias",
+    "applicability-narrowed": "the rule does not apply to this subject or resource kind, and now says so",
+    "sanitizer-recognized": "the value reaching the sink is neutralized for this vulnerability class",
+    "refined-away": "a cheaper semantic fact refutes the candidate the pattern generated",
+    "rule-removed": "the rule was deleted outright; no survivor reports the condition"
+  },
+  "entries": [
+    {
+      "rule": "IAC-132",
+      "classification": "applicability-narrowed",
+      "pr": 582,
+      "reason": "A PodDisruptionBudget is meaningless on a workload that runs one replica: there is no availability to preserve. absence_subject_min_int on spec.replicas exempts single-replica Deployments and StatefulSets. An unreadable replicas value reports rather than exempts."
+    },
+    {
+      "rule": "IAC-142",
+      "classification": "applicability-narrowed",
+      "pr": 582,
+      "reason": "Pod anti-affinity spreads replicas across nodes. With one replica there is nothing to spread, so the same precondition applies as IAC-132."
+    },
+    {
+      "rule": "IAC-139",
+      "classification": "applicability-narrowed",
+      "pr": 583,
+      "reason": "A liveness probe restarts a container the kubelet believes is wedged. A Job or CronJob container is meant to run to completion and exit, so the probe restarts work that finished correctly. Narrowed to Deployment, StatefulSet, DaemonSet, ReplicaSet and Pod."
+    },
+    {
+      "rule": "IAC-140",
+      "classification": "applicability-narrowed",
+      "pr": 583,
+      "reason": "A readiness probe gates traffic to a container. Batch workloads receive none, so the probe gates nothing. Same workload kinds as IAC-139."
+    },
+    {
+      "rule": "IAC-183",
+      "classification": "duplicate-retired",
+      "pr": 591,
+      "reason": "Byte-identical absence configuration to IAC-132 — same anchor, same property, absence_span: file — without the subject precondition, so it re-reported exactly what IAC-132 refuted. Retired into IAC-132, which carries the alias. 17 of the removals across the corpus were HorizontalPodAutoscaler documents where the bare kind regex matched spec.scaleTargetRef; the rest were the single-replica workloads #582 exempted."
+    },
+    {
+      "rule": "IAC-176",
+      "classification": "duplicate-retired",
+      "pr": 591,
+      "reason": "Reported the same missing securityContext as IAC-145 from the weaker text path: one YAML document searched for the word, only on kind: Deployment. IAC-145 resolves seven workload kinds structurally with absence_require_all. Retired into IAC-145, which carries the alias. Every removal measured on podinfo was a HorizontalPodAutoscaler."
+    },
+    {
+      "rule": "IAC-286",
+      "classification": "duplicate-retired",
+      "pr": 591,
+      "reason": "The same NetworkPolicy advisory as IAC-131 over the same three kinds and the same file patterns, differing only by tolerating a space before the colon. Every workload manifest reported it twice. Retired into IAC-131, which carries the alias; per-file overlap on podinfo was 21 of 21, so nothing was removed that IAC-131 does not still report."
+    }
+  ]
+}

--- a/scripts/rule-diff.sh
+++ b/scripts/rule-diff.sh
@@ -24,9 +24,58 @@ set -euo pipefail
 BASE_BIN="${1:?usage: rule-diff.sh <baseline-nox> <candidate-nox> [corpus.json]}"
 CAND_BIN="${2:?usage: rule-diff.sh <baseline-nox> <candidate-nox> [corpus.json]}"
 CORPUS="${3:-$(dirname "$0")/rule-diff-corpus.json}"
+LEDGER="${4:-$(dirname "$0")/rule-deltas.json}"
+# Whether this run used the committed corpus. The stale-entry check below asks
+# "does this entry still describe a real drop?", and only a full run of the
+# default corpus can answer no: on a reduced corpus an entry looks stale
+# whenever the repo that witnessed it was left out, which is missing evidence
+# rather than a stale reason.
+FULL_CORPUS=1
+[ -n "${3:-}" ] && FULL_CORPUS=0
+BASELINE_TAG="${RULE_DIFF_BASELINE_TAG:-}"
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
 [ -f "$CORPUS" ] || { echo "corpus manifest not found: $CORPUS" >&2; exit 2; }
+[ -f "$LEDGER" ] || { echo "delta ledger not found: $LEDGER" >&2; exit 2; }
+
+# The ledger is only meaningful against the release it was written for. If the
+# caller knows which release the baseline binary came from and it disagrees,
+# every entry describes a comparison nobody is making. Report that as a stale
+# ledger rather than letting entries silently match, or silently rot.
+ledger_release="$(jq -r '.nox_release // ""' "$LEDGER")"
+if [ -n "$BASELINE_TAG" ] && [ -n "$ledger_release" ] && [ "$BASELINE_TAG" != "$ledger_release" ]; then
+  echo "::error::rule-deltas.json declares nox_release $ledger_release but the baseline is $BASELINE_TAG."
+  echo "A release was cut since the ledger was written. Clear the entries it explains, then set nox_release to $BASELINE_TAG."
+  exit 3
+fi
+
+# An entry with no reason, or naming a classification nobody defined, explains
+# nothing. Checking it here means a malformed ledger cannot pass by matching a
+# rule ID and contributing an empty sentence.
+# Note the `. as $e` binding: inside `has(...)` the input is the
+# classifications object, so a bare `.classification` there resolves against
+# THAT and matches nothing -- a check that flags every entry, which is as
+# broken as one that flags none. Verified against a known-good and two
+# known-bad ledgers before it was trusted.
+malformed="$(jq -r '
+  . as $l
+  | [ ($l.entries // [])[]
+      | . as $e
+      | select((($e.rule // "") == "")
+            or (($e.reason // "") == "")
+            or (($l.classifications // {}) | has($e.classification // "") | not))
+      | ($e.rule // "(entry with no rule)") ]
+  | join(", ")' "$LEDGER")"
+if [ -n "$malformed" ]; then
+  echo "::error::rule-deltas.json entries are malformed: $malformed"
+  echo "Every entry needs a rule, a non-empty reason, and a classification listed under .classifications."
+  exit 3
+fi
+
+# explained <RULE> -- does the ledger account for a drop in this rule?
+explained() {
+  jq -e --arg r "$1" '[.entries[] | select(.rule == $r)] | length > 0' "$LEDGER" >/dev/null 2>&1
+}
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -49,6 +98,8 @@ scan_counts() {
 
 total_delta=0
 repo_count=0
+skipped=0
+dropped_rules=""   # rules whose count FELL somewhere; newline-separated, deduped at the end
 
 while read -r name url sha; do
   [ -n "$name" ] || continue
@@ -56,9 +107,9 @@ while read -r name url sha; do
   echo "── $name @ ${sha:0:8}"
   src="$work/src-$name"
   git clone -q --filter=blob:none "$url" "$src" 2>/dev/null || {
-    echo "   SKIP: clone failed (network or repo moved)"; continue; }
+    echo "   SKIP: clone failed (network or repo moved)"; skipped=$((skipped + 1)); continue; }
   git -C "$src" checkout -q "$sha" 2>/dev/null || {
-    echo "   SKIP: pinned sha $sha not found -- repo history rewritten?"; continue; }
+    echo "   SKIP: pinned sha $sha not found -- repo history rewritten?"; skipped=$((skipped + 1)); continue; }
   rm -rf "$src/.git"
 
   # A scan that does not run is FATAL, never a skip. Skipping here would turn
@@ -77,6 +128,15 @@ while read -r name url sha; do
   else
     echo "$delta"
     total_delta=$((total_delta + $(printf '%s\n' "$delta" | wc -l)))
+    # A rule whose count FELL removed findings from a real repository. That is
+    # the direction that can hide a vulnerability, so it is the direction the
+    # ledger has to account for. Rising counts are reported and not gated:
+    # a new false positive is visible in the output and costs nobody a
+    # vulnerability.
+    dropped_rules="$dropped_rules$(join -t"$(printf '\t')" -a1 -a2 -e0 -o '0,1.2,2.2' \
+        "$work/base-$name.tsv" "$work/cand-$name.tsv" \
+      | awk -F'\t' '$3 < $2 {print $1}')
+"
   fi
 done < <(jq -r '.repos[] | "\(.name) \(.url) \(.sha)"' "$CORPUS")
 
@@ -89,5 +149,58 @@ if [ "$total_delta" -eq 0 ]; then
   echo "no rule-level change across $repo_count repo(s)"
   exit 0
 fi
-echo "$total_delta rule(s) changed across $repo_count repo(s) -- each needs an explanation"
+echo "$total_delta rule(s) changed across $repo_count repo(s)"
+echo
+
+# ---------------------------------------------------------------------------
+# Milestone 0.4 -- negative deltas are auditable.
+#
+# Up to here this script was a report: it printed what moved and left "is that
+# correct?" to whoever read the summary. A drop and a correct narrowing look
+# identical in that output, so the answer was whatever the reader assumed.
+# ---------------------------------------------------------------------------
+dropped="$(printf '%s' "$dropped_rules" | grep -v '^$' | sort -u || true)"
+
+unexplained=""
+for rule in $dropped; do
+  explained "$rule" || unexplained="$unexplained $rule"
+done
+
+# The other half: an entry describing a drop that no longer happens. Without
+# this the ledger only ever grows, and a stale reason reads exactly like a
+# current one -- the failure mode this whole harness exists to make visible.
+stale=""
+for rule in $(jq -r '.entries[].rule' "$LEDGER" | sort -u); do
+  printf '%s\n' "$dropped" | grep -qx "$rule" || stale="$stale $rule"
+done
+
+if [ -n "$unexplained" ]; then
+  echo "::error title=Unexplained narrowing::These rules removed findings from real repositories with no entry in scripts/rule-deltas.json:$unexplained"
+  echo
+  echo "A rule that reports less is either a fix or a hidden vulnerability, and the"
+  echo "count alone cannot tell you which. Add an entry per rule with a"
+  echo "classification and a reason, or explain in review why the drop is correct"
+  echo "and the ledger is the wrong place to say so."
+  exit 3
+fi
+
+if [ -n "$stale" ]; then
+  if [ "$skipped" -gt 0 ] || [ "$FULL_CORPUS" -eq 0 ]; then
+    echo "::warning::ledger entries with no matching drop:$stale -- but this run skipped $skipped repo(s) or used a reduced corpus, so it is missing evidence rather than a stale entry"
+  else
+    echo "::error title=Stale ledger entry::These rules have an entry in scripts/rule-deltas.json but no longer drop anything:$stale"
+    echo
+    echo "Either the change was reverted, or a release was cut and the entries it"
+    echo "explained should have been cleared. A ledger nothing validates rots into"
+    echo "decoration, which is worse than no ledger."
+    exit 3
+  fi
+fi
+
+if [ -n "$dropped" ]; then
+  echo "every negative delta is accounted for in scripts/rule-deltas.json:"
+  for rule in $dropped; do
+    printf '   %-10s %s\n' "$rule" "$(jq -r --arg r "$rule" '[.entries[] | select(.rule==$r) | "\(.classification) (#\(.pr))"] | join(", ")' "$LEDGER")"
+  done
+fi
 exit 1


### PR DESCRIPTION
Milestone 0.4, and the last structural piece of Phase 0.

`rule-diff.sh` printed every per-rule count change between the last release and
the build under test, then exited 1 as a `::notice`. That is a report, and
reporting is not accountability: **a fix and a hidden vulnerability both print
as a smaller number**, so the answer to "is that drop correct?" was whatever
the reader assumed. Nothing recorded the answer, and nothing failed when there
wasn't one.

## The ledger

`scripts/rule-deltas.json`. Every rule whose count **falls** on a real
repository needs an entry naming a classification from a fixed vocabulary, the
PR that made the change, and a reason. Rising counts stay reported and ungated
— a new false positive is visible in the output and costs nobody a
vulnerability.

Four ways the harness now fails (**exit 3**, job red):

1. a rule dropped findings with no entry;
2. an entry describes a drop that no longer happens;
3. an entry has no reason, or names a classification nobody defined;
4. the ledger's `nox_release` disagrees with the baseline the harness resolved
   — a release was cut and the entries it explained were never cleared.

## Falsified, not asserted

All five paths exercised against the real `v1.34.0` release binary:

| ledger | result |
|---|---|
| committed | exit 1, seven negative deltas each named with classification and PR |
| IAC-183 entry deleted | exit 3 — `Unexplained narrowing: IAC-183` |
| phantom IAC-001 entry | exit 3 — `Stale ledger entry: IAC-001` |
| `nox_release: v1.30.0` | exit 3 — release mismatch |
| unknown classification | exit 3 — `entries are malformed: IAC-999` |

The seven entries are the unreleased narrowings: IAC-132 and IAC-142 (#582),
IAC-139 and IAC-140 (#583), IAC-176, IAC-183 and IAC-286 (#591).

## Two things the testing changed

**The malformed-entry check flagged every entry on first run.** Inside jq's
`has(...)` the input is the classifications object, so a bare `.classification`
there resolves against *that* and matches nothing. A check that flags
everything is as broken as one that flags nothing — and testing it only against
a bad ledger would have shown a plausible-looking pass. It is now verified
against one known-good and two known-bad ledgers, with the binding commented in
place.

**The stale-entry check is corpus-dependent.** On a reduced corpus every entry
whose witnessing repo was left out looked stale, which is missing evidence
rather than a stale reason. It is an error only on a full run of the committed
corpus with nothing skipped, and a warning otherwise.

## Fast failure

Two Go tests in `core/catalog` check the ledger's shape, and that every entry
names a rule that exists or one a surviving rule retired. A typo'd ID can never
match a drop, so without that guard it is invisible to the unexplained-narrowing
check and surfaces only as a *stale* entry — blaming a reverted change rather
than the typo. They run in `go test ./...`, so a malformed ledger fails in
seconds instead of after four minutes and ten clones.

## Phase 0 after this

| | |
|---|---|
| 0.1 baseline | done (#586) |
| 0.2 refutation corpus | done (#589) |
| 0.3 semantic coverage | done (#589) |
| 0.4 negative-delta accountability | **this PR** |
| 0.5 path coherence | open — measured clean, 0 of 185 IaC rules incoherent |

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT