### PR TITLE
0.5: a rule whose fields nothing reads no longer loads

### DIFF
--- a/core/catalog/coherence_test.go
+++ b/core/catalog/coherence_test.go
@@ -1,0 +1,51 @@
+package catalog
+
+import "testing"
+
+// TestBuiltinRulesAreCoherent applies the load-time check to the rules that
+// never pass through the loader.
+//
+// validateRule guards YAML rules. Every built-in is a Go struct built in
+// package init, so nothing validated them at all: a built-in could declare a
+// subject precondition the matcher never reads, or a span nobody implements,
+// and the only symptom would be a rule that quietly finds nothing.
+//
+// Measured when this landed: 1531 rules, 55 on the absence matcher, 31 of
+// those structural, 2 carrying a subject precondition — and zero incoherent.
+// The counts are asserted below because a check that runs over no absence
+// rules passes for the wrong reason.
+func TestBuiltinRulesAreCoherent(t *testing.T) {
+	total, absence, structural := 0, 0, 0
+
+	for _, rs := range allRuleSets() {
+		for _, r := range rs.Rules() {
+			total++
+			if r.MatcherType == "absence" {
+				absence++
+			}
+			if len(r.AbsenceResourceTypes) > 0 {
+				structural++
+			}
+			if err := r.CheckCoherence(); err != nil {
+				t.Errorf("%v", err)
+			}
+		}
+	}
+
+	// Floors, not equalities: rules are added constantly, and an equality here
+	// would fail on every unrelated rule PR. What must never happen is the
+	// count collapsing, which would mean this test walked a set with nothing
+	// in it to check.
+	if total < 1000 {
+		t.Errorf("walked %d rules; the catalog is far smaller than expected, so this check "+
+			"is passing over the wrong input", total)
+	}
+	if absence < 20 {
+		t.Errorf("only %d absence rules seen; the absence clauses are the ones with teeth "+
+			"and they are not being exercised", absence)
+	}
+	if structural < 10 {
+		t.Errorf("only %d structural absence rules seen; the structural/text split is what "+
+			"CheckCoherence exists to police", structural)
+	}
+}

--- a/core/rules/coherence.go
+++ b/core/rules/coherence.go
@@ -1,0 +1,161 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validAbsenceSpans are the span modes absenceSpan() implements. Anything else
+// falls to its default branch and returns nil for every anchor, which disables
+// the rule without any error: it loads, it lists, and it never fires.
+var validAbsenceSpans = map[string]bool{
+	"":                true, // treated as "file"
+	"file":            true,
+	"line":            true,
+	"line-continued":  true,
+	"brace-block":     true,
+	"brace-enclosing": true,
+	"yaml-block":      true,
+	"yaml-doc":        true,
+}
+
+// CheckCoherence reports declared semantics that the rule's own evaluation path
+// cannot consume.
+//
+// A rule is a set of fields and a matcher type, and nothing has ever connected
+// the two. `validateRule` checks that the ID is non-empty, the matcher type is
+// known and the severity is known — none of which notice a rule whose fields
+// are read by a path it never takes. The result is a rule that loads without
+// complaint, appears in `nox rules`, and finds nothing. That failure is
+// indistinguishable from a rule that ran and found nothing wrong, which is the
+// shape this repository keeps being bitten by: `jsonpath`, `yamlpath` and
+// `heuristic` were removed from ValidMatcherTypes for exactly this reason —
+// they validated at load and were served by a stub that matched nothing.
+//
+// The absence matcher has two evaluation paths and they read DISJOINT field
+// sets. structuralAbsence parses the document and reads AbsenceResourceTypes,
+// AbsencePropertyPath, AbsenceRequireAll, AbsenceCompanion* and
+// AbsenceSubjectMinInt; it returns "undecided" unless resource types are set
+// AND one of companion types or property path is. Everything else falls through
+// to the text path, which reads AbsenceAnchor, AbsenceProperty, AbsenceSpan and
+// AbsenceRequire and ignores the first group entirely.
+//
+// So a rule declaring `absence_subject_min_int` without a property path loads,
+// lists, and applies no precondition at all — the precondition is not wrong,
+// it is not read. That is what this function refuses.
+func (r *Rule) CheckCoherence() error {
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	structuralOnly := r.structuralOnlyFields()
+	reachesStructural := len(r.AbsenceResourceTypes) > 0 &&
+		(len(r.AbsenceCompanionTypes) > 0 || len(r.AbsencePropertyPath) > 0)
+
+	if r.MatcherType != "absence" {
+		if fields := r.absenceFields(); len(fields) > 0 {
+			add("matcher_type is %q, but %s only the absence matcher reads",
+				r.MatcherType, describeFields(fields))
+		}
+	} else {
+		if !validAbsenceSpans[r.AbsenceSpan] {
+			add("absence_span %q is not a span absenceSpan() implements, so every anchor "+
+				"resolves to no span and the rule cannot fire", r.AbsenceSpan)
+		}
+		// The text path needs both an anchor and a property: compile("")
+		// returns a nil regexp and Match gives up, silently. A rule that
+		// reaches the structural path does not need them, because the document
+		// answers instead.
+		if !reachesStructural {
+			if r.AbsenceAnchor == "" {
+				add("no absence_anchor and no structural descriptor, so the text path " +
+					"returns nil before it looks at anything")
+			}
+			if r.AbsenceProperty == "" {
+				add("no absence_property and no structural descriptor, so the text path " +
+					"returns nil before it looks at anything")
+			}
+		}
+		if len(structuralOnly) > 0 && !reachesStructural {
+			add("%s read only by structuralAbsence, which this rule never reaches: "+
+				"it needs absence_resource_types AND one of absence_property_path or "+
+				"absence_companion_types. As written the field is inert",
+				describeFields(structuralOnly))
+		}
+		if len(r.AbsenceResourceTypes) > 0 && !reachesStructural {
+			add("absence_resource_types is set with neither absence_property_path nor " +
+				"absence_companion_types, so structuralAbsence returns undecided and the " +
+				"resource types are never consulted")
+		}
+		if (r.AbsenceCompanionLink != "" || r.AbsenceCompanionPath != "") &&
+			len(r.AbsenceCompanionTypes) == 0 {
+			add("absence_companion_link/path without absence_companion_types: the companion " +
+				"branch is selected by the types, so the link and path are never read")
+		}
+	}
+
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("rule %s is incoherent: %s", r.ID, strings.Join(problems, "; "))
+}
+
+// absenceFields names every Absence* field this rule sets.
+func (r *Rule) absenceFields() []string {
+	var f []string
+	if r.AbsenceAnchor != "" {
+		f = append(f, "absence_anchor")
+	}
+	if r.AbsenceProperty != "" {
+		f = append(f, "absence_property")
+	}
+	if r.AbsenceRequire != "" {
+		f = append(f, "absence_require")
+	}
+	if r.AbsenceSpan != "" {
+		f = append(f, "absence_span")
+	}
+	return append(f, r.structuralOnlyFields()...)
+}
+
+// structuralOnlyFields names the fields ONLY structuralAbsence reads. The text
+// path does not look at any of them, so setting one on a rule that falls
+// through is a declaration with no reader.
+func (r *Rule) structuralOnlyFields() []string {
+	var f []string
+	if len(r.AbsenceResourceTypes) > 0 {
+		f = append(f, "absence_resource_types")
+	}
+	if len(r.AbsencePropertyPath) > 0 {
+		f = append(f, "absence_property_path")
+	}
+	if r.AbsenceRequireAll {
+		f = append(f, "absence_require_all")
+	}
+	if len(r.AbsenceSubjectMinInt) > 0 {
+		f = append(f, "absence_subject_min_int")
+	}
+	if len(r.AbsenceCompanionTypes) > 0 {
+		f = append(f, "absence_companion_types")
+	}
+	if r.AbsenceCompanionLink != "" {
+		f = append(f, "absence_companion_link")
+	}
+	if r.AbsenceCompanionPath != "" {
+		f = append(f, "absence_companion_path")
+	}
+	return f
+}
+
+// describeFields renders a field list with the right verb, so the message reads
+// as a sentence in both the one-field and many-field cases.
+func describeFields(fields []string) string {
+	sorted := append([]string{}, fields...)
+	sort.Strings(sorted)
+	if len(sorted) == 1 {
+		return sorted[0] + " is a field"
+	}
+	return strings.Join(sorted, ", ") + " are fields"
+}

--- a/core/rules/coherence_test.go
+++ b/core/rules/coherence_test.go
@@ -1,0 +1,153 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+// base returns a coherent absence rule, so each case below changes exactly one
+// thing and the failure it produces is attributable to that change.
+func base() Rule {
+	return Rule{
+		ID:              "TEST-001",
+		MatcherType:     "absence",
+		Severity:        "medium",
+		AbsenceAnchor:   `(?i)kind\s*:\s*Deployment`,
+		AbsenceProperty: `(?i)securityContext`,
+		AbsenceSpan:     "yaml-block",
+	}
+}
+
+func TestCoherentRulePasses(t *testing.T) {
+	r := base()
+	if err := r.CheckCoherence(); err != nil {
+		t.Fatalf("a coherent rule was rejected: %v", err)
+	}
+	// And the structural shape, which reads an entirely different field set.
+	s := base()
+	s.AbsenceResourceTypes = []string{"Deployment"}
+	s.AbsencePropertyPath = []string{"spec.template.spec.securityContext"}
+	s.AbsenceRequireAll = true
+	s.AbsenceSubjectMinInt = map[string]int{"spec.replicas": 2}
+	if err := s.CheckCoherence(); err != nil {
+		t.Fatalf("a coherent structural rule was rejected: %v", err)
+	}
+}
+
+// The defect this milestone exists for: a subject precondition on a rule that
+// never reaches the path which reads it. The rule loads, lists, and applies no
+// precondition — and the output is identical to a rule whose precondition
+// simply never excluded anything.
+func TestSubjectPreconditionWithoutStructuralPathIsRejected(t *testing.T) {
+	r := base()
+	r.AbsenceSubjectMinInt = map[string]int{"spec.replicas": 2}
+
+	err := r.CheckCoherence()
+	if err == nil {
+		t.Fatal("absence_subject_min_int without a structural descriptor was accepted; " +
+			"the precondition would be silently inert")
+	}
+	if !strings.Contains(err.Error(), "absence_subject_min_int") {
+		t.Errorf("error does not name the inert field: %v", err)
+	}
+}
+
+func TestStructuralOnlyFieldsRequireTheStructuralPath(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Rule)
+		want   string
+	}{
+		{"require_all", func(r *Rule) { r.AbsenceRequireAll = true }, "absence_require_all"},
+		{"property_path alone", func(r *Rule) {
+			r.AbsencePropertyPath = []string{"spec.x"}
+		}, "absence_property_path"},
+		{"companion types alone", func(r *Rule) {
+			r.AbsenceCompanionTypes = []string{"PodDisruptionBudget"}
+		}, "absence_companion_types"},
+		{"resource types alone", func(r *Rule) {
+			r.AbsenceResourceTypes = []string{"Deployment"}
+		}, "absence_resource_types"},
+		{"companion link without types", func(r *Rule) {
+			r.AbsenceResourceTypes = []string{"Deployment"}
+			r.AbsencePropertyPath = []string{"spec.x"}
+			r.AbsenceCompanionLink = "selector"
+		}, "absence_companion_link"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := base()
+			tc.mutate(&r)
+			err := r.CheckCoherence()
+			if err == nil {
+				t.Fatalf("%s was accepted on a rule that cannot read it", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error does not name %s: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// A span nobody implements sends absenceSpan() to its default branch, which
+// returns nil for every anchor. The rule cannot fire, and says nothing about
+// it. This is the same shape as the jsonpath/yamlpath/heuristic matcher types
+// that were removed from ValidMatcherTypes.
+func TestUnknownAbsenceSpanIsRejected(t *testing.T) {
+	for _, span := range []string{"yaml-blok", "block", "yaml_block", "FILE"} {
+		r := base()
+		r.AbsenceSpan = span
+		if err := r.CheckCoherence(); err == nil {
+			t.Errorf("absence_span %q was accepted; the rule could never fire", span)
+		}
+	}
+	// Every implemented span, and the empty string that means "file".
+	for _, span := range []string{"", "file", "line", "line-continued", "brace-block",
+		"brace-enclosing", "yaml-block", "yaml-doc"} {
+		r := base()
+		r.AbsenceSpan = span
+		if err := r.CheckCoherence(); err != nil {
+			t.Errorf("implemented span %q was rejected: %v", span, err)
+		}
+	}
+}
+
+// compile("") returns a nil regexp and Match gives up before looking at
+// anything. A rule missing either half of the text path is silent, not wrong.
+func TestTextPathNeedsBothAnchorAndProperty(t *testing.T) {
+	r := base()
+	r.AbsenceAnchor = ""
+	if err := r.CheckCoherence(); err == nil {
+		t.Error("absence rule with no anchor was accepted; the text path returns nil immediately")
+	}
+	r = base()
+	r.AbsenceProperty = ""
+	if err := r.CheckCoherence(); err == nil {
+		t.Error("absence rule with no property was accepted; the text path returns nil immediately")
+	}
+
+	// A structural rule legitimately needs neither: the document answers.
+	s := base()
+	s.AbsenceAnchor, s.AbsenceProperty = "", ""
+	s.AbsenceResourceTypes = []string{"Deployment"}
+	s.AbsencePropertyPath = []string{"spec.template.spec.securityContext"}
+	if err := s.CheckCoherence(); err != nil {
+		t.Errorf("structural rule rejected for missing text-path fields it does not use: %v", err)
+	}
+}
+
+// Absence fields on a regex or entropy rule are read by nobody.
+func TestAbsenceFieldsOnANonAbsenceMatcherAreRejected(t *testing.T) {
+	for _, mt := range []string{"regex", "entropy"} {
+		r := base()
+		r.MatcherType = mt
+		err := r.CheckCoherence()
+		if err == nil {
+			t.Errorf("matcher_type %q accepted absence fields that only the absence matcher reads", mt)
+		}
+	}
+	// A plain regex rule with no absence fields is fine.
+	clean := Rule{ID: "TEST-002", MatcherType: "regex", Severity: "low", Pattern: `foo`}
+	if err := clean.CheckCoherence(); err != nil {
+		t.Errorf("a plain regex rule was rejected: %v", err)
+	}
+}

--- a/core/rules/loader.go
+++ b/core/rules/loader.go
@@ -86,5 +86,9 @@ func validateRule(r *Rule) error {
 	if !validSeverities[string(r.Severity)] {
 		return fmt.Errorf("invalid severity %q for rule %s", r.Severity, r.ID)
 	}
-	return nil
+	// The three checks above ask whether each field is individually legal. None
+	// of them notices a rule whose fields are read by an evaluation path it
+	// never takes — which loads without complaint, appears in `nox rules`, and
+	// finds nothing. See Rule.CheckCoherence.
+	return r.CheckCoherence()
 }

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -156,9 +156,10 @@ completeness:
 4. **No unevaluated rate.** There is no denominator today for "what fraction of
    propositions this scan did not evaluate", because the scan output carries no
    proposition-level evaluation state. Phase 1.
-5. **Path coherence is unguarded but currently clean.** A probe over
-   `builtinBaseIaCRules()` counted 185 rules, 31 reaching the structural
-   absence path, and **0 setting a structural-only field while falling through
-   to the regex path**. Nothing at load time would reject one. Milestone 0.5.
+5. ~~**Path coherence is unguarded but currently clean.**~~ **Closed by
+   Milestone 0.5** — `Rule.CheckCoherence` runs in `validateRule` and over all
+   built-ins. Re-measured across the whole catalog rather than IaC alone:
+   1,531 rules, 55 on the absence matcher, 31 structural, 2 with a subject
+   precondition, **0 incoherent**.
 6. **No wrong-PREVENTED rate.** `PREVENTED` is reachable only through Gate B's
    single suppressible case; the metric exists but has one observation.

--- a/docs/design/roadmap-refutation-safe.md
+++ b/docs/design/roadmap-refutation-safe.md
@@ -56,13 +56,18 @@ A second north-star question joins the first:
 
 ## Phase 0 — Refutation observability and benchmark safety
 
+**Complete.** Ground-truth refutation measurement, a corpus that covers rule
+narrowing as well as refiners, coverage that fails when a branch loses its last
+fixture, negative deltas that must be argued in writing, and a loader that
+refuses a rule whose declared semantics nothing reads.
+
 | Milestone | Exit criterion | State on 2026-09-06 |
 |---|---|---|
 | **0.1** Current-state baseline | one authoritative baseline exists | **done** — `docs/benchmarks/2026-09` |
 | **0.2** Refutation corpus | a deliberately wrong refutation fails CI | **done** — 23 cases over 11 branches, refiners *and* rule narrowing |
 | **0.3** Semantic corpus coverage | removing the only fixture for a branch fails coverage | **done** — `bench.RefutationBranches`, 16 branches, `TestRefutationBranchCoverage` |
 | **0.4** Negative-delta accountability | unexplained narrowing is rejected or reviewed | **done** — `scripts/rule-deltas.json`; rule-diff exits 3 and fails the job |
-| **0.5** Path-coherence validation | no rule loads with behaviourally inert mandatory fields | open |
+| **0.5** Path-coherence validation | no rule loads with behaviourally inert mandatory fields | **done** — `Rule.CheckCoherence`, wired into `validateRule` and guarded over all 1,531 built-ins |
 
 ### 0.1 — Current-state baseline
 
@@ -156,9 +161,31 @@ through to the regex path, which reads `AbsenceAnchor`, `AbsenceProperty`,
 declaring `absence_subject_min_int` without a property path therefore loads,
 lists, and applies no precondition at all.
 
-**Measured 2026-09-06: 185 built-in IaC rules, 31 on the structural path, 0
-incoherent.** This is a latent hazard, not a live defect — which is the right
-time to close it, and the reason 0.5 is a gate rather than a bug fix.
+**Measured 2026-09-06: 1,531 built-in rules, 55 on the absence matcher, 31 of
+those structural, 2 carrying a subject precondition — 0 incoherent.** A latent
+hazard, not a live defect, which is the right time to close it and the reason
+0.5 is a gate rather than a bug fix.
+
+`Rule.CheckCoherence` refuses six shapes, each of which loads silently today:
+
+1. a structural-only field on a rule that never reaches `structuralAbsence`
+   (the `absence_subject_min_int` case);
+2. `absence_resource_types` with neither a property path nor companion types,
+   so the descriptor is never consulted;
+3. `absence_companion_link`/`path` without `absence_companion_types`, which
+   select the companion branch;
+4. an `absence_span` nobody implements — `absenceSpan()` falls to its default,
+   returns nil for every anchor, and the rule cannot fire;
+5. an absence rule missing an anchor or a property with no structural
+   descriptor to answer instead — `compile("")` returns a nil regexp and
+   `Match` gives up before looking at anything;
+6. absence fields on a `regex` or `entropy` rule, where nothing reads them.
+
+It runs in `validateRule` for YAML rules and in a catalog test for the
+built-ins, which never pass through the loader and so were previously validated
+by nothing at all. A custom rule declaring `absence_subject_min_int` without a
+property path now fails the scan with exit 2 and a message naming the inert
+field, instead of scanning with no precondition.
 
 ---
 


### PR DESCRIPTION
Milestone 0.5, and **Phase 0 is complete**.

`validateRule` checked three things: non-empty ID, known matcher type, known
severity. Each asks whether a field is individually *legal*. None notices a
rule whose fields are read by an evaluation path it never takes — which loads
without complaint, appears in `nox rules`, and finds nothing. That failure is
indistinguishable from a rule that ran and found nothing wrong.

This repo has been here before: `jsonpath`, `yamlpath` and `heuristic` were
removed from `ValidMatcherTypes` because they validated at load and were served
by a stub that matched nothing.

## The specific hazard

The absence matcher has two evaluation paths reading **disjoint** field sets.
`structuralAbsence` parses the document and reads `AbsenceResourceTypes`,
`AbsencePropertyPath`, `AbsenceRequireAll`, `AbsenceCompanion*` and
`AbsenceSubjectMinInt`; it returns undecided unless resource types are set
**and** one of companion types or property path is. Everything else falls
through to the text path, which reads `AbsenceAnchor`, `AbsenceProperty`,
`AbsenceSpan` and `AbsenceRequire` and ignores the first group entirely.

So a rule declaring `absence_subject_min_int` without a property path loads,
lists, and applies no precondition at all. **The precondition is not wrong; it
is not read.**

## What `Rule.CheckCoherence` refuses

Six shapes, each of which loads silently today:

1. a structural-only field on a rule that never reaches `structuralAbsence`;
2. `absence_resource_types` with neither a property path nor companion types;
3. `absence_companion_link`/`path` without `absence_companion_types`;
4. an `absence_span` nobody implements — `absenceSpan()` falls to its default,
   returns nil for every anchor, and the rule cannot fire;
5. an absence rule missing an anchor or a property with no structural
   descriptor to answer instead — `compile("")` returns a nil regexp and
   `Match` gives up before looking at anything;
6. absence fields on a `regex` or `entropy` rule, where nothing reads them.

Every clause has a test that changes exactly one field on a known-coherent rule
and asserts the error names the inert field.

## Measured, and the measurement is asserted

**1,531 built-in rules, 55 on the absence matcher, 31 of those structural, 2
carrying a subject precondition — 0 incoherent.** A latent hazard rather than a
live defect, which is the right time to close it.

Those counts are **floors in the test**, not a comment. A coherence check that
walks a set with no absence rules in it passes for the wrong reason, and the
absence clauses are the ones with teeth. The floors fail if the walk ever
collapses, which is the only way this test could go quietly green.

It runs in `validateRule` for YAML rules and in a catalog test for the
built-ins — which are Go structs built in package init, never pass through the
loader, and so were validated by **nothing at all** before this.

## End to end

```
$ nox scan . -rules custom.yaml      # absence_subject_min_int, no property path
error: rule CUSTOM-001 is incoherent: absence_subject_min_int is a field read
only by structuralAbsence, which this rule never reaches: it needs
absence_resource_types AND one of absence_property_path or
absence_companion_types. As written the field is inert
exit 2

$ nox scan . -rules custom-fixed.yaml   # descriptor added
exit 1                                   # scans normally, reports findings
```

## Phase 0 complete

| | |
|---|---|
| 0.1 current-state baseline | #586 |
| 0.2 refutation corpus | #589 |
| 0.3 semantic corpus coverage | #589 |
| 0.4 negative-delta accountability | #592 |
| 0.5 path-coherence validation | **this PR** |

Ground-truth refutation measurement; a corpus covering rule narrowing as well
as refiners; coverage that fails when a branch loses its last fixture; negative
deltas that must be argued in writing; and a loader that refuses a rule whose
declared semantics nothing reads.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT