### PR TITLE
PHASE 1.2: what nox could not ask has to survive to the artifact

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nox-hq/nox/core/replay"
 	"github.com/nox-hq/nox/core/report"
 	htmlreport "github.com/nox-hq/nox/core/report/html"
-	"github.com/nox-hq/nox/core/report/sarif"
 	"github.com/nox-hq/nox/core/report/sbom"
 	"github.com/nox-hq/nox/server"
 )
@@ -718,12 +717,9 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		switch format {
 		case "json":
 			path := filepath.Join(outputDir, "findings.json")
-			r := report.NewJSONReporter(version)
+			r := result.JSONReporter(version)
 			r.Offline = offlineFlag
 			r.Prioritize = sortFlag == "priority"
-			r.SASTLanguages = result.SASTProfile
-			r.Degradations = report.DegradationsFrom(result.Degradations)
-			r.Enrichments = result.Enrichments
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2
@@ -734,7 +730,10 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 
 		case "sarif":
 			path := filepath.Join(outputDir, "results.sarif")
-			r := sarif.NewReporter(version, result.Rules)
+			r := result.SARIFReporter(version)
+			// The CLI writes to a file, not to a response budget, so it can
+			// afford the full rule catalog the MCP surface cannot.
+			r.Rules = result.Rules
 			if err := r.WriteToFile(result.Findings, path); err != nil {
 				fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", path, err)
 				return 2

--- a/cli/mcp_cmd.go
+++ b/cli/mcp_cmd.go
@@ -234,14 +234,20 @@ func mcpDrift(args []string) int {
 		return 2
 	}
 	jsonPath := filepath.Join(outputDir, "findings.json")
-	// no degradations: every failure above — an unreadable baseline, a manifest
-	// that could not be captured — exits 2 rather than continuing, so this
-	// command has no partial-result state to report.
+	// `nox mcp drift` compares two manifests. It runs no analyzers, and every
+	// failure above — an unreadable baseline, a manifest that could not be
+	// captured — exits 2 rather than continuing. So there is no capability
+	// matrix and no partial-result state to publish, and omitting both is the
+	// honest artifact: a matrix of zeroes would describe an installation that
+	// answered nothing, which is not what happened here.
+	//
+	// no scan behind this report
 	if err := report.NewJSONReporter(version).WriteToFile(fsSet, jsonPath); err != nil {
 		fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", jsonPath, err)
 		return 2
 	}
 	sarifPath := filepath.Join(outputDir, "results.sarif")
+	// no scan behind this report — see above.
 	if err := sarif.NewReporter(version, nil).WriteToFile(fsSet, sarifPath); err != nil {
 		fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", sarifPath, err)
 		return 2

--- a/conformance/degradation_reporting_test.go
+++ b/conformance/degradation_reporting_test.go
@@ -7,9 +7,14 @@ import (
 	"testing"
 )
 
-// A degradation says a check did not run, so "no findings" does not mean
-// "nothing to find". That distinction is only useful if it reaches the person —
-// or the agent — reading the results.
+// An artifact has to state what the scan could not do, or a consumer reads its
+// silence as an all-clear. Two things say so, and both die at the artifact
+// boundary if an adapter forgets them:
+//
+//   - Degradations report what BROKE — a failed OSV lookup, a plugin that never
+//     started, an unparsed lockfile.
+//   - Capabilities report what was never POSSIBLE — an installation with no call
+//     graph produces a scan with no call-graph errors and no call-graph answers.
 //
 // The CLI printed degradations to stderr and recorded them in findings.json.
 // The MCP server built its JSON report without them at all, across three
@@ -17,10 +22,21 @@ import (
 // artifact that said nothing about the checks that had not run: the consumer
 // least able to notice, because it has no stderr to read.
 //
-// This guard requires every JSONReporter construction to set Degradations.
+// That was fixed by assignment at each site, and this guard existed to keep the
+// assignments in place. It is now a guard on something stronger: the fields are
+// set by ScanResult.JSONReporter / ScanResult.SARIFReporter, once, next to the
+// result they are derived from — so a new surface inherits them rather than
+// remembering them. A site that builds a reporter by hand has opted out of that
+// and must prove it did so deliberately.
 
-// reporterSites returns the non-test Go files that construct a JSON reporter.
-func reporterSites(t *testing.T) map[string]string {
+// noScanBehindIt is the escape hatch, and it is deliberately a sentence a
+// reader has to mean. A report with no ScanResult in reach — `nox mcp drift`
+// compares two manifests — has no degradations and no capability matrix, and
+// must say so rather than leave the omission looking like an oversight.
+const noScanBehindIt = "no scan behind this report"
+
+// adapterSources returns the non-test Go files in the CLI and MCP adapters.
+func adapterSources(t *testing.T) map[string]string {
 	t.Helper()
 	out := map[string]string{}
 	for _, dir := range []string{"cli", "server"} {
@@ -38,49 +54,88 @@ func reporterSites(t *testing.T) map[string]string {
 			if err != nil {
 				t.Fatalf("reading %s: %v", path, err)
 			}
-			if strings.Contains(string(raw), "NewJSONReporter(") {
-				out[dir+"/"+name] = string(raw)
-			}
+			out[dir+"/"+name] = string(raw)
 		}
 	}
 	return out
 }
 
-// TestEveryJSONReportCarriesDegradations pins that no adapter drops them.
-func TestEveryJSONReportCarriesDegradations(t *testing.T) {
-	sites := reporterSites(t)
-	if len(sites) == 0 {
-		t.Fatal("found no JSON reporter construction sites; the guard is vacuous")
-	}
-
+// checkReporterSites walks every construction of a reporter and requires each
+// one to either go through the shared constructor or set the field by hand.
+//
+// shared is the method that fills everything in ("JSONReporter("); bare is the
+// raw constructor a hand-rolled site would call; field is what such a site must
+// then assign. Returns the number of sites examined so the caller can assert
+// the pattern has not drifted out from under the guard.
+func checkReporterSites(t *testing.T, shared, bare, field, why string) int {
+	t.Helper()
 	var total int
-	for file, src := range sites {
+	for file, src := range adapterSources(t) {
 		lines := strings.Split(src, "\n")
 		for i, line := range lines {
-			if !strings.Contains(line, "NewJSONReporter(") {
+			viaShared := strings.Contains(line, shared)
+			viaBare := strings.Contains(line, bare)
+			if !viaShared && !viaBare {
 				continue
 			}
 			total++
-			// The assignment follows the construction; an explicit "no
-			// degradations" note may sit just above it. Look both ways.
-			window := strings.Join(lines[maxInt(i-4, 0):minInt(i+8, len(lines))], "\n")
-			if strings.Contains(window, ".Degradations = ") {
+			// The shared constructor sets the field from the ScanResult. That
+			// is the whole point of it existing, and such a site needs nothing.
+			if viaShared {
 				continue
 			}
-			// A site with no ScanResult in reach has nothing to report; it must
-			// say so rather than leave the omission looking like an oversight.
-			if strings.Contains(window, "no degradations") {
+			// A hand-rolled site: the assignment follows the construction, and
+			// an explicit exemption may sit just above it. Look both ways.
+			window := strings.Join(lines[maxInt(i-5, 0):minInt(i+9, len(lines))], "\n")
+			if strings.Contains(window, field) || strings.Contains(window, noScanBehindIt) {
 				continue
 			}
-			t.Errorf("%s:%d constructs a JSON reporter without setting Degradations. The artifact "+
-				"then cannot distinguish a clean scan from one whose checks did not run — and an "+
-				"MCP client has no stderr to read instead. Set it from the ScanResult, or say "+
-				"\"no degradations\" in a comment if none are in reach.", file, i+1)
+			t.Errorf("%s:%d builds a reporter by hand without setting %s. %s Use the "+
+				"ScanResult constructor (%s), set the field explicitly, or write %q in a "+
+				"comment if there is genuinely no scan to describe.",
+				file, i+1, strings.TrimSuffix(strings.TrimPrefix(field, "."), " = "),
+				why, shared, noScanBehindIt)
 		}
 	}
+	return total
+}
+
+// TestEveryJSONReportCarriesDegradations pins that no adapter drops them.
+func TestEveryJSONReportCarriesDegradations(t *testing.T) {
+	total := checkReporterSites(t, ".JSONReporter(", "NewJSONReporter(", ".Degradations = ",
+		"The artifact then cannot distinguish a clean scan from one whose checks did not run — "+
+			"and an MCP client has no stderr to read instead.")
 	if total < 4 {
-		t.Errorf("only %d reporter sites were checked; the pattern has drifted and sites are going "+
-			"unguarded", total)
+		t.Errorf("only %d JSON reporter sites were found; the pattern has drifted and sites are "+
+			"going unguarded", total)
+	}
+}
+
+// TestEveryJSONReportCarriesCapabilities pins the other half.
+//
+// This one matters more than it looks, because an omitted capability matrix
+// does not read as missing information. A findings.json with no `capabilities`
+// key looks exactly like a scan that asked every question and found nothing —
+// which is the single inference the capability model exists to prevent.
+func TestEveryJSONReportCarriesCapabilities(t *testing.T) {
+	total := checkReporterSites(t, ".JSONReporter(", "NewJSONReporter(", ".Capabilities = ",
+		"A report with no capability matrix looks identical to one from an installation that "+
+			"could answer every question.")
+	if total < 4 {
+		t.Errorf("only %d JSON reporter sites were found; the pattern has drifted and sites are "+
+			"going unguarded", total)
+	}
+}
+
+// TestEverySARIFReportCarriesCapabilities holds the same line for SARIF, where
+// the consumer is usually GitHub Code Scanning and the failure is a green run.
+func TestEverySARIFReportCarriesCapabilities(t *testing.T) {
+	total := checkReporterSites(t, ".SARIFReporter(", "sarif.NewReporter(", ".Capabilities = ",
+		"SARIF has no other slot for what the run could not establish, so Code Scanning shows a "+
+			"scan that could not look and a scan that looked and found nothing identically.")
+	if total < 4 {
+		t.Errorf("only %d SARIF reporter sites were found; the pattern has drifted and sites are "+
+			"going unguarded", total)
 	}
 }
 
@@ -88,10 +143,15 @@ func TestEveryJSONReportCarriesDegradations(t *testing.T) {
 // It was duplicated in the CLI while the server had none, which is how the two
 // surfaces came to disagree about whether degradations are part of a report.
 func TestDegradationConversionHasOneImplementation(t *testing.T) {
-	for file, src := range reporterSites(t) {
+	for file, src := range adapterSources(t) {
 		if strings.Contains(src, "func degradationsForReport(") {
 			t.Errorf("%s defines its own degradation conversion; use report.DegradationsFrom so "+
 				"every surface reports the same thing", file)
+		}
+		if strings.Contains(src, "func capabilitiesForReport(") {
+			t.Errorf("%s defines its own capability conversion; use report.CapabilitiesFrom so "+
+				"findings.json and results.sarif cannot disagree about what nox could establish",
+				file)
 		}
 	}
 }

--- a/core/report/capability_coverage_test.go
+++ b/core/report/capability_coverage_test.go
@@ -1,0 +1,202 @@
+package report_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/report"
+)
+
+func subj(t *testing.T, id string) evidence.Subject {
+	t.Helper()
+	return evidence.Subject{Kind: evidence.SubjectCandidate, ID: id}
+}
+
+// The matrix lists every capability, always — including the ones nothing
+// provides and the ones that answered nothing.
+//
+// A matrix that listed only what worked would be worse than no matrix at all: a
+// reader would take the rows present as the complete set of questions nox asks,
+// and a capability missing from the list is exactly the one they need to know
+// about.
+func TestCapabilityMatrixListsEveryCapability(t *testing.T) {
+	got := report.CapabilitiesFrom(capability.DefaultRegistry(), nil)
+	if len(got) != len(capability.All()) {
+		t.Fatalf("matrix has %d rows, want one per capability (%d)", len(got), len(capability.All()))
+	}
+	for i, c := range capability.All() {
+		if got[i].Capability != string(c) {
+			t.Errorf("row %d is %q, want %q — order must follow capability.All()", i, got[i].Capability, c)
+		}
+	}
+}
+
+// A capability nothing implements is reported as unprovided rather than
+// omitted. On a stock installation that is call_graph and entry_point, and an
+// operator reading a clean scan has no other way to learn it.
+func TestUnprovidedCapabilitiesAreReportedNotOmitted(t *testing.T) {
+	got := report.CapabilitiesFrom(capability.DefaultRegistry(), nil)
+	want := map[string]bool{"call_graph": true, "entry_point": true}
+	seen := map[string]bool{}
+	for _, row := range got {
+		if !row.Provided {
+			seen[row.Capability] = true
+			if len(row.Providers) != 0 {
+				t.Errorf("%s: unprovided but names providers %v", row.Capability, row.Providers)
+			}
+		}
+	}
+	for c := range want {
+		if !seen[c] {
+			t.Errorf("%s is not provided by any builtin, but the matrix does not say so", c)
+		}
+	}
+}
+
+// THE EXIT CRITERION for milestone 1.2: two scans differing only in what could
+// be analyzed must not produce the same artifact.
+//
+// Before this, they did. Capability state lived on ScanResult and was
+// serialized nowhere, so an installation that lost its taint engine wrote a
+// findings.json byte-identical to one that had it and found nothing — and an
+// empty findings list is read as clean by every consumer that cannot see the
+// difference.
+func TestLosingAProviderChangesTheArtifact(t *testing.T) {
+	full := capability.NewRegistry()
+	for _, p := range capability.Builtins() {
+		full.Register(p)
+	}
+	// The same installation minus the taint engine.
+	reduced := capability.NewRegistry()
+	for _, p := range capability.Builtins() {
+		if p.Name() == "core/taint" {
+			continue
+		}
+		reduced.Register(p)
+	}
+
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "SEC-001", Message: "m", Severity: findings.SeverityHigh})
+
+	render := func(reg *capability.Registry) string {
+		r := report.NewJSONReporter("test")
+		r.Capabilities = report.CapabilitiesFrom(reg, nil)
+		data, err := r.Generate(fs)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		return string(data)
+	}
+
+	withTaint, withoutTaint := render(full), render(reduced)
+	if withTaint == withoutTaint {
+		t.Fatal("a scan that lost the taint engine produced a byte-identical artifact " +
+			"to one that had it — the capability state never reached the report")
+	}
+	if !strings.Contains(withTaint, `"capability": "taint"`) {
+		t.Error("the taint row is missing from the artifact entirely")
+	}
+}
+
+// Answered and Provided are different questions and must not collapse.
+//
+// reachability is provided by every nox build, and on a scan whose advisory
+// source was unreachable it establishes nothing. A consumer reading only
+// Provided would see a capability nox has; the run-level truth is that it
+// answered nobody.
+func TestProvidedAndAnsweredAreSeparate(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+	cov.Record(subj(t, "a"), capability.Reachability, capability.Negative)
+	cov.Record(subj(t, "b"), capability.Reachability, capability.Unknown)
+	cov.Record(subj(t, "c"), capability.Taint, capability.Positive)
+
+	rows := map[string]report.CapabilityCoverage{}
+	for _, row := range report.CapabilitiesFrom(reg, cov) {
+		rows[row.Capability] = row
+	}
+
+	// Negative is an answer — the strongest a static scan reaches.
+	if got := rows["reachability"]; got.Answered != 1 || got.Inconclusive != 1 {
+		t.Errorf("reachability: answered=%d inconclusive=%d, want 1 and 1", got.Answered, got.Inconclusive)
+	}
+	// Provided, and asked nothing. Answered must stay 0, never be inferred
+	// from the capability existing.
+	if got := rows["constant_evaluation"]; !got.Provided || got.Answered != 0 {
+		t.Errorf("constant_evaluation: provided=%v answered=%d, want provided with nothing answered",
+			got.Provided, got.Answered)
+	}
+}
+
+// An inconclusive result is not coverage. Counting "evaluated and could not
+// tell" toward Answered would rebuild the false all-clear one layer up, in the
+// very field added to prevent it.
+func TestInconclusiveNeverCountsAsAnswered(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+	cov.Record(subj(t, "a"), capability.Taint, capability.Unknown)
+	cov.Record(subj(t, "b"), capability.Taint, capability.TimedOut)
+
+	for _, row := range report.CapabilitiesFrom(reg, cov) {
+		if row.Capability != "taint" {
+			continue
+		}
+		if row.Answered != 0 {
+			t.Errorf("taint answered=%d, want 0: unknown and timed_out are not answers", row.Answered)
+		}
+		if row.Inconclusive != 2 {
+			t.Errorf("taint inconclusive=%d, want 2", row.Inconclusive)
+		}
+	}
+}
+
+// A report with no scan behind it — a fixture, a filtered re-render — must not
+// publish a capability matrix it never had. Absent is honest; a matrix of
+// zeroes claiming a full installation is not.
+func TestReportWithoutCoverageOmitsTheMatrix(t *testing.T) {
+	fs := findings.NewFindingSet()
+	data, err := report.NewJSONReporter("test").Generate(fs)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var rep report.JSONReport
+	if err := json.Unmarshal(data, &rep); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rep.Meta.Capabilities) != 0 {
+		t.Errorf("a reporter given no coverage emitted %d capability rows", len(rep.Meta.Capabilities))
+	}
+	if strings.Contains(string(data), "capabilities") {
+		t.Error(`the "capabilities" key is present in a report with no capability data`)
+	}
+}
+
+// The matrix round-trips: what a consumer reads back is what was written.
+func TestCapabilityMatrixRoundTrips(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+	cov.Record(subj(t, "a"), capability.LexicalContext, capability.Positive)
+
+	r := report.NewJSONReporter("test")
+	r.Capabilities = report.CapabilitiesFrom(reg, cov)
+	data, err := r.Generate(findings.NewFindingSet())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var rep report.JSONReport
+	if err := json.Unmarshal(data, &rep); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rep.Meta.Capabilities) != len(capability.All()) {
+		t.Fatalf("read back %d rows, wrote %d", len(rep.Meta.Capabilities), len(capability.All()))
+	}
+	for _, row := range rep.Meta.Capabilities {
+		if row.Capability == "lexical_context" && row.Answered != 1 {
+			t.Errorf("lexical_context answered=%d after round-trip, want 1", row.Answered)
+		}
+	}
+}

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nox-hq/nox-core/degrade"
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/findings"
 )
 
@@ -64,6 +65,52 @@ type Meta struct {
 	// indistinguishable from a scan that never looked. Omitted when the scan
 	// was complete.
 	Degradations []Degradation `json:"degradations,omitempty"`
+	// Capabilities records which analysis questions this scan could ask, and
+	// how many of them it actually answered.
+	//
+	// Degradations report what BROKE. This reports what was never possible in
+	// the first place, which no failure will ever announce: an installation
+	// that provides no call graph produces a scan with no call-graph errors
+	// and no call-graph answers, and the artifact reads exactly like one from
+	// an installation that has it and found nothing. That is the state
+	// core/capability exists to make visible, and until now it died at the
+	// artifact boundary — held on ScanResult, serialized nowhere, so the only
+	// consumers who could see it were the ones already inside the process.
+	//
+	// Omitted when the reporter was given no coverage, which keeps a report
+	// built without a scan (a filtered re-render, a fixture) from claiming a
+	// capability matrix it never had.
+	Capabilities []CapabilityCoverage `json:"capabilities,omitempty"`
+}
+
+// CapabilityCoverage is one analysis capability's standing in a scan: whether
+// this installation can answer the question at all, and how often it did.
+//
+// The two halves are separate on purpose and must not be collapsed. Provided
+// is a property of the INSTALLATION — permanent, and knowable without running
+// anything. Answered is a property of this RUN, and the two come apart exactly
+// when something fails at runtime: reachability is provided by every nox build,
+// and on a scan whose advisory source was unreachable it establishes nothing.
+// A consumer that reads only Provided sees a capability nox has; one that reads
+// only Answered cannot tell "nothing to say" from "nothing to say it with".
+type CapabilityCoverage struct {
+	Capability string `json:"capability"`
+	// Provided reports whether any implementation on this installation offers
+	// the capability. False is a limit nox can state plainly — not a failure,
+	// and never a clearance.
+	Provided bool `json:"provided"`
+	// Providers names the implementations, sorted. Empty when none.
+	Providers []string `json:"providers,omitempty"`
+	// Answered counts the subjects this capability reached a conclusion about,
+	// positive or negative. Negative counts: "the build links no package under
+	// crypto/md5" is a real answer, and the strongest a static scan reaches.
+	Answered int `json:"answered"`
+	// Inconclusive counts the subjects it was asked about and could not
+	// determine — evaluated-and-unknown, or timed out. These are the ones that
+	// must never be added to Answered: they mean the question was put and came
+	// back empty, and counting them as coverage rebuilds the false all-clear
+	// one layer up.
+	Inconclusive int `json:"inconclusive"`
 }
 
 // Degradation is a single incomplete check, as recorded in the artifact.
@@ -154,6 +201,34 @@ func DegradationsFrom(ds []degrade.Degradation) []Degradation {
 	return out
 }
 
+// CapabilitiesFrom converts a scan's capability registry and coverage into
+// their report form: one row per defined capability, cheapest first.
+//
+// Every capability is emitted, including the ones nothing provides and the ones
+// that answered nothing. That is the whole point — a matrix that lists only
+// what worked is a matrix a reader will mistake for the complete set of
+// questions. Nine rows, always, is what lets a consumer see that two of them
+// were never askable.
+//
+// A nil registry and a nil coverage are both usable: the result is every
+// capability marked unprovided with nothing answered, which is the honest
+// description of an installation that declared nothing.
+func CapabilitiesFrom(reg *capability.Registry, cov *capability.Coverage) []CapabilityCoverage {
+	all := capability.All()
+	out := make([]CapabilityCoverage, 0, len(all))
+	for _, c := range all {
+		answered, inconclusive := cov.Answered(c)
+		out = append(out, CapabilityCoverage{
+			Capability:   string(c),
+			Provided:     reg.Provided(c),
+			Providers:    reg.ProvidedBy(c),
+			Answered:     answered,
+			Inconclusive: inconclusive,
+		})
+	}
+	return out
+}
+
 // JSONReporter produces deterministic JSON output from a FindingSet.
 type JSONReporter struct {
 	ToolVersion string
@@ -177,6 +252,10 @@ type JSONReporter struct {
 	// plugin's output never reaches the artifact, which makes a plugin that
 	// annotates rather than detects indistinguishable from one that did not run.
 	Enrichments []findings.Enrichment
+	// Capabilities is the analysis capability matrix for this scan. Set it with
+	// CapabilitiesFrom(result.Capabilities, result.Coverage) — or, better, let
+	// core.ScanResult.JSONReporter set it, so no surface has to remember.
+	Capabilities []CapabilityCoverage
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -212,6 +291,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			Offline:       r.Offline,
 			SASTLanguages: r.SASTLanguages,
 			Degradations:  r.Degradations,
+			Capabilities:  r.Capabilities,
 		},
 		Findings:    f,
 		Enrichments: r.Enrichments,

--- a/core/report/sarif/notifications_test.go
+++ b/core/report/sarif/notifications_test.go
@@ -1,0 +1,134 @@
+package sarif
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/report"
+)
+
+func generate(t *testing.T, caps []report.CapabilityCoverage) Report {
+	t.Helper()
+	r := NewReporter("test", nil)
+	r.Capabilities = caps
+	fs := findings.NewFindingSet()
+	fs.Add(findings.Finding{RuleID: "SEC-001", Message: "m", Severity: findings.SeverityHigh})
+	data, err := r.Generate(fs)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var doc Report
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return doc
+}
+
+func notifications(t *testing.T, doc Report) []Notification {
+	t.Helper()
+	if len(doc.Runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(doc.Runs))
+	}
+	if len(doc.Runs[0].Invocations) == 0 {
+		return nil
+	}
+	return doc.Runs[0].Invocations[0].ToolExecutionNotifications
+}
+
+// SARIF has no slot for "this analysis was never able to run here", so a
+// consumer reading results.sarif sees a green run whether nox looked and found
+// nothing or never had the ability to look. These notifications are the whole
+// difference.
+func TestUnprovidedCapabilityIsNotified(t *testing.T) {
+	doc := generate(t, []report.CapabilityCoverage{
+		{Capability: "call_graph", Provided: false},
+	})
+	notes := notifications(t, doc)
+	if len(notes) != 1 {
+		t.Fatalf("got %d notifications, want 1", len(notes))
+	}
+	if notes[0].Descriptor == nil || notes[0].Descriptor.ID != "nox/capability/unsupported" {
+		t.Errorf("descriptor = %+v, want nox/capability/unsupported", notes[0].Descriptor)
+	}
+	if !strings.Contains(notes[0].Message.Text, "not an all-clear") {
+		t.Errorf("message does not warn against reading silence as safety: %q", notes[0].Message.Text)
+	}
+}
+
+// A capability that answered everything it was asked is not a notification.
+// Reporting the successes too would bury the two rows that matter in seven that
+// do not, and a signal nobody reads is not a signal.
+func TestFullyAnsweredCapabilitiesProduceNoNotification(t *testing.T) {
+	doc := generate(t, []report.CapabilityCoverage{
+		{Capability: "lexical_context", Provided: true, Answered: 12},
+		{Capability: "taint", Provided: true, Answered: 3},
+	})
+	if notes := notifications(t, doc); len(notes) != 0 {
+		t.Errorf("got %d notifications for a fully-answered matrix, want none: %+v", len(notes), notes)
+	}
+	if len(doc.Runs[0].Invocations) != 0 {
+		t.Error("emitted an invocations block with nothing to report")
+	}
+}
+
+// Provided-but-silent is the state this whole model exists for: the capability
+// is installed, nothing asked it, and no error was raised. It must be reported
+// distinctly from a capability that does not exist, because the operator's
+// remedy differs — one is a gap they can close, the other a limit they cannot.
+func TestProvidedButUnaskedIsReportedDistinctly(t *testing.T) {
+	doc := generate(t, []report.CapabilityCoverage{
+		{Capability: "reachability", Provided: true, Answered: 0},
+		{Capability: "entry_point", Provided: false},
+	})
+	notes := notifications(t, doc)
+	if len(notes) != 2 {
+		t.Fatalf("got %d notifications, want 2", len(notes))
+	}
+	ids := []string{notes[0].Descriptor.ID, notes[1].Descriptor.ID}
+	if ids[0] != "nox/capability/not-evaluated" || ids[1] != "nox/capability/unsupported" {
+		t.Errorf("ids = %v, want a gap and a limit reported under different descriptors", ids)
+	}
+}
+
+// A capability that ran and could not decide is neither answered nor absent.
+func TestInconclusiveIsReportedEvenWhenSomeSubjectsAnswered(t *testing.T) {
+	doc := generate(t, []report.CapabilityCoverage{
+		{Capability: "reachability", Provided: true, Answered: 5, Inconclusive: 2},
+	})
+	notes := notifications(t, doc)
+	if len(notes) != 1 {
+		t.Fatalf("got %d notifications, want 1", len(notes))
+	}
+	if !strings.Contains(notes[0].Message.Text, "5") || !strings.Contains(notes[0].Message.Text, "2") {
+		t.Errorf("message drops the counts: %q", notes[0].Message.Text)
+	}
+}
+
+// Every notification is a note, never an error. A capability nobody implements
+// is a permanent honest limit, and a run that reports it as a failure is one
+// whose users learn to filter these out.
+func TestNotificationsAreNotesNotFailures(t *testing.T) {
+	doc := generate(t, []report.CapabilityCoverage{
+		{Capability: "call_graph", Provided: false},
+		{Capability: "reachability", Provided: true, Answered: 0},
+	})
+	if !doc.Runs[0].Invocations[0].ExecutionSuccessful {
+		t.Error("executionSuccessful is false — a missing capability is not a failed run")
+	}
+	for _, n := range notifications(t, doc) {
+		if n.Level != "note" {
+			t.Errorf("%s: level %q, want note", n.Descriptor.ID, n.Level)
+		}
+	}
+}
+
+// A reporter with no capability data emits no invocations block at all —
+// absence, rather than an empty claim of full coverage.
+func TestNoCapabilityDataEmitsNoInvocations(t *testing.T) {
+	doc := generate(t, nil)
+	if len(doc.Runs[0].Invocations) != 0 {
+		t.Errorf("got %d invocations without capability data, want 0", len(doc.Runs[0].Invocations))
+	}
+}

--- a/core/report/sarif/sarif.go
+++ b/core/report/sarif/sarif.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nox-hq/nox/core/compliance"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/report"
 	"github.com/nox-hq/nox/core/rules"
 )
 
@@ -47,8 +48,38 @@ type Report struct {
 
 // Run represents a single invocation of an analysis tool.
 type Run struct {
-	Tool    Tool     `json:"tool"`
-	Results []Result `json:"results"`
+	Tool Tool `json:"tool"`
+	// Invocations carries what the run could and could not establish. SARIF has
+	// no slot for "this analysis was never able to run here", so the standard's
+	// nearest honest home for it is a tool execution notification — see
+	// buildInvocations.
+	Invocations []Invocation `json:"invocations,omitempty"`
+	Results     []Result     `json:"results"`
+}
+
+// Invocation describes one execution of the tool, per SARIF §3.20.
+type Invocation struct {
+	// ExecutionSuccessful is required by the schema. It is true whenever nox
+	// produced a report at all: a capability nox never had is not a failed
+	// execution, and saying otherwise would turn every installation without a
+	// call graph into a broken run.
+	ExecutionSuccessful bool `json:"executionSuccessful"`
+	// ToolExecutionNotifications reports conditions about the run itself
+	// rather than about the code — SARIF §3.20.21.
+	ToolExecutionNotifications []Notification `json:"toolExecutionNotifications,omitempty"`
+}
+
+// Notification is a SARIF notification object (§3.58).
+type Notification struct {
+	Descriptor *ReportingDescriptorReference `json:"descriptor,omitempty"`
+	Level      string                        `json:"level"`
+	Message    Message                       `json:"message"`
+}
+
+// ReportingDescriptorReference identifies the notification's kind (§3.52), so a
+// consumer can group or filter on the id rather than parse the message text.
+type ReportingDescriptorReference struct {
+	ID string `json:"id"`
 }
 
 // Tool describes the analysis tool that produced the run.
@@ -155,6 +186,14 @@ type Reporter struct {
 	// Rules is an optional RuleSet used to populate the SARIF rule catalog.
 	// When nil, the catalog is derived from the findings themselves.
 	Rules *rules.RuleSet
+
+	// Capabilities is the scan's analysis capability matrix, rendered as tool
+	// execution notifications. It takes the type core/report already derives so
+	// that findings.sarif and findings.json cannot disagree about what nox
+	// could establish — one derivation, two artifacts. Nil for a report with no
+	// scan behind it, which emits no invocations at all rather than an empty
+	// claim of full coverage.
+	Capabilities []report.CapabilityCoverage
 }
 
 // NewReporter returns a Reporter configured with the given tool
@@ -236,7 +275,7 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 		results = append(results, result)
 	}
 
-	report := Report{
+	doc := Report{
 		Version: sarifVersion,
 		Schema:  sarifSchema,
 		Runs: []Run{
@@ -249,12 +288,68 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 						Rules:          ruleCatalog,
 					},
 				},
-				Results: results,
+				Invocations: r.buildInvocations(),
+				Results:     results,
 			},
 		},
 	}
 
-	return json.MarshalIndent(report, "", "  ")
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// buildInvocations renders the capability matrix as tool execution
+// notifications — the one slot SARIF has for a statement about the RUN rather
+// than about the code.
+//
+// It reports only the questions that went unanswered, and that asymmetry is
+// deliberate. A SARIF consumer already sees what nox found; nothing in the
+// format tells it what nox was never able to look for, so a scan from an
+// installation with no call graph and a scan from one that has a call graph and
+// found nothing clean arrive identical. Code Scanning shows both as green.
+// These notifications are the difference, and they are the reason this milestone
+// exists: the state was already computed, and it died at the artifact boundary.
+//
+// Every notification is level "note". None of these is an execution failure — a
+// capability nobody implements is a permanent, honest limit — and levelling a
+// limit as a warning is how a signal gets filtered out by the people who most
+// need to read it.
+func (r *Reporter) buildInvocations() []Invocation {
+	if len(r.Capabilities) == 0 {
+		return nil
+	}
+	var notes []Notification
+	for _, c := range r.Capabilities {
+		var id, text string
+		switch {
+		case !c.Provided:
+			id = "nox/capability/unsupported"
+			text = fmt.Sprintf("%s: no implementation on this installation. "+
+				"This scan could not ask the question, and its silence about it is not an all-clear.", c.Capability)
+		case c.Answered == 0 && c.Inconclusive == 0:
+			id = "nox/capability/not-evaluated"
+			text = fmt.Sprintf("%s: available but evaluated nothing in this scan. "+
+				"No result here means the question was not put, not that it was answered.", c.Capability)
+		case c.Answered == 0:
+			id = "nox/capability/inconclusive"
+			text = fmt.Sprintf("%s: evaluated %d subject(s) and determined none of them.", c.Capability, c.Inconclusive)
+		case c.Inconclusive > 0:
+			id = "nox/capability/inconclusive"
+			text = fmt.Sprintf("%s: answered %d subject(s); %d could not be determined.",
+				c.Capability, c.Answered, c.Inconclusive)
+		default:
+			// Answered everything it was asked. Nothing to report.
+			continue
+		}
+		notes = append(notes, Notification{
+			Descriptor: &ReportingDescriptorReference{ID: id},
+			Level:      "note",
+			Message:    Message{Text: text},
+		})
+	}
+	if len(notes) == 0 {
+		return nil
+	}
+	return []Invocation{{ExecutionSuccessful: true, ToolExecutionNotifications: notes}}
 }
 
 // WriteToFile generates the SARIF report and writes it to the specified path

--- a/core/scan_report.go
+++ b/core/scan_report.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"github.com/nox-hq/nox/core/report"
+	"github.com/nox-hq/nox/core/report/sarif"
+)
+
+// JSONReporter returns a findings.json reporter carrying everything this scan
+// must state about itself.
+//
+// It exists because the alternative had already failed. Every field below is
+// one a surface previously set by hand after calling report.NewJSONReporter,
+// and each new one multiplied the ways a surface could quietly omit it: the MCP
+// server shipped three reporter sites that never set Degradations, so an agent
+// — the consumer with no stderr to fall back on — asked for the findings report
+// and got one that said nothing about the checks that had not run. Adding
+// capability coverage as a fifth field to remember would have re-run that
+// experiment with a worse payload, because an omitted capability matrix does
+// not read as missing information. It reads as a scan that asked everything.
+//
+// So the knowledge lives here, once, next to the ScanResult it is derived from.
+// The caller still sets what the caller alone knows — Offline, Prioritize —
+// because those are invocation choices rather than properties of the result.
+func (r *ScanResult) JSONReporter(version string) *report.JSONReporter {
+	rep := report.NewJSONReporter(version)
+	if r == nil {
+		return rep
+	}
+	rep.SASTLanguages = r.SASTProfile
+	rep.Degradations = report.DegradationsFrom(r.Degradations)
+	rep.Enrichments = r.Enrichments
+	rep.Capabilities = report.CapabilitiesFrom(r.Capabilities, r.Coverage)
+	return rep
+}
+
+// SARIFReporter returns a results.sarif reporter carrying this scan's
+// capability matrix, derived once by core/report so the two artifacts state the
+// same thing.
+//
+// It deliberately does NOT set Rules. A full rule catalog is 1,500+ descriptors,
+// and the MCP surface serves SARIF under a response budget that a catalog that
+// size would blow past — so whether to embed the catalog is the caller's
+// size-and-audience decision, the same class as Prioritize. Capability coverage
+// is not: it is a property of the result, it is small, and a surface that omits
+// it publishes a scan that looks like it asked every question.
+func (r *ScanResult) SARIFReporter(version string) *sarif.Reporter {
+	rep := sarif.NewReporter(version, nil)
+	if r == nil {
+		return rep
+	}
+	rep.Capabilities = report.CapabilitiesFrom(r.Capabilities, r.Coverage)
+	return rep
+}

--- a/core/scan_report_test.go
+++ b/core/scan_report_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/degrade"
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// The adapters now trust ScanResult.JSONReporter to carry everything the
+// artifact must state. The conformance guard checks that they call it; nothing
+// there checks that it still fills anything in.
+//
+// That is the shape of hole this whole milestone is about — a check written
+// against the wrong input passes while the thing it guards is empty — so the
+// constructor is pinned behaviourally, field by field, against a result that
+// has something to say in each one.
+func TestJSONReporterCarriesEverythingTheArtifactMustState(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	cov := capability.NewCoverage(reg)
+	cov.Record(SubjectForFinding(findings.Finding{RuleID: "SEC-001", Location: findings.Location{FilePath: "a.go"}}),
+		capability.LexicalContext, capability.Positive)
+
+	r := &ScanResult{
+		SASTProfile: map[string]string{"go": "deep"},
+		Degradations: []Degradation{{
+			Kind: degrade.OSV, Detail: "d", Impact: "i",
+		}},
+		Enrichments:  []findings.Enrichment{{FindingFingerprint: "fp"}},
+		Capabilities: reg,
+		Coverage:     cov,
+	}
+
+	rep := r.JSONReporter("test")
+	if len(rep.SASTLanguages) == 0 {
+		t.Error("SASTLanguages is empty: the depth strategy will not be auditable in the artifact")
+	}
+	if len(rep.Degradations) == 0 {
+		t.Error("Degradations is empty: a scan whose checks failed will read as a clean scan")
+	}
+	if len(rep.Enrichments) == 0 {
+		t.Error("Enrichments is empty: a plugin that annotates will look like one that did not run")
+	}
+	if len(rep.Capabilities) != len(capability.All()) {
+		t.Fatalf("Capabilities has %d rows, want one per capability (%d): a report with no matrix "+
+			"looks like one from an installation that could answer every question",
+			len(rep.Capabilities), len(capability.All()))
+	}
+	var answered bool
+	for _, c := range rep.Capabilities {
+		if c.Capability == "lexical_context" && c.Answered == 1 {
+			answered = true
+		}
+	}
+	if !answered {
+		t.Error("the recorded coverage did not reach the reporter; the matrix is derived from " +
+			"nothing and would be all zeroes on every scan")
+	}
+}
+
+// The SARIF constructor carries the matrix and deliberately does NOT carry the
+// rule catalog — 1,500+ descriptors would blow the MCP response budget, so that
+// stays the caller's size decision. Pinning both halves keeps a later "make it
+// consistent" change from quietly reintroducing the overflow.
+func TestSARIFReporterCarriesCapabilitiesButNotTheCatalog(t *testing.T) {
+	reg := capability.DefaultRegistry()
+	r := &ScanResult{Capabilities: reg, Coverage: capability.NewCoverage(reg)}
+
+	rep := r.SARIFReporter("test")
+	if len(rep.Capabilities) != len(capability.All()) {
+		t.Errorf("Capabilities has %d rows, want %d", len(rep.Capabilities), len(capability.All()))
+	}
+	if rep.Rules != nil {
+		t.Error("SARIFReporter set Rules; the full catalog is the caller's size decision, and " +
+			"embedding it here overflows the MCP response budget")
+	}
+}
+
+// A nil result must not panic and must not fabricate a matrix. Absence is
+// honest; nine rows of zeroes claiming a full installation is not.
+func TestNilScanResultProducesNoMatrix(t *testing.T) {
+	var r *ScanResult
+	if got := len(r.JSONReporter("test").Capabilities); got != 0 {
+		t.Errorf("nil result produced %d capability rows", got)
+	}
+	if got := len(r.SARIFReporter("test").Capabilities); got != 0 {
+		t.Errorf("nil result produced %d SARIF capability rows", got)
+	}
+}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -59,23 +59,31 @@ are provided (`call_graph` and `entry_point` are not). `ScanResult` carries
 `Coverage` and `Capabilities`. `policy.require_capabilities` and
 `--fail-on-degraded` already fail a scan that lost a capability at runtime.
 
-**Missing.** `core/report.Meta` carries `schema_version`, `generated_at`,
-`tool_name`, `tool_version`, `offline`, `sast_languages` and `degradations` —
-and nothing about capability coverage. A consumer reading only `findings.json`
-cannot tell that two of nine questions were never asked. The state exists in
-process and dies at the artifact boundary.
+**Missing.** 1.3 only. `report.Meta` now carries the capability matrix (#602).
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **1.1** | Nothing — the states exist and are used | already met |
-| **1.2** | Add `capabilities` to `report.Meta`, populated from `ScanResult.Coverage`; SARIF `invocation.toolExecutionNotifications` for the same | two scans differing only by analyzer availability are not byte-identical |
-| **1.3** | Default `policy.uncertainty` to a value that does not treat unevaluated as clean | uninstalling an analyzer cannot turn a failing scan green **by default**, not only when configured |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **1.1** | Nothing — the states exist and are used | already met | ✅ |
+| **1.2** | `capabilities` on `report.Meta` from `ScanResult.Coverage`; SARIF `invocations[].toolExecutionNotifications` for the same | two scans differing only by analyzer availability are not byte-identical | ✅ #602 |
+| **1.3** | Default `policy.uncertainty` to a value that does not treat unevaluated as clean | uninstalling an analyzer cannot turn a failing scan green **by default**, not only when configured | |
 
-**Size:** small. 1.2 is a struct field and a serializer. 1.3 is a default flip
-and needs a deprecation note — it can fail scans that pass today.
+1.2 landed larger than "a struct field and a serializer" for one reason worth
+carrying forward: the four adapter sites each set `Degradations` by hand, and
+the MCP server had already shipped three that forgot. Adding capability coverage
+as a fifth field to remember would have re-run that experiment with a worse
+payload — an omitted degradation list reads as missing information, an omitted
+capability matrix reads as a scan that asked everything. So the derivation moved
+into `ScanResult.JSONReporter` / `.SARIFReporter`, and the conformance guard now
+pins the constructor rather than the assignments.
+
+**Size:** 1.3 is a default flip and needs a deprecation note — it can fail scans
+that pass today.
 
 **Gate:** B (unevaluated honesty). 1.3 must ship with a corpus case where a
-capability is removed and the scan goes from pass to fail.
+capability is removed and the scan goes from pass to fail. 1.2's own Gate B case
+is `TestLosingAProviderChangesTheArtifact`: an installation without the taint
+engine used to write a byte-identical `findings.json` to one that had it and
+found nothing.
 
 ---
 
@@ -338,7 +346,7 @@ The critical path is **1.2 → 2.2 → 3.2 → 4.1**, because everything downstr
 reads an adjudicated finding.
 
 ```
-1.2  artifact carries capability coverage        small    unblocks 2.x
+1.2  artifact carries capability coverage        DONE     unblocks 2.x
  └─ 2.2  per-claim competence                    medium   unblocks 3.3, 4.2
      └─ 3.2  ledger authoritative for one family medium   unblocks 4.1
          └─ 4.1  adjudicator authoritative       large    THE FLIP

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1082,6 +1082,54 @@ policy:
   baseline_mode: strict
 ```
 
+#### In the artifacts
+
+Every `findings.json` carries a `meta.capabilities` matrix: one row per analysis
+capability, what provides it on this installation, and how many subjects it
+actually reached a conclusion about in this scan.
+
+```json
+{
+  "meta": {
+    "capabilities": [
+      {"capability": "lexical_context", "provided": true,
+       "providers": ["core/lexctx"], "answered": 48, "inconclusive": 0},
+      {"capability": "call_graph", "provided": false,
+       "answered": 0, "inconclusive": 0},
+      {"capability": "reachability", "provided": true,
+       "providers": ["core/analyzers/deps"], "answered": 0, "inconclusive": 0}
+    ]
+  }
+}
+```
+
+Read the three rows above as three different things, because they are:
+
+- `call_graph` is a **limit**. Nothing on this installation can answer it, so
+  the scan could not ask. Install a plugin that provides it, or read any finding
+  that depends on it as unevaluated.
+- `reachability` is a **gap**. It is provided, and this scan put the question to
+  nobody. That is not a clean result — it is an unused analysis.
+- `lexical_context` answered 48 subjects. `inconclusive` counts the ones it was
+  asked about and could not determine, and those are never added to `answered`:
+  "ran and could not tell" is not coverage.
+
+`provided` and `answered` are separate on purpose. `provided` is a property of
+the **installation** and is knowable without running anything; `answered` is a
+property of **this run**. They come apart exactly when something fails at
+runtime — `reachability` is provided by every nox build, and on a scan whose
+advisory source was unreachable it establishes nothing at all.
+
+`results.sarif` carries the same information as
+`invocations[].toolExecutionNotifications`, at level `note`. SARIF has no other
+slot for a statement about the run rather than the code, and without it Code
+Scanning renders a scan that *could not look* and a scan that *looked and found
+nothing* identically — both green.
+
+This is why the matrix is emitted even when everything worked: a report listing
+only the capabilities that succeeded is one a reader will take for the complete
+set of questions nox asks.
+
 #### Via MCP
 
 The evidence surface is on the MCP server too, because an agent triaging a scan

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/nox-hq/nox/core/fix"
 	"github.com/nox-hq/nox/core/git"
 	"github.com/nox-hq/nox/core/report"
-	"github.com/nox-hq/nox/core/report/sarif"
 	"github.com/nox-hq/nox/core/report/sbom"
 	"github.com/nox-hq/nox/core/vex"
 	"github.com/nox-hq/nox/plugin"
@@ -563,14 +562,13 @@ func (s *Server) handleGetFindings(_ context.Context, input getFindingsInput) (s
 
 	switch format {
 	case "sarif":
-		r := sarif.NewReporter(s.version, nil)
+		r := pc.result.SARIFReporter(s.version)
 		data, err = r.Generate(pc.result.Findings)
 	default:
-		r := report.NewJSONReporter(s.version)
-		// Degradations must ride the artifact here above all: an agent has no
-		// stderr to read, so without this it cannot tell a clean scan from one
-		// whose checks did not run.
-		r.Degradations = report.DegradationsFrom(pc.result.Degradations)
+		// The result builds its own reporter here above all: an agent has no
+		// stderr to read, so degradations and capability coverage reach it
+		// through the artifact or not at all.
+		r := pc.result.JSONReporter(s.version)
 		data, err = r.Generate(pc.result.Findings)
 	}
 
@@ -1281,8 +1279,7 @@ func (s *Server) handleResourceFindings(_ context.Context, uri string, _ map[str
 		return nil, fmt.Errorf("no scan results available")
 	}
 
-	r := report.NewJSONReporter(s.version)
-	r.Degradations = report.DegradationsFrom(pc.result.Degradations)
+	r := pc.result.JSONReporter(s.version)
 	data, err := r.Generate(pc.result.Findings)
 	if err != nil {
 		return nil, fmt.Errorf("generating findings JSON: %w", err)
@@ -1301,7 +1298,7 @@ func (s *Server) handleResourceSARIF(_ context.Context, uri string, _ map[string
 		return nil, fmt.Errorf("no scan results available")
 	}
 
-	r := sarif.NewReporter(s.version, nil)
+	r := pc.result.SARIFReporter(s.version)
 	data, err := r.Generate(pc.result.Findings)
 	if err != nil {
 		return nil, fmt.Errorf("generating SARIF: %w", err)
@@ -1435,8 +1432,7 @@ func (s *Server) handleProjectResourceFindings(_ context.Context, uri string, pa
 		return nil, fmt.Errorf("no scan results for project %q", path)
 	}
 
-	r := report.NewJSONReporter(s.version)
-	r.Degradations = report.DegradationsFrom(pc.result.Degradations)
+	r := pc.result.JSONReporter(s.version)
 	data, err := r.Generate(pc.result.Findings)
 	if err != nil {
 		return nil, fmt.Errorf("generating findings JSON: %w", err)
@@ -1459,7 +1455,7 @@ func (s *Server) handleProjectResourceSARIF(_ context.Context, uri string, param
 		return nil, fmt.Errorf("no scan results for project %q", path)
 	}
 
-	r := sarif.NewReporter(s.version, nil)
+	r := pc.result.SARIFReporter(s.version)
 	data, err := r.Generate(pc.result.Findings)
 	if err != nil {
 		return nil, fmt.Errorf("generating SARIF: %w", err)


### PR DESCRIPTION
First milestone on the Phase 1–12 critical path (`1.2 → 2.2 → 3.2 → 4.1`).

## The state it fixes

A scan from an installation with no call graph produces no call-graph errors and no call-graph answers. Its `findings.json` was **byte-identical** to one from an installation that has a call graph and found nothing. Every consumer that cannot see inside the process — a CI job, a dashboard, an MCP client, GitHub Code Scanning — read both as the same green result.

`core/capability` has had the whole vocabulary for a while: six evaluation states, a registry of what this build provides, per-subject coverage. All of it was held on `ScanResult` and serialized nowhere. The state existed in process and died at the artifact boundary.

## What lands

**`findings.json` gains `meta.capabilities`** — one row per capability, what provides it, and how many subjects it actually concluded about.

`Provided` and `Answered` stay separate fields. `Provided` is a property of the *installation*; `Answered` is a property of *this run*, and the two come apart exactly when something fails at runtime — reachability is provided by every nox build, and on a scan whose advisory source was unreachable it establishes nothing. `Inconclusive` is counted apart from both: "ran and could not tell" is not coverage, and folding it into `Answered` would rebuild the false all-clear inside the field added to prevent it.

**`results.sarif` gains `invocations[].toolExecutionNotifications`** for the unanswered questions only, at level `note`. SARIF has no other slot for a statement about the run rather than the code. Notes rather than warnings: a capability nobody implements is a permanent honest limit, and levelling a limit as a failure teaches people to filter it out.

## Why it is bigger than a struct field

The four adapter sites each set `Degradations` by hand, and the MCP server had already shipped three that forgot — the consumer with no stderr got a report that said nothing about the checks that had not run. Adding capability coverage as a fifth field to remember would have re-run that experiment with a worse payload: an omitted degradation list reads as missing information, an omitted capability matrix reads as a scan that asked everything.

So the derivation moved into `ScanResult.JSONReporter` / `.SARIFReporter`, and the conformance guard now pins the constructor rather than the assignments (and covers SARIF too). `nox mcp drift` is the one exempt site — it compares two manifests and runs no analyzers, so a matrix of zeroes there would describe an installation that answered nothing, which is not what happened.

`SARIFReporter` deliberately does **not** set `Rules`: the full catalog is 1,500+ descriptors and would blow the MCP response budget, so that stays the caller's size decision. Pinned by a test so a later "make it consistent" change cannot quietly reintroduce the overflow.

## Measured, not reasoned about

Ran against `testdata/precision-suite` and read the artifacts:

| capability | provided | answered |
|---|---|---|
| lexical_context | ✅ core/lexctx | 48 |
| constant_evaluation | ✅ core/consteval | 44 |
| symbol_resolution / taint | ✅ core/taint | 30 |
| **call_graph** | ❌ | 0 |
| **entry_point** | ❌ | 0 |
| reachability | ✅ core/analyzers/deps | **0** |
| attacker_reachability | ✅ core/attack | **0** |
| dynamic_verification | ✅ core/attack | **0** |

Five SARIF notifications: two limits, three gaps.

- **Detection 231 TP / 0 FP / 0 FN**, **refutation 37 / 0 / 0** — both unchanged. This adds output; it removes no findings, so Gate A is not implicated.
- Both new guards were **falsified**: removing `Capabilities` from `Meta` fails `TestLosingAProviderChangesTheArtifact`; removing it from the constructor fails `TestJSONReporterCarriesEverythingTheArtifactMustState`.
- Full suite green, `golangci-lint` 0 issues, determinism test unaffected.

## Gate

**B (unevaluated honesty).** `TestLosingAProviderChangesTheArtifact` is the Gate B case for this milestone: an installation without the taint engine used to write a byte-identical artifact to one that had it.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT