### PR TITLE
BASELINE: one entry accepts one finding, not every future one

### DIFF
--- a/core/baseline/baseline.go
+++ b/core/baseline/baseline.go
@@ -33,7 +33,13 @@ type Entry struct {
 type Baseline struct {
 	SchemaVersion string  `json:"schema_version"`
 	Entries       []Entry `json:"entries"`
-	index         map[string]*Entry
+	// index holds EVERY entry per fingerprint, not the last one written.
+	//
+	// It used to hold one, and that quietly made a baseline unable to express
+	// "two of these were accepted" — which matters because two genuinely
+	// distinct findings share a fingerprint whenever a rule's message is a
+	// static description. See Matcher.
+	index map[string][]*Entry
 }
 
 // Load reads a baseline file from path. If the file does not exist, an empty
@@ -44,7 +50,7 @@ func Load(path string) (*Baseline, error) {
 		if os.IsNotExist(err) {
 			return &Baseline{
 				SchemaVersion: schemaVersion,
-				index:         make(map[string]*Entry),
+				index:         make(map[string][]*Entry),
 			}, nil
 		}
 		return nil, fmt.Errorf("reading baseline %s: %w", path, err)
@@ -104,14 +110,28 @@ func (b *Baseline) lookup(fingerprint string) *Entry {
 	if fingerprint == "" {
 		return nil
 	}
-	e, ok := b.index[fingerprint]
-	if !ok {
+	for _, e := range b.index[fingerprint] {
+		if e.ExpiresAt != nil && time.Now().After(*e.ExpiresAt) {
+			continue
+		}
+		return e
+	}
+	return nil
+}
+
+// live returns the unexpired entries for a fingerprint, in file order.
+func (b *Baseline) live(fingerprint string) []*Entry {
+	if fingerprint == "" {
 		return nil
 	}
-	if e.ExpiresAt != nil && time.Now().After(*e.ExpiresAt) {
-		return nil
+	out := make([]*Entry, 0, len(b.index[fingerprint]))
+	for _, e := range b.index[fingerprint] {
+		if e.ExpiresAt != nil && time.Now().After(*e.ExpiresAt) {
+			continue
+		}
+		out = append(out, e)
 	}
-	return e
+	return out
 }
 
 // Add appends an entry to the baseline and updates the index.
@@ -120,25 +140,32 @@ func (b *Baseline) Add(e *Entry) {
 		return
 	}
 	b.Entries = append(b.Entries, *e)
-	if b.index == nil {
-		b.index = make(map[string]*Entry)
-	}
-	b.index[e.Fingerprint] = &b.Entries[len(b.Entries)-1]
+	// Appending can reallocate the slice, which invalidates every pointer the
+	// index holds. Rebuilding is O(n) per Add and this is not a hot path;
+	// keeping stale pointers would be a bug that only appears past the
+	// slice's initial capacity, which is the hardest kind to find.
+	b.buildIndex()
 }
 
 // Prune removes entries whose fingerprints are not present in the current
 // findings slice. Returns the number of entries removed.
 func (b *Baseline) Prune(current []findings.Finding) int {
-	active := make(map[string]struct{}, len(current))
+	// Counted, not a presence set. Entries are consumed one per finding now, so
+	// a baseline holding four entries for a fingerprint that only two findings
+	// still match is carrying two spares — and a spare is exactly what absorbs
+	// the next occurrence without anyone accepting it. Pruning to the live
+	// count keeps the file honest about how many were accepted.
+	active := make(map[string]int, len(current))
 	for i := range current {
-		active[current[i].Fingerprint] = struct{}{}
+		active[current[i].Fingerprint]++
 	}
 
 	kept := make([]Entry, 0, len(b.Entries))
 	removed := 0
 	for i := range b.Entries {
 		entry := b.Entries[i]
-		if _, ok := active[entry.Fingerprint]; ok {
+		if active[entry.Fingerprint] > 0 {
+			active[entry.Fingerprint]--
 			kept = append(kept, entry)
 		} else {
 			removed++
@@ -217,8 +244,92 @@ func FromFindings(ff []findings.Finding) []Entry {
 }
 
 func (b *Baseline) buildIndex() {
-	b.index = make(map[string]*Entry, len(b.Entries))
+	b.index = make(map[string][]*Entry, len(b.Entries))
 	for i := range b.Entries {
-		b.index[b.Entries[i].Fingerprint] = &b.Entries[i]
+		fp := b.Entries[i].Fingerprint
+		b.index[fp] = append(b.index[fp], &b.Entries[i])
 	}
+}
+
+// Matcher applies a baseline to ONE scan's findings, consuming an entry per
+// finding it suppresses.
+//
+// Baseline.Match answers "is this fingerprint accepted?", which sounds like the
+// right question and is not. Under fingerprint v2 the digest is
+// sha256(rule_id || path || message), and FindingSet.Add passes the finding's
+// Message as content — so a rule whose message is a static description produces
+// ONE fingerprint for every occurrence in a file. Four workflow steps with
+// continue-on-error are four real findings and one digest.
+//
+// With a fingerprint-only lookup, accepting one of them accepted all four, and
+// — the part that makes this a false negative rather than an inconvenience — it
+// accepted the fifth somebody added a month later. That finding was born
+// baselined. `nox scan` printed "0 findings (3 suppressed)" for a file whose
+// problems had grown by half.
+//
+// Counting fixes it without giving back what v2 bought. An entry records that
+// ONE instance was accepted:
+//
+//   - the code moves — one finding, one entry, still matched, which is the
+//     whole reason the line was dropped from the digest
+//   - a second instance appears — no entry left to consume, so it is reported
+//   - an instance is removed — a spare entry remains, and Prune clears it
+//
+// A Matcher is single-use and not safe for concurrent use: the scan applies a
+// baseline in one pass over an already-sorted finding set, so the assignment is
+// deterministic without any ordering rule of its own.
+type Matcher struct {
+	b         *Baseline
+	remaining map[string]int
+}
+
+// NewMatcher returns a consuming matcher over b. A nil Baseline yields a
+// matcher that suppresses nothing.
+func (b *Baseline) NewMatcher() *Matcher {
+	m := &Matcher{b: b, remaining: map[string]int{}}
+	if b == nil {
+		return m
+	}
+	for fp := range b.index {
+		m.remaining[fp] = len(b.live(fp))
+	}
+	return m
+}
+
+// Match returns the entry accepting f, consuming it, or nil when the baseline
+// has no unconsumed entry for this finding.
+//
+// The alias fallback is preserved: a finding that inherited a retired rule ID
+// is looked up under the fingerprint that rule would have produced, so retiring
+// a duplicate rule ID does not un-baseline every finding accepted under it.
+func (m *Matcher) Match(f *findings.Finding) *Entry {
+	if m == nil || m.b == nil || f == nil {
+		return nil
+	}
+	if e := m.consume(f.Fingerprint); e != nil {
+		return e
+	}
+	for _, fp := range f.AliasFingerprints {
+		if e := m.consume(fp); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// consume takes one entry for fingerprint if any remain.
+func (m *Matcher) consume(fingerprint string) *Entry {
+	if fingerprint == "" || m.remaining[fingerprint] <= 0 {
+		return nil
+	}
+	live := m.b.live(fingerprint)
+	if len(live) == 0 {
+		return nil
+	}
+	// Which entry is handed back does not affect suppression — they share a
+	// fingerprint — but taking them in file order keeps the reported reason
+	// stable across runs.
+	e := live[len(live)-m.remaining[fingerprint]]
+	m.remaining[fingerprint]--
+	return e
 }

--- a/core/baseline/matcher_test.go
+++ b/core/baseline/matcher_test.go
@@ -1,0 +1,169 @@
+package baseline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+func entry(fp string) Entry {
+	return Entry{Fingerprint: fp, RuleID: "IAC-018", FilePath: "w.yml", CreatedAt: time.Now()}
+}
+
+func finding(fp string, line int) findings.Finding {
+	return findings.Finding{
+		RuleID:      "IAC-018",
+		Fingerprint: fp,
+		Severity:    findings.SeverityMedium,
+		Location:    findings.Location{FilePath: "w.yml", StartLine: line},
+	}
+}
+
+func loaded(entries ...Entry) *Baseline {
+	b := &Baseline{SchemaVersion: schemaVersion, Entries: entries}
+	b.buildIndex()
+	return b
+}
+
+// One accepted finding accepts one finding.
+//
+// Under fingerprint v2 the digest is sha256(rule_id || path || message), and
+// FindingSet.Add passes the Message — so a rule whose message is a static
+// description produces ONE fingerprint for every occurrence in a file. Four
+// workflow steps with continue-on-error are four real findings and one digest.
+//
+// A fingerprint-only lookup accepted all four on the strength of one entry, and
+// accepted the fifth somebody added later: born baselined, and `nox scan`
+// reported "0 findings (3 suppressed)" for a file whose problems had grown.
+func TestOneEntryAcceptsOneFinding(t *testing.T) {
+	b := loaded(entry("fp1"))
+	m := b.NewMatcher()
+
+	first := finding("fp1", 9)
+	if m.Match(&first) == nil {
+		t.Fatal("the accepted finding was not matched")
+	}
+	second := finding("fp1", 12)
+	if e := m.Match(&second); e != nil {
+		t.Errorf("a second, distinct finding at line 12 consumed entry %+v. Nobody accepted "+
+			"it, and under the old lookup nobody would ever have seen it either.", e)
+	}
+	third := finding("fp1", 15)
+	if m.Match(&third) != nil {
+		t.Error("a third finding was suppressed by a baseline holding one entry")
+	}
+}
+
+// N entries accept N findings, which is what makes `nox baseline write` on a
+// file with four occurrences mean what it says.
+func TestEntriesAcceptExactlyTheirCount(t *testing.T) {
+	b := loaded(entry("fp1"), entry("fp1"), entry("fp1"))
+	m := b.NewMatcher()
+
+	var accepted int
+	for line := 1; line <= 5; line++ {
+		f := finding("fp1", line)
+		if m.Match(&f) != nil {
+			accepted++
+		}
+	}
+	if accepted != 3 {
+		t.Errorf("three entries accepted %d findings, want exactly 3", accepted)
+	}
+}
+
+// The property v2 exists for, which the fix must not cost: a baselined finding
+// that moves up or down its file is still baselined. That is the entire reason
+// the line was dropped from the digest, and a fix that reintroduced position
+// would have traded one silent failure for a noisy one.
+func TestAMovedFindingIsStillAccepted(t *testing.T) {
+	b := loaded(entry("fp1"))
+
+	atLine9 := finding("fp1", 9)
+	if b.NewMatcher().Match(&atLine9) == nil {
+		t.Fatal("the finding was not matched at its original line")
+	}
+	// Same finding, four lines further down after a comment was added above.
+	atLine13 := finding("fp1", 13)
+	if b.NewMatcher().Match(&atLine13) == nil {
+		t.Error("a baselined finding stopped matching after the code moved; the v2 " +
+			"fingerprint is line-independent precisely so this cannot happen")
+	}
+}
+
+// Each scan gets its own matcher, so consumption never leaks between runs.
+func TestMatchersAreIndependent(t *testing.T) {
+	b := loaded(entry("fp1"))
+	for i := 0; i < 3; i++ {
+		f := finding("fp1", 9)
+		if b.NewMatcher().Match(&f) == nil {
+			t.Fatalf("run %d: the entry was consumed by an earlier matcher", i+1)
+		}
+	}
+}
+
+// An expired entry accepts nothing, and does not occupy a slot that would
+// otherwise let a live entry match.
+func TestExpiredEntriesAcceptNothing(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	expired := entry("fp1")
+	expired.ExpiresAt = &past
+
+	b := loaded(expired)
+	f := finding("fp1", 9)
+	if e := b.NewMatcher().Match(&f); e != nil {
+		t.Errorf("an expired entry accepted a finding: %+v", e)
+	}
+
+	// One expired and one live: the live one still works.
+	b2 := loaded(expired, entry("fp1"))
+	f2 := finding("fp1", 9)
+	if b2.NewMatcher().Match(&f2) == nil {
+		t.Error("a live entry stopped matching because an expired one shared its fingerprint")
+	}
+}
+
+// The alias fallback survives counting. A finding that inherited a retired rule
+// ID is looked up under the fingerprint that rule would have produced —
+// otherwise retiring a duplicate rule ID un-baselines every finding accepted
+// under it.
+func TestAliasFingerprintsStillMatch(t *testing.T) {
+	b := loaded(entry("retired-fp"))
+	f := finding("current-fp", 9)
+	f.AliasFingerprints = []string{"retired-fp"}
+
+	m := b.NewMatcher()
+	if m.Match(&f) == nil {
+		t.Fatal("a finding carrying a retired rule's fingerprint was not matched")
+	}
+	// And the alias entry is consumed, not reusable.
+	g := finding("current-fp", 12)
+	g.AliasFingerprints = []string{"retired-fp"}
+	if m.Match(&g) != nil {
+		t.Error("the alias entry accepted a second finding")
+	}
+}
+
+// A nil baseline suppresses nothing rather than panicking.
+func TestNilBaselineMatcherIsUsable(t *testing.T) {
+	var b *Baseline
+	f := finding("fp1", 9)
+	if b.NewMatcher().Match(&f) != nil {
+		t.Error("a nil baseline accepted a finding")
+	}
+}
+
+// Prune counts too. Four entries against two live findings leaves two spares,
+// and a spare is exactly what absorbs the next occurrence without anyone
+// accepting it.
+func TestPruneRemovesSpareEntries(t *testing.T) {
+	b := loaded(entry("fp1"), entry("fp1"), entry("fp1"), entry("fp1"))
+	removed := b.Prune([]findings.Finding{finding("fp1", 9), finding("fp1", 12)})
+	if removed != 2 {
+		t.Errorf("Prune removed %d entries, want 2", removed)
+	}
+	if len(b.Entries) != 2 {
+		t.Errorf("baseline kept %d entries, want 2", len(b.Entries))
+	}
+}

--- a/core/baseline_absorption_test.go
+++ b/core/baseline_absorption_test.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// workflowWithSteps writes a GitHub workflow with n continue-on-error steps.
+// Each is a real, distinct finding, and under fingerprint v2 they all share one
+// digest because IAC-018's message is a static description.
+func workflowWithSteps(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "name: demo\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n"
+	for i := 0; i < n; i++ {
+		body += "      - name: step\n        run: echo hi\n        continue-on-error: true\n"
+	}
+	path := filepath.Join(dir, ".github", "workflows", "w.yml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing workflow: %v", err)
+	}
+	return dir
+}
+
+func iac018(fs *findings.FindingSet) []findings.Finding {
+	var out []findings.Finding
+	for _, f := range fs.Findings() {
+		if f.RuleID == "IAC-018" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func writeBaselineFor(t *testing.T, dir string, entries []baseline.Entry) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".nox"), 0o755); err != nil {
+		t.Fatalf("mkdir .nox: %v", err)
+	}
+	data, err := json.Marshal(baseline.Baseline{SchemaVersion: "1.0.0", Entries: entries})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nox", "baseline.json"), data, 0o600); err != nil {
+		t.Fatalf("writing baseline: %v", err)
+	}
+}
+
+// The whole chain, through a real scan, because the unit tests in core/baseline
+// prove the Matcher and not that the pipeline uses it.
+//
+// Accept one continue-on-error step, then add two more. Under the old
+// fingerprint-only lookup all three were suppressed and `nox scan` printed
+// "0 findings (3 suppressed)" — the third had never been seen by anyone, and it
+// was introduced after the baseline was written.
+func TestABaselineEntryDoesNotAbsorbLaterFindings(t *testing.T) {
+	dir := workflowWithSteps(t, 3)
+
+	// Establish what the fingerprint is, and accept ONE of the three.
+	first, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	found := iac018(first.Findings)
+	if len(found) != 3 {
+		t.Fatalf("fixture produced %d IAC-018 findings, want 3", len(found))
+	}
+	if found[0].Fingerprint != found[1].Fingerprint || found[1].Fingerprint != found[2].Fingerprint {
+		t.Skip("the three findings no longer share a fingerprint; this test has nothing to prove")
+	}
+
+	writeBaselineFor(t, dir, baseline.FromFindings(found[:1]))
+
+	second, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	var baselined, active int
+	for _, f := range iac018(second.Findings) {
+		if f.Status == findings.StatusBaselined {
+			baselined++
+		} else if f.Status.IsActive() {
+			active++
+		}
+	}
+	if baselined != 1 {
+		t.Errorf("%d findings were baselined by a one-entry baseline, want 1", baselined)
+	}
+	if active != 2 {
+		t.Errorf("%d findings are active, want 2. One entry accepted one finding; the other "+
+			"two were never accepted by anyone, and silence about them is a false negative "+
+			"that grows every time somebody adds another step.", active)
+	}
+}
+
+// The property the fix must not cost. Fingerprint v2 drops the line so a
+// baseline survives code moving, and a fix that keyed on position would have
+// traded a silent failure for a noisy one.
+func TestAMovedFindingStaysBaselinedThroughAScan(t *testing.T) {
+	dir := workflowWithSteps(t, 1)
+
+	first, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	found := iac018(first.Findings)
+	if len(found) != 1 {
+		t.Fatalf("fixture produced %d IAC-018 findings, want 1", len(found))
+	}
+	writeBaselineFor(t, dir, baseline.FromFindings(found))
+
+	// Push the step down the file.
+	path := filepath.Join(dir, ".github", "workflows", "w.yml")
+	body, err := os.ReadFile(path) //nolint:gosec // test-owned fixture
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	if err := os.WriteFile(path, append([]byte("# a\n# b\n# c\n# d\n"), body...), 0o600); err != nil {
+		t.Fatalf("rewriting fixture: %v", err)
+	}
+
+	second, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	moved := iac018(second.Findings)
+	if len(moved) != 1 {
+		t.Fatalf("after the move there are %d IAC-018 findings, want 1", len(moved))
+	}
+	if moved[0].Status != findings.StatusBaselined {
+		t.Errorf("a baselined finding became %q after moving to line %d; v2 drops the line "+
+			"from the fingerprint precisely so this cannot happen",
+			moved[0].Status, moved[0].Location.StartLine)
+	}
+}

--- a/core/scan.go
+++ b/core/scan.go
@@ -2028,13 +2028,17 @@ func applyBaseline(fs *findings.FindingSet, baselinePath string, deg *degrade.De
 		return
 	}
 
+	// A consuming matcher, not bl.Match. One entry accepts one finding, so a
+	// baseline written when a file had two continue-on-error steps does not
+	// silently accept the third somebody adds later — see baseline.Matcher.
+	m := bl.NewMatcher()
 	items := fs.Findings()
 	for i := range items {
 		f := items[i]
 		if f.Status != "" && f.Status != findings.StatusNew {
 			continue // already suppressed
 		}
-		if bl.Match(&f) != nil {
+		if m.Match(&f) != nil {
 			fs.SetStatus(i, findings.StatusBaselined)
 		}
 	}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -242,19 +242,41 @@ corpus, every edge evidence-backed. `core/attack/graph.go` has a typed security
 graph with path search.
 
 **Missing.** The graph is confined to `core/attack`; the scan pipeline has no
-graph identity beyond `FlowID`. Structural deduplication is partial — the
-2026-09 self-scan still shows **7 duplicate fingerprints out of 62 findings**.
+graph identity beyond `FlowID`.
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **5.1** | Bind findings to symbols/nodes/edges/paths, not just flows | a finding can reference the path that established it |
-| **5.2** | Structural dedup over flow identity | TRIAGE-002 solved by identity, never by deleting a detector |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **5.1** | Bind findings to symbols/nodes/edges/paths, not just flows | a finding can reference the path that established it | |
+| **5.2** | Identity, not deletion, decides what is one finding | TRIAGE-002 solved by identity, never by deleting a detector | ✅ #610 |
 
-**Size:** medium. 5.2 has a measurable target already: 7 → 0 duplicates on the
-self-scan.
+**5.2's stated target was a mismeasurement, and chasing it would have deleted
+real findings.** "7 duplicate fingerprints out of 62 findings" counts
+**suppressed** findings — 60 of the 62 on the self-scan are waived. Among active
+findings there are **zero** duplicates. And of the seven, four are IAC-018 on
+four *different* workflow steps: genuinely distinct findings sharing one digest,
+because the v2 fingerprint is `sha256(rule_id, path, message)` and that rule's
+message is a static description. Deduplicating them to zero would have deleted
+three real findings — the exact failure the milestone's own exit criterion
+names.
+
+`FindingSet.Deduplicate` already implements the right rule and documents this
+hazard: it keys on fingerprint **plus position**, because "two findings at
+different positions are never duplicates".
+
+What the measurement did surface is that the same hazard was unfixed one layer
+over, where it is worse. `Baseline.Match` looked up by fingerprint alone, so
+accepting one finding accepted every other occurrence in that file — including
+ones added *after* the baseline was written. A newly introduced problem was born
+baselined and `nox scan` reported `0 findings`. Fixed in #610 by consuming one
+entry per finding, which keeps what v2 bought: a finding that moves still
+matches.
+
+**Size:** small, once measured. The lesson is the plan's, not the code's — the
+number had never been read past its total.
 
 **Gate:** A — `r5_two_distinct.py` exists precisely because two sinks sharing a
-source are two vulnerabilities.
+source are two vulnerabilities. 5.2 ADDED findings rather than removing them, so
+Gate A was not the binding constraint; the release note is.
 
 ---
 
@@ -413,7 +435,7 @@ reads an adjudicated finding.
      └─ 3.2  subject-scoped adjudication         DONE     unblocks 4.1
          └─ 4.1  adjudicator authoritative       DONE     small, not large
              ├─ 4.2  safe PREVENTED              DONE
-             ├─ 5.2  structural dedup (7 → 0)    medium   independent now
+             ├─ 5.2  identity, not deletion      DONE     target was a mismeasurement
              └─ 11.1 replay holds post-promotion small
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -312,6 +312,26 @@ nox baseline show .
 
 The baseline file is stored at `.nox/baseline.json` by default. When a finding matches a baseline entry (by fingerprint), it is marked as `baselined` and may be excluded from CI failure depending on the policy `baseline_mode` setting.
 
+**One entry accepts one finding.** Two genuinely distinct findings can share a
+fingerprint: the v2 digest is `sha256(rule_id, path, message)`, and a rule whose
+message is a static description — most IaC rules — produces the same digest for
+every occurrence in a file. Four workflow steps with `continue-on-error` are
+four real findings and one fingerprint.
+
+So entries are *consumed*, one per finding. If you accept one of those four,
+the other three are still reported, and a fifth added next month is reported
+too. Accept them all with `nox baseline write`, which records one entry each.
+
+This does not cost you the thing the v2 fingerprint was designed for: a
+baselined finding that moves up or down its file — an import shift, a `gofmt`,
+a comment added above — still matches, because the line is not part of the
+digest.
+
+> **Upgrading:** if your baseline has fewer entries than there are findings
+> sharing a fingerprint, the surplus findings will start appearing. They were
+> being suppressed without anyone having accepted them. Re-run
+> `nox baseline update .` to accept the ones you want and prune the rest.
+
 **Baseline file format:**
 
 ```json


### PR DESCRIPTION
Fixes #609. Found while measuring Phase 5.2 — whose stated target turned out to be a mismeasurement, covered at the bottom.

## The defect

Accept one finding into the baseline, and every *later* finding of the same rule in the same file was **born baselined**. Reproduced with the shipped binary — three `continue-on-error` steps in one workflow, one accepted:

```
line 9  -> baselined
line 12 -> baselined     <- never accepted by anyone
line 15 -> baselined     <- added AFTER the baseline was written

[results] 0 findings (3 suppressed)
```

Under fingerprint v2 the digest is `sha256(rule_id, normalised_path, content)`, and `FindingSet.Add` passes the **Message** as content. A rule whose message is a static description — most IaC rules — produces one fingerprint for every occurrence in a file. `Baseline.Match` looked up by fingerprint alone.

## A known class, fixed in one place and not the other

`FindingSet.Deduplicate` already carries the fix and documents the hazard in its own comment:

> Keying dedup on fingerprint alone then silently dropped the second, real finding. **Two findings at different positions are never duplicates.**

Dedup keys on fingerprint **+ line + column**. Baseline matching did not — and baselines are the higher-stakes half: dedup dropping a finding is at least visible in that scan's output, whereas a baseline absorbing a *future* finding produces silence nobody has a reason to question.

## The fix, and what it must not cost

Not fixable by putting position back in the fingerprint — v2 drops the line deliberately so baselines survive code moving, with a documented migration.

Instead an entry **consumes** one finding:

| | |
|---|---|
| the code moves | one finding, one entry, still matched — v2's benefit preserved |
| a second appears | no entry left, so it is reported |
| one is removed | a spare remains, and `Prune` now clears it |

Both properties are asserted **end to end through a real scan**, because the unit tests prove the `Matcher` and not that the pipeline uses it. Falsified: reinstating the fingerprint-only lookup fails `TestABaselineEntryDoesNotAbsorbLaterFindings`.

## ⚠️ Behaviour change — needs a release note

A repository whose baseline holds one entry for a fingerprint matching four findings **will start seeing three of them**. That is the correct direction — they were suppressed without anyone accepting them — but it can turn a green build red on upgrade.

`nox baseline update .` accepts the ones you want and prunes the rest. Documented in `docs/usage.md`.

## How this was found — and a correction to the plan

Phase 5.2's target was *"7 duplicate fingerprints out of 62 findings on the self-scan, take it to 0"*. Re-measured:

- that number counts **suppressed** findings — 60 of the 62 are waived
- among **active** findings there are **zero** duplicates
- four of the seven are IAC-018 on four *different* workflow steps — distinct findings sharing a digest

**Chasing the stated target would have deleted three real findings** — precisely the failure 5.2's own exit criterion names ("never by deleting a detector"). The number had never been read past its total.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged.
- Full suite green, `golangci-lint` 0 issues.
- nox has no committed baseline, so its own gate is unaffected.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT