### PR TITLE
PHASE 8.1: a scan can state what would settle its findings

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -12,6 +12,7 @@ import (
 
 	nox "github.com/nox-hq/nox/core"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/hypothesize"
 	"github.com/nox-hq/nox/core/replay"
 	"github.com/nox-hq/nox/core/report"
 	htmlreport "github.com/nox-hq/nox/core/report/html"
@@ -453,6 +454,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		failOnDegraded        bool
 		sortFlag              string
 		evidenceOutFlag       string
+		hypothesesOutFlag     string
 	)
 	scanFS.BoolVar(&historyFlag, "history", false, "scan git history for secrets in past commits")
 	scanFS.IntVar(&historyDepthFlag, "history-depth", 0, "max number of commits to scan (0 = unlimited)")
@@ -479,6 +481,7 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 	// operator who wants to ask, later, why nox said what it said asks for the
 	// artifact now. A scan that does not ask is byte-identical to before.
 	scanFS.StringVar(&evidenceOutFlag, "evidence-out", "", "write the replayable evidence behind this scan to a JSON file (see `nox replay`)")
+	scanFS.StringVar(&hypothesesOutFlag, "emit-hypotheses", "", "write the active-testing questions this scan raises to a JSON file (see `nox attack run --plan`). Emits only; the scan stays read-only.")
 	var fingerprintVersionFlag string
 	scanFS.StringVar(&fingerprintVersionFlag, "fingerprint-version", "", "fingerprint algorithm version (1 = legacy, line+path+content; 2 = line-independent + path-normalised). Default v2 (line-independent) unless NOX_FINGERPRINT_VERSION is set.")
 	scanFS.Usage = func() {
@@ -598,6 +601,13 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 		if evidenceOutFlag != "" {
 			opts.RecordReasoning = true
 		}
+		// Same reason as --evidence-out. A hypothesis carries what the scan
+		// established about its subject, and without recording there is nothing
+		// to carry — the plan would still be written, with every ledger empty,
+		// which reads as "nox established nothing" rather than "nobody asked".
+		if hypothesesOutFlag != "" {
+			opts.RecordReasoning = true
+		}
 		result, err = nox.RunScanWithOptions(target, opts)
 	}
 	if err != nil {
@@ -622,6 +632,10 @@ func runScan(args []string, formatFlag, outputDir, rulesPath string, quiet, verb
 			fmt.Fprintf(os.Stderr, "evidence: wrote %s (%d subject(s), %d verdict(s)) — replay with `nox replay %s`\n",
 				evidenceOutFlag, len(art.Subjects), len(art.Findings), evidenceOutFlag)
 		}
+	}
+
+	if hypothesesOutFlag != "" {
+		emitHypotheses(result, target, hypothesesOutFlag, quiet)
 	}
 
 	activeFindings := result.Findings.ActiveFindings()
@@ -869,4 +883,44 @@ func parseFormats(fmtFlag string) []string {
 		return []string{"json"}
 	}
 	return formats
+}
+
+// emitHypotheses writes the active-testing questions a scan raises.
+//
+// Failure is a warning, never fatal — the same rule --evidence-out follows. The
+// scan's own results are complete and already computed, and failing the run
+// because an optional artifact could not be written would turn a convenience
+// into a way to break CI.
+//
+// It emits and stops. Nothing here contacts the target: `nox scan` is
+// read-only, and every verb that touches a running system stays behind
+// `nox attack ... --authorize`. The file this writes is an input to that,
+// not a substitute for the consent it requires.
+func emitHypotheses(result *nox.ScanResult, target, path string, quiet bool) {
+	plan, err := hypothesize.From(result, target, report.GeneratedAt())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not build hypotheses: %v\n", err)
+		return
+	}
+	raw, err := plan.JSON()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not marshal hypotheses: %v\n", err)
+		return
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o644); err != nil { //nolint:gosec // plan artifact, not a secret
+		fmt.Fprintf(os.Stderr, "warning: could not write %s: %v\n", path, err)
+		return
+	}
+	if quiet {
+		return
+	}
+	if len(plan.Hypotheses) == 0 {
+		fmt.Fprintf(os.Stderr, "hypotheses: wrote %s — no finding in this scan raises a "+
+			"testable question; %d were considered and the reasons are in `skipped`\n",
+			path, len(plan.Skipped))
+		return
+	}
+	fmt.Fprintf(os.Stderr, "hypotheses: wrote %s (%d question(s) from %d scenario(s)) — "+
+		"nothing was tested; run them with `nox attack run --plan %s --authorize`\n",
+		path, len(plan.Hypotheses), len(plan.Scenarios), path)
 }

--- a/cli/scan_flag_efficacy_test.go
+++ b/cli/scan_flag_efficacy_test.go
@@ -54,6 +54,7 @@ var scanFlagBindings = []scanFlagBinding{
 	{"sort", "sortFlag"},
 	{"fingerprint-version", "fingerprintVersionFlag"},
 	{"evidence-out", "evidenceOutFlag"},
+	{"emit-hypotheses", "hypothesesOutFlag"},
 }
 
 // inertScanFlags are flags that deliberately do nothing. An entry is a promise

--- a/core/attack/passive_active_boundary_test.go
+++ b/core/attack/passive_active_boundary_test.go
@@ -117,7 +117,15 @@ func TestTheScanCannotReachTheAttackPackage(t *testing.T) {
 		}
 		checked++
 		for _, imp := range f.Imports {
-			if strings.Contains(imp.Path.Value, "nox/core/attack") {
+			// core/hypothesize is listed alongside core/attack because it
+			// imports it. It exists so the scan-to-attack handoff has one
+			// implementation, and it sits ABOVE the pipeline deliberately: it
+			// takes a finished ScanResult and computes over it, so nothing in a
+			// scan can reach it. Importing it from core/ would hand the
+			// pipeline a transitive route to attack code and defeat this guard
+			// without tripping it.
+			if strings.Contains(imp.Path.Value, "nox/core/attack") ||
+				strings.Contains(imp.Path.Value, "nox/core/hypothesize") {
 				t.Errorf("%s imports core/attack. The scan pipeline must not be able "+
 					"to reach code that touches a target; a scanner that can "+
 					"unknowingly attack what it is pointed at is unsafe to run in most "+

--- a/core/attack/plan.go
+++ b/core/attack/plan.go
@@ -123,6 +123,43 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 	var hyps []Hypothesis
 	grounded := map[string]bool{} // fingerprints that grounded a hypothesis
 
+	// A finding the operator waived does not ground an attack.
+	//
+	// `nox attack run --authorize` fires real payloads at a live target, and it
+	// was doing so for findings somebody had explicitly accepted — a
+	// nox:ignore, a baseline entry, a VEX statement. report.ActiveFindings
+	// already names `attack` as a consumer that needs this rule; nothing
+	// applied it, and no comment recorded a decision not to.
+	//
+	// There is a real argument for testing a waiver — dynamic validation is how
+	// you learn one is wrong — but that is an argument for an opt-in. As it
+	// stood the plan gave no signal either way, so an operator could not tell
+	// deliberate re-testing from nox having ignored them.
+	//
+	// The filter lives HERE and not in the loader, because a plan is meant to
+	// be a complete account of what was considered: SkipNote exists so that "a
+	// finding either grounds a hypothesis or appears here". Filtering upstream
+	// would drop waived findings out of Skipped too, trading one silent
+	// behaviour for another.
+	considered := make([]findings.Finding, 0, len(in.Findings))
+	var waived []SkipNote
+	for i := range in.Findings {
+		f := in.Findings[i]
+		if f.Status.IsActive() {
+			considered = append(considered, f)
+			continue
+		}
+		waived = append(waived, SkipNote{
+			Fingerprint: f.Fingerprint,
+			RuleID:      f.RuleID,
+			Reason: fmt.Sprintf("the finding is %s, so it grounds no attack; "+
+				"active verification of a waived finding is a deliberate act, not a default",
+				f.Status),
+		})
+	}
+	in.Findings = considered
+	plan.Skipped = append(plan.Skipped, waived...)
+
 	// Injection findings → PI-DIRECT + PI-INDIRECT. Dedupe shared sinks the way
 	// core/confirm does: two rules pointing at the same handler are one sink.
 	type sinkKey struct {
@@ -199,7 +236,17 @@ func BuildPlan(in PlanInput) (*Plan, error) {
 	plan.Boundaries = sortedBoundaries(boundaries)
 	plan.Scenarios = selectedScenarios(usedScenarios)
 	sort.Slice(hyps, func(i, j int) bool { return hyps[i].ID < hyps[j].ID })
+	// Non-nil, so a plan with nothing to attempt serialises as [] rather than
+	// null. The same reasoning the SARIF reporter applies to locations: a
+	// consumer that can iterate an empty list cannot iterate a null, and a plan
+	// with no hypotheses is a normal, common result rather than an error.
+	if hyps == nil {
+		hyps = []Hypothesis{}
+	}
 	plan.Hypotheses = hyps
+	if plan.Skipped == nil {
+		plan.Skipped = []SkipNote{}
+	}
 	sort.Slice(plan.Skipped, func(i, j int) bool {
 		if plan.Skipped[i].Fingerprint != plan.Skipped[j].Fingerprint {
 			return plan.Skipped[i].Fingerprint < plan.Skipped[j].Fingerprint
@@ -315,8 +362,18 @@ func triggerConditionOf(f findings.Finding, scen Scenario) string {
 // Naming them is what lets a reader disagree with the hypothesis rather than
 // only with its result. Every entry here is something nox did NOT establish.
 func assumptionsOf(f findings.Finding, entry string) []string {
+	// An unnamed entry point is the weaker assumption and must read as one.
+	// Most findings carry no route — nothing in a scan identifies entry points,
+	// which is why entry_point is one of the capabilities nox reports as not
+	// provided — and the previous wording rendered as "the entry point  is
+	// reachable by an attacker", which reads like a value went missing rather
+	// than like the assumption it is.
+	reachable := "some entry point reaches this code and an attacker can reach that entry point"
+	if entry != "" {
+		reachable = "the entry point " + entry + " is reachable by an attacker"
+	}
 	out := []string{
-		"the entry point " + entry + " is reachable by an attacker",
+		reachable,
 		"the code path observed statically is the one that executes",
 	}
 	if f.Metadata["reach_level"] == "" {

--- a/core/attack/waived_findings_test.go
+++ b/core/attack/waived_findings_test.go
@@ -1,0 +1,110 @@
+package attack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+)
+
+func waivedInjection(status findings.Status) findings.Finding {
+	return findings.Finding{
+		RuleID:      "AI-PI-001",
+		Fingerprint: "fp-" + string(status),
+		Severity:    findings.SeverityHigh,
+		Confidence:  findings.ConfidenceMedium,
+		Status:      status,
+		Message:     "Prompt injection: untrusted source flows into LLM call",
+		Location:    findings.Location{FilePath: "app.py", StartLine: 6},
+	}
+}
+
+// A finding somebody waived does not ground an attack.
+//
+// `nox attack run --authorize` fires real payloads at a live target, and it was
+// doing so for findings an operator had explicitly accepted — a nox:ignore, a
+// baseline entry, a VEX statement. report.ActiveFindings already named `attack`
+// as a consumer that needs this rule; nothing applied it.
+func TestWaivedFindingsGroundNoAttack(t *testing.T) {
+	for _, status := range []findings.Status{
+		findings.StatusSuppressed,
+		findings.StatusBaselined,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			plan, err := BuildPlan(PlanInput{
+				Root:     ".",
+				Findings: []findings.Finding{waivedInjection(status)},
+				Now:      "2026-09-08T00:00:00Z",
+			})
+			if err != nil {
+				t.Fatalf("BuildPlan: %v", err)
+			}
+			if len(plan.Hypotheses) != 0 {
+				t.Errorf("a %s finding produced %d hypotheses; an operator who accepted it "+
+					"would have had payloads fired at their target for it",
+					status, len(plan.Hypotheses))
+			}
+		})
+	}
+}
+
+// Waived is not the same as silent. SkipNote exists so a plan is a complete
+// account — "a finding either grounds a hypothesis or appears here" — which is
+// why the filter is in BuildPlan and not in the loader. Filtering upstream
+// would have dropped waived findings out of Skipped as well, trading one silent
+// behaviour for another.
+func TestWaivedFindingsAreRecordedAsSkipped(t *testing.T) {
+	plan, err := BuildPlan(PlanInput{
+		Root:     ".",
+		Findings: []findings.Finding{waivedInjection(findings.StatusSuppressed)},
+		Now:      "2026-09-08T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.Skipped) != 1 {
+		t.Fatalf("got %d skip notes, want 1", len(plan.Skipped))
+	}
+	if !strings.Contains(plan.Skipped[0].Reason, "suppressed") {
+		t.Errorf("the skip reason does not say the finding was waived: %q", plan.Skipped[0].Reason)
+	}
+	if plan.Skipped[0].RuleID != "AI-PI-001" {
+		t.Errorf("skip note names rule %q", plan.Skipped[0].RuleID)
+	}
+}
+
+// An active finding still grounds one, so the filter above is not simply
+// switching hypothesis generation off.
+func TestActiveFindingsStillGroundAttacks(t *testing.T) {
+	plan, err := BuildPlan(PlanInput{
+		Root:     ".",
+		Findings: []findings.Finding{waivedInjection(findings.StatusNew)},
+		Now:      "2026-09-08T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.Hypotheses) == 0 {
+		t.Error("an active injection finding grounded no hypothesis; the waiver filter is " +
+			"suppressing everything")
+	}
+}
+
+// A plan with nothing to attempt serialises as [] rather than null. A consumer
+// that can iterate an empty list cannot iterate a null, and no hypotheses is a
+// normal result — most scans raise none.
+func TestEmptyPlanSerialisesAsEmptyLists(t *testing.T) {
+	plan, err := BuildPlan(PlanInput{Root: ".", Now: "2026-09-08T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	raw, err := plan.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	for _, key := range []string{`"hypotheses": null`, `"skipped": null`} {
+		if strings.Contains(string(raw), key) {
+			t.Errorf("plan contains %s", key)
+		}
+	}
+}

--- a/core/hypothesize/hypothesize.go
+++ b/core/hypothesize/hypothesize.go
@@ -1,0 +1,121 @@
+// Package hypothesize turns a finished scan into the active-testing questions
+// its findings raise.
+//
+// It is a package of its own, above both, for a reason the dependency graph has
+// to keep rather than a comment: core (the scan pipeline) must not be able to
+// import core/attack. TestTheScanCannotReachTheAttackPackage enforces that by
+// reading the imports, and its wording is the point — "a scanner that can
+// unknowingly attack what it is pointed at is unsafe to run in most places nox
+// should be ubiquitous".
+//
+// So this sits outside the pipeline and runs after it. It takes a ScanResult
+// that has already been produced and computes over it. Nothing here can execute
+// during a scan, because nothing in a scan can reach it.
+//
+// One implementation rather than one per adapter: the CLI, the MCP server and
+// the LSP all need the same handoff, and three copies of it would disagree the
+// first time one changed.
+package hypothesize
+
+import (
+	"github.com/nox-hq/nox-core/evidence"
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/adjudicate"
+	"github.com/nox-hq/nox/core/attack"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// From turns a scan's findings into the active-testing questions they raise: what an attacker would have to do, what would settle it, and what nox
+// does not know.
+//
+// It is milestone 8.1, and it is the passive half of a handoff that already
+// existed in two pieces. `nox attack plan` could build these, but only from
+// artifacts on disk — so getting the scan's evidence onto a hypothesis meant
+// `nox scan --evidence-out`, then `nox attack plan --evidence`, with the two
+// rejoined by fingerprint. Two commands, two files, and a join that can only
+// carry what the artifact happens to record.
+//
+// Built in-process it carries more, and the difference is not cosmetic. The
+// artifact records capability counts per SCAN, so unknownsFromArtifact hands
+// every hypothesis the same scan-wide list and says so. Here the coverage is
+// per-subject — that is what milestone 2.2 built — so each hypothesis states
+// the questions still open about ITS OWN subject. "Nothing established taint
+// for this finding" is actionable; "taint answered 30 subjects somewhere in
+// this scan" is not.
+//
+// Nothing here executes anything. BuildPlan is pure computation over findings
+// and an inventory, which is what keeps Gate E intact: `nox scan` remains
+// read-only, and every verb that touches a target still lives behind
+// `nox attack ... --authorize`.
+func From(r *nox.ScanResult, root, now string) (*attack.Plan, error) {
+	if r == nil {
+		return attack.BuildPlan(attack.PlanInput{Root: root, Now: now})
+	}
+	var ff []findings.Finding
+	if r.Findings != nil {
+		// Every finding, not only the active ones. BuildPlan applies the
+		// active-findings rule itself and records each waived finding as a
+		// SkipNote — filtering here would drop them out of that account, and
+		// the plan is meant to say why each finding did or did not raise a
+		// question.
+		ff = r.Findings.Findings()
+	}
+	return attack.BuildPlan(attack.PlanInput{
+		Root:      root,
+		Findings:  ff,
+		Inventory: r.AIInventory,
+		Now:       now,
+		Evidence:  evidenceFor(r),
+		Unknowns:  UnknownsFor(r),
+	})
+}
+
+// evidenceForHypotheses returns the subject and ledger a hypothesis should
+// carry for a finding, straight from this scan's store.
+//
+// Nil when the scan recorded no reasoning, which BuildPlan reads as "no
+// evidence" rather than as an empty one. A hypothesis carrying an empty ledger
+// it was told to expect is honest; one carrying an empty ledger because nobody
+// asked for reasoning would look like a scan that established nothing.
+func evidenceFor(r *nox.ScanResult) func(findings.Finding) (evidence.Subject, evidence.Ledger) {
+	if r.Reasoning == nil {
+		return nil
+	}
+	return func(f findings.Finding) (evidence.Subject, evidence.Ledger) {
+		s := nox.SubjectForFinding(f)
+		return s, r.Reasoning.About(s)
+	}
+}
+
+// UnknownsFor returns a lookup of the open questions about one subject,
+// cheapest first — the reason a hypothesis is a hypothesis and not a conclusion.
+//
+// Per-subject, unlike the artifact-driven path, which can only report scan-wide
+// counts. adjudicate.MissingEvidence answers from the same coverage the
+// capability matrix and `nox why` read, so a hypothesis and an explanation
+// cannot disagree about what was left unanswered.
+// It is exported so a test can assert the per-subject property directly;
+// callers should use From, which wires it.
+func UnknownsFor(r *nox.ScanResult) func(evidence.Subject) []string {
+	if r.Coverage == nil {
+		return nil
+	}
+	return func(s evidence.Subject) []string {
+		gaps := adjudicate.MissingEvidence(r.Coverage, r.Capabilities, s)
+		if len(gaps) == 0 {
+			return nil
+		}
+		out := make([]string, 0, len(gaps))
+		for _, g := range gaps {
+			// Whether anything COULD answer it is the difference between a
+			// next step and a standing limit, so it is stated rather than left
+			// for the reader to look up.
+			suffix := " (nothing on this installation can answer it)"
+			if g.Available {
+				suffix = ""
+			}
+			out = append(out, string(g.Capability)+": "+g.Question+suffix)
+		}
+		return out
+	}
+}

--- a/core/hypothesize/hypothesize_test.go
+++ b/core/hypothesize/hypothesize_test.go
@@ -1,0 +1,242 @@
+package hypothesize_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	nox "github.com/nox-hq/nox/core"
+	"github.com/nox-hq/nox/core/hypothesize"
+)
+
+// injectionFixture writes a Python file that trips AI-PI-001: untrusted request
+// data interpolated into an LLM call.
+func injectionFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := `import openai
+from flask import request
+
+def chat():
+    client = openai.OpenAI()
+    return client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": f"Answer this: {request.json['q']}"}],
+    )
+`
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return dir
+}
+
+// Milestone 8.1: a scan produces a structured active-testing question.
+func TestAScanEmitsAStructuredQuestion(t *testing.T) {
+	dir := injectionFixture(t)
+	res, err := nox.RunScanWithOptions(dir, nox.ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	plan, err := hypothesize.From(res, dir, "2026-09-08T00:00:00Z")
+	if err != nil {
+		t.Fatalf("hypotheses: %v", err)
+	}
+	if len(plan.Hypotheses) == 0 {
+		t.Fatal("an injection finding raised no hypothesis; this test asserts nothing")
+	}
+
+	h := plan.Hypotheses[0]
+	// The fields the milestone names. Each is a separate assertion because a
+	// hypothesis missing any one of them is not a question somebody can act on.
+	if h.Subject.Kind == "" || h.Subject.ID == "" {
+		t.Error("the hypothesis names no subject, so a run could not file its claims against " +
+			"the proposition it tested")
+	}
+	if h.TriggerCondition == "" {
+		t.Error("no trigger condition: nothing states what would have to hold")
+	}
+	if h.ExpectedOracle == "" {
+		t.Error("no expected oracle: a reader cannot tell what success would look like " +
+			"before anything runs")
+	}
+	if len(h.Assumptions) == 0 {
+		t.Error("no assumptions: a reader can only disagree with the result, not the question")
+	}
+	if len(h.Unknowns) == 0 {
+		t.Error("no unknowns: nothing says why this is a hypothesis rather than a conclusion")
+	}
+	if len(h.Evidence.Claims) == 0 {
+		t.Error("no evidence: the hypothesis carries nothing the scan established, so a run " +
+			"would rediscover it badly or not at all")
+	}
+	for _, a := range h.Assumptions {
+		if strings.Contains(a, "  ") {
+			t.Errorf("assumption has a hole where a value should be: %q", a)
+		}
+	}
+}
+
+// The reason this is worth building in-process rather than reading an artifact.
+//
+// The artifact records capability counts per SCAN, so the file-driven path
+// hands every hypothesis the same scan-wide list and its own comment says so.
+// Coverage is per-subject since milestone 2.2, and "nothing established taint
+// for this finding" is actionable where "taint answered 30 subjects somewhere"
+// is not.
+//
+// It takes a corpus spanning more than one language to show the difference, and
+// that is the point rather than an inconvenience: competence varies by
+// (language x analyses) class, so a fixture with one class produces one answer
+// legitimately. The first version of this test used a single Python file, got
+// the same seven unknowns for every subject, and was measuring its fixture.
+func TestUnknownsAreAboutTheSubjectNotTheScan(t *testing.T) {
+	res, err := nox.RunScanWithOptions(filepath.Join("..", "..", "testdata", "precision-suite"),
+		nox.ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	unknowns := hypothesize.UnknownsFor(res)
+	if unknowns == nil {
+		t.Fatal("no unknowns function; the scan recorded coverage and should have one")
+	}
+
+	distinct := map[string]int{}
+	for _, f := range res.Findings.Findings() {
+		distinct[strings.Join(unknowns(nox.SubjectForFinding(f)), "|")]++
+	}
+	if len(distinct) < 2 {
+		t.Errorf("every finding in a corpus spanning Go, Python and YAML reports the same "+
+			"open questions (%d distinct sets). The list is scan-wide, not per-subject, and "+
+			"each hypothesis is being told the same thing about a different proposition.",
+			len(distinct))
+	}
+}
+
+// An unknown nothing can answer must say so. It is still worth naming — the
+// silence is a limit rather than an oversight — but it is not a next step, and
+// a reader who cannot tell the two apart will go looking for a plugin that does
+// not exist.
+func TestUnansweredCapabilitiesSayWhetherAnythingCouldAnswerThem(t *testing.T) {
+	dir := injectionFixture(t)
+	res, err := nox.RunScanWithOptions(dir, nox.ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	plan, err := hypothesize.From(res, dir, "2026-09-08T00:00:00Z")
+	if err != nil {
+		t.Fatalf("hypotheses: %v", err)
+	}
+	if len(plan.Hypotheses) == 0 {
+		t.Fatal("no hypotheses")
+	}
+
+	var flagged int
+	for _, u := range plan.Hypotheses[0].Unknowns {
+		if strings.Contains(u, "nothing on this installation can answer it") {
+			flagged++
+		}
+	}
+	// call_graph and entry_point have no implementation on a stock build.
+	if flagged < 2 {
+		t.Errorf("%d unknowns are marked unanswerable; call_graph and entry_point have no "+
+			"implementation here and both should be", flagged)
+	}
+}
+
+// A scan with no reasoning still emits a plan, and says nothing it did not
+// establish. The ledger being absent is different from the ledger being empty.
+func TestHypothesesWithoutReasoning(t *testing.T) {
+	dir := injectionFixture(t)
+	res, err := nox.RunScanWithOptions(dir, nox.ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	plan, err := hypothesize.From(res, dir, "2026-09-08T00:00:00Z")
+	if err != nil {
+		t.Fatalf("hypotheses: %v", err)
+	}
+	if len(plan.Hypotheses) == 0 {
+		t.Fatal("no hypotheses without reasoning; the finding is the same either way")
+	}
+	if n := len(plan.Hypotheses[0].Evidence.Claims); n != 0 {
+		t.Errorf("a scan that recorded no reasoning produced %d claims", n)
+	}
+}
+
+// A nil result must not panic. Emitting is optional and its failure is a
+// warning, so the path has to survive being called on nothing.
+func TestNilResultEmitsAnEmptyPlan(t *testing.T) {
+	var r *nox.ScanResult
+	plan, err := hypothesize.From(r, ".", "2026-09-08T00:00:00Z")
+	if err != nil {
+		t.Fatalf("hypotheses: %v", err)
+	}
+	if len(plan.Hypotheses) != 0 {
+		t.Errorf("a nil result produced %d hypotheses", len(plan.Hypotheses))
+	}
+}
+
+// Gate E: emitting a question is not asking it.
+//
+// The whole value of the passive/active split is that `nox scan` never contacts
+// what it is scanning. Producing hypotheses is the one place that boundary could
+// plausibly erode — the output is literally a list of attacks — so the property
+// is asserted rather than assumed.
+//
+// The proof is structural, not behavioural, and deliberately so. A test that
+// watched for network traffic would pass on a build where the traffic happened
+// to be suppressed. What matters is that BuildPlan is pure computation over
+// findings and an inventory: it takes no target, no client, no address, and
+// there is nothing in a Plan for it to have contacted.
+func TestEmittingHypothesesContactsNothing(t *testing.T) {
+	dir := injectionFixture(t)
+	res, err := nox.RunScanWithOptions(dir, nox.ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	before, err := os.ReadFile(filepath.Join(dir, "app.py"))
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	entriesBefore, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("listing fixture: %v", err)
+	}
+
+	plan, err := hypothesize.From(res, dir, "2026-09-08T00:00:00Z")
+	if err != nil {
+		t.Fatalf("hypotheses: %v", err)
+	}
+	if len(plan.Hypotheses) == 0 {
+		t.Fatal("no hypotheses; this test asserts nothing")
+	}
+
+	// Nothing was written into the scanned tree, and nothing was modified.
+	// `nox attack` plants canaries; a scan must not.
+	after, err := os.ReadFile(filepath.Join(dir, "app.py"))
+	if err != nil {
+		t.Fatalf("re-reading fixture: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("emitting hypotheses modified the scanned source")
+	}
+	entriesAfter, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("re-listing fixture: %v", err)
+	}
+	if len(entriesBefore) != len(entriesAfter) {
+		t.Errorf("emitting hypotheses changed the scanned tree from %d entries to %d",
+			len(entriesBefore), len(entriesAfter))
+	}
+
+	// And every hypothesis is a question, not a result: nothing ran, so none of
+	// them may carry a verdict stronger than the scan earned.
+	for _, h := range plan.Hypotheses {
+		if h.ExpectedOracle == "" {
+			t.Errorf("%s names no oracle, so it states no way to be settled", h.ID)
+		}
+	}
+}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -337,16 +337,43 @@ to a determined one (the reachability-suite's own rule 4).
 **Missing.** `nox scan` cannot emit a hypothesis. The handoff exists inside
 `attack`, not across the passive/active boundary.
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **8.1** | `nox scan --emit-hypotheses`: subject, entry point, flow, attacker input, trigger condition, assumptions, oracle, missing evidence | a scan produces a structured active-testing question |
-| **8.2** | Reproduction hierarchy: trigger / invariant / crash / security effect / exploit | a reproduced overflow does not claim RCE |
-| **8.3** | Controlled-reproduction contract | removing any of the five conditions prevents `CONFIRMED` |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **8.1** | `nox scan --emit-hypotheses`: subject, entry point, flow, attacker input, trigger condition, assumptions, oracle, missing evidence | a scan produces a structured active-testing question | ✅ #612 |
+| **8.2** | Reproduction hierarchy: trigger / invariant / crash / security effect / exploit | a reproduced overflow does not claim RCE | already met |
+| **8.3** | Controlled-reproduction contract | removing any of the five conditions prevents `CONFIRMED` | already met |
 
-**Size:** medium. 8.3 is mostly assertion work over the existing evidence
-kernel, which already enforces the deterministic gate.
+8.2 and 8.3 were already in the tree before this milestone started. The
+hierarchy is enforced per subject by `evidence.DeriveExploitabilityAbout` and
+audited across all thirteen kinds by #607; the five-condition contract is
+`TestFailClosed_ConfirmedOnlyFromTheExactIntendedCombination` in the kernel plus
+`TestACompletedRunIsSubsumedByReproduction` at the producer, with the PREVENTED
+half added in #608.
 
-**Gate:** E (active consent) — `nox scan` stays read-only throughout.
+8.1's value turned out not to be the fields — `nox attack plan` already built
+every one of them — but **where** they come from. Getting the scan's evidence
+onto a hypothesis previously meant `nox scan --evidence-out`, then
+`nox attack plan --evidence`, rejoined by fingerprint. The artifact records
+capability counts per SCAN, so `unknownsFromArtifact` hands every hypothesis the
+same scan-wide list and says so in its own comment. In-process the coverage is
+per-subject — what 2.2 built — so each hypothesis states the questions open
+about ITS OWN subject. "Nothing established taint for this finding" is
+actionable; "taint answered 30 subjects somewhere in this scan" is not.
+
+**Gate E held, and cost a redesign.** The first implementation put the method on
+`ScanResult`, which made `core` import `core/attack` — the exact thing
+`TestTheScanCannotReachTheAttackPackage` forbids, in the same change that added
+a test asserting Gate E. The guard caught it. The wiring moved to
+`core/hypothesize`, a package ABOVE the pipeline that takes a finished
+`ScanResult`, and the guard was extended to reject importing that from `core/`
+too — otherwise it would have been a transitive route past a check that reads
+only direct imports.
+
+**Size:** small, given what existed.
+
+**Gate:** E (active consent) — `nox scan` stays read-only throughout, and the
+guarantee is structural: the pipeline cannot import the code that touches a
+target, so it cannot execute one by accident.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1150,6 +1150,48 @@ This is why the matrix is emitted even when everything worked: a report listing
 only the capabilities that succeeded is one a reader will take for the complete
 set of questions nox asks.
 
+#### Asking what would settle it: `--emit-hypotheses`
+
+A scan can write the active-testing questions its findings raise:
+
+```bash
+nox scan . --emit-hypotheses hypotheses.json
+```
+
+Each hypothesis states the subject it is about, the entry point and attacker
+input, what would have to hold for it to succeed, what oracle would settle it,
+the assumptions it makes without evidence, and — the reason it is a hypothesis
+rather than a conclusion — the questions still open about that finding:
+
+```
+unknowns:
+  - symbol_resolution: does the build actually reference the affected symbol?
+  - taint: does untrusted input reach this location?
+  - call_graph: is there any call path that reaches this code?
+      (nothing on this installation can answer it)
+  - reachability: is this code reachable from an entry point?
+```
+
+Those are **per finding**, not per scan. A YAML finding and a Go finding in the
+same scan carry different open questions, because different analyses applied to
+them.
+
+**Nothing is tested.** `nox scan` executes nothing, ever — the guarantee is
+structural, not a check: the scan pipeline cannot even import the code that
+touches a target. This writes a file. Running it is a separate, explicit act:
+
+```bash
+nox attack run --plan hypotheses.json --authorize
+```
+
+A finding you have waived — `nox:ignore`, a baseline entry, a VEX statement —
+raises no hypothesis, and appears in the plan's `skipped` list saying so.
+Actively verifying something you accepted is a deliberate act, not a default.
+
+The flag implies `--evidence-out`'s recording, because a hypothesis carries what
+the scan established about its subject and there would otherwise be nothing to
+carry.
+
 #### Every finding says whether it was validated
 
 Every finding a scan reports carries an `Exploitability` state, and for a scan


### PR DESCRIPTION
`nox scan --emit-hypotheses hypotheses.json` writes the active-testing questions a scan raises. Also fixes #611.

## What 8.1 actually changes

The fields already existed — `nox attack plan` builds every one. What changes is **where they come from**.

Getting a scan's evidence onto a hypothesis previously meant `nox scan --evidence-out`, then `nox attack plan --evidence`, rejoined by fingerprint. Two commands, two artifacts, and a join that carries only what the artifact records.

The artifact records capability counts **per scan**, so `unknownsFromArtifact` hands every hypothesis the same scan-wide list and says so in its own comment. In-process the coverage is **per-subject** — what milestone 2.2 built:

```
unknowns:
  - symbol_resolution: does the build actually reference the affected symbol?
  - taint: does untrusted input reach this location?
  - call_graph: is there any call path that reaches this code?
      (nothing on this installation can answer it)
  - reachability: is this code reachable from an entry point?
```

"Nothing established taint for **this finding**" is actionable. "Taint answered 30 subjects somewhere in this scan" is not.

## Gate E held, and cost a redesign

The first version put the method on `ScanResult` — which made `core` import `core/attack`, the exact thing `TestTheScanCannotReachTheAttackPackage` forbids. I introduced that violation *in the same change that added a test asserting Gate E*. The guard caught it, and its wording is why it exists:

> a scanner that can unknowingly attack what it is pointed at is unsafe to run in most places nox should be ubiquitous

The wiring moved to `core/hypothesize`, a package **above** the pipeline that takes a finished `ScanResult`, so nothing in a scan can reach it. The guard was then extended to reject importing *that* from `core/` as well — it reads direct imports only, so `hypothesize` would otherwise have been a transitive route straight past it. Falsified: a one-line file in `core/` importing it fails the guard.

## Fixes #611 — waived findings grounded attacks

A `nox:ignore`, baseline entry or VEX statement did not stop a finding grounding a hypothesis, so `nox attack run --authorize` would fire real payloads at a live target for something the operator had **explicitly accepted**. `report.ActiveFindings` already names `attack` as a consumer needing that rule; nothing applied it.

There is a real argument for testing a waiver — dynamic validation is how you learn one is wrong — but that argues for an opt-in, not a default, and the plan gave no signal either way.

Skipped in `BuildPlan`, **with a `SkipNote`**, not in the loader. That type exists so *"a finding either grounds a hypothesis or appears here"*; filtering upstream would have dropped waived findings out of `Skipped` too — trading one silent behaviour for another. In `BuildPlan`, the CLI, MCP and the scan-side emitter inherit one rule.

## Two smaller things found on the way

- A plan with nothing to attempt serialised as `"hypotheses": null`. A consumer that can iterate an empty list cannot iterate a null, and no hypotheses is the *common* result. Same reasoning the SARIF reporter already applies to locations.
- An unnamed entry point rendered as `"the entry point  is reachable by an attacker"` — reads like a value went missing rather than like the assumption it is. Most findings carry no route, which is precisely why `entry_point` is reported as not provided.

## 8.2 and 8.3 were already met

The reproduction hierarchy is enforced per subject and audited across thirteen kinds by #607; the five-condition contract is `TestFailClosed_ConfirmedOnlyFromTheExactIntendedCombination` in the kernel plus #608's PREVENTED half. Marked as such in the plan rather than re-done.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged.
- Full suite green, `golangci-lint` 0 issues.
- The flag-inventory guard required registering `--emit-hypotheses` with the variable it drives, which it now is.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT