### PR TITLE
PHASE 2.2: competence belongs to the claim, not to the run

### DIFF
--- a/core/analyzers/deps/deps.go
+++ b/core/analyzers/deps/deps.go
@@ -746,26 +746,30 @@ func (a *Analyzer) ScanArtifacts(ctx context.Context, artifacts []discovery.Arti
 
 					if pkg.Ecosystem == "go" {
 						affected := goAffectedImports(&ov, pkg.Name)
-						if r, ok := goSymbolReferenced(affected, linkedGoPkgs, linkedGoKnown); ok {
+						// The result is recorded whatever it concluded, and the
+						// second return value is deliberately ignored.
+						//
+						// It used to gate this whole block, and goSymbolReferenced
+						// returns false for EVERY undetermined outcome — an
+						// advisory with no import metadata, a toolchain that could
+						// not enumerate the build. Those findings then carried no
+						// reach annotation at all, so the capability matrix read
+						// them as never-evaluated and the Undetermined arm of the
+						// switch that maps them was unreachable. "Asked and could
+						// not tell" arrived looking exactly like "nobody asked",
+						// which is the one distinction this vocabulary exists to
+						// preserve.
+						r, _ := goSymbolReferenced(affected, linkedGoPkgs, linkedGoKnown)
+						if len(affected) > 0 {
 							meta["affected_imports"] = strings.Join(affected, ",")
-							// The LEVEL, named. `go list -deps` establishes that
-							// the affected import is in the linked set, which is
-							// symbol_referenced and nothing above it. This used to
-							// be written as meta["reachable"], a name that reads as
-							// call_reachable, and the capability matrix then counted
-							// it as the reachability capability — evidence for one
-							// proposition establishing a later one, which is the
-							// invariant this vocabulary exists to hold.
-							meta["reach_level"] = string(r.Level)
-							meta["reach_outcome"] = string(r.Outcome)
-							meta["reach_scope"] = r.Scope.Describe()
-							if r.Outcome == reach.Refuted {
-								// Refuted at symbol_referenced only: the build links
-								// no affected package. Severity drops because there
-								// is nothing here to call, not because the
-								// application was shown to be unaffected.
-								sev = findings.SeverityInfo
-							}
+						}
+						applyReachMetadata(meta, r)
+						if r.Outcome == reach.Refuted {
+							// Refuted at symbol_referenced only: the build links
+							// no affected package. Severity drops because there
+							// is nothing here to call, not because the
+							// application was shown to be unaffected.
+							sev = findings.SeverityInfo
 						}
 					}
 

--- a/core/analyzers/deps/reach_metadata_e2e_test.go
+++ b/core/analyzers/deps/reach_metadata_e2e_test.go
@@ -1,0 +1,154 @@
+package deps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox-core/vulnsource"
+	"github.com/nox-hq/nox/core/discovery"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// goModuleWithDep writes a real, buildable Go module requiring one dependency,
+// and returns the artifact list the analyzer takes.
+//
+// Both halves matter. It must be a real module because the reachability path
+// shells out to the toolchain — the first version of this helper wrote a go.mod
+// and no source, so `go list -deps ./...` failed, every case came back
+// undetermined for that reason, and a test written for the other branch would
+// have passed for the wrong one.
+//
+// The source imports only the standard library, like the reachability suite's
+// own fixtures, so the toolchain needs no network and no module cache. A
+// fixture that needed either would be one that quietly stopped running, and the
+// first thing anyone would notice is that it had stopped failing.
+func goModuleWithDep(t *testing.T, module, version string) []discovery.Artifact {
+	t.Helper()
+	dir := t.TempDir()
+	body := "module example.com/app\n\ngo 1.21\n\nrequire " + module + " " + version + "\n"
+	path := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+	src := "package main\n\nimport (\n\t\"crypto/sha256\"\n\t\"fmt\"\n)\n\n" +
+		"func main() { fmt.Printf(\"%x\\n\", sha256.Sum256([]byte(\"x\"))) }\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing main.go: %v", err)
+	}
+	return []discovery.Artifact{{Path: "go.mod", AbsPath: path, Type: discovery.Lockfile}}
+}
+
+// The end of the chain, asserted through the real analyzer rather than through
+// the helper it calls.
+//
+// applyReachMetadata being correct proves nothing on its own — the defect was
+// never in the writing, it was that the ANALYZER only called it for outcomes
+// that concluded something. goSymbolReferenced returns ok=false for every
+// undetermined result, that value gated the whole block, and so an advisory
+// with no ecosystem_specific.imports produced a finding carrying no reach
+// annotation at all.
+//
+// That is the common case, not an edge one: only the Go vulndb populates import
+// metadata, so every GHSA-sourced Go advisory lands here. Downstream, the
+// capability matrix read those findings as never-evaluated, and the Undetermined
+// arm of the switch that maps them was unreachable code.
+func TestAnalyzerRecordsUndeterminedReachability(t *testing.T) {
+	src := &stubSource{
+		name: "stub",
+		records: map[string][]vulnsource.Record{
+			"golang.org/x/text": {{
+				ID:      "STUB-NO-IMPORTS",
+				Summary: "advisory with no import metadata",
+				// Affected names the module and NOTHING under
+				// ecosystem_specific.imports — the shape that scopes an
+				// advisory to a whole module.
+				Affected: []vulnsource.Affected{{
+					Package: vulnsource.Package{Name: "golang.org/x/text", Ecosystem: "Go"},
+				}},
+			}},
+		},
+	}
+
+	artifacts := goModuleWithDep(t, "golang.org/x/text", "v0.3.7")
+	_, fs, err := NewAnalyzer(WithSource(src)).ScanArtifacts(context.Background(), artifacts)
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+
+	f := vulnFinding(t, fs)
+	if got := f.Metadata["reach_outcome"]; got != string(reach.Undetermined) {
+		t.Errorf("reach_outcome = %q, want %q. A finding whose reachability was asked and "+
+			"could not be answered must not arrive looking like one nobody asked about.",
+			got, reach.Undetermined)
+	}
+	if f.Metadata["reach_level"] != string(reach.SymbolReferenced) {
+		t.Errorf("reach_level = %q, want %q", f.Metadata["reach_level"], reach.SymbolReferenced)
+	}
+	if f.Metadata["reach_limitations"] == "" {
+		t.Error("reach_limitations is empty; an operator cannot act on an undetermined answer " +
+			"that does not say what defeated it")
+	}
+	// The severity must NOT drop. Only a refutation earns that, and an
+	// undetermined result is not a refutation however much it resembles one in
+	// the output.
+	if f.Severity == findings.SeverityInfo {
+		t.Error("an undetermined reachability result demoted the finding to info; only a " +
+			"deterministic refutation may do that")
+	}
+}
+
+// An advisory that DOES name its affected imports still reaches a CONCLUSION.
+// The unconditional write must not have turned the deciding paths into
+// undetermined ones.
+//
+// This module requires x/text and imports only the standard library, so the
+// toolchain enumerates the whole closure and the affected import is genuinely
+// not in it: refuted, and severity may drop. That is the one basis on which a
+// finding is allowed to be demoted, and the test asserts the demotion happens
+// here so the previous test's assertion that it does NOT happen on an
+// undetermined result means something.
+func TestAnalyzerStillConcludesReachability(t *testing.T) {
+	src := &stubSource{
+		name: "stub",
+		records: map[string][]vulnsource.Record{
+			"golang.org/x/text": {{
+				ID:      "STUB-WITH-IMPORTS",
+				Summary: "advisory naming an affected import",
+				Affected: []vulnsource.Affected{{
+					Package: vulnsource.Package{Name: "golang.org/x/text", Ecosystem: "Go"},
+					EcosystemSpecific: vulnsource.EcosystemSpecific{
+						Imports: []vulnsource.Import{{Path: "golang.org/x/text/language"}},
+					},
+				}},
+			}},
+		},
+	}
+
+	artifacts := goModuleWithDep(t, "golang.org/x/text", "v0.3.7")
+	_, fs, err := NewAnalyzer(WithSource(src)).ScanArtifacts(context.Background(), artifacts)
+	if err != nil {
+		t.Fatalf("ScanArtifacts: %v", err)
+	}
+
+	f := vulnFinding(t, fs)
+	if got := f.Metadata["reach_outcome"]; got == "" {
+		t.Fatal("reach_outcome is absent on an advisory that named its affected imports")
+	}
+	if f.Metadata["affected_imports"] == "" {
+		t.Error("affected_imports is absent; the advisory named one")
+	}
+	if got := f.Metadata["reach_outcome"]; got != string(reach.Refuted) {
+		t.Errorf("reach_outcome = %q, want %q: the toolchain enumerated the whole closure "+
+			"and the affected import is not in it", got, reach.Refuted)
+	}
+	if f.Metadata["reach_limitations"] != "" {
+		t.Errorf("a refuted result carries limitations %q; reach.Refute must refuse to build "+
+			"a negative from an incomplete scope at all", f.Metadata["reach_limitations"])
+	}
+	if f.Severity != findings.SeverityInfo {
+		t.Errorf("severity = %q on a refuted result, want info", f.Severity)
+	}
+}

--- a/core/analyzers/deps/reachability.go
+++ b/core/analyzers/deps/reachability.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -184,6 +185,40 @@ func goSymbolReferenced(affectedImports []string, linked map[string]struct{}, li
 	}
 	r, ok := reach.Refute(subject, reach.SymbolReferenced, scope)
 	return r, ok
+}
+
+// applyReachMetadata writes a reachability result onto a finding's metadata.
+//
+// One function, called unconditionally, because the previous arrangement wrote
+// these keys only for the outcomes that concluded something. An analysis that
+// ran and could not tell wrote nothing, and nothing is how a scanner says "we
+// never looked".
+//
+// reach_limitations is the machine-readable half of reach_scope. The prose
+// description is for a person reading `nox why`; a CI job or an agent deciding
+// whether to trust an absent reachability answer needs the named reasons, and
+// parsing them back out of an English sentence is not a contract.
+func applyReachMetadata(meta map[string]string, r reach.Result) {
+	if meta == nil || r.Level == "" {
+		return
+	}
+	// The LEVEL, named. `go list -deps` establishes that the affected import is
+	// in the linked set, which is symbol_referenced and nothing above it. This
+	// used to be written as meta["reachable"], a name that reads as
+	// call_reachable, and the capability matrix then counted it as the
+	// reachability capability — evidence for one proposition establishing a
+	// later one, which is the invariant this vocabulary exists to hold.
+	meta["reach_level"] = string(r.Level)
+	meta["reach_outcome"] = string(r.Outcome)
+	meta["reach_scope"] = r.Scope.Describe()
+	if len(r.Scope.Limitations) > 0 {
+		names := make([]string, 0, len(r.Scope.Limitations))
+		for _, l := range r.Scope.Limitations {
+			names = append(names, string(l))
+		}
+		sort.Strings(names)
+		meta["reach_limitations"] = strings.Join(names, ",")
+	}
 }
 
 // maxImportScanBytes bounds a single file read when indexing imports. A source

--- a/core/analyzers/deps/reachability_suite_test.go
+++ b/core/analyzers/deps/reachability_suite_test.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/reach"
 )
 
 // expectation is one case's declared ground truth: what the advisory scopes to,
@@ -81,6 +84,79 @@ func TestReachabilitySuiteMatchesGroundTruth(t *testing.T) {
 			}
 			if reachable != exp.WantReachable {
 				t.Errorf("reachable = %v, want %v — %s", reachable, exp.WantReachable, exp.Why)
+			}
+		})
+	}
+}
+
+// TestSuiteStatesReachTheCapabilityMatrix asserts the `want_state` field every
+// fixture in this suite has always declared and nothing has ever checked.
+//
+// The ground truth was written down, the struct field was defined to hold it,
+// and no assertion consumed it. That is the shape of gap this suite's own
+// README warns about — "the difference between them exists only if something
+// checks it" — reproduced inside the test file that says so.
+//
+// It matters because the state, not the boolean, is what the artifact and the
+// capability gate read. A case that answers (reachable=true, determined=false)
+// and a case nobody ever asked both produce a finding with no reachability
+// annotation. Only the state tells them apart.
+func TestSuiteStatesReachTheCapabilityMatrix(t *testing.T) {
+	for name, exp := range loadCases(t) {
+		t.Run(name, func(t *testing.T) {
+			if exp.WantState == "" {
+				t.Fatal("expect.json declares no want_state")
+			}
+			dir := filepath.Join(suiteDir(), name)
+			linked, linkedKnown := goImportedPackages(context.Background(), dir)
+			r, _ := goSymbolReferenced(exp.AdvisoryImports, linked, linkedKnown)
+
+			// unsupported_ecosystem never reaches the Go path at all: the
+			// analyzer gates on pkg.Ecosystem == "go", so no reach.Result is
+			// produced and the matrix answers from the registry. There is
+			// nothing here to map.
+			if exp.WantState == string(capability.Unsupported) {
+				return
+			}
+			if got := r.Outcome.CapabilityState(); string(got) != exp.WantState {
+				t.Errorf("capability state = %q, want %q — %s", got, exp.WantState, exp.Why)
+			}
+		})
+	}
+}
+
+// TestUndeterminedOutcomesReachTheFinding is the end of that chain.
+//
+// goSymbolReferenced returns (result, false) for EVERY undetermined outcome,
+// and the analyzer wrote the reach metadata only when the second value was
+// true. So an advisory with no import metadata — the common case, since only
+// the Go vulndb populates ecosystem_specific.imports — produced a finding with
+// no reach_outcome at all, and every downstream reader saw a question that was
+// never asked rather than one that was asked and came back empty.
+//
+// The suite's four cases were all checked at the function. None of them was
+// checked at the artifact, which is where the distinction is spent.
+func TestUndeterminedOutcomesReachTheFinding(t *testing.T) {
+	for name, exp := range loadCases(t) {
+		if exp.WantState != string(capability.Unknown) {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(suiteDir(), name)
+			linked, linkedKnown := goImportedPackages(context.Background(), dir)
+			r, _ := goSymbolReferenced(exp.AdvisoryImports, linked, linkedKnown)
+
+			meta := map[string]string{}
+			applyReachMetadata(meta, r)
+
+			if meta["reach_outcome"] != string(reach.Undetermined) {
+				t.Errorf("reach_outcome = %q, want %q — an undetermined result that records "+
+					"nothing is indistinguishable from one nobody asked for",
+					meta["reach_outcome"], reach.Undetermined)
+			}
+			if meta["reach_limitations"] == "" {
+				t.Error("reach_limitations is empty; an undetermined result that does not say " +
+					"what defeated it cannot be acted on")
 			}
 		})
 	}

--- a/core/capability/coverage.go
+++ b/core/capability/coverage.go
@@ -2,6 +2,8 @@ package capability
 
 import (
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/nox-hq/nox-core/evidence"
@@ -195,4 +197,92 @@ func (c *Coverage) Answered(ac AnalysisCapability) (answered, inconclusive int) 
 		}
 	}
 	return answered, inconclusive
+}
+
+// Profile is one distinct set of unanswered questions, shared by every subject
+// it was derived for.
+//
+// It exists because competence is per-claim but not per-finding: a scan holds
+// as many distinct competence states as it has (language × analyses) classes,
+// which is a handful, not one per result. Measured on nox's own corpora, 53
+// findings resolve to 4 profiles and 62 to 3. Naming the class once and
+// referring to it is what lets every finding carry its own competence without
+// the artifact paying for it — the same reasoning that put the evidence ledger
+// out-of-band (docs/benchmarks/2026-Q3/ledger-budget.md).
+type Profile struct {
+	// ID is stable within one scan and assigned in sorted signature order, so
+	// two runs over the same tree number the profiles identically. It is not
+	// stable ACROSS scans and must not be stored as if it were: it names a set
+	// of gaps, and which sets exist depends on what was scanned.
+	ID string `json:"id"`
+	// Subjects counts how many subjects resolved to this profile.
+	Subjects int `json:"subjects"`
+	// Gaps are the capabilities that did not conclude, cheapest first. An empty
+	// Gaps means every capability concluded — a state no scan has reached, and
+	// one that would still be reported rather than omitted.
+	Gaps []Gap `json:"gaps"`
+}
+
+// Profiles groups subjects by the set of capabilities that did not conclude
+// about them, and returns the distinct profiles plus the subject-to-profile
+// assignment.
+//
+// A subject nothing was recorded about still gets a profile — the one where
+// nothing concluded — because that is the most important case to be able to
+// name, not the one to leave out. Omitting it would put the findings nox knows
+// least about into the group with no entry at all.
+//
+// A nil Coverage yields no profiles and no assignment: there is nothing to say
+// about competence when nothing recorded any, and inventing a full-coverage
+// profile would be the opposite of true.
+func Profiles(c *Coverage, subjects []evidence.Subject) (profiles []Profile, bySubject map[evidence.Subject]string) {
+	if c == nil || len(subjects) == 0 {
+		return nil, nil
+	}
+	bySignature := make(map[string][]Gap)
+	counts := make(map[string]int)
+	subjectSig := make(map[evidence.Subject]string, len(subjects))
+	for _, s := range subjects {
+		// A repeated subject is one subject. Counting it twice would make the
+		// profile look like it covers more of the scan than it does.
+		if _, done := subjectSig[s]; done {
+			continue
+		}
+		gaps := c.Gaps(s)
+		var sig strings.Builder
+		for _, g := range gaps {
+			sig.WriteString(string(g.Capability))
+			sig.WriteByte('=')
+			sig.WriteString(string(g.State))
+			sig.WriteByte(';')
+		}
+		key := sig.String()
+		if _, ok := bySignature[key]; !ok {
+			bySignature[key] = gaps
+		}
+		subjectSig[s] = key
+		counts[key]++
+	}
+
+	// Sorted signature order, so the same tree numbers its profiles the same
+	// way on every run. A scan artifact whose contents renumber between
+	// identical runs is not a reproducible one.
+	sigs := make([]string, 0, len(bySignature))
+	for k := range bySignature {
+		sigs = append(sigs, k)
+	}
+	sort.Strings(sigs)
+
+	profiles = make([]Profile, 0, len(sigs))
+	idBySig := make(map[string]string, len(sigs))
+	for i, sig := range sigs {
+		id := "c" + strconv.Itoa(i+1)
+		idBySig[sig] = id
+		profiles = append(profiles, Profile{ID: id, Subjects: counts[sig], Gaps: bySignature[sig]})
+	}
+	bySubject = make(map[evidence.Subject]string, len(subjectSig))
+	for s, sig := range subjectSig {
+		bySubject[s] = idBySig[sig]
+	}
+	return profiles, bySubject
 }

--- a/core/capability/profile_test.go
+++ b/core/capability/profile_test.go
@@ -1,0 +1,154 @@
+package capability
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+func sub(id string) evidence.Subject {
+	return evidence.Subject{Kind: evidence.SubjectCandidate, ID: id}
+}
+
+// THE EXIT CRITERION for milestone 2.2: one scan legitimately holds different
+// competence states for different findings.
+//
+// The run-level matrix cannot express this. It can say constant evaluation ran;
+// it cannot say it ran for the Go findings and could not apply to the YAML
+// ones. A consumer with only the run-level view has to assume the best case for
+// every finding, and the best case is the reading this model exists to
+// withhold.
+func TestOneScanHoldsDifferentCompetencePerSubject(t *testing.T) {
+	reg := DefaultRegistry()
+	cov := NewCoverage(reg)
+
+	// A Go finding: lexed, constants evaluated, taint concluded.
+	goSubj := sub("SEC-001@main.go:4:9")
+	cov.Record(goSubj, LexicalContext, Positive)
+	cov.Record(goSubj, ConstantEvaluation, Positive)
+	cov.Record(goSubj, Taint, Positive)
+	cov.Record(goSubj, SymbolResolution, Positive)
+
+	// A YAML finding: no lexer, no evaluator, nothing else asked.
+	yamlSubj := sub("DATA-001@values.yaml:2:1")
+	cov.Record(yamlSubj, LexicalContext, Unsupported)
+	cov.Record(yamlSubj, ConstantEvaluation, Unsupported)
+
+	profiles, assignment := Profiles(cov, []evidence.Subject{goSubj, yamlSubj})
+	if len(profiles) != 2 {
+		t.Fatalf("got %d profiles for two genuinely different competence states, want 2", len(profiles))
+	}
+	if assignment[goSubj] == assignment[yamlSubj] {
+		t.Fatalf("both subjects resolved to profile %q; a finding nox lexed and one it could "+
+			"not read are being reported as equally well understood", assignment[goSubj])
+	}
+
+	byID := map[string]Profile{}
+	for _, p := range profiles {
+		byID[p.ID] = p
+	}
+	// The YAML finding's profile must name lexical_context as unsupported. If
+	// it does not, the artifact says nox distinguished code from comments in a
+	// file it has no lexer for.
+	var found bool
+	for _, g := range byID[assignment[yamlSubj]].Gaps {
+		if g.Capability == LexicalContext && g.State == Unsupported {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the YAML finding's profile does not record lexical_context as unsupported")
+	}
+	// And the Go finding's must NOT, because it was answered.
+	for _, g := range byID[assignment[goSubj]].Gaps {
+		if g.Capability == LexicalContext {
+			t.Errorf("the Go finding's profile lists lexical_context as %q; it was answered", g.State)
+		}
+	}
+}
+
+// Profile IDs are assigned in sorted signature order, so two runs over the same
+// tree number them identically. A scan artifact that renumbers between runs is
+// not a reproducible one.
+func TestProfileIDsAreDeterministic(t *testing.T) {
+	reg := DefaultRegistry()
+	build := func() ([]Profile, map[evidence.Subject]string) {
+		cov := NewCoverage(reg)
+		subjects := []evidence.Subject{}
+		for _, spec := range []struct {
+			id  string
+			cap AnalysisCapability
+		}{
+			{"z", Taint}, {"a", LexicalContext}, {"m", ConstantEvaluation},
+			{"b", Taint}, {"q", LexicalContext},
+		} {
+			s := sub(spec.id)
+			cov.Record(s, spec.cap, Positive)
+			subjects = append(subjects, s)
+		}
+		return Profiles(cov, subjects)
+	}
+
+	p1, a1 := build()
+	for i := 0; i < 8; i++ {
+		p2, a2 := build()
+		if len(p1) != len(p2) {
+			t.Fatalf("profile count moved between runs: %d then %d", len(p1), len(p2))
+		}
+		for j := range p1 {
+			if p1[j].ID != p2[j].ID || p1[j].Subjects != p2[j].Subjects {
+				t.Fatalf("profile %d differs between runs: %+v vs %+v", j, p1[j], p2[j])
+			}
+		}
+		for s, id := range a1 {
+			if a2[s] != id {
+				t.Fatalf("subject %s moved from %q to %q between runs", s.ID, id, a2[s])
+			}
+		}
+	}
+}
+
+// A subject nothing was recorded about still gets a profile — the one where
+// nothing concluded. Leaving it out would put the findings nox knows least
+// about into the group with no entry at all, which reads as no gaps.
+func TestUnrecordedSubjectStillGetsAProfile(t *testing.T) {
+	cov := NewCoverage(DefaultRegistry())
+	s := sub("SEC-001@x.txt:1:1")
+
+	profiles, assignment := Profiles(cov, []evidence.Subject{s})
+	if len(profiles) != 1 {
+		t.Fatalf("got %d profiles, want 1", len(profiles))
+	}
+	if assignment[s] == "" {
+		t.Fatal("a subject nothing was recorded about got no profile")
+	}
+	if len(profiles[0].Gaps) != len(All()) {
+		t.Errorf("profile has %d gaps, want all %d capabilities: nothing concluded about this "+
+			"subject, and a short list would understate that", len(profiles[0].Gaps), len(All()))
+	}
+}
+
+// A nil Coverage yields nothing. Inventing a full-coverage profile for a scan
+// that recorded no competence would be the opposite of true.
+func TestNilCoverageInventsNoProfile(t *testing.T) {
+	profiles, assignment := Profiles(nil, []evidence.Subject{sub("a")})
+	if profiles != nil || assignment != nil {
+		t.Errorf("nil coverage produced %d profiles and %d assignments", len(profiles), len(assignment))
+	}
+}
+
+// A repeated subject is one subject. Counting it twice would make a profile
+// look like it covers more of the scan than it does.
+func TestRepeatedSubjectsCountOnce(t *testing.T) {
+	cov := NewCoverage(DefaultRegistry())
+	s := sub("SEC-001@a.go:1:1")
+	cov.Record(s, LexicalContext, Positive)
+
+	profiles, _ := Profiles(cov, []evidence.Subject{s, s, s})
+	if len(profiles) != 1 {
+		t.Fatalf("got %d profiles, want 1", len(profiles))
+	}
+	if profiles[0].Subjects != 1 {
+		t.Errorf("Subjects = %d for one subject listed three times, want 1", profiles[0].Subjects)
+	}
+}

--- a/core/competence_e2e_test.go
+++ b/core/competence_e2e_test.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/report"
+)
+
+// The whole chain, through a real scan and the artifact it writes.
+//
+// Every piece below is individually unit-tested, and that is exactly why this
+// test exists: the pieces have been right before while the pipeline that joins
+// them dropped the result on the floor. The reach-undetermined defect fixed in
+// this same change was of that shape — a correct mapping function, a correct
+// state vocabulary, and an analyzer whose `ok` guard meant neither was ever
+// reached.
+func TestCompetenceReachesTheArtifact(t *testing.T) {
+	res, err := RunScan(filepath.Join("..", "testdata", "precision-suite"))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res.CompetenceProfiles) < 2 {
+		t.Fatalf("the scan holds %d competence profile(s); a corpus spanning Go, Python and "+
+			"YAML cannot honestly have one", len(res.CompetenceProfiles))
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "findings.json")
+	if err := res.JSONReporter("test").WriteToFile(res.Findings, path); err != nil {
+		t.Fatalf("writing report: %v", err)
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // test-owned temp file
+	if err != nil {
+		t.Fatalf("reading report: %v", err)
+	}
+	var rep report.JSONReport
+	if err := json.Unmarshal(raw, &rep); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(rep.Meta.CompetenceProfiles) != len(res.CompetenceProfiles) {
+		t.Fatalf("artifact carries %d profiles, scan held %d",
+			len(rep.Meta.CompetenceProfiles), len(res.CompetenceProfiles))
+	}
+
+	// Every finding names a profile, and every named profile exists. A dangling
+	// reference is worse than none: it reads as "competence was recorded" while
+	// resolving to nothing.
+	known := map[string]capability.Profile{}
+	for _, p := range rep.Meta.CompetenceProfiles {
+		known[p.ID] = p
+	}
+	seen := map[string]int{}
+	for _, f := range rep.Findings {
+		if f.CompetenceProfile == "" {
+			t.Fatalf("%s at %s carries no competence profile", f.RuleID, f.Location.FilePath)
+		}
+		if _, ok := known[f.CompetenceProfile]; !ok {
+			t.Fatalf("%s references profile %q, which the artifact does not define",
+				f.RuleID, f.CompetenceProfile)
+		}
+		seen[f.CompetenceProfile]++
+	}
+	if len(seen) < 2 {
+		t.Fatalf("every finding resolved to the same profile (%v); the artifact cannot "+
+			"distinguish a finding nox lexed from one it could not read", seen)
+	}
+
+	// The subject counts on the profiles must match what the findings claim.
+	// A profile that says it covers twenty findings while three reference it is
+	// a summary nobody can trust.
+	for id, n := range seen {
+		if got := known[id].Subjects; got != n {
+			t.Errorf("profile %s reports %d subjects, %d findings reference it", id, got, n)
+		}
+	}
+
+	// A file with no lexer must not be reported as lexically analysed. This is
+	// the concrete claim the run-level matrix cannot make: lexical_context is
+	// provided and answered 48 subjects, and that says nothing about the ones
+	// it could not read.
+	var yamlProfile string
+	for _, f := range rep.Findings {
+		if filepath.Ext(f.Location.FilePath) == ".yaml" {
+			yamlProfile = f.CompetenceProfile
+			break
+		}
+	}
+	if yamlProfile == "" {
+		t.Skip("no YAML finding in the corpus to check")
+	}
+	var lexical bool
+	for _, g := range known[yamlProfile].Gaps {
+		if g.Capability == capability.LexicalContext && g.State == capability.Unsupported {
+			lexical = true
+		}
+	}
+	if !lexical {
+		t.Error("a YAML finding's profile does not record lexical_context as unsupported; " +
+			"the artifact claims nox distinguished code from comments in a file it has no " +
+			"lexer for")
+	}
+}
+
+// Determinism, at the artifact level. Profile IDs are part of the output now,
+// and an artifact that renumbers between identical runs breaks CI caching,
+// baseline diffs and the reproducibility claim.
+func TestCompetenceProfilesAreStableAcrossRuns(t *testing.T) {
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+	render := func() string {
+		res, err := RunScan(filepath.Join("..", "testdata", "precision-suite"))
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		data, err := res.JSONReporter("test").Generate(res.Findings)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		return string(data)
+	}
+	if a, b := render(), render(); a != b {
+		t.Error("two identical scans produced different artifacts; competence profile " +
+			"numbering is not deterministic")
+	}
+}

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -192,6 +192,26 @@ type Finding struct {
 	// resolved — see ScanResult.Divergences.
 	EvidenceConfidence string `json:",omitempty"`
 
+	// CompetenceProfile names the set of analysis questions that were NOT
+	// answered about this finding, resolved against meta.competence_profiles in
+	// the report.
+	//
+	// Competence is per-claim, not per-run. One scan legitimately holds
+	// different states for different findings: a match in a Go file had its
+	// constants evaluated and a match in a YAML file did not, because there is
+	// no evaluator for YAML — and neither fact is visible from a run-level
+	// summary, which can only report that constant evaluation ran at all.
+	//
+	// It is an ID rather than an inline list because competence varies by CLASS
+	// and not by finding. Measured: 53 findings on the precision suite resolve
+	// to 4 distinct profiles, and 62 on nox's own tree to 3. Inlining would
+	// repeat one of a handful of values once per finding, which is the shape
+	// docs/benchmarks/2026-Q3/ledger-budget.md ruled out for the ledger itself.
+	//
+	// Empty means the scan recorded no coverage, not that everything was
+	// evaluated. Consumers must not read an absent value as full competence.
+	CompetenceProfile string `json:",omitempty"`
+
 	// RetiredRuleIDs are the IDs of retired rules that reported THIS finding's
 	// condition at THIS location before they were retired, and AliasFingerprints
 	// are the fingerprints those rules would have produced here.
@@ -788,6 +808,13 @@ func (fs *FindingSet) SetExploitability(i int, state string) {
 func (fs *FindingSet) SetEvidenceConfidence(i int, level string) {
 	if i >= 0 && i < len(fs.items) {
 		fs.items[i].EvidenceConfidence = level
+	}
+}
+
+// SetCompetenceProfile records which competence profile finding i belongs to.
+func (fs *FindingSet) SetCompetenceProfile(i int, id string) {
+	if i >= 0 && i < len(fs.items) {
+		fs.items[i].CompetenceProfile = id
 	}
 }
 

--- a/core/findings/fingerprint_contract_test.go
+++ b/core/findings/fingerprint_contract_test.go
@@ -53,8 +53,14 @@ var fingerprintIngredients = map[string]fingerprintRole{
 	"Status":               notAnIngredient,
 	"Exploitability":       notAnIngredient,
 	"EvidenceConfidence":   notAnIngredient,
-	"RetiredRuleIDs":       notAnIngredient,
-	"AliasFingerprints":    notAnIngredient,
+	// Competence describes what nox did NOT establish about a finding. It must
+	// never move the fingerprint: installing a plugin that provides call graphs
+	// changes this field on every finding in the repository, and if that moved
+	// the hash it would un-waive every baseline entry and nox:ignore in one
+	// release that fixed nothing.
+	"CompetenceProfile": notAnIngredient,
+	"RetiredRuleIDs":    notAnIngredient,
+	"AliasFingerprints": notAnIngredient,
 }
 
 func contractBase() Finding {

--- a/core/reach/reach.go
+++ b/core/reach/reach.go
@@ -208,6 +208,32 @@ const (
 	Undetermined Outcome = "undetermined"
 )
 
+// CapabilityState is what this outcome means to the capability matrix.
+//
+// The mapping lives here, once, because both halves of it are load-bearing and
+// they were previously written out at the single place that consumed them —
+// which is how the Undetermined arm came to be unreachable without anything
+// noticing. An analysis that ran and could not tell must record Unknown, and
+// Unknown is not NotEvaluated: one says the question was put and came back
+// empty, the other says nobody asked. They call for different responses from an
+// operator, and only one of them is a gap they can close.
+//
+// An unrecognised outcome maps to NotEvaluated rather than to anything
+// conclusive. A producer that cannot name what it concluded has concluded
+// nothing.
+func (o Outcome) CapabilityState() capability.State {
+	switch o {
+	case Established:
+		return capability.Positive
+	case Refuted:
+		return capability.Negative
+	case Undetermined:
+		return capability.Unknown
+	default:
+		return capability.NotEvaluated
+	}
+}
+
 // Result is one reachability proposition, its outcome, and the scope it was
 // decided under.
 type Result struct {

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -81,6 +81,19 @@ type Meta struct {
 	// built without a scan (a filtered re-render, a fixture) from claiming a
 	// capability matrix it never had.
 	Capabilities []CapabilityCoverage `json:"capabilities,omitempty"`
+	// CompetenceProfiles are the distinct sets of unanswered questions this
+	// scan holds. Each finding names the one it belongs to in its
+	// CompetenceProfile field.
+	//
+	// Capabilities above is the run-level summary and cannot answer the
+	// question a triager actually asks, which is about ONE finding: was
+	// reachability evaluated for THIS one? A run-level "reachability answered 4
+	// subjects" leaves every reader of the other forty-nine to guess, and the
+	// comfortable guess is the wrong one.
+	//
+	// Omitted when the scan recorded no coverage. Absent does not mean full
+	// competence.
+	CompetenceProfiles []capability.Profile `json:"competence_profiles,omitempty"`
 }
 
 // CapabilityCoverage is one analysis capability's standing in a scan: whether
@@ -256,6 +269,9 @@ type JSONReporter struct {
 	// CapabilitiesFrom(result.Capabilities, result.Coverage) — or, better, let
 	// core.ScanResult.JSONReporter set it, so no surface has to remember.
 	Capabilities []CapabilityCoverage
+	// CompetenceProfiles is the per-claim half of the same picture. Set from
+	// ScanResult.CompetenceProfiles, and likewise best left to the constructor.
+	CompetenceProfiles []capability.Profile
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -292,6 +308,8 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			SASTLanguages: r.SASTLanguages,
 			Degradations:  r.Degradations,
 			Capabilities:  r.Capabilities,
+
+			CompetenceProfiles: r.CompetenceProfiles,
 		},
 		Findings:    f,
 		Enrichments: r.Enrichments,

--- a/core/report/sarif/sarif.go
+++ b/core/report/sarif/sarif.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/compliance"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/report"
@@ -194,6 +195,15 @@ type Reporter struct {
 	// scan behind it, which emits no invocations at all rather than an empty
 	// claim of full coverage.
 	Capabilities []report.CapabilityCoverage
+
+	// CompetenceProfiles resolves each finding's CompetenceProfile ID into the
+	// capabilities that did not conclude about it.
+	//
+	// SARIF gets the RESOLVED list rather than the ID. A profile reference is a
+	// nox concept that a SARIF consumer has no way to look up — Code Scanning
+	// reads the result, not nox's meta block — so shipping the identifier alone
+	// would be shipping nothing.
+	CompetenceProfiles []capability.Profile
 }
 
 // NewReporter returns a Reporter configured with the given tool
@@ -270,7 +280,7 @@ func (r *Reporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			Message:      Message{Text: f.Message},
 			Locations:    locations,
 			Fingerprints: map[string]string{"nox/v1": f.Fingerprint},
-			Properties:   sarifProperties(f),
+			Properties:   r.resultProperties(f),
 		}
 		results = append(results, result)
 	}
@@ -433,6 +443,48 @@ func sarifProperties(f findings.Finding) map[string]any {
 		props[k] = v
 	}
 	return props
+}
+
+// resultProperties is sarifProperties plus this finding's own competence.
+//
+// The run-level notifications say what the scan could not establish anywhere.
+// This says what it did not establish about THIS alert, which is the question
+// somebody triaging one alert in the Code Scanning UI is actually asking — and
+// the run-level answer forces them to assume the best case for every alert.
+//
+// The list is resolved to capability names, never a profile ID: nothing on the
+// consuming side can look an ID up.
+func (r *Reporter) resultProperties(f findings.Finding) map[string]any {
+	props := sarifProperties(f)
+	gaps := r.gapsFor(f.CompetenceProfile)
+	if len(gaps) == 0 {
+		return props
+	}
+	if props == nil {
+		props = make(map[string]any, 1)
+	}
+	names := make([]string, 0, len(gaps))
+	for _, g := range gaps {
+		names = append(names, string(g.Capability)+"="+string(g.State))
+	}
+	props["nox_unevaluated"] = strings.Join(names, ",")
+	return props
+}
+
+// gapsFor resolves a competence profile ID. An ID naming no profile resolves to
+// nothing rather than to an empty gap list, because an empty gap list means
+// every question was answered — the one claim an unresolvable reference must
+// never be turned into.
+func (r *Reporter) gapsFor(id string) []capability.Gap {
+	if id == "" {
+		return nil
+	}
+	for i := range r.CompetenceProfiles {
+		if r.CompetenceProfiles[i].ID == id {
+			return r.CompetenceProfiles[i].Gaps
+		}
+	}
+	return nil
 }
 
 func (r *Reporter) buildRuleCatalog(items []findings.Finding) (catalog []ReportingDescriptor, index map[string]int) {

--- a/core/scan.go
+++ b/core/scan.go
@@ -104,6 +104,17 @@ type ScanResult struct {
 	Capabilities *capability.Registry
 	Coverage     *capability.Coverage
 
+	// CompetenceProfiles are the distinct sets of unanswered questions this
+	// scan holds, referenced by Finding.CompetenceProfile.
+	//
+	// Competence is a property of the CLAIM, not of the run. The run-level
+	// matrix on Coverage can say that constant evaluation ran; only this can
+	// say it ran for the Go findings and could not apply to the YAML ones. A
+	// consumer that has only the run-level view has to assume the best case for
+	// every finding, and the best case is precisely the reading this model
+	// exists to withhold.
+	CompetenceProfiles []capability.Profile
+
 	// Reasoning holds the claims for and against each candidate this scan
 	// considered: why a finding was reported, and why a dropped one was not.
 	//
@@ -849,6 +860,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// a larger change than this one and are left to the E track.
 	recordObservations(reasons, allFindings)
 	recordCapabilityCoverage(coverage, allFindings)
+	competenceProfiles := assignCompetenceProfiles(coverage, allFindings)
 	recordAnalysisLimitations(allFindings, target, reasons)
 	divergences, conflicts := adjudicateFindings(reasons, allFindings)
 
@@ -861,20 +873,21 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	contributeObservations(ctx, cfg, opts, allFindings.Findings(), degradations)
 
 	return &ScanResult{
-		Capabilities: capabilities,
-		Coverage:     coverage,
-		Reasoning:    reasons,
-		Divergences:  divergences,
-		Conflicts:    conflicts,
-		Findings:     allFindings,
-		Enrichments:  pluginEnrichments,
-		Graphs:       pluginGraphs,
-		Inventory:    inventory,
-		AIInventory:  aiInventory,
-		PolicyResult: policyResult,
-		Rules:        allRules,
-		Degradations: degradations.Items(),
-		SASTProfile:  cfg.Scan.SAST.ResolvedProfile(),
+		Capabilities:       capabilities,
+		Coverage:           coverage,
+		CompetenceProfiles: competenceProfiles,
+		Reasoning:          reasons,
+		Divergences:        divergences,
+		Conflicts:          conflicts,
+		Findings:           allFindings,
+		Enrichments:        pluginEnrichments,
+		Graphs:             pluginGraphs,
+		Inventory:          inventory,
+		AIInventory:        aiInventory,
+		PolicyResult:       policyResult,
+		Rules:              allRules,
+		Degradations:       degradations.Items(),
+		SASTProfile:        cfg.Scan.SAST.ResolvedProfile(),
 	}, nil
 }
 
@@ -2123,6 +2136,41 @@ func adjudicateFindings(store *reasoning.Store, fs *findings.FindingSet) ([]adju
 	return out, conflicts
 }
 
+// assignCompetenceProfiles groups findings by what was NOT answered about them
+// and stamps each finding with its profile's ID.
+//
+// This is where per-claim competence becomes readable. The run-level matrix can
+// say constant evaluation ran; only this can say it ran for the Go findings and
+// could not apply to the YAML ones — and a consumer holding only the run-level
+// view has to assume the best case for every finding, which is exactly the
+// reading the capability model exists to withhold.
+//
+// Grouping rather than inlining is a measurement, not a preference: 53 findings
+// on the precision suite resolve to 4 distinct profiles and 62 on nox's own
+// tree to 3, because competence varies by (language × analyses) class. Writing
+// the same five-entry gap list onto every finding would spend the artifact on
+// repetition, which is the shape ledger-budget.md already ruled out once.
+func assignCompetenceProfiles(cov *capability.Coverage, fs *findings.FindingSet) []capability.Profile {
+	if cov == nil || fs == nil {
+		return nil
+	}
+	items := fs.Findings()
+	subjects := make([]evidence.Subject, 0, len(items))
+	for _, f := range items {
+		subjects = append(subjects, SubjectForFinding(f))
+	}
+	profiles, assignment := capability.Profiles(cov, subjects)
+	if len(profiles) == 0 {
+		return nil
+	}
+	for i, f := range items {
+		if id, ok := assignment[SubjectForFinding(f)]; ok {
+			fs.SetCompetenceProfile(i, id)
+		}
+	}
+	return profiles
+}
+
 // recordCapabilityCoverage records, per reported finding, what the analyses
 // that ran actually concluded about it.
 //
@@ -2189,14 +2237,13 @@ func recordCapabilityCoverage(cov *capability.Coverage, fs *findings.FindingSet)
 		// a call graph, so call_path_exists is unevaluated for every finding,
 		// and saying nothing is what makes `nox why` and the capability gate
 		// report it as unevaluated rather than as answered.
-		switch reach.Outcome(f.Metadata["reach_outcome"]) {
-		case reach.Established:
-			cov.Record(subject, capability.SymbolResolution, capability.Positive)
-		case reach.Refuted:
-			cov.Record(subject, capability.SymbolResolution, capability.Negative)
-		case reach.Undetermined:
-			cov.Record(subject, capability.SymbolResolution, capability.Unknown)
-		}
+		// The mapping lives on reach.Outcome so this switch and the
+		// reachability suite's own expectations cannot drift apart. It used to
+		// be written out here, and its Undetermined arm was unreachable for as
+		// long as the deps analyzer wrote no metadata for an undetermined
+		// result — a dead branch that looked live.
+		cov.Record(subject, capability.SymbolResolution,
+			reach.Outcome(f.Metadata["reach_outcome"]).CapabilityState())
 	}
 }
 

--- a/core/scan_report.go
+++ b/core/scan_report.go
@@ -30,6 +30,7 @@ func (r *ScanResult) JSONReporter(version string) *report.JSONReporter {
 	rep.Degradations = report.DegradationsFrom(r.Degradations)
 	rep.Enrichments = r.Enrichments
 	rep.Capabilities = report.CapabilitiesFrom(r.Capabilities, r.Coverage)
+	rep.CompetenceProfiles = r.CompetenceProfiles
 	return rep
 }
 
@@ -49,5 +50,6 @@ func (r *ScanResult) SARIFReporter(version string) *sarif.Reporter {
 		return rep
 	}
 	rep.Capabilities = report.CapabilitiesFrom(r.Capabilities, r.Coverage)
+	rep.CompetenceProfiles = r.CompetenceProfiles
 	return rep
 }

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -100,13 +100,28 @@ that is not that workflow re-implements or omits it. And competence is
 per-scan, not per-claim: one scan cannot yet say "taint ran, but hit an
 unmodelled construct on *this* path".
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **2.1** | Move degradation/baseline-drift/capability-loss gating into `core/policy`; the workflow calls it | all consumers inherit identical semantics; the bash shrinks to an invocation |
-| **2.2** | Per-claim competence: attach `capability.State` + `reach.Limitation` to the claim, not the run | one scan legitimately holds different competence states for different findings |
-| **2.3** | A negative claim that met an unmodelled construct cannot render unqualified | reports and API expose scope on every negative |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **2.1** | Move degradation/baseline-drift/capability-loss gating into `core/policy`; the workflow calls it | all consumers inherit identical semantics; the bash shrinks to an invocation | |
+| **2.2** | Per-claim competence: `capability.State` + `reach.Limitation` on the claim, not the run | one scan legitimately holds different competence states for different findings | ✅ #604 |
+| **2.3** | A negative claim that met an unmodelled construct cannot render unqualified | reports and API expose scope on every negative | |
 
-**Size:** medium. 2.2 touches every refiner that records a claim.
+2.2 landed as competence **profiles**: every finding names the set of questions
+that went unanswered about it, and the sets are grouped because competence
+varies by (language × analyses) class rather than by finding — measured, 53
+findings resolve to 4 profiles and 62 to 3.
+
+It also surfaced a live defect (#603). `goSymbolReferenced` returns `ok=false` for
+every UNDETERMINED outcome, and the deps analyzer wrote its reach metadata only
+when `ok` was true. So an advisory with no `ecosystem_specific.imports` — the
+common case, since only the Go vulndb populates it — produced a finding with no
+reach annotation at all, the capability matrix read it as never-evaluated, and
+the `Undetermined` arm of the switch that maps it was unreachable code. The
+reachability suite had declared `want_state` in every fixture since it was
+written, and nothing asserted it.
+
+**Size:** medium. 2.2 touched the deps analyzer, `core/capability`, the finding
+schema and both reporters.
 
 **Gate:** B, and D for 2.3 — an unqualified negative is how absence of evidence
 becomes evidence of absence.
@@ -347,7 +362,7 @@ reads an adjudicated finding.
 
 ```
 1.2  artifact carries capability coverage        DONE     unblocks 2.x
- └─ 2.2  per-claim competence                    medium   unblocks 3.3, 4.2
+ └─ 2.2  per-claim competence                    DONE     unblocks 3.3, 4.2
      └─ 3.2  ledger authoritative for one family medium   unblocks 4.1
          └─ 4.1  adjudicator authoritative       large    THE FLIP
              ├─ 4.2  safe PREVENTED              medium

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1130,6 +1130,53 @@ This is why the matrix is emitted even when everything worked: a report listing
 only the capabilities that succeeded is one a reader will take for the complete
 set of questions nox asks.
 
+#### Per finding, not per scan
+
+The matrix above is a run-level summary, and it cannot answer the question
+somebody triaging one finding actually asks: was reachability evaluated for
+**this** one? "reachability answered 4 subjects" leaves the reader of the other
+forty-nine to guess, and the comfortable guess is the wrong one.
+
+So every finding names its own competence profile:
+
+```json
+{
+  "RuleID": "DATA-001",
+  "Location": {"FilePath": "values.yaml"},
+  "CompetenceProfile": "c3"
+}
+```
+
+resolved against `meta.competence_profiles`:
+
+```json
+{"id": "c3", "subjects": 5, "gaps": [
+  {"capability": "lexical_context", "state": "unsupported",
+   "reason": "unsupported — this analysis cannot apply here"},
+  {"capability": "constant_evaluation", "state": "unsupported", "reason": "..."},
+  {"capability": "taint", "state": "not_evaluated", "reason": "..."}
+]}
+```
+
+That YAML finding was **not** lexically analysed — nox has no YAML lexer, so it
+could not tell a match in a comment from one in a value. A Go finding in the
+same scan was, and resolves to a different profile. One scan, different
+competence for different findings, which is the fact a run-level matrix
+structurally cannot express.
+
+It is an ID rather than an inline list because competence varies by class and
+not by finding: measured, 53 findings on the precision suite resolve to 4
+distinct profiles, and 62 on nox's own tree to 3. Profile IDs are stable within
+a scan and assigned in sorted order, so identical runs number them identically —
+but they are **not** stable across scans and must not be stored as if they were.
+
+In `results.sarif` the same information is resolved inline on each result, as
+`properties.nox_unevaluated`, because a SARIF consumer has no way to look a nox
+profile ID up.
+
+An empty `CompetenceProfile` means the scan recorded no coverage. It does not
+mean everything was evaluated.
+
 #### Via MCP
 
 The evidence surface is on the MCP server too, because an agent triaging a scan


### PR DESCRIPTION
Second milestone on the critical path (`1.2 → 2.2 → 3.2 → 4.1`). **Stacked on #602** — review that first; this PR's base is the 1.2 branch, so the diff here is 2.2 alone.

Closes #603.

## The gap 1.2 left

The run-level matrix can say constant evaluation ran. It cannot say it ran for the Go findings and could not apply to the YAML ones — and a consumer holding only the run-level view has to assume the best case for every finding, which is the reading this model exists to withhold.

Every finding now names the set of questions that went unanswered about **it**:

```json
{"RuleID": "DATA-001", "Location": {"FilePath": "values.yaml"}, "CompetenceProfile": "c3"}
```

```json
{"id": "c3", "subjects": 5, "gaps": [
  {"capability": "lexical_context", "state": "unsupported", "reason": "..."},
  {"capability": "constant_evaluation", "state": "unsupported", "reason": "..."}
]}
```

That YAML finding was **not** lexically analysed — nox has no YAML lexer, so it could not tell a match in a comment from one in a value. A Go finding in the same scan resolves elsewhere. One scan, different competence for different findings.

**Grouped rather than inlined, because I measured first:** 53 findings on the precision suite resolve to **4** distinct profiles, 62 on nox's own tree to **3**. Competence varies by (language × analyses) class, not by finding. Writing the same five-entry gap list onto every finding is the shape `ledger-budget.md` ruled out once already.

`results.sarif` carries the **resolved** list per result as `properties.nox_unevaluated`, because a profile ID is a nox concept a SARIF consumer cannot look up.

## The defect this surfaced (#603)

`goSymbolReferenced` returns `ok=false` for **every** undetermined outcome, and the deps analyzer gated its whole reach-metadata block on that value:

```go
if r, ok := goSymbolReferenced(...); ok {   // false for every Undetermined
    meta["reach_outcome"] = ...
}
```

So "asked and could not tell" arrived looking exactly like "nobody asked", and the `Undetermined` arm of the switch that maps it was **unreachable code**. Two live paths reach it; the common one is an advisory with no `ecosystem_specific.imports` — only the Go vulndb populates that field, so every GHSA-sourced Go advisory lands there.

**Being precise about severity:** this never hid a vulnerability. Both states are non-conclusive, neither may suppress a finding, and the severity demotion is gated on `Refuted` separately. What was lost is the *reason*, and the two states call for different operator responses — which `docs/usage.md` already documents as different rows in a table.

The ground truth was already in the repo. `want_state` has been in every `reachability-suite` fixture since it was written, and nothing asserted it. The suite tested the function; nothing tested that the state reached an artifact — which the suite's own README warns about:

> All four look identical downstream... The difference between them exists only if something checks it.

Fixed by recording unconditionally via a shared `applyReachMetadata`, adding a machine-readable `reach_limitations` (`reach_scope` is prose, and parsing English back out is not a contract), and moving the outcome→state mapping onto `reach.Outcome.CapabilityState()` so the suite and the pipeline cannot drift.

## Two notes on testing

A unit test on `applyReachMetadata` would have proved nothing — the defect was never in the writing, it was that the analyzer only called it for outcomes that concluded something. So the real test runs the **analyzer** over a real Go module with a stub advisory.

My first version of that fixture had a `go.mod` and no Go source, so the toolchain legitimately failed and *every* case came back undetermined for the wrong reason. I fixed the fixture, not the assertion.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged.
- Determinism pinned at the artifact level: profile IDs are assigned in sorted signature order, and two identical scans produce byte-identical output.
- `CompetenceProfile` is classified `notAnIngredient` in the fingerprint contract. Installing a plugin that provides call graphs changes it on every finding in a repo; if that moved the hash it would un-waive every baseline entry and `nox:ignore` in a release that fixed nothing.
- Falsified: reinstating the `ok` gate fails `TestAnalyzerRecordsUndeterminedReachability`.
- Full suite green, `golangci-lint` 0 issues.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT