### PR TITLE
IAC: a kind under a reference field names another object, it does not declare this one

### DIFF
--- a/core/analyzers/iac/comment_context_test.go
+++ b/core/analyzers/iac/comment_context_test.go
@@ -99,3 +99,47 @@ func TestTerraformIsNotFilteredYet(t *testing.T) {
 			"and update issue #588 rather than only changing this test", got)
 	}
 }
+
+// A `kind:` under a field that points at another object names that object; it
+// does not declare this one. An HPA has no pod template, no containers and no
+// securityContext to be missing. Issue #590.
+func TestKindUnderAReferenceFieldIsNotADeclaration(t *testing.T) {
+	ids := scan(t, "hpa.yaml",
+		"apiVersion: autoscaling/v2\nkind: HorizontalPodAutoscaler\nmetadata:\n  name: backend\n"+
+			"spec:\n  scaleTargetRef:\n    apiVersion: apps/v1\n    kind: Deployment\n    name: backend\n"+
+			"  minReplicas: 3\n  maxReplicas: 40\n")
+	if has(ids, "IAC-131") {
+		t.Errorf("a workload rule fired on an autoscaler's scaleTargetRef: %v", ids)
+	}
+}
+
+// The reason the test keys on the enclosing FIELD and not on indentation.
+// A List holds real objects under `items:`, and every rule that applies to a
+// Deployment applies to one declared there. A depth rule deletes all of it,
+// and no repo in the rule-diff corpus contains a List, so nothing else would
+// notice. r13_workloads_inside_a_list.yaml pins this end to end.
+func TestWorkloadsInsideAListAreStillDeclarations(t *testing.T) {
+	ids := scan(t, "list.yaml",
+		"apiVersion: v1\nkind: List\nitems:\n  - apiVersion: apps/v1\n    kind: Deployment\n"+
+			"    metadata:\n      name: checkout\n    spec:\n      replicas: 3\n      template:\n"+
+			"        spec:\n          containers:\n            - name: api\n              image: reg/app:1\n")
+	for _, want := range []string{"IAC-131", "IAC-139", "IAC-145"} {
+		if !has(ids, want) {
+			t.Errorf("%s did not fire on a Deployment declared inside a List: %v", want, ids)
+		}
+	}
+}
+
+// A reference field nobody listed keeps producing a finding. That is the safe
+// direction for an allowlist to fail in, and it is worth pinning: the opposite
+// choice — treat anything nested as a reference — is what this design rejected.
+func TestUnlistedNestingIsNotTreatedAsAReference(t *testing.T) {
+	ids := scan(t, "tpl.yaml",
+		"apiVersion: v1\nkind: Template\nobjects:\n  - apiVersion: apps/v1\n    kind: Deployment\n"+
+			"    metadata:\n      name: from-template\n    spec:\n      template:\n        spec:\n"+
+			"          containers:\n            - name: api\n              image: reg/app:1\n")
+	if !has(ids, "IAC-131") {
+		t.Errorf("a Deployment under an unlisted key `objects:` was dropped; the allowlist "+
+			"must fail toward reporting: %v", ids)
+	}
+}

--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -105,6 +105,7 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 	}
 	out := dropArtifactsWhenAlways(results, content)
 	out = dropMatchesInComments(path, out, content)
+	out = dropKindReferences(path, out, content)
 	embedded, err := a.scanEmbedded(path, content, out)
 	if err != nil {
 		return nil, err
@@ -167,6 +168,87 @@ func dropMatchesInComments(path string, in []findings.Finding, content []byte) [
 		kept = append(kept, f)
 	}
 	return kept
+}
+
+// kindReferenceFields are the Kubernetes fields whose value POINTS AT another
+// object. A `kind:` nested under one of them names something else; it does not
+// declare the document it sits in.
+//
+// This is an allowlist rather than a depth test, and that distinction is the
+// whole fix. Indentation would be cheaper and, on the ten-repo corpus, exactly
+// right: 34 of 36 IAC-131 matches sit at column 0 and both nested ones are
+// references. It is also wrong, because a `kind: List` holds real objects
+// indented under `items:` — a depth rule deletes every workload in one, and no
+// corpus repo contains a List, so nothing would have caught it.
+// r13_workloads_inside_a_list.yaml is that case.
+//
+// An allowlist fails toward reporting: a reference field nobody listed keeps
+// producing a finding, which is noise. A depth rule fails toward silence.
+var kindReferenceFields = map[string]bool{
+	"scaleTargetRef":              true, // HorizontalPodAutoscaler -> workload
+	"targetRef":                   true, // ServiceMonitor, Gateway API, Flagger
+	"roleRef":                     true, // RoleBinding -> Role
+	"subjects":                    true, // RoleBinding -> ServiceAccount/User
+	"ownerReferences":             true, // any object -> its controller
+	"crossVersionObjectReference": true, // autoscaling/v1 HPA
+	"resourceRef":                 true, // Crossplane and friends
+	"targetService":               true,
+	"backendRef":                  true, // Gateway API HTTPRoute
+	"parentRefs":                  true, // Gateway API
+}
+
+// dropKindReferences removes findings anchored to a `kind:` line that names
+// another object rather than declaring this one.
+//
+// IAC-131 matched `kind\s*:\s*Deployment` anywhere in a YAML file, so a
+// HorizontalPodAutoscaler reported "Kubernetes workload detected - verify
+// NetworkPolicy exists" because it names the Deployment it scales. The document
+// is an autoscaler: no pod template, no containers, nothing the rule is about.
+// Issue #590.
+//
+// Two rules with the same defect were already removed by retiring them into
+// structural survivors (#591) — IAC-183 and IAC-176, 17 findings on podinfo
+// alone. IAC-131 has no structural survivor to retire into, so the reference
+// test is applied directly.
+//
+// The check is deliberately narrow: only findings whose own matched line is a
+// `kind:` mapping entry are considered, and only when the nearest enclosing key
+// is a known reference field. A rule that matched something else on that line
+// is untouched.
+func dropKindReferences(path string, in []findings.Finding, content []byte) []findings.Finding {
+	if len(in) == 0 || configLang(path) != lexctx.LangYAML {
+		return in
+	}
+
+	var lines []string
+	kept := in[:0]
+	for _, f := range in {
+		if lines == nil {
+			lines = strings.Split(string(content), "\n")
+		}
+		if isKindReference(lines, f.Location.StartLine) {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
+}
+
+// isKindReference reports whether the 1-based line is a `kind:` entry sitting
+// under a field that points at another object.
+func isKindReference(lines []string, line int) bool {
+	if line < 1 || line > len(lines) {
+		return false
+	}
+	trimmed := strings.TrimSpace(lines[line-1])
+	// A list item declares the object it introduces: `- kind: Deployment` inside
+	// `subjects:` is a reference, but the leading dash is part of the entry, so
+	// strip it before testing the key.
+	trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "-"))
+	if !strings.HasPrefix(trimmed, "kind:") {
+		return false
+	}
+	return kindReferenceFields[enclosingKey(lines, line)]
 }
 
 // configLang resolves the lexer language for an IaC file.

--- a/core/bench/coverage.go
+++ b/core/bench/coverage.go
@@ -125,6 +125,12 @@ var RefutationBranches = []Branch{
 		Proposition: "this configuration keyword is prose describing configuration, not configuration",
 	},
 	{
+		ID: "resource-kind-reference", Corpus: "refutation-suite",
+		Wrong:  "every nested `kind:` is treated as a reference to another object, which silently drops every workload declared inside a List's items",
+		Family: "IAC", Matcher: "iac/enclosing-key",
+		Proposition: "this kind names another object rather than declaring this one",
+	},
+	{
 		ID: "unmodelled-reflection", Corpus: "refutation-hard",
 		Wrong:  "no flow found through MethodByName is reported as no flow exists",
 		Family: "TAINT", Matcher: "taint/structural",

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -27,7 +27,7 @@ Machine-readable: `precision.json`.
 | Corpus | TP | FP | FN | Precision | Recall |
 |---|---:|---:|---:|---:|---:|
 | precision-corpus | 5 | 0 | 0 | 1.000 | 1.000 |
-| precision-suite | 52 | 0 | 0 | 1.000 | 1.000 |
+| precision-suite | 53 | 0 | 0 | 1.000 | 1.000 |
 | precision-suite-clojure | 20 | 0 | 0 | 1.000 | 1.000 |
 | precision-suite-cpp | 7 | 0 | 0 | 1.000 | 1.000 |
 | precision-suite-csharp | 6 | 0 | 0 | 1.000 | 1.000 |
@@ -46,7 +46,7 @@ Machine-readable: `precision.json`.
 | precision-suite-scala | 7 | 0 | 0 | 1.000 | 1.000 |
 | precision-suite-shell | 16 | 0 | 0 | 1.000 | 1.000 |
 | precision-suite-swift | 7 | 0 | 0 | 1.000 | 1.000 |
-| **Total** | **230** | **0** | **0** | **1.000** | **1.000** |
+| **Total** | **231** | **0** | **0** | **1.000** | **1.000** |
 
 ### The seven false negatives are closed, and they were closed the right way
 
@@ -74,7 +74,7 @@ This is the half the roadmap adds, and the half nothing else watches.
 
 | Corpus | Cases | Result | Guard | Gate |
 |---|---:|---|---|---|
-| `refutation-suite` | 29 | 29 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
+| `refutation-suite` | 37 | 37 TP / 0 FP / 0 FN — recall **1.000** | `TestRefutationSuiteRecall` + `TestRefutationBranchCoverage` | A |
 | `refutation-hard` | 5 | not precision-scored by design | `TestRefutationBranchCoverage` | A |
 | `reachability-suite` | 5 | 1 case may suppress, by name | `TestGateB` | B |
 
@@ -83,7 +83,7 @@ with *"4 real vulnerabilities are no longer reported"* until those annotations
 were removed in the same commit as the rule change. A duplicate ID cannot leave
 the corpus by accident.
 
-**Branch coverage: 16 of 16 registered refutation branches witnessed**
+**Branch coverage: 18 of 18 registered refutation branches witnessed**
 (`core/bench.RefutationBranches`). Milestone 0.3 added the registry, four
 rule-level fixtures, and a gate that fails when the last fixture for a branch
 is deleted — a deletion recall alone cannot see, because it removes the

--- a/docs/benchmarks/2026-09/precision.json
+++ b/docs/benchmarks/2026-09/precision.json
@@ -14,7 +14,7 @@
     },
     {
       "corpus": "precision-suite",
-      "tp": 52,
+      "tp": 53,
       "fp": 0,
       "fn": 0,
       "precision": 1.0,
@@ -166,7 +166,7 @@
     }
   ],
   "detection_total": {
-    "tp": 230,
+    "tp": 231,
     "fp": 0,
     "fn": 0,
     "precision": 1.0,
@@ -176,14 +176,14 @@
     {
       "corpus": "refutation-suite",
       "scored": true,
-      "tp": 29,
+      "tp": 37,
       "fp": 0,
       "fn": 0,
       "precision": 1.0,
       "recall": 1.0,
       "guard": "cli.TestRefutationSuiteRecall + cli.TestRefutationBranchCoverage",
       "gate": "A",
-      "branches": 12,
+      "branches": 13,
       "note": "27 -> 23: IAC-183 and IAC-286 annotations removed when the duplicates were retired; Gate A required that removal to be deliberate"
     },
     {
@@ -264,8 +264,8 @@
   },
   "branch_coverage": {
     "registry": "core/bench.RefutationBranches",
-    "branches": 17,
-    "covered": 17,
+    "branches": 18,
+    "covered": 18,
     "uncovered": 0,
     "gate": "cli.TestRefutationBranchCoverage",
     "note": "removing the only fixture for a branch fails coverage while recall stays 1.000"

--- a/scripts/rule-deltas.json
+++ b/scripts/rule-deltas.json
@@ -113,6 +113,12 @@
       "classification": "refined-away",
       "pr": 599,
       "reason": "A comment in a YAML manifest is prose ABOUT configuration, and prose configures nothing. Every dropped location on the corpus was checked by hand and every one is a comment: the words 'HorizontalPodAutoscaler (HPA)' inside a header comment explaining what the manifest does. Issue #588."
+    },
+    {
+      "rule": "IAC-131",
+      "classification": "refined-away",
+      "pr": 600,
+      "reason": "A kind: under a field that POINTS AT another object names that object; it does not declare this one. IAC-131 matched kind: Deployment anywhere in a YAML file, so every HorizontalPodAutoscaler reported \"workload detected\" because it names the Deployment it scales \u2014 a document with no pod template, no containers and nothing the rule is about. All 11 removals across the corpus were checked by hand and every one sits under scaleTargetRef: 9 on podinfo, 2 on kubernetes-examples. The test keys on the enclosing FIELD, not on depth, because a kind: List holds real objects under items: and a depth rule would delete every workload in one \u2014 pinned by r13_workloads_inside_a_list.yaml, since no corpus repo contains a List. Issue #590."
     }
   ]
 }

--- a/testdata/precision-suite/tp_hpa_scaletargetref.yaml
+++ b/testdata/precision-suite/tp_hpa_scaletargetref.yaml
@@ -1,0 +1,39 @@
+# A HorizontalPodAutoscaler names the workload it scales in spec.scaleTargetRef.
+# That `kind: Deployment` is a REFERENCE, not a declaration: this document has
+# no pod template, no containers and no securityContext to be missing, so the
+# workload rules must stay silent on it.
+#
+# This sample was written during #591 and withdrawn twice, because it could not
+# score clean for two reasons that had nothing to do with each other:
+#
+#   #588  the header you are reading was itself matched, so explaining the case
+#         in prose produced the findings the case is about
+#   #590  IAC-131 fired on the scaleTargetRef below
+#
+# Both are fixed, and it lands with the second of them. Three rules used to
+# report here — IAC-183 and IAC-176 were retired into structural survivors that
+# were always correct on this shape, and IAC-131 now tests the enclosing field.
+#
+# What must stay silent is every WORKLOAD rule. IAC-398 is annotated and
+# correct: this document really is an autoscaler, and that rule is the advisory
+# about autoscalers. A fixture that claimed the file was findings-free would be
+# asserting something untrue in order to look tidier.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler  # nox-expect: IAC-398
+metadata:
+  name: backend
+  namespace: prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 3
+  maxReplicas: 40
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/testdata/refutation-suite/r13_workloads_inside_a_list.yaml
+++ b/testdata/refutation-suite/r13_workloads_inside_a_list.yaml
@@ -1,0 +1,43 @@
+# Guards: resource-kind-reference (IAC-131; issue #590).
+# nox-cover: resource-kind-reference
+#
+# #590 is that a workload rule fires on `kind: Deployment` written inside an
+# autoscaler's scaleTargetRef, where it NAMES the object being scaled rather
+# than declaring one. The document there is an autoscaler and holds no pod
+# template at all.
+#
+# The cheap fix is indentation: a kind at column 0 declares this document, a
+# nested one refers to something else. On the ten-repo corpus that heuristic is
+# exactly right — 34 of 36 matches sit at indent 0, and both nested ones are
+# references.
+#
+# It is also wrong, and this file is why. A List is a real Kubernetes document
+# whose items are real objects, indented under `items:`. Every workload below
+# is declared here, runs here, and is exactly what the rules are for: no
+# probes, no limits, no security context, nothing binding them to a policy.
+# An indentation rule silently deletes all of it, and the corpus repos happen
+# to contain no List, so nothing would have caught it.
+#
+# The reference test therefore keys on the ENCLOSING FIELD, not the depth: a
+# kind is a reference when the key above it is one of the fields Kubernetes
+# uses to point at another object. `items` is not one of them.
+apiVersion: v1
+kind: List  # a List is not itself a workload kind, so no workload rule fires here
+items:
+  - apiVersion: apps/v1
+    kind: Deployment  # nox-expect: IAC-131, IAC-132, IAC-137, IAC-138, IAC-139, IAC-140, IAC-142, IAC-145
+    metadata:
+      name: checkout
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app: checkout
+      template:
+        metadata:
+          labels:
+            app: checkout
+        spec:
+          containers:
+            - name: api
+              image: registry.internal/checkout@sha256:5555555555555555555555555555555555555555555555555555555555555555


### PR DESCRIPTION
Closes #590.

`IAC-131` matched `kind: Deployment` anywhere in a YAML file, so every
HorizontalPodAutoscaler reported *"Kubernetes workload detected — verify
NetworkPolicy exists"* because it names the Deployment it scales. The document
is an autoscaler: no pod template, no containers, nothing the rule is about.

Two rules with the same defect were removed in #591 by retiring them into
structural survivors that resolve the document's own kind — 17 findings on
podinfo alone. IAC-131 has no survivor to retire into, so the reference test is
applied directly.

## The cheap fix would have been wrong, and the corpus could not have said so

Indentation is the obvious test: a `kind:` at column 0 declares this document,
a nested one refers to something else. On the corpus it is **exactly right** —
34 of 36 matches in kubernetes-examples sit at indent 0, and both nested ones
are references.

It is also wrong. A `kind: List` holds real objects indented under `items:`,
and every rule that applies to a Deployment applies to one declared there. A
depth rule silently deletes all of it — and **no repo in the rule-diff corpus
contains a List**, so neither the corpus nor the gate would have noticed.

So the test keys on the **enclosing field**: a kind is a reference when the key
above it is one Kubernetes uses to point at another object (`scaleTargetRef`,
`roleRef`, `subjects`, `ownerReferences`, `backendRef`, …). An allowlist fails
toward *reporting* — a reference field nobody listed keeps producing a finding,
which is noise. A depth rule fails toward *silence*.

`r13_workloads_inside_a_list.yaml` is that case, registered as the refutation
branch `resource-kind-reference` **before** the fix, so the failing coverage
test was the specification. Three unit tests pin the three directions: a
`scaleTargetRef` is dropped, a List's items are kept, and an unlisted nesting
key (`objects:`) is kept.

## Measured

`rule-diff` against v1.34.0: **IAC-131 drops 11, and nothing else moves.**
podinfo 21 → 12, kubernetes-examples 36 → 34. Every one of the 11 was read by
hand and every one sits under `scaleTargetRef`.

| | |
|---|---|
| Detection corpora | 230 → **231** (the HPA fixture) |
| Refutation suite | 29 → **37 TP / 0 FP / 0 FN** |
| Branch coverage | **18 of 18** |
| rule-diff | exit 1, all 16 negative deltas accounted for |

## The fixture that was withdrawn twice

`tp_hpa_scaletargetref.yaml` finally lands. It was written during #591 and
pulled twice — first because **#588** matched its own explanatory header, then
because **#590** fired on the `scaleTargetRef` it describes.

It is committed as `tp_` rather than `clean_`, because IAC-398 does fire on it
and is right to: the document really is an autoscaler, and that rule is the
advisory about autoscalers. A fixture claiming the file was findings-free would
assert something untrue in order to look tidier.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT