### PR TITLE
IAC: a keyword in a comment is prose about configuration, not configuration

### DIFF
--- a/core/analyzers/iac/comment_context_test.go
+++ b/core/analyzers/iac/comment_context_test.go
@@ -1,0 +1,101 @@
+package iac
+
+import "testing"
+
+func scan(t *testing.T, path, body string) []string {
+	t.Helper()
+	fs, err := NewAnalyzer().ScanFile(path, []byte(body))
+	if err != nil {
+		t.Fatalf("ScanFile(%s): %v", path, err)
+	}
+	var ids []string
+	for _, f := range fs {
+		ids = append(ids, f.RuleID)
+	}
+	return ids
+}
+
+func has(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A rule keyword written in a comment is prose about configuration. The
+// manifest below declares a ConfigMap and nothing else; before this filter it
+// reported IAC-395, "K8s defines PodDisruptionBudget (positive)".
+func TestKeywordInAYAMLCommentIsNotConfiguration(t *testing.T) {
+	ids := scan(t, "notes.yaml",
+		"# This comment mentions PodDisruptionBudget and nothing else.\n"+
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: notes\ndata:\n  a: b\n")
+	if len(ids) != 0 {
+		t.Errorf("a comment produced findings: %v", ids)
+	}
+}
+
+// Commented-out configuration is not configuration. This is the Helm values
+// convention — list the option, comment it out, show the default — and it was
+// the single largest source of the noise: `# namespace: default` reported as a
+// resource deployed to the default namespace.
+func TestCommentedOutConfigurationIsNotConfiguration(t *testing.T) {
+	ids := scan(t, "values.yaml", "replicaCount: 2\n# namespace: default\n# type: LoadBalancer\n")
+	for _, id := range []string{"IAC-143", "IAC-232", "IAC-034"} {
+		if has(ids, id) {
+			t.Errorf("%s fired on a commented-out setting: %v", id, ids)
+		}
+	}
+}
+
+// The asymmetry that matters. A match beginning in code and running into a
+// trailing comment is REAL configuration and must survive: this filter removes
+// findings, and the direction it must never fail in is dropping one that is
+// partly real.
+func TestCodeWithATrailingCommentIsKept(t *testing.T) {
+	ids := scan(t, "release.yml",
+		"on: push\npermissions:\n  contents: read\n  id-token: write # cosign keyless signing (OIDC)\n")
+	if !has(ids, "IAC-306") {
+		t.Errorf("a real `id-token: write` with a trailing comment was dropped: %v", ids)
+	}
+}
+
+// A '#' inside a quoted YAML scalar is data, not the start of a comment. A
+// filter that cut each line at the first '#' would delete the rest of this
+// line and with it a container running with full host capabilities.
+// r12_hash_in_quoted_value.yaml pins the same shape end to end.
+func TestHashInsideAQuotedScalarDoesNotStartAComment(t *testing.T) {
+	ids := scan(t, "pod.yaml",
+		"apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - name: a\n"+
+			"      securityContext: { seLinuxOptions: { level: \"s0:c1#c2\" }, privileged: true }\n")
+	if !has(ids, "IAC-007") {
+		t.Errorf("privileged container after an in-string '#' was dropped: %v", ids)
+	}
+}
+
+// Dockerfiles use the same '#' line comments and route to the same lexer.
+func TestDockerfileCommentsAreNotInstructions(t *testing.T) {
+	quiet := scan(t, "Dockerfile", "# USER root is deliberately not used here\nFROM alpine:3.20\nUSER app\n")
+	for _, id := range quiet {
+		if id == "IAC-002" || id == "IAC-001" {
+			t.Errorf("a Dockerfile comment produced %s: %v", id, quiet)
+		}
+	}
+	// And the real instruction still reports.
+	loud := scan(t, "Dockerfile", "FROM alpine:3.20\nUSER root\n")
+	if len(loud) == 0 {
+		t.Error("a real `USER root` produced no finding; the filter is over-reaching")
+	}
+}
+
+// Terraform is deliberately untouched: lexctx has no HCL lexer, and guessing
+// at comment syntax to remove findings is the direction that hides
+// vulnerabilities. This test records that as a decision, so the day an HCL
+// lexer lands it fails and someone extends configLang on purpose.
+func TestTerraformIsNotFilteredYet(t *testing.T) {
+	if got := configLang("main.tf"); got != 0 { // 0 == lexctx.LangUnknown
+		t.Errorf("configLang(main.tf) = %v; if lexctx gained an HCL lexer, extend the filter "+
+			"and update issue #588 rather than only changing this test", got)
+	}
+}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -9,10 +9,13 @@ import (
 	"os"
 	"strings"
 
+	"path/filepath"
+
 	"github.com/nox-hq/nox-core/evidence"
 
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/lexctx"
 	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
 	"github.com/nox-hq/nox/core/rules/structural"
@@ -101,6 +104,7 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 		return nil, err
 	}
 	out := dropArtifactsWhenAlways(results, content)
+	out = dropMatchesInComments(path, out, content)
 	embedded, err := a.scanEmbedded(path, content, out)
 	if err != nil {
 		return nil, err
@@ -108,6 +112,88 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 	out = append(out, embedded...)
 	a.recordStructuralClaims(path, out)
 	return out, nil
+}
+
+// dropMatchesInComments removes findings whose match lies entirely inside a
+// comment.
+//
+// An IaC rule's evidence is configuration. A rule keyword written in a comment
+// is prose ABOUT configuration, and prose configures nothing: a manifest that
+// says
+//
+//	# This comment mentions PodDisruptionBudget and nothing else.
+//
+// reported IAC-395, "K8s defines PodDisruptionBudget (positive)", against a
+// ConfigMap. Kubernetes and Terraform files are heavily commented, and the
+// comments name exactly the resource kinds and property names the rules match,
+// so every explanatory line in a manifest was a candidate finding — landing on
+// the files operators read most. Issue #588.
+//
+// This is the IaC half of a refinement the secrets analyzer has had since
+// srccontext.go: `lexctx` is the single source of truth for lexical context,
+// and `WithinComments` is the same primitive that path uses. The rules
+// themselves need no change, which is the point — the comment question is
+// lexical, not per-rule, and answering it once is why lexctx exists.
+//
+// Unlike secrets, there is no carve-out here. That analyzer deliberately keeps
+// comment matches for PROVIDER rules, because a credential pasted into a
+// comment is a real leak: the token itself is the evidence, wherever it sits.
+// No IaC rule has that property. A Deployment named in a comment is not a
+// Deployment, and a commented-out `privileged: true` is not privileged.
+//
+// The span test is strict — every non-blank byte the match covers must be
+// comment — so a match that begins in code and runs into a trailing comment is
+// kept. That asymmetry is deliberate: this filter removes findings, and the
+// direction it must never fail in is dropping one that is partly real.
+func dropMatchesInComments(path string, in []findings.Finding, content []byte) []findings.Finding {
+	if len(in) == 0 {
+		return in
+	}
+	lang := configLang(path)
+	if lang == lexctx.LangUnknown {
+		return in
+	}
+
+	kept := in[:0]
+	for _, f := range in {
+		start := lexctx.LineColToOffset(content, f.Location.StartLine, f.Location.StartColumn)
+		end := lexctx.LineColToOffset(content, f.Location.EndLine, f.Location.EndColumn)
+		if end <= start {
+			end = start + 1
+		}
+		if lexctx.WithinComments(lang, content, start, end) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
+}
+
+// configLang resolves the lexer language for an IaC file.
+//
+// It cannot use lexctx.LangFromPath, and the reason is written into that
+// function: LangYAML and LangDockerfile are deliberately NOT mapped there,
+// because the secrets, taint, ai and agentflow analyzers all gate on
+// LangFromPath and mapping .yaml would silently change their behaviour on
+// every such file. The languages exist and Classify handles them; only the
+// path lookup withholds them. So this analyzer answers the question for its
+// own files and changes nothing for anyone else.
+//
+// Terraform is absent because lexctx has no HCL lexer. `.tf` comments are
+// therefore still matched, and issue #588 stays open for them: a filter that
+// guessed at HCL comment syntax would be removing findings on a lexer nobody
+// wrote, which is the direction that hides vulnerabilities.
+func configLang(path string) lexctx.Lang {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return lexctx.LangYAML
+	}
+	base := filepath.Base(path)
+	if base == "Dockerfile" || base == "Containerfile" ||
+		strings.HasPrefix(base, "Dockerfile.") || strings.HasPrefix(base, "Containerfile.") {
+		return lexctx.LangDockerfile
+	}
+	return lexctx.LangUnknown
 }
 
 // dropArtifactsWhenAlways removes IAC-348 findings whose `when: always` sits
@@ -156,7 +242,7 @@ func enclosingKey(lines []string, line int) string {
 	if line < 1 || line > len(lines) {
 		return ""
 	}
-	indent := func(s string) int { return len(s) - len(strings.TrimLeft(s, " \t")) }
+	indent := func(s string) int { return len(s) - len(strings.TrimLeft(s, " 	")) }
 	target := indent(lines[line-1])
 	for i := line - 2; i >= 0; i-- {
 		l := lines[i]

--- a/core/bench/coverage.go
+++ b/core/bench/coverage.go
@@ -119,6 +119,12 @@ var RefutationBranches = []Branch{
 		Proposition: "an upstream pipeline segment quoted this value for the downstream parser",
 	},
 	{
+		ID: "lexical-context-iac", Corpus: "refutation-suite",
+		Wrong:  "a comment-aware IaC filter that starts a comment at the first bare # rather than tracking YAML string state swallows the rest of a flow-style line, taking a real misconfiguration with it",
+		Family: "IAC", Matcher: "lexctx/iac",
+		Proposition: "this configuration keyword is prose describing configuration, not configuration",
+	},
+	{
 		ID: "unmodelled-reflection", Corpus: "refutation-hard",
 		Wrong:  "no flow found through MethodByName is reported as no flow exists",
 		Family: "TAINT", Matcher: "taint/structural",

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -74,7 +74,7 @@ This is the half the roadmap adds, and the half nothing else watches.
 
 | Corpus | Cases | Result | Guard | Gate |
 |---|---:|---|---|---|
-| `refutation-suite` | 23 | 23 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
+| `refutation-suite` | 29 | 29 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
 | `refutation-hard` | 5 | not precision-scored by design | `TestRefutationBranchCoverage` | A |
 | `reachability-suite` | 5 | 1 case may suppress, by name | `TestGateB` | B |
 

--- a/docs/benchmarks/2026-09/precision.json
+++ b/docs/benchmarks/2026-09/precision.json
@@ -176,14 +176,14 @@
     {
       "corpus": "refutation-suite",
       "scored": true,
-      "tp": 23,
+      "tp": 29,
       "fp": 0,
       "fn": 0,
       "precision": 1.0,
       "recall": 1.0,
       "guard": "cli.TestRefutationSuiteRecall + cli.TestRefutationBranchCoverage",
       "gate": "A",
-      "branches": 11,
+      "branches": 12,
       "note": "27 -> 23: IAC-183 and IAC-286 annotations removed when the duplicates were retired; Gate A required that removal to be deliberate"
     },
     {
@@ -264,8 +264,8 @@
   },
   "branch_coverage": {
     "registry": "core/bench.RefutationBranches",
-    "branches": 16,
-    "covered": 16,
+    "branches": 17,
+    "covered": 17,
     "uncovered": 0,
     "gate": "cli.TestRefutationBranchCoverage",
     "note": "removing the only fixture for a branch fails coverage while recall stays 1.000"

--- a/scripts/rule-deltas.json
+++ b/scripts/rule-deltas.json
@@ -69,49 +69,49 @@
     {
       "rule": "IAC-034",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# type: LoadBalancer` in three guestbook manifests, so the Service is not a LoadBalancer. Issue #588."
     },
     {
       "rule": "IAC-143",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# namespace: default` in Helm values files and archived PV examples. Issue #588."
     },
     {
       "rule": "IAC-232",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: the same commented-out `# namespace: default` lines, matched by the kustomize rule. Issue #588."
     },
     {
       "rule": "IAC-254",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: Cassandra's shipped cassandra.yaml, where every option is listed commented-out with its default: `# truststore_password: cassandra`. This is the assignment-shaped class the secrets analyzer already drops in comments (dropConfigFieldRuleInComment); a real credential in a comment is still reported there by the provider rules, verified \u2014 SEC-001/SEC-508 fire on an AWS key in a YAML comment before and after this change. Issue #588."
     },
     {
       "rule": "IAC-306",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: `# and `id-token: write` for the OIDC keyless flow (see release.yml).` \u2014 a comment explaining the permission, matched as if it granted it. The real `id-token: write` on release.yml:20, which carries a TRAILING comment, is correctly kept. Issue #588."
     },
     {
       "rule": "IAC-357",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# type: Opaque` in an archived newrelic config. Issue #588."
     },
     {
       "rule": "IAC-397",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `#  maxUnavailable: 1` in a Helm values file. Issue #588."
     },
     {
       "rule": "IAC-398",
       "classification": "refined-away",
-      "pr": 594,
+      "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: the words 'HorizontalPodAutoscaler (HPA)' inside a header comment explaining what the manifest does. Issue #588."
     }
   ]

--- a/scripts/rule-deltas.json
+++ b/scripts/rule-deltas.json
@@ -52,7 +52,7 @@
       "rule": "IAC-183",
       "classification": "duplicate-retired",
       "pr": 591,
-      "reason": "Byte-identical absence configuration to IAC-132 — same anchor, same property, absence_span: file — without the subject precondition, so it re-reported exactly what IAC-132 refuted. Retired into IAC-132, which carries the alias. 17 of the removals across the corpus were HorizontalPodAutoscaler documents where the bare kind regex matched spec.scaleTargetRef; the rest were the single-replica workloads #582 exempted."
+      "reason": "Byte-identical absence configuration to IAC-132 \u2014 same anchor, same property, absence_span: file \u2014 without the subject precondition, so it re-reported exactly what IAC-132 refuted. Retired into IAC-132, which carries the alias. 17 of the removals across the corpus were HorizontalPodAutoscaler documents where the bare kind regex matched spec.scaleTargetRef; the rest were the single-replica workloads #582 exempted."
     },
     {
       "rule": "IAC-176",
@@ -65,6 +65,54 @@
       "classification": "duplicate-retired",
       "pr": 591,
       "reason": "The same NetworkPolicy advisory as IAC-131 over the same three kinds and the same file patterns, differing only by tolerating a space before the colon. Every workload manifest reported it twice. Retired into IAC-131, which carries the alias; per-file overlap on podinfo was 21 of 21, so nothing was removed that IAC-131 does not still report."
+    },
+    {
+      "rule": "IAC-034",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# type: LoadBalancer` in three guestbook manifests, so the Service is not a LoadBalancer. Issue #588."
+    },
+    {
+      "rule": "IAC-143",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# namespace: default` in Helm values files and archived PV examples. Issue #588."
+    },
+    {
+      "rule": "IAC-232",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: the same commented-out `# namespace: default` lines, matched by the kustomize rule. Issue #588."
+    },
+    {
+      "rule": "IAC-254",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: Cassandra's shipped cassandra.yaml, where every option is listed commented-out with its default: `# truststore_password: cassandra`. This is the assignment-shaped class the secrets analyzer already drops in comments (dropConfigFieldRuleInComment); a real credential in a comment is still reported there by the provider rules, verified \u2014 SEC-001/SEC-508 fire on an AWS key in a YAML comment before and after this change. Issue #588."
+    },
+    {
+      "rule": "IAC-306",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: `# and `id-token: write` for the OIDC keyless flow (see release.yml).` \u2014 a comment explaining the permission, matched as if it granted it. The real `id-token: write` on release.yml:20, which carries a TRAILING comment, is correctly kept. Issue #588."
+    },
+    {
+      "rule": "IAC-357",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `# type: Opaque` in an archived newrelic config. Issue #588."
+    },
+    {
+      "rule": "IAC-397",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: commented-out `#  maxUnavailable: 1` in a Helm values file. Issue #588."
+    },
+    {
+      "rule": "IAC-398",
+      "classification": "refined-away",
+      "pr": 594,
+      "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: the words 'HorizontalPodAutoscaler (HPA)' inside a header comment explaining what the manifest does. Issue #588."
     }
   ]
 }

--- a/testdata/refutation-suite/r12_hash_in_quoted_value.yaml
+++ b/testdata/refutation-suite/r12_hash_in_quoted_value.yaml
@@ -1,0 +1,33 @@
+# Guards: lexical-context-iac (IAC-007; issue #588).
+# nox-cover: lexical-context-iac
+#
+# r1 pins this for Python. This is the same hazard one file format over, and it
+# is the reason it exists: IaC rules match their keywords anywhere in the file,
+# including inside comments, so a manifest's own explanatory prose reports as
+# configuration. Fixing that means teaching the IaC path where a comment starts.
+#
+# The tempting way to do it is to cut each line at the first '#'. In YAML that
+# is wrong: a '#' inside a quoted scalar is data, and a comment only begins at
+# a '#' that follows whitespace outside a string.
+#
+# On the line below the '#' sits at column 59, inside the quoted SELinux level,
+# and the setting that grants full host capabilities follows it at column 69.
+# A first-hash cut deletes the rest of the line and with it a container running
+# with that setting — a real, high severity finding, removed by a filter added
+# to remove noise, with the count going down and every dashboard looking better
+# for it.
+#
+# This header spells no rule keyword, and that is not stylistic. Until the
+# filter exists these lines are scanned like any other, so naming the setting
+# in the prose made this very file report it twice — which is issue #588
+# demonstrating itself on the fixture written to guard its fix, and the reason
+# the fixture had to be worded around it rather than annotating it.
+apiVersion: v1
+kind: Pod  # nox-expect: IAC-137, IAC-138, IAC-139, IAC-140
+metadata:
+  name: build-agent
+spec:
+  containers:
+    - name: agent
+      image: registry.internal/agent@sha256:4444444444444444444444444444444444444444444444444444444444444444
+      securityContext: { seLinuxOptions: { level: "s0:c123#c456" }, privileged: true }  # nox-expect: IAC-135, IAC-007


### PR DESCRIPTION
Closes #588.

A manifest whose only content is

```yaml
# This comment mentions PodDisruptionBudget and nothing else.
apiVersion: v1
kind: ConfigMap
```

reported `IAC-395`, *"K8s defines PodDisruptionBudget (positive)"*. Kubernetes
and Terraform files are heavily commented, and the comments name exactly the
resource kinds and property names the rules match — so every explanatory line
in a manifest was a candidate finding, landing on the files operators read most.

## The fix

One post-filter in the IaC analyzer using `lexctx.WithinComments`, the same
primitive the secrets analyzer has used since `srccontext.go`. **No rule
changes** — the comment question is lexical, not per-rule, and answering it
once is why `lexctx` exists.

It cannot use `lexctx.LangFromPath`, and the reason is documented there:
`LangYAML` and `LangDockerfile` are deliberately unmapped because the secrets,
taint, ai and agentflow analyzers all gate on that lookup. The languages exist
and `Classify` handles them; only the path lookup withholds them. `configLang`
answers for this analyzer's own files and changes nothing for anyone else.

Terraform is untouched — `lexctx` has no HCL lexer, and guessing at comment
syntax in order to *remove* findings is the direction that hides
vulnerabilities. `TestTerraformIsNotFilteredYet` records that as a decision
rather than an oversight.

## It would have shipped as a no-op

The first version called `lexctx.LangFromPath`, every YAML file came back
`LangUnknown`, and the filter returned its input unchanged. The repro still
reported IAC-395 and the tests still passed. **Third defect of this shape in
the programme**: a check written correctly against the wrong input.

## What the Phase 0 instrumentation caught

**Gate A coverage (0.3).** The branch `lexical-context-iac` was registered
first and `TestRefutationBranchCoverage` failed naming it — which is the
specification for `r12_hash_in_quoted_value.yaml`. That fixture is the IaC `r1`:
a `#` at column 59 inside a quoted SELinux level, and the setting granting full
host capabilities at column 69. A filter cutting each line at the first `#`
deletes the rest and takes a real high-severity finding with it. It still fires.

The fixture's header had to be *worded around* the bug: naming the setting in
the prose made the file report it twice — #588 demonstrating itself on the
fixture written to guard its fix.

**The 0.4 ledger.** `rule-diff` exited 3 with eight unexplained drops. Every
dropped location across the corpus was then read by hand, and every one is a
comment:

| | |
|---|---|
| `# type: LoadBalancer` | commented out, so the Service is not one |
| `# namespace: default` | the Helm values convention — listed and disabled |
| `# type: Opaque` | commented out in an archived config |
| `#  maxUnavailable: 1` | commented out in a Helm values file |
| `# ... HorizontalPodAutoscaler (HPA) ...` | a header comment explaining the manifest |
| `# truststore_password: cassandra` | Cassandra's shipped defaults file |
| ``# and `id-token: write` for the OIDC flow`` | a comment explaining a permission |

The **real** `id-token: write` on warden's `release.yml:20`, which carries a
*trailing* comment, is correctly kept. The span test requires the match to
**begin** in a comment, because this filter removes findings and the direction
it must never fail in is dropping one that is partly real.

## The one that needed an argument, not a count

`IAC-254` is a hardcoded-secret rule, and it dropped
`# truststore_password: cassandra`. That is credential-shaped, which is exactly
where the secrets analyzer *keeps* comment matches.

It is assignment-shaped (`PASSWORD: value`), which is the class
`dropConfigFieldRuleInComment` already drops in comments — so this is
consistent with existing doctrine, not a new exception. Falsified rather than
assumed:

```
$ nox scan .        # AWS key inside a YAML comment
SEC-001   AWS Access Key ID detected
SEC-508   Detected AWS Access Key ID (alternate)
```

Reported by **both** binaries, before and after. A provider rule's token is
evidence wherever it sits.

## Measurements

| | |
|---|---|
| Detection corpora | 230 / 0 / 0 — unchanged |
| Refutation suite | 23 → **29 TP / 0 FP / 0 FN** |
| Branch coverage | 17 of 17 |
| `go test ./...` | 76 packages ok |
| rule-diff | exit 1, all 15 negative deltas accounted for |

#590 (IAC-131 on an HPA's `scaleTargetRef`) stays open, so the withdrawn clean
HPA fixture still cannot land — it now fails on that rule alone.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT