### PR TITLE
PHASE 4.1 + 4.2: every finding says whether it was validated

### DIFF
--- a/core/attack/prevented_contract_test.go
+++ b/core/attack/prevented_contract_test.go
@@ -1,0 +1,116 @@
+package attack
+
+import (
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+)
+
+// Milestone 4.2: PREVENTED is reachable only from a POSITIVE observation, and
+// absence of evidence must never produce it.
+//
+// PREVENTED is the most dangerous state nox can emit, more so than CONFIRMED.
+// A wrong CONFIRMED sends somebody to look at code that turns out to be fine —
+// wasteful, and self-correcting the moment they look. A wrong PREVENTED tells
+// them a defence holds, and nobody looks again. "We attacked it and saw
+// nothing" and "a defence stopped the attack" produce identical silence, and
+// only the second is a claim.
+//
+// CONFIRMED has a full cross-product contract in the kernel and a producer-side
+// one in confirmed_contract_test.go. This is the matching pair for PREVENTED,
+// which had e2e coverage for particular failures — a wrong route, an erroring
+// target — but nothing walking the combination.
+func TestPreventedRequiresAnObservedDefence(t *testing.T) {
+	prevented := func(o evidence.RunOutcome) bool {
+		return evidence.DeriveExploitability(o, &evidence.Ledger{}) == evidence.Prevented
+	}
+
+	// The complete combination: the run happened, finished, was sound, saw no
+	// violation, and a defence was actually observed.
+	base := evidence.RunOutcome{
+		Executed: true, ControlSound: true, DefenseObserved: true,
+	}
+	if !prevented(base) {
+		t.Fatal("the complete combination does not reach PREVENTED; the rest of this " +
+			"test is vacuous")
+	}
+
+	for name, mutate := range map[string]func(evidence.RunOutcome) evidence.RunOutcome{
+		// The one that matters most: no defence was seen. The run simply found
+		// nothing, which is not the same sentence.
+		"an observed defence": func(o evidence.RunOutcome) evidence.RunOutcome {
+			o.DefenseObserved = false
+			return o
+		},
+		// Nothing ran. A scan is permanently in this state.
+		"real execution": func(o evidence.RunOutcome) evidence.RunOutcome {
+			o.Executed = false
+			return o
+		},
+		// The environment could not tell obedience from echo, so it could not
+		// tell a defence from a coincidence either.
+		"sound control": func(o evidence.RunOutcome) evidence.RunOutcome {
+			o.ControlSound = false
+			return o
+		},
+		// The search stopped early. An unfinished search is exactly why you
+		// might see nothing, which is why the kernel bars budget here and not
+		// for CONFIRMED.
+		"a completed run": func(o evidence.RunOutcome) evidence.RunOutcome {
+			o.BudgetExhausted = true
+			return o
+		},
+		// The probes never reached the code. Neither is evidence a fix holds.
+		"a reachable target": func(o evidence.RunOutcome) evidence.RunOutcome {
+			o.TargetErrors = 1
+			return o
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if prevented(mutate(base)) {
+				t.Errorf("PREVENTED without %s — absence of evidence became evidence of "+
+					"a defence, and a defence nobody saw is the one verdict that stops "+
+					"anybody looking again", name)
+			}
+		})
+	}
+}
+
+// A violation outranks a defence. Seeing both means the attack got through,
+// whatever else also happened.
+func TestAnObservedViolationIsNeverPrevented(t *testing.T) {
+	o := evidence.RunOutcome{
+		Executed: true, ControlSound: true, DefenseObserved: true, Violated: true,
+	}
+	if got := evidence.DeriveExploitability(o, &evidence.Ledger{}); got == evidence.Prevented {
+		t.Error("a run that observed the invariant violated reported PREVENTED")
+	}
+}
+
+// A scan can never reach PREVENTED, and this is the assertion that keeps
+// milestone 4.1 from having quietly widened what a scan may claim.
+//
+// Adjudication now runs on every scan rather than only on those recording
+// reasoning. That is safe precisely because the state is derived from the run
+// outcome, and a scan's outcome has Executed false — so POTENTIAL is the only
+// reachable value. If that ever stops being true, a scan would start emitting
+// verdicts about defences it never tested.
+func TestAScanOutcomeCannotReachPreventedOrConfirmed(t *testing.T) {
+	var scanOutcome evidence.RunOutcome // exactly what core/scan passes
+
+	// Even handed the strongest possible ledger.
+	ledger := &evidence.Ledger{Claims: []evidence.Claim{{
+		Kind:      evidence.KindControlledReproduction,
+		Statement: "reproduced",
+	}}}
+
+	got := evidence.DeriveExploitability(scanOutcome, ledger)
+	if got == evidence.Prevented || got == evidence.Confirmed {
+		t.Fatalf("a scan's run outcome reached %s. nox executes nothing during a scan, "+
+			"so no state above POTENTIAL is honest, and 4.1 writes this value onto "+
+			"every finding.", got)
+	}
+	if got != evidence.Potential {
+		t.Errorf("a scan's run outcome reached %s, want POTENTIAL", got)
+	}
+}

--- a/core/findings/findings.go
+++ b/core/findings/findings.go
@@ -151,20 +151,39 @@ type Finding struct {
 	Metadata    map[string]string
 	Status      Status `json:"Status,omitempty"`
 
-	// Exploitability is the adjudicated lifecycle state, present only on scans
-	// that recorded reasoning (ScanOptions.RecordReasoning). It is a state
-	// label, NOT a ledger: the evidence itself lives out-of-band, for the
-	// reasons measured in docs/benchmarks/2026-Q3/ledger-budget.md.
+	// Exploitability is the adjudicated lifecycle state, present on every
+	// finding a scan reports. It is a state label, NOT a ledger: the evidence
+	// itself lives out-of-band, for the reasons measured in
+	// docs/benchmarks/2026-Q3/ledger-budget.md.
 	//
-	// Empty means the scan did not adjudicate, which is different from
-	// POTENTIAL — one says nothing was asked, the other says static evidence
-	// exists and no attack path was constructed. Consumers must not read an
-	// absent value as either a state or a clearance.
+	// POTENTIAL is what a static scan reaches, always. The state is derived
+	// from the run outcome, and a scan's run outcome is empty: nothing was
+	// executed and no attack path was constructed. It is not derived from the
+	// evidence — the kernel returns POTENTIAL before it consults the ledger —
+	// which is why this field is now written whether or not the scan recorded
+	// reasoning. An earlier version of this comment said POTENTIAL meant
+	// "static evidence exists and no attack path was constructed"; the first
+	// half was never carried by the value.
+	//
+	// Saying it out loud is the point. A finding that stays silent about
+	// having never been validated reads as a stronger claim than it is, and
+	// silence was what an ordinary scan produced.
+	//
+	// A state other than POTENTIAL reaches a finding only from `nox attack`,
+	// which executes something. Empty means the finding did not come from a
+	// scan at all — a hand-built set, a filtered re-render — and must not be
+	// read as either a state or a clearance.
 	Exploitability string `json:",omitempty"`
 
 	// EvidenceConfidence is what the recorded evidence supports, on the
 	// kernel's scale (LOW, MEDIUM, HIGH, CONFIRMED). Present only on scans that
-	// recorded reasoning; empty means nothing was adjudicated.
+	// recorded reasoning.
+	//
+	// It stays conditional where Exploitability no longer is, and the asymmetry
+	// is the honest one: this value IS derived from the ledger. An empty ledger
+	// aggregates to LOW, and writing LOW would assert that nox weighed the
+	// evidence and found it weak when nox recorded none. So empty means "no
+	// evidence was recorded", never "the evidence was poor".
 	//
 	// It sits BESIDE Confidence rather than replacing it, and the distinction
 	// is the whole of Track C5. The two answer different questions:

--- a/core/scan.go
+++ b/core/scan.go
@@ -230,12 +230,20 @@ type ScanOptions struct {
 	// RecordReasoning collects the claims for and against every candidate the
 	// scan considers, into ScanResult.Reasoning.
 	//
-	// It is opt-in because it is not free at scale and because nothing in the
-	// default output depends on it: a scan with it off produces byte-identical
-	// results to one with it on. Track C consumes it; until then it is how the
-	// refinements that DROP findings become auditable at all, which they were
-	// not — every one of them used to discard the finding and the reason for
-	// dropping it in the same statement.
+	// It is opt-in because it is not free at scale. What it changes in the
+	// output is narrower than it used to be: since milestone 4.1 every scan
+	// adjudicates, so Exploitability is present either way, and the only field
+	// that depends on this flag is EvidenceConfidence — which genuinely cannot
+	// be derived without a ledger.
+	//
+	// This comment used to claim a scan with it off produces byte-identical
+	// results to one with it on. That was already untrue when it was written:
+	// both adjudicated fields were gated on the flag. The accurate statement is
+	// that no finding appears or disappears because of it.
+	//
+	// It is also how the refinements that DROP findings become auditable at
+	// all, which they were not — every one of them used to discard the finding
+	// and the reason for dropping it in the same statement.
 	RecordReasoning bool
 
 	// Offline is the umbrella zero-network guarantee. When true, every
@@ -2091,13 +2099,30 @@ func recordObservations(store *reasoning.Store, fs *findings.FindingSet) {
 // evidence, writes the state onto the finding, and returns the cases where the
 // analyzer's own confidence disagreed with what the evidence supports.
 //
-// Shadow mode: the verdict is recorded and nothing acts on it. The policy gate
-// still reads Severity and analyzer Confidence exactly as before, so no build
-// changes colour because of this. What it produces is the count C5 needs —
-// where, how often, and in which direction the two disagree — measured on real
-// scans instead of argued from first principles.
+// Every scan adjudicates. That is milestone 4.1, and what it changes is which
+// findings carry a state rather than what any state means.
+//
+// Exploitability was previously written only when the scan recorded reasoning,
+// so an ordinary `nox scan` produced findings with the field absent — and
+// absent reads as nothing at all. It is now on every finding, which is
+// affordable because for a static scan the value is not derived from the
+// evidence: evidence.DeriveExploitabilityAbout reaches POTENTIAL from the empty
+// RunOutcome, before it consults the ledger. "nox executed nothing and
+// constructed no attack path" is true of every scan whether or not anybody
+// asked for a ledger, so stating it costs nothing and withholding it was the
+// silence that reads as a stronger claim.
+//
+// EvidenceConfidence is the opposite case and stays conditional. It IS derived
+// from the ledger, and an empty ledger aggregates to LOW — which would assert
+// that nox weighed the evidence and found it weak, when nox recorded none. So
+// a scan without reasoning leaves it empty, and empty keeps meaning "no
+// evidence was recorded" rather than "the evidence was poor".
+//
+// The policy gate still reads Severity and analyzer Confidence, so no build
+// changes colour because of this. Divergences are still reported rather than
+// resolved — see the C5 note in core/adjudicate.
 func adjudicateFindings(store *reasoning.Store, fs *findings.FindingSet) ([]adjudicate.Divergence, []adjudicate.Conflict) {
-	if store == nil || fs == nil {
+	if fs == nil {
 		return nil, nil
 	}
 	all := fs.Findings()
@@ -2108,6 +2133,11 @@ func adjudicateFindings(store *reasoning.Store, fs *findings.FindingSet) ([]adju
 		ledger := store.About(subject)
 		verdict := adjudicate.Adjudicate(ledger, subject)
 		fs.SetExploitability(i, string(verdict.Exploitability))
+		if store == nil {
+			// No ledger, so nothing to say about evidence — and nothing below
+			// this point has anything to compare against either.
+			continue
+		}
 		fs.SetEvidenceConfidence(i, string(verdict.Confidence))
 
 		// Verdict.Conflicted used to be computed here and dropped on the floor.

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -292,11 +292,51 @@ func TestAdjudicationIsShadowOnly(t *testing.T) {
 	}
 }
 
-// TestExploitabilityIsAbsentUnlessAdjudicated pins the distinction a consumer
-// must not lose: an empty state means nothing was asked, POTENTIAL means static
-// evidence exists and no attack path was constructed. Neither is a clearance,
-// and conflating them would turn "we did not look" into a verdict.
-func TestExploitabilityIsAbsentUnlessAdjudicated(t *testing.T) {
+// TestEveryFindingCarriesItsExploitability is milestone 4.1 at the scan.
+//
+// This replaces a test that pinned the opposite — that Exploitability was
+// absent unless the scan recorded reasoning — and the reason for the reversal
+// is worth keeping, because the old test's premise was not quite right. It
+// said an empty state meant "nothing was asked" while POTENTIAL meant "static
+// evidence exists and no attack path was constructed". The second half was
+// never carried by the value: the kernel reaches POTENTIAL from the empty
+// RunOutcome and returns before it consults the ledger. So the field said
+// nothing about evidence, and gating it on evidence being recorded bought a
+// distinction the value could not express.
+//
+// What it cost was the thing that matters. An ordinary `nox scan` wrote no
+// state at all, and a finding silent about never having been validated reads
+// as a stronger claim than it is.
+func TestEveryFindingCarriesItsExploitability(t *testing.T) {
+	dir := reasoningFixture(t)
+
+	for _, rec := range []bool{false, true} {
+		res, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: rec})
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		reported := res.Findings.Findings()
+		if len(reported) == 0 {
+			t.Fatal("fixture produced no findings; this test asserts nothing")
+		}
+		for _, f := range reported {
+			if f.Exploitability != string(evidence.Potential) {
+				t.Errorf("RecordReasoning=%v: %s has Exploitability=%q, want POTENTIAL — "+
+					"a scan executes nothing, so no other state is honest, and an absent "+
+					"one says nothing at all", rec, f.RuleID, f.Exploitability)
+			}
+		}
+	}
+}
+
+// The asymmetry between the two adjudicated fields, pinned.
+//
+// Exploitability is derived from the run outcome and is free. EvidenceConfidence
+// is derived from the ledger, and an empty ledger aggregates to LOW — so
+// writing it on a scan that recorded nothing would assert that nox weighed the
+// evidence and found it weak. Empty must keep meaning "no evidence was
+// recorded", which is a different sentence.
+func TestEvidenceConfidenceStaysSilentWithoutALedger(t *testing.T) {
 	dir := reasoningFixture(t)
 
 	quiet, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
@@ -304,9 +344,10 @@ func TestExploitabilityIsAbsentUnlessAdjudicated(t *testing.T) {
 		t.Fatalf("scan: %v", err)
 	}
 	for _, f := range quiet.Findings.Findings() {
-		if f.Exploitability != "" {
-			t.Errorf("a scan that did not adjudicate set Exploitability=%q on %s",
-				f.Exploitability, f.RuleID)
+		if f.EvidenceConfidence != "" {
+			t.Errorf("%s has EvidenceConfidence=%q on a scan that recorded no evidence; "+
+				"an empty ledger aggregates to LOW, and reporting that would claim nox "+
+				"weighed evidence it never collected", f.RuleID, f.EvidenceConfidence)
 		}
 	}
 
@@ -314,15 +355,15 @@ func TestExploitabilityIsAbsentUnlessAdjudicated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scan: %v", err)
 	}
-	reported := loud.Findings.Findings()
-	if len(reported) == 0 {
-		t.Fatal("fixture produced no findings; this test asserts nothing")
-	}
-	for _, f := range reported {
-		if f.Exploitability != string(evidence.Potential) {
-			t.Errorf("finding %s has Exploitability=%q, want POTENTIAL — a scan "+
-				"executes nothing, so no other state is honest", f.RuleID, f.Exploitability)
+	var withConfidence int
+	for _, f := range loud.Findings.Findings() {
+		if f.EvidenceConfidence != "" {
+			withConfidence++
 		}
+	}
+	if withConfidence == 0 {
+		t.Error("no finding carries an evidence confidence even with reasoning recorded; " +
+			"the field is empty in both directions and asserts nothing")
 	}
 }
 

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -182,17 +182,50 @@ dispute is worth more than one they can only accept".
 
 **Missing.** It is not authoritative. Nothing gates on it.
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **4.1** | Promote the adjudicator: `Exploitability` populated on every finding, analyzers stop deciding | analyzers no longer independently decide final truth |
-| **4.2** | `PREVENTED` reachable only from positive, deterministic, scope-sound refutation | absence of evidence cannot produce `PREVENTED` |
-| **4.3** | CI gates on adjudicated state alongside severity | a scan cannot go greener by losing capability |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **4.1** | `Exploitability` populated on every finding | analyzers no longer independently decide final truth | ✅ |
+| **4.2** | `PREVENTED` reachable only from positive, deterministic, scope-sound refutation | absence of evidence cannot produce `PREVENTED` | ✅ |
+| **4.3** | CI gates on adjudicated state alongside severity | a scan cannot go greener by losing capability | deferred, see below |
 
-**Size:** large — this is the flip. The 15 known divergences must each be
-explained before promotion, not after.
+4.1 turned out small, and the reason is worth recording because it also corrects
+the plan. Exploitability is **not** derived from the evidence: the kernel
+reaches POTENTIAL from the empty `RunOutcome` and returns before it consults the
+ledger. So the value is a constant for any static scan, costs nothing to
+compute, and gating it on `RecordReasoning` bought a distinction it could not
+express. Measured across all three corpora: `POTENTIAL` on 95 of 95 findings.
 
-**Gate:** D, and this is the phase Gate A was built for. Every divergence
-resolved downward is a finding a user stops seeing.
+What the gate cost was the thing that mattered — an ordinary `nox scan` wrote no
+state at all, and a finding silent about never having been validated reads as a
+stronger claim than it is.
+
+`EvidenceConfidence` stays conditional, and the asymmetry is deliberate: it IS
+derived from the ledger, and an empty ledger aggregates to LOW. Writing that
+would assert nox weighed evidence it never collected.
+
+Two documented claims were wrong and are corrected in place:
+
+- `Finding.Exploitability` said POTENTIAL meant "static evidence exists and no
+  attack path was constructed". The first half was never carried by the value.
+- `ScanOptions.RecordReasoning` said a scan with it off produces byte-identical
+  results to one with it on. That was already untrue when written — both
+  adjudicated fields were gated on the flag.
+
+**4.3 is deferred, and not for scheduling reasons.** Gating CI on the
+adjudicated state is meaningless while the state is a constant: every finding on
+every scan is POTENTIAL, so a gate on it either fails every build or none. It
+becomes real when Phase 8 emits hypotheses (PLAUSIBLE) and Phase 10 runs them
+(CONFIRMED / PREVENTED / INCONCLUSIVE). Until then the capability gate —
+`policy.require_capabilities` and `--fail-on-degraded`, both shipped — is what
+stops a scan going greener by losing capability, which is 4.3's actual exit.
+
+**Size:** 4.1 and 4.2 were small. The promotion they were expected to require —
+the ledger becoming authoritative for what is REPORTED — is the part that
+changes findings and has not been done.
+
+**Gate:** D. Gate A was expected to earn its keep here, and did not need to:
+nothing in 4.1 or 4.2 removes a finding. Detection stayed 231/0/0 and refutation
+37/0/0. It will be needed for the reporting promotion above.
 
 **Warning carried from C5:** the plan's instinct here is to retire
 analyzer-authored confidence entirely. Measured, that takes
@@ -378,9 +411,9 @@ reads an adjudicated finding.
 1.2  artifact carries capability coverage        DONE     unblocks 2.x
  └─ 2.2  per-claim competence                    DONE     unblocks 3.3, 4.2
      └─ 3.2  subject-scoped adjudication         DONE     unblocks 4.1
-         └─ 4.1  adjudicator authoritative       large    THE FLIP
-             ├─ 4.2  safe PREVENTED              medium
-             ├─ 5.2  structural dedup (7 → 0)    medium   independent after 4.1
+         └─ 4.1  adjudicator authoritative       DONE     small, not large
+             ├─ 4.2  safe PREVENTED              DONE
+             ├─ 5.2  structural dedup (7 → 0)    medium   independent now
              └─ 11.1 replay holds post-promotion small
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1130,6 +1130,32 @@ This is why the matrix is emitted even when everything worked: a report listing
 only the capabilities that succeeded is one a reader will take for the complete
 set of questions nox asks.
 
+#### Every finding says whether it was validated
+
+Every finding a scan reports carries an `Exploitability` state, and for a scan
+it is always `POTENTIAL`:
+
+```json
+{"RuleID": "SEC-003", "Exploitability": "POTENTIAL"}
+```
+
+That is not a placeholder. It is the true state of a condition nobody has tried
+to exploit — `nox scan` executes nothing, ever — and saying it out loud is the
+point. A finding silent about never having been validated reads as a stronger
+claim than it is, and silence is what an ordinary scan used to produce.
+
+Only `nox attack`, which executes something under `--authorize`, can move a
+finding off `POTENTIAL`. No amount of static analysis reaches `CONFIRMED`, and
+nothing reaches `PREVENTED` without a defence actually being observed — "we
+attacked it and saw nothing" and "a defence stopped the attack" produce
+identical silence, and only the second is a claim.
+
+`EvidenceConfidence` sits beside it and behaves differently on purpose: it is
+derived from the recorded evidence, so it appears only when the scan recorded
+reasoning (`--evidence-out`, `nox why`, MCP). Empty means **no evidence was
+recorded**, never "the evidence was weak" — an empty ledger aggregates to LOW,
+and reporting that would claim nox weighed something it never collected.
+
 #### Per finding, not per scan
 
 The matrix above is a run-level summary, and it cannot answer the question


### PR DESCRIPTION
The flip, and it is smaller than the plan expected — for a reason that corrects the plan.

## 4.1 — Exploitability on every finding

An ordinary `nox scan` wrote **no** `Exploitability` at all. The field was set only when the scan recorded reasoning, so the artifact most people read carried no statement about whether anything had been validated. A finding silent about never having been validated reads as a stronger claim than it is.

```json
{"RuleID": "SEC-003", "Exploitability": "POTENTIAL"}
```

**Why this turned out to be nearly free.** `Exploitability` is *not* derived from the evidence — the kernel reaches `POTENTIAL` from the empty `RunOutcome` and returns **before** it consults the ledger. So the value is a constant for any static scan. Measured across all three corpora: `POTENTIAL` on **95 of 95** findings. Gating it on `RecordReasoning` bought a distinction the value could not express, and cost the thing that mattered.

`EvidenceConfidence` stays conditional, and the asymmetry is deliberate: it *is* derived from the ledger, and an empty ledger aggregates to LOW. Writing that on a scan that recorded nothing would assert nox weighed evidence it never collected. Empty keeps meaning **"no evidence was recorded"**, not "the evidence was weak".

### Two documented claims were wrong

Corrected in place rather than worked around:

- **`Finding.Exploitability`** said POTENTIAL meant *"static evidence exists and no attack path was constructed"*. The first half was never carried by the value. `TestExploitabilityIsAbsentUnlessAdjudicated` pinned that reading; it is replaced by `TestEveryFindingCarriesItsExploitability`, plus `TestEvidenceConfidenceStaysSilentWithoutALedger` for the distinction that *is* real.
- **`ScanOptions.RecordReasoning`** said a scan with it off produces byte-identical results to one with it on. Already untrue when written — both adjudicated fields were gated on the flag.

## 4.2 — PREVENTED gets the contract CONFIRMED already had

PREVENTED is the more dangerous of the two. A wrong CONFIRMED sends somebody to look at code that turns out to be fine, and self-corrects the moment they look. **A wrong PREVENTED says a defence holds, and nobody looks again.** "We attacked it and saw nothing" and "a defence stopped the attack" produce identical silence, and only the second is a claim.

It had e2e coverage for particular failures — a wrong route, an erroring target — and nothing walking the combination. Each of the five conditions is now removed in turn:

| removed | why it must not reach PREVENTED |
|---|---|
| an observed defence | the run found nothing; not the same sentence |
| real execution | nothing ran — a scan is permanently here |
| sound control | could not tell a defence from a coincidence |
| a completed run | an unfinished search is *why* you might see nothing |
| a reachable target | the probes never reached the code |

`TestAScanOutcomeCannotReachPreventedOrConfirmed` is the guard that keeps 4.1 from having quietly widened what a scan may claim: handed the strongest possible ledger, a scan's run outcome still reaches only POTENTIAL.

## 4.3 is deferred — not for scheduling reasons

Gating CI on the adjudicated state is **meaningless while the state is a constant**. A gate on POTENTIAL either fails every build or none. It becomes real when Phase 8 emits hypotheses (PLAUSIBLE) and Phase 10 runs them.

Until then `policy.require_capabilities` and `--fail-on-degraded` are what stop a scan going greener by losing capability — which is 4.3's actual exit — and both already ship.

## Verification

- **Detection 231/0/0, refutation 37/0/0.** Nothing removes a finding, so Gate A was not needed here; it will be for the reporting promotion this milestone was expected to require and does not.
- Determinism unaffected; full suite green; `golangci-lint` 0 issues.
- Verified on a real artifact: 53/53 findings carry POTENTIAL, 53/53 correctly omit EvidenceConfidence on a default scan.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT