### PR TITLE
PHASE 7.1: nox can answer where a call comes from, for Go

### DIFF
--- a/cli/capabilities_cmd.go
+++ b/cli/capabilities_cmd.go
@@ -74,6 +74,25 @@ func runAnalysisCapabilities(args []string) int {
 		return 2
 	}
 
+	// The standing limits, printed whether or not anything is missing.
+	//
+	// They used to print only alongside a missing capability, which was fine
+	// while two were missing and became a silent regression the moment
+	// core/callgraph filled the last of them: a full matrix with no caveat
+	// under it reads as a full answer. None of these limits is a gap an
+	// operator can close by installing something — they are properties of what
+	// a scanner is — so they belong here unconditionally.
+	fmt.Println("\nWhat a full matrix still does not mean:")
+	fmt.Println("  - a scan executes nothing, so dynamic_verification is never")
+	fmt.Println("    answered by `nox scan` however it is listed above")
+	fmt.Println("  - call_graph and entry_point are answered for Go only; for every")
+	fmt.Println("    other language a finding's own matrix reads `unsupported`")
+	fmt.Println("  - the call graph answers EXISTENTIALLY. It can show a path and")
+	fmt.Println("    name the calls; it never reports that no path exists, because")
+	fmt.Println("    interface dispatch, function values and reflection are calls")
+	fmt.Println("    it cannot see")
+	fmt.Println("\nRun `nox why <finding>` for what was actually established about one finding.")
+
 	missing := registry.Missing()
 	if len(missing) == 0 {
 		return 0

--- a/cli/capabilities_limits_test.go
+++ b/cli/capabilities_limits_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A full matrix must still state what nox cannot do.
+//
+// The limits used to print only alongside a missing capability, which was fine
+// while two were missing and became a silent regression the moment
+// core/callgraph filled the last of them: every row said "provided", the
+// caveats vanished, and a reader would take a complete matrix for a complete
+// answer.
+//
+// None of these is a gap an operator can close by installing something. They
+// are properties of what a scanner is, which is exactly why they cannot be
+// conditional on something being absent.
+func TestAFullMatrixStillStatesItsLimits(t *testing.T) {
+	out := captureStdout(t, func() { runAnalysisCapabilities(nil) })
+
+	for _, claim := range []string{
+		"a scan executes nothing",
+		"Go only",
+		"never reports that no path exists",
+	} {
+		if !strings.Contains(out, claim) {
+			t.Errorf("`nox analysis-capabilities` does not say %q. With nothing missing, "+
+				"this output is the only place an operator is told what a full matrix "+
+				"still does not mean.", claim)
+		}
+	}
+}

--- a/core/adjudicate/missing.go
+++ b/core/adjudicate/missing.go
@@ -72,16 +72,25 @@ var costs = []struct {
 func MissingEvidence(cov *capability.Coverage, reg *capability.Registry, s evidence.Subject) []Gap {
 	var out []Gap
 	for _, c := range costs {
-		switch cov.State(s, c.AnalysisCapability) {
+		state := cov.State(s, c.AnalysisCapability)
+		switch state {
 		case capability.Positive, capability.Negative:
 			// Answered. Not a gap, whichever way it went.
 			continue
 		}
+		// Available is about THIS subject, not only about the installation.
+		//
+		// Registry.Provided answers "does an implementation exist anywhere",
+		// and taking that as the whole answer overstates it the moment an
+		// implementation covers one language. core/callgraph provides
+		// call_graph for Go; for a Python finding the per-subject state is
+		// Unsupported, and telling a reader the question is answerable would
+		// send them looking for a way to ask it that does not exist.
 		out = append(out, Gap{
 			Capability: c.AnalysisCapability,
 			Question:   c.question,
 			Cost:       c.cost,
-			Available:  reg.Provided(c.AnalysisCapability),
+			Available:  reg.Provided(c.AnalysisCapability) && state != capability.Unsupported,
 		})
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Cost < out[j].Cost })

--- a/core/adjudicate/missing_test.go
+++ b/core/adjudicate/missing_test.go
@@ -82,7 +82,14 @@ func TestAnInconclusiveAnswerLeavesTheQuestionOpen(t *testing.T) {
 // stops where it does — but recommending it would send a reader to do something
 // they cannot.
 func TestTheRecommendationIsSomethingTheReaderCanDo(t *testing.T) {
-	reg := capability.DefaultRegistry()
+	// A registry that genuinely lacks something, constructed rather than
+	// borrowed. This used to use DefaultRegistry and relied on nox having a
+	// capability nothing implemented; core/callgraph filled the last of those,
+	// and the test began asserting a property of the installation instead of a
+	// property of the code. An operator's installation can gain a plugin at any
+	// time, so the fixture has to own the gap.
+	reg := capability.NewRegistry()
+	reg.Register(partialProvider{})
 	cov := capability.NewCoverage(reg)
 
 	gaps := adjudicate.MissingEvidence(cov, reg, subj())
@@ -93,8 +100,8 @@ func TestTheRecommendationIsSomethingTheReaderCanDo(t *testing.T) {
 		}
 	}
 	if unavailable == 0 {
-		t.Fatal("every capability is available on this installation, so the " +
-			"distinction this test is about cannot be exercised")
+		t.Fatal("the fixture registry provides everything, so the distinction this " +
+			"test is about cannot be exercised")
 	}
 
 	next, ok := adjudicate.CheapestAvailable(gaps)
@@ -121,5 +128,16 @@ func TestGapsAreNamedAsQuestions(t *testing.T) {
 		if g.Question == "" {
 			t.Errorf("%s is an open question with no question", g.Capability)
 		}
+	}
+}
+
+// partialProvider offers the cheap capabilities and none of the expensive ones,
+// so a gap that nothing can fill is guaranteed to exist in the fixture.
+type partialProvider struct{}
+
+func (partialProvider) Name() string { return "test/partial" }
+func (partialProvider) Provides() []capability.AnalysisCapability {
+	return []capability.AnalysisCapability{
+		capability.LexicalContext, capability.ConstantEvaluation,
 	}
 }

--- a/core/callgraph/build.go
+++ b/core/callgraph/build.go
@@ -1,0 +1,356 @@
+package callgraph
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// maxSourceBytes bounds one file read. A Go file past this is generated or
+// vendored data, and its call structure is not what anybody is asking about.
+const maxSourceBytes = 4 << 20
+
+// BuildGo parses every Go file under root and returns the call graph.
+//
+// Errors are absorbed rather than returned. A file that will not parse is a
+// file this graph does not model, which is a limitation and not a failure —
+// recorded as such, so a caller reading the scope can see that the search was
+// narrower than it looks. Returning an error instead would make one
+// unparseable file cost the answer for the whole module.
+func BuildGo(root string) *Graph {
+	g := &Graph{
+		funcs:   map[string]*Func{},
+		callers: map[string][]string{},
+		limits:  map[reach.Limitation]bool{},
+		root:    root,
+		module:  modulePath(root),
+	}
+
+	fset := token.NewFileSet()
+	type parsed struct {
+		file *ast.File
+		dir  string
+		path string
+	}
+	var files []parsed
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			// vendor/ is somebody else's code and testdata/ is deliberately
+			// broken by convention; neither is the program under analysis.
+			switch d.Name() {
+			case "vendor", "testdata", ".git", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil || info.Size() > maxSourceBytes {
+			g.limits[reach.BudgetExhausted] = true
+			return nil
+		}
+		src, rerr := os.ReadFile(path) //nolint:gosec // caller-supplied scan root
+		if rerr != nil {
+			g.limits[reach.BudgetExhausted] = true
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
+		if perr != nil || f == nil {
+			// A file nox could not read is a file whose calls are invisible.
+			g.limits[reach.UnsupportedLanguage] = true
+			return nil
+		}
+		rel, rerr2 := filepath.Rel(root, filepath.Dir(path))
+		if rerr2 != nil {
+			rel = filepath.Dir(path)
+		}
+		files = append(files, parsed{file: f, dir: filepath.ToSlash(rel), path: path})
+		return nil
+	})
+
+	// Pass 1: declarations. Every call target must exist before edges are
+	// resolved, or a function defined later in the walk would look unresolved.
+	for _, p := range files {
+		collectDecls(g, fset, p.file, p.dir, p.path)
+	}
+	// Pass 2: edges.
+	for _, p := range files {
+		collectCalls(g, p.file, p.dir)
+	}
+
+	for target, cs := range g.callers {
+		sort.Strings(cs)
+		g.callers[target] = cs
+	}
+	for _, f := range g.funcs {
+		sort.Strings(f.Calls)
+	}
+	return g
+}
+
+// declKey builds the unique identifier for a declaration. The directory rather
+// than the package name, because one module can hold two packages called
+// `util` and collapsing them would invent call edges between unrelated code.
+func declKey(dir, recv, name string) string {
+	// The module root is "." from filepath.Rel, and prefixing with it produced
+	// keys like "..main". A key is read by people — it appears in the witness
+	// path written onto a finding — so the root's functions are named bare.
+	prefix := dir + "."
+	if dir == "." || dir == "" {
+		prefix = ""
+	}
+	if recv != "" {
+		return prefix + "(" + recv + ")." + name
+	}
+	return prefix + name
+}
+
+// receiverName returns the bare type name of a method receiver, without
+// pointer or type-parameter decoration.
+func receiverName(fl *ast.FieldList) string {
+	if fl == nil || len(fl.List) == 0 {
+		return ""
+	}
+	return typeName(fl.List[0].Type)
+}
+
+func typeName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return typeName(t.X)
+	case *ast.IndexExpr: // generic receiver: Foo[T]
+		return typeName(t.X)
+	case *ast.IndexListExpr:
+		return typeName(t.X)
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	}
+	return ""
+}
+
+// collectDecls records every function and method, and decides which are entry
+// points.
+func collectDecls(g *Graph, fset *token.FileSet, f *ast.File, dir, path string) {
+	pkg := f.Name.Name
+	isTest := strings.HasSuffix(path, "_test.go")
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Name == nil {
+			continue
+		}
+		recv := receiverName(fd.Recv)
+		key := declKey(dir, recv, fd.Name.Name)
+		kind, reason := entryPoint(pkg, recv, fd.Name.Name, isTest)
+		g.funcs[key] = &Func{
+			Key:         key,
+			Name:        fd.Name.Name,
+			File:        path,
+			Line:        fset.Position(fd.Pos()).Line,
+			Kind:        kind,
+			EntryReason: reason,
+		}
+	}
+}
+
+// entryPoint decides whether execution can begin at a declaration, and says
+// why.
+//
+// The reason is recorded rather than implied because the set is a judgement an
+// operator may disagree with, and one they cannot argue with is one they will
+// distrust. An exported function in a library IS an entry point — somebody
+// else's code calls it, and that code is not in this module — even though
+// nothing here calls it.
+func entryPoint(pkg, recv, name string, isTest bool) (kind EntryKind, reason string) {
+	switch {
+	case pkg == "main" && recv == "" && name == "main":
+		return EntryConcrete, "package main's entry function"
+	case recv == "" && name == "init":
+		return EntryConcrete, "runs before main, whoever imports the package"
+	case isTest && (strings.HasPrefix(name, "Test") ||
+		strings.HasPrefix(name, "Benchmark") || strings.HasPrefix(name, "Fuzz")):
+		return EntryTest, "the test runner calls it directly"
+	case pkg != "main" && recv == "" && ast.IsExported(name):
+		return EntryExported, "exported from a library package, so a caller outside this module could reach it"
+	case pkg != "main" && recv != "" && ast.IsExported(name) && ast.IsExported(recv):
+		return EntryExported, "an exported method on an exported type"
+	}
+	return NotAnEntry, ""
+}
+
+// collectCalls walks every function body and records the edges it can resolve.
+//
+// What it cannot resolve is counted, not ignored. A call through an interface,
+// a function value or reflection is a real edge this graph does not have, and
+// the count is what tells a reader how much of the program is missing — see
+// Graph.Scope, which refuses to support a universal claim because of it.
+func collectCalls(g *Graph, f *ast.File, dir string) {
+	imports := importAliases(f)
+	pkg := f.Name.Name
+
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Name == nil || fd.Body == nil {
+			continue
+		}
+		from := declKey(dir, receiverName(fd.Recv), fd.Name.Name)
+		caller, exists := g.funcs[from]
+		if !exists {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			switch call := n.(type) {
+			case *ast.CallExpr:
+				g.resolveCall(caller, call, dir, pkg, imports)
+			case *ast.SelectorExpr:
+				// reflect and unsafe make calls nothing syntactic can follow.
+				if id, ok := call.X.(*ast.Ident); ok {
+					switch imports[id.Name] {
+					case "reflect":
+						g.limits[reach.Reflection] = true
+					case "plugin":
+						g.limits[reach.DynamicLoading] = true
+					}
+				}
+			}
+			return true
+		})
+	}
+}
+
+// resolveCall binds one call expression to a declaration where it can.
+func (g *Graph) resolveCall(caller *Func, call *ast.CallExpr, dir, pkg string, imports map[string]string) {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		// A bare name: a function in this package, or a local variable holding
+		// a func. Only the first is resolvable from syntax.
+		if to, ok := g.funcs[declKey(dir, "", fn.Name)]; ok {
+			g.addEdge(caller, to.Key)
+			return
+		}
+		g.unresolvedCall()
+	case *ast.SelectorExpr:
+		x, ok := fn.X.(*ast.Ident)
+		if !ok {
+			// Something like a.b.C() — a field or chained value. Not resolvable.
+			g.unresolvedCall()
+			return
+		}
+		if importPath, isImport := imports[x.Name]; isImport {
+			// A call into another package. Within this module the import path
+			// maps back to a directory, so the edge is resolvable; outside it
+			// — the standard library, a dependency — the callee's source is not
+			// here to bind to.
+			//
+			// An unresolvable stdlib call is NOT the same kind of gap as an
+			// unresolved dispatch, and counting them together made the resolved
+			// ratio meaningless: 21% on nox's own tree, almost all of it
+			// fmt.Sprintf. So it is counted apart and does not add
+			// UnresolvedDispatch, which is reserved for a call whose far end
+			// could be anywhere.
+			if dir, ok := g.moduleDir(importPath); ok {
+				if to, found := g.funcs[declKey(dir, "", fn.Sel.Name)]; found {
+					g.addEdge(caller, to.Key)
+					return
+				}
+			}
+			g.external++
+			return
+		}
+		// A method call on a receiver whose type is unknown to us. This is the
+		// interface-dispatch case and the reason this package never refutes:
+		// the edge exists and we cannot name its far end.
+		if to, ok := g.funcs[declKey(dir, x.Name, fn.Sel.Name)]; ok {
+			g.addEdge(caller, to.Key)
+			return
+		}
+		g.limits[reach.UnresolvedDispatch] = true
+		g.unresolvedCall()
+	case *ast.FuncLit:
+		// An immediately-invoked literal. Its body was already walked by the
+		// enclosing Inspect, so there is nothing to add and nothing lost.
+	default:
+		g.unresolvedCall()
+	}
+	_ = pkg
+}
+
+func (g *Graph) addEdge(from *Func, to string) {
+	from.Calls = append(from.Calls, to)
+	g.callers[to] = append(g.callers[to], from.Key)
+	g.resolved++
+}
+
+func (g *Graph) unresolvedCall() {
+	g.unresolved++
+	g.limits[reach.UnresolvedDispatch] = true
+}
+
+// importAliases maps the identifier a file uses for each import to its path.
+func importAliases(f *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, imp := range f.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		path := strings.Trim(imp.Path.Value, `"`)
+		name := path
+		if i := strings.LastIndex(path, "/"); i >= 0 {
+			name = path[i+1:]
+		}
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		out[name] = path
+	}
+	return out
+}
+
+// modulePath reads the module line from go.mod, or "" when there is none.
+//
+// Without it every cross-package call inside the module is unresolvable, which
+// is most of a real program's call graph. It is read once rather than shelled
+// out for, so the graph builds offline and without the toolchain.
+func modulePath(root string) string {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod")) //nolint:gosec // caller-supplied scan root
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
+
+// moduleDir maps an import path to the directory holding it, when it is inside
+// this module.
+func (g *Graph) moduleDir(importPath string) (string, bool) {
+	if g.module == "" {
+		return "", false
+	}
+	if importPath == g.module {
+		return ".", true
+	}
+	rest, ok := strings.CutPrefix(importPath, g.module+"/")
+	if !ok {
+		return "", false
+	}
+	return rest, true
+}

--- a/core/callgraph/callgraph.go
+++ b/core/callgraph/callgraph.go
@@ -1,0 +1,310 @@
+// Package callgraph builds a syntactic call graph over a Go module and answers
+// two questions nothing in nox could answer before: is there a call path to
+// this code, and does one start at an entry point.
+//
+// # What it can and cannot establish, and why the asymmetry is the design
+//
+// Finding a path is EXISTENTIAL. One witness settles it, and a witness this
+// package produces is a real chain of call expressions a reader can follow. An
+// analysis that missed other paths can still have found this one, so a positive
+// answer is sound however incomplete the search was.
+//
+// Proving no path exists is UNIVERSAL, and a syntactic graph cannot do it. Go
+// dispatches through interfaces, function values, struct fields holding
+// funcs, generics, embedded types, reflection and generated code. Every one of
+// those is a call this package cannot resolve from syntax alone, and each is a
+// place a path could hide.
+//
+// So this package NEVER refutes. Every Scope it builds carries at least one
+// limitation, which makes reach.Refute decline to construct a negative from it
+// and hand back Undetermined instead. That is not a gap to close later — a
+// scanner that reports "no call path" from a graph that cannot see interface
+// dispatch is reporting its own blind spot as an all-clear, which is the single
+// failure the whole capability model exists to prevent.
+//
+// The useful half is still large. Before this, call_graph and entry_point were
+// provided by nothing, so every finding carried "nothing on this installation
+// can answer it". Now a Go finding can carry a path from main to the line, with
+// the calls named.
+package callgraph
+
+import (
+	"sort"
+
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// Func is one function or method in the graph.
+type Func struct {
+	// Key is the unique identifier: "<dir>.<name>" for a function,
+	// "<dir>.(<recv>).<name>" for a method. The directory rather than the
+	// package name, because two packages in one module can share a name.
+	Key string
+	// Name is the declared identifier, for rendering.
+	Name string
+	// File and Line locate the declaration.
+	File string
+	Line int
+	// Calls are the keys this function calls, resolved where possible.
+	Calls []string
+	// Kind says whether execution can begin here, and on whose authority.
+	Kind EntryKind
+	// EntryReason says why, so an operator can disagree with the set.
+	EntryReason string
+}
+
+// EntryKind distinguishes where execution can actually begin from where it
+// could in principle.
+//
+// The distinction is load-bearing and was missing from the first version of
+// this package, which counted every exported function as an entry point. On
+// nox's own tree that made 5,088 of 7,652 functions entry points, so every
+// query returned a path of length one — "this exported function is reachable
+// because it is exported" — which is true, trivial, and reads like a much
+// stronger claim than it is.
+//
+// An exported function in a library IS reachable by somebody. What nothing here
+// establishes is that anybody actually calls it, which is precisely the
+// difference between reach.CallPathExists and reach.AttackerEntryPathExists.
+type EntryKind int
+
+const (
+	// NotAnEntry — nothing begins execution here.
+	NotAnEntry EntryKind = iota
+	// EntryExported — an external caller COULD reach it. Evidence that a path
+	// is possible, never that one exists.
+	EntryExported
+	// EntryTest — the test runner calls it. Real execution, but of the test
+	// suite rather than of the program an attacker meets.
+	EntryTest
+	// EntryConcrete — main or init. Execution genuinely begins here when the
+	// program runs, with no caller outside the module required.
+	EntryConcrete
+)
+
+// String renders the kind for a scope description.
+func (k EntryKind) String() string {
+	switch k {
+	case EntryConcrete:
+		return "concrete"
+	case EntryTest:
+		return "test"
+	case EntryExported:
+		return "exported"
+	default:
+		return "none"
+	}
+}
+
+// Graph is a call graph over one module.
+//
+// The zero Graph is usable and answers nothing, which is what a caller gets
+// when the module could not be read — an empty graph reports no paths and its
+// scope says why, rather than the build failing.
+type Graph struct {
+	funcs map[string]*Func
+	// callers is the reverse index, built once, so PathTo can search backwards
+	// from the target instead of forwards from every entry.
+	callers map[string][]string
+	limits  map[reach.Limitation]bool
+	// unresolved counts calls that could not be bound to a declaration. It is
+	// the honest measure of how much of the program this graph does not model.
+	unresolved int
+	resolved   int
+	// external counts calls out of the module — the standard library, a
+	// dependency. Counted apart from unresolved because they are a different
+	// kind of not-knowing: the callee is real and its source is simply not
+	// here, which does not make a path inside this module invisible.
+	external int
+	root     string
+	module   string
+}
+
+// Len returns the number of functions in the graph.
+func (g *Graph) Len() int {
+	if g == nil {
+		return 0
+	}
+	return len(g.funcs)
+}
+
+// Unresolved returns how many call sites could not be bound to a declaration,
+// and how many could. The ratio is what a reader should judge a negative
+// result by — and the reason this package does not produce negatives.
+func (g *Graph) Unresolved() (unresolved, resolved, external int) {
+	if g == nil {
+		return 0, 0, 0
+	}
+	return g.unresolved, g.resolved, g.external
+}
+
+// EntryPoints returns the functions execution can begin at, at kind or
+// stronger, sorted.
+//
+// Passing EntryConcrete asks the question that matters for exploitability —
+// where does this program actually start — and on a library the answer is often
+// "nowhere", which is the honest result rather than an empty one.
+func (g *Graph) EntryPoints(atLeast EntryKind) []string {
+	if g == nil {
+		return nil
+	}
+	var out []string
+	for k, f := range g.funcs {
+		if f.Kind >= atLeast && f.Kind != NotAnEntry {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Func returns the declaration for a key.
+func (g *Graph) Func(key string) (*Func, bool) {
+	if g == nil {
+		return nil, false
+	}
+	f, ok := g.funcs[key]
+	return f, ok
+}
+
+// Scope describes what this analysis covered and what defeated it.
+//
+// It always carries limitations. See the package doc: a syntactic graph cannot
+// see every call Go can make, so no scope built here may support a universal
+// claim, and reach.Refute declines to build one from it.
+func (g *Graph) Scope() reach.Scope {
+	s := reach.Scope{
+		Analysis: "go/ast call graph",
+		BuildID:  "syntactic, single module",
+	}
+	if g != nil {
+		// The concrete set. Listing every exported function would describe a
+		// search far broader than the one that answers "can this run".
+		s.EntryPoints = g.EntryPoints(EntryConcrete)
+		for l := range g.limits {
+			s.Limitations = append(s.Limitations, l)
+		}
+	}
+	// The floor. Even a module where nothing dynamic was OBSERVED is a module
+	// this analysis read syntactically, and a call it did not see is exactly
+	// the call it cannot report not seeing.
+	if len(s.Limitations) == 0 {
+		s.Limitations = append(s.Limitations, reach.UnresolvedDispatch)
+	}
+	sort.Slice(s.Limitations, func(i, j int) bool { return s.Limitations[i] < s.Limitations[j] })
+	return s
+}
+
+// PathToFunc returns a call path reaching target, and the strongest kind of
+// entry point that path starts at.
+//
+// The second return is not a detail. reach.AttackerEntryPathExists is strictly
+// stronger than reach.CallPathExists, and a path from main is different
+// evidence from a path from an exported function nothing in this module calls.
+// Returning a path without saying which would let a caller promote one to the
+// other by accident, which is the promotion the whole ladder exists to prevent.
+func (g *Graph) PathToFunc(target string) (path []string, reached EntryKind) {
+	if g == nil {
+		return nil, NotAnEntry
+	}
+	if _, ok := g.funcs[target]; !ok {
+		return nil, NotAnEntry
+	}
+	// Breadth-first backwards over callers, so the first path found is a
+	// shortest one — the most readable witness, and deterministic because the
+	// caller lists are sorted at build time.
+	seen := map[string]bool{target: true}
+	queue := []*searchNode{{key: target}}
+	var best *searchNode
+	bestKind := NotAnEntry
+
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		if f, ok := g.funcs[n.key]; ok && f.Kind > bestKind {
+			best, bestKind = n, f.Kind
+			// Concrete is the strongest answer available, so stop. Anything
+			// weaker keeps searching, because a longer path from main beats a
+			// short one from an exported function nothing calls.
+			if bestKind == EntryConcrete {
+				break
+			}
+		}
+		for _, c := range g.callers[n.key] {
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			queue = append(queue, &searchNode{key: c, prev: n})
+		}
+	}
+	if best != nil {
+		return chain(best), bestKind
+	}
+	return nil, NotAnEntry
+}
+
+// searchNode is one step of the backwards walk, linked to the step it came
+// from so a completed search can be read back as a path.
+type searchNode struct {
+	key  string
+	prev *searchNode
+}
+
+// chain walks a search node back to its origin and returns the path in CALL
+// order — caller first, target last, which is how a person reads a stack. The
+// walk itself runs the other way, and returning it unreversed would hand the
+// reader a path that appears to start at the vulnerability.
+func chain(n *searchNode) []string {
+	var out []string
+	for cur := n; cur != nil; cur = cur.prev {
+		out = append(out, cur.key)
+	}
+	return out
+}
+
+// FuncAt returns the function whose declaration encloses file:line.
+//
+// It answers the question a finding actually poses. A finding names a line, the
+// graph names functions, and without this join every reachability question
+// about a scan result would have to be asked by hand.
+//
+// "Encloses" is approximated by the nearest declaration at or above the line in
+// the same file, because the graph records declaration positions rather than
+// bodies. That is right for the overwhelming case and wrong for a line after
+// the last function in a file — a package-level var, an import — which is why
+// it returns false rather than guessing when nothing precedes the line.
+func (g *Graph) FuncAt(file string, line int) (string, bool) {
+	if g == nil || file == "" || line <= 0 {
+		return "", false
+	}
+	best, bestLine := "", 0
+	for key, f := range g.funcs {
+		if f.File != file || f.Line > line {
+			continue
+		}
+		if f.Line > bestLine || (f.Line == bestLine && key < best) {
+			best, bestLine = key, f.Line
+		}
+	}
+	return best, best != ""
+}
+
+// Files returns the source files the graph parsed, sorted. A caller uses it to
+// tell "this file was analysed and held nothing" from "this file was not
+// analysed" — the same distinction the capability model draws everywhere else.
+func (g *Graph) Files() []string {
+	if g == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, f := range g.funcs {
+		seen[f.File] = true
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/callgraph/callgraph_test.go
+++ b/core/callgraph/callgraph_test.go
@@ -1,0 +1,279 @@
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/reach"
+)
+
+// module writes a small Go module and returns its root.
+func module(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if _, ok := files["go.mod"]; !ok {
+		files["go.mod"] = "module example.com/m\n\ngo 1.21\n"
+	}
+	for name, body := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// THE property. This package never refutes, and the guarantee is structural
+// rather than a rule somebody has to remember.
+//
+// A syntactic graph cannot see interface dispatch, function values, struct
+// fields holding funcs, generics, embedding, reflection or generated code.
+// Every one is a call it does not have, and each is a place a path could hide.
+// So no Scope it builds may support a universal claim, and reach.Refute must
+// decline to construct one from it.
+//
+// A scanner that reported "no call path" from a graph like this would be
+// reporting its own blind spot as an all-clear — the single failure the whole
+// capability model exists to prevent.
+func TestTheGraphCanNeverRefuteACallPath(t *testing.T) {
+	// Deliberately the friendliest possible input: one package, one call, no
+	// interfaces, no function values, nothing dynamic. If any module could
+	// justify a complete scope this is it, and it must not.
+	dir := module(t, map[string]string{
+		"main.go": `package main
+
+func helper() {}
+
+func main() { helper() }
+`,
+	})
+	g := BuildGo(dir)
+	scope := g.Scope()
+
+	if scope.Complete() {
+		t.Fatal("the scope reports itself complete, so reach.Refute would build a negative " +
+			"from a graph that cannot see interface dispatch")
+	}
+	subject := evidence.Subject{Kind: evidence.SubjectSymbol, ID: "helper"}
+	if _, ok := reach.Refute(subject, reach.CallPathExists, scope); ok {
+		t.Error("reach.Refute accepted this scope; a finding could be suppressed on the " +
+			"strength of a path this analysis merely did not find")
+	}
+	// And the result it hands back instead says so rather than saying nothing.
+	r := reach.Undeterminable(subject, reach.CallPathExists, scope)
+	if !strings.Contains(r.Describe(), "unknown") {
+		t.Errorf("the undetermined result does not read as unknown: %q", r.Describe())
+	}
+}
+
+// A found path is a real chain of calls, not a claim.
+func TestAWitnessPathIsTheActualCallChain(t *testing.T) {
+	dir := module(t, map[string]string{
+		"main.go": `package main
+
+func third() {}
+func second() { third() }
+func first() { second() }
+
+func main() { first() }
+`,
+	})
+	g := BuildGo(dir)
+	path, kind := g.PathToFunc("third")
+	if kind != EntryConcrete {
+		t.Fatalf("reached = %s, want concrete (main calls into this chain)", kind)
+	}
+	want := []string{"main", "first", "second", "third"}
+	if len(path) != len(want) {
+		t.Fatalf("path = %v, want %v", path, want)
+	}
+	for i := range want {
+		if path[i] != want[i] {
+			t.Errorf("path[%d] = %q, want %q — a witness that is not the real chain is worse "+
+				"than no witness", i, path[i], want[i])
+		}
+	}
+}
+
+// A function nothing calls gets no path, and the absence is Unknown rather than
+// a refutation. `unused` here really is unreferenced, and this package still
+// declines to say so.
+func TestAnUnreachedFunctionIsNotRefuted(t *testing.T) {
+	dir := module(t, map[string]string{
+		"main.go": `package main
+
+func unused() {}
+
+func main() {}
+`,
+	})
+	g := BuildGo(dir)
+	path, kind := g.PathToFunc("unused")
+	if len(path) > 1 {
+		t.Errorf("a function nothing calls got a path of %d: %v", len(path), path)
+	}
+	if kind == EntryConcrete {
+		t.Error("an unreferenced unexported function was reported as a concrete entry point")
+	}
+}
+
+// Concrete and exported entry points are different claims and must not merge.
+//
+// The first version of this package counted every exported function as an entry
+// point, which on nox's own tree made 5,088 of 7,652 functions entries. Every
+// query then returned a path of length one — "this exported function is
+// reachable because it is exported" — true, trivial, and reading like a much
+// stronger claim than it is.
+func TestExportedIsNotTheSameEntryAsMain(t *testing.T) {
+	dir := module(t, map[string]string{
+		"lib/lib.go": `package lib
+
+// Exported is reachable by an outside caller, and nothing here calls it.
+func Exported() {}
+
+func internal() {}
+`,
+		"main.go": `package main
+
+func main() {}
+`,
+	})
+	g := BuildGo(dir)
+
+	concrete := g.EntryPoints(EntryConcrete)
+	if len(concrete) != 1 || concrete[0] != "main" {
+		t.Errorf("concrete entry points = %v, want exactly [main]", concrete)
+	}
+	all := g.EntryPoints(EntryExported)
+	if len(all) < 2 {
+		t.Errorf("entry points at exported-or-stronger = %v, want main and lib.Exported", all)
+	}
+
+	if _, kind := g.PathToFunc("lib.Exported"); kind != EntryExported {
+		t.Errorf("lib.Exported reached = %s, want exported — nothing in this module calls it, "+
+			"and reporting it as concrete would claim execution begins there", kind)
+	}
+	if _, kind := g.PathToFunc("lib.internal"); kind != NotAnEntry {
+		t.Errorf("an unexported, uncalled function reached = %s, want none", kind)
+	}
+}
+
+// Calls between packages of the same module resolve. Without the module path
+// from go.mod they cannot, and most of a real program's call graph is
+// cross-package — 21% of in-module calls resolved before this, 29% after.
+func TestCrossPackageCallsInsideTheModuleResolve(t *testing.T) {
+	dir := module(t, map[string]string{
+		"lib/lib.go": `package lib
+
+func Target() {}
+`,
+		"main.go": `package main
+
+import "example.com/m/lib"
+
+func main() { lib.Target() }
+`,
+	})
+	g := BuildGo(dir)
+	path, kind := g.PathToFunc("lib.Target")
+	if kind != EntryConcrete {
+		t.Fatalf("reached = %s, want concrete; the cross-package edge did not resolve", kind)
+	}
+	if len(path) != 2 || path[0] != "main" {
+		t.Errorf("path = %v, want [main lib.Target]", path)
+	}
+}
+
+// A call into the standard library is not the same kind of not-knowing as an
+// unresolved dispatch. Counting them together made the resolved ratio
+// meaningless — 21% on nox's own tree, almost all of it fmt.Sprintf.
+func TestStdlibCallsAreCountedApartFromUnresolvedDispatch(t *testing.T) {
+	dir := module(t, map[string]string{
+		"main.go": `package main
+
+import "fmt"
+
+func main() { fmt.Println("hi") }
+`,
+	})
+	g := BuildGo(dir)
+	unresolved, _, external := g.Unresolved()
+	if external == 0 {
+		t.Error("a call into fmt was not counted as external")
+	}
+	if unresolved != 0 {
+		t.Errorf("a stdlib call was counted as an unresolved dispatch (%d); the two are "+
+			"different kinds of not-knowing and only one is a hole in this module's graph",
+			unresolved)
+	}
+}
+
+// Interface dispatch is named as the limitation it is.
+func TestInterfaceDispatchIsRecordedAsALimitation(t *testing.T) {
+	dir := module(t, map[string]string{
+		"main.go": `package main
+
+type Doer interface{ Do() }
+
+func run(d Doer) { d.Do() }
+
+func main() { run(nil) }
+`,
+	})
+	g := BuildGo(dir)
+	var found bool
+	for _, l := range g.Scope().Limitations {
+		if l == reach.UnresolvedDispatch {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a call through an interface did not record unresolved_dispatch; "+
+			"limitations = %v", g.Scope().Limitations)
+	}
+}
+
+// The same tree produces the same graph. A witness path that reordered between
+// runs would make findings.json non-reproducible.
+func TestGraphIsDeterministic(t *testing.T) {
+	files := map[string]string{
+		"main.go": `package main
+
+func c() {}
+func b() { c() }
+func a() { c() }
+
+func main() { a(); b() }
+`,
+	}
+	dir := module(t, files)
+	first, _ := BuildGo(dir).PathToFunc("c")
+	for i := 0; i < 8; i++ {
+		again, _ := BuildGo(dir).PathToFunc("c")
+		if strings.Join(first, ",") != strings.Join(again, ",") {
+			t.Fatalf("run %d produced %v, first run produced %v", i+2, again, first)
+		}
+	}
+}
+
+// A directory that is not a module still parses; it simply cannot resolve
+// cross-package calls. It must not panic or claim more than it has.
+func TestNoGoModStillBuilds(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n\nfunc F() {}\n"), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	g := BuildGo(dir)
+	if g.Len() != 1 {
+		t.Errorf("graph holds %d functions, want 1", g.Len())
+	}
+	if g.Scope().Complete() {
+		t.Error("a graph with no module path called its scope complete")
+	}
+}

--- a/core/callgraph_coverage_test.go
+++ b/core/callgraph_coverage_test.go
@@ -1,0 +1,167 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nox-hq/nox/core/capability"
+	"github.com/nox-hq/nox/core/findings"
+)
+
+// mixedModule writes a Go module that also contains a YAML file, so one scan
+// holds findings in a language the call graph reads and one it cannot.
+func mixedModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"go.mod": "module example.com/m\n\ngo 1.21\n",
+		"main.go": `package main
+
+import "crypto/md5"
+
+func weak() []byte {
+	h := md5.New()
+	return h.Sum(nil)
+}
+
+func main() { weak() }
+`,
+		"deploy.yaml": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\nspec:\n" +
+			"  replicas: 1\n  template:\n    spec:\n      containers:\n      - name: c\n" +
+			"        image: nginx:latest\n        securityContext:\n          privileged: true\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func stateOf(t *testing.T, res *ScanResult, f findings.Finding, c capability.AnalysisCapability) capability.State {
+	t.Helper()
+	return res.Coverage.State(SubjectForFinding(f), c)
+}
+
+// A language the call graph cannot read reports UNSUPPORTED, not NOT_EVALUATED.
+//
+// This is the half that keeps declaring call_graph at installation level
+// honest. Provided() is a claim that an implementation exists; for a YAML
+// finding nothing could have asked the question, and not_evaluated would read
+// as a gap somebody could close by running something differently.
+func TestCallGraphIsUnsupportedOutsideGo(t *testing.T) {
+	dir := mixedModule(t)
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var checkedYAML, checkedGo int
+	for _, f := range res.Findings.Findings() {
+		switch filepath.Ext(f.Location.FilePath) {
+		case ".yaml":
+			checkedYAML++
+			for _, c := range []capability.AnalysisCapability{
+				capability.CallGraph, capability.EntryPoint,
+			} {
+				if got := stateOf(t, res, f, c); got != capability.Unsupported {
+					t.Errorf("%s on a YAML finding = %q, want unsupported. Nothing could have "+
+						"asked this question there, and %q reads as a gap somebody could close.",
+						c, got, got)
+				}
+			}
+		case ".go":
+			checkedGo++
+			if got := stateOf(t, res, f, capability.CallGraph); got == capability.Unsupported {
+				t.Errorf("call_graph on a Go finding = unsupported; the analysis exists for Go")
+			}
+		}
+	}
+	if checkedYAML == 0 {
+		t.Fatal("the fixture produced no YAML finding; this test asserts nothing")
+	}
+	if checkedGo == 0 {
+		t.Fatal("the fixture produced no Go finding; this test asserts nothing")
+	}
+}
+
+// A Go finding reached from main carries the chain that reaches it.
+func TestAGoFindingCarriesItsCallPath(t *testing.T) {
+	dir := mixedModule(t)
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var found bool
+	for _, f := range res.Findings.Findings() {
+		if filepath.Ext(f.Location.FilePath) != ".go" {
+			continue
+		}
+		if path := f.Metadata["call_path"]; path != "" {
+			found = true
+			if f.Metadata["entry_kind"] != "concrete" {
+				t.Errorf("entry_kind = %q for a path from main, want concrete",
+					f.Metadata["entry_kind"])
+			}
+			if got := stateOf(t, res, f, capability.EntryPoint); got != capability.Positive {
+				t.Errorf("entry_point = %q for a finding reached from main, want positive", got)
+			}
+		}
+	}
+	if !found {
+		t.Error("no Go finding carries a call path; main calls weak(), which holds the finding")
+	}
+}
+
+// Gate B at the scan. The call graph may never suppress a finding, in any
+// language, however confident it looks — it cannot see interface dispatch, and
+// "no path found" is not "no path exists".
+func TestCallGraphNeverSuppressesAFinding(t *testing.T) {
+	dir := mixedModule(t)
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, f := range res.Findings.Findings() {
+		for _, c := range []capability.AnalysisCapability{
+			capability.CallGraph, capability.EntryPoint,
+		} {
+			got := stateOf(t, res, f, c)
+			if got.SuppressesFinding() {
+				t.Errorf("%s reported %q for %s, which may suppress a finding. A syntactic "+
+					"graph cannot see every call Go can make, so it must never reach a "+
+					"state that hides one.", c, got, f.RuleID)
+			}
+		}
+	}
+}
+
+// A Go project with no go.mod is unsupported rather than badly answered: the
+// import paths cannot be resolved, so a graph would be mostly disconnected and
+// its silence would mean nothing.
+func TestGoWithoutAModuleIsUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	src := "package main\n\nimport \"crypto/md5\"\n\nfunc main() { md5.New() }\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var checked int
+	for _, f := range res.Findings.Findings() {
+		if filepath.Ext(f.Location.FilePath) != ".go" {
+			continue
+		}
+		checked++
+		if got := stateOf(t, res, f, capability.CallGraph); got != capability.Unsupported {
+			t.Errorf("call_graph = %q with no go.mod, want unsupported", got)
+		}
+	}
+	if checked == 0 {
+		t.Skip("no Go finding in the fixture")
+	}
+}

--- a/core/capability/capability_test.go
+++ b/core/capability/capability_test.go
@@ -155,14 +155,14 @@ func TestUnknownCapabilitiesAreNeverTreatedAsCoverage(t *testing.T) {
 func TestBuiltinsAreHonestAboutWhatIsMissing(t *testing.T) {
 	r := capability.DefaultRegistry()
 
-	for _, c := range []capability.AnalysisCapability{
-		capability.CallGraph, capability.EntryPoint,
-	} {
-		if r.Provided(c) {
-			t.Errorf("%q is declared as built-in; nox has no such analysis, and "+
-				"claiming one turns a limit into a false assurance", c)
-		}
-	}
+	// call_graph and entry_point moved into the provided list when
+	// core/callgraph was built, on the same terms as Reachability and
+	// ConstantEvaluation before them: Go only, and answering existentially.
+	//
+	// What must stay true is the per-finding half. A declaration at the
+	// installation level says the question CAN be put; it must not make a
+	// Python finding read "provided but nobody asked" when nothing could have
+	// asked. TestCallGraphIsUnsupportedOutsideGo in core is where that is held.
 	// ConstantEvaluation moved into the list below when core/consteval was
 	// built. It is declared on the same terms as Reachability, which has always
 	// been here and has always answered for Go alone: Provided() is an
@@ -172,16 +172,24 @@ func TestBuiltinsAreHonestAboutWhatIsMissing(t *testing.T) {
 	// the matrix is what says which were.
 	for _, c := range []capability.AnalysisCapability{
 		capability.LexicalContext, capability.Taint, capability.Reachability,
-		capability.ConstantEvaluation,
+		capability.ConstantEvaluation, capability.CallGraph, capability.EntryPoint,
 	} {
 		if !r.Provided(c) {
 			t.Errorf("%q is not declared but nox does provide it; an undeclared "+
 				"capability reads as Unsupported when it is really available", c)
 		}
 	}
-	if len(r.Missing()) == 0 {
-		t.Error("the registry claims nox is missing nothing, which cannot be true " +
-			"of a scanner that never executes the code it reads")
+	// Every defined capability now has an implementation, which is a true
+	// statement about the INSTALLATION and a dangerous one to leave standing
+	// alone. A scan still executes nothing, still reads one language for call
+	// graphs, and still cannot refute a path in any of them.
+	//
+	// So the assertion moves rather than disappears: with nothing missing,
+	// `nox analysis-capabilities` must still say what nox cannot do, or an
+	// operator reading a full matrix will take it for a full answer.
+	// TestAFullMatrixStillStatesItsLimits in cli holds that.
+	if len(r.Missing()) != 0 {
+		t.Logf("capabilities with no implementation: %v", r.Missing())
 	}
 }
 

--- a/core/capability/providers.go
+++ b/core/capability/providers.go
@@ -28,9 +28,10 @@ func (b builtin) Provides() []AnalysisCapability { return b.provides }
 //
 // The list is deliberately short, and its shortness is the honest reading of
 // what a pattern scanner is. nox lexes, it resolves constants where a language
-// engine exists, and it tracks taint. It does not build a call graph, does not
-// know entry points, and cannot establish reachability or attacker
-// reachability — those come from plugins, or from nowhere.
+// engine exists, it tracks taint, and — for Go only — it builds a syntactic
+// call graph and names entry points. It cannot establish attacker reachability,
+// and it cannot refute a call path in any language: those come from plugins, or
+// from nowhere.
 //
 // Stating that plainly is the point. An operator running nox with no plugins
 // should be able to see that reachability was never on the table, rather than
@@ -57,6 +58,15 @@ func Builtins() []Provider {
 		// `go list -deps`, and answers it with (reachable, determined) so an
 		// undetermined result never reads as unreachable.
 		builtin{"core/analyzers/deps", []AnalysisCapability{Reachability}},
+		// core/callgraph relates callers to callees across function boundaries
+		// in a Go module, and names where execution begins. It answers
+		// EXISTENTIALLY only: it can produce a call path with a witness, and it
+		// never reports that no path exists, because a syntactic graph cannot
+		// see interface dispatch, function values or reflection. Listing it
+		// here says the questions can be put, not that every answer will be
+		// conclusive — which is the distinction between Unsupported and
+		// NotEvaluated that this whole registry exists to draw.
+		builtin{"core/callgraph", []AnalysisCapability{CallGraph, EntryPoint}},
 		// core/attack constructs and executes exploit hypotheses. It is listed
 		// because it exists, NOT because a scan uses it: `nox scan` never
 		// executes anything, so DynamicVerification is NotEvaluated on every

--- a/core/capability_gate_run_test.go
+++ b/core/capability_gate_run_test.go
@@ -162,14 +162,24 @@ func TestScanAlwaysSuppliesARunView(t *testing.T) {
 		t.Fatal("the scan produced no coverage, so the policy gate fell back to the " +
 			"installation-only answer that Track H replaced")
 	}
-	// call_graph has no implementation at all, so this is the unsupported
-	// branch — the one case where the installation answer is the whole story.
+	// call_graph is now implemented for Go, and this project is Python — so the
+	// gate must still fail, but for the OTHER reason: the analysis exists and
+	// nothing in this scan reached a conclusion with it.
+	//
+	// That distinction is the point of the whole run-level view. An operator
+	// told "not provided" installs a plugin; one told "nothing put the
+	// question" checks whether the scan reached the code they meant. Before
+	// Track H both came out as the same silence.
 	if res.PolicyResult == nil || res.PolicyResult.Pass {
-		t.Error("a capability nothing implements satisfied a requirement for it")
+		t.Error("a capability that concluded nothing satisfied a requirement for it")
 	}
-	if !strings.Contains(strings.Join(res.PolicyResult.Warnings, " "),
-		"not provided by this installation") {
-		t.Errorf("an unimplemented capability was not reported as unprovided: %v",
+	warnings := strings.Join(res.PolicyResult.Warnings, " ")
+	if !strings.Contains(warnings, "nothing in this scan put the question") {
+		t.Errorf("a provided-but-unexercised capability was not reported as such: %v",
+			res.PolicyResult.Warnings)
+	}
+	if strings.Contains(warnings, "not provided by this installation") {
+		t.Errorf("call_graph was reported as unprovided; core/callgraph implements it: %v",
 			res.PolicyResult.Warnings)
 	}
 }

--- a/core/e2e_evidence_test.go
+++ b/core/e2e_evidence_test.go
@@ -142,8 +142,18 @@ func TestEndToEndEvidenceChain(t *testing.T) {
 	if res.Coverage.Len() == 0 {
 		t.Error("no capability results recorded")
 	}
-	if len(res.Capabilities.Missing()) == 0 {
-		t.Error("the scan claims to be missing no capability, which cannot be true " +
+	// Missing() is empty now that every defined capability has an
+	// implementation — true of the INSTALLATION, and misleading alone. The
+	// property that must survive is about the SCAN: it executes nothing and
+	// reads one language for call graphs, so questions stay unanswered.
+	var unanswered int
+	for _, c := range capability.All() {
+		if answered, _ := res.Coverage.Answered(c); answered == 0 {
+			unanswered++
+		}
+	}
+	if unanswered == 0 {
+		t.Error("this scan answered every capability for something, which cannot be true " +
 			"of a scanner that never executes the code it reads")
 	}
 	for _, f := range all {

--- a/core/explain/explain_test.go
+++ b/core/explain/explain_test.go
@@ -152,6 +152,15 @@ func TestUndeterminedIsNotNo(t *testing.T) {
 // different places, and collapsing them wastes the answer.
 func TestWhatWasNotEvaluatedSeparatesALimitFromAGap(t *testing.T) {
 	in := baseInputs()
+	// A registry that genuinely lacks something, constructed rather than
+	// borrowed. This used DefaultRegistry and depended on nox having a
+	// capability nothing implemented; core/callgraph filled the last of those,
+	// and the test started asserting a property of the installation instead of
+	// one of the code. An installation can gain a plugin at any time, so the
+	// fixture has to own the gap it is about.
+	partial := capability.NewRegistry()
+	partial.Register(cheapOnly{})
+	in.Coverage = capability.NewCoverage(partial)
 	in.Coverage.Record(subject(), capability.Taint, capability.Unknown)
 	lines := strings.Join(explain.Explain(in).NotEvaluated, "\n")
 
@@ -226,5 +235,16 @@ func TestTheMatchedValueIsNeverPrinted(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// cheapOnly provides the cheap capabilities and none of the expensive ones, so
+// a limit nothing can fill is guaranteed to exist in the fixture.
+type cheapOnly struct{}
+
+func (cheapOnly) Name() string { return "test/cheap-only" }
+func (cheapOnly) Provides() []capability.AnalysisCapability {
+	return []capability.AnalysisCapability{
+		capability.LexicalContext, capability.ConstantEvaluation, capability.Taint,
 	}
 }

--- a/core/report/capability_coverage_test.go
+++ b/core/report/capability_coverage_test.go
@@ -39,22 +39,41 @@ func TestCapabilityMatrixListsEveryCapability(t *testing.T) {
 // omitted. On a stock installation that is call_graph and entry_point, and an
 // operator reading a clean scan has no other way to learn it.
 func TestUnprovidedCapabilitiesAreReportedNotOmitted(t *testing.T) {
-	got := report.CapabilitiesFrom(capability.DefaultRegistry(), nil)
-	want := map[string]bool{"call_graph": true, "entry_point": true}
-	seen := map[string]bool{}
+	// A registry that genuinely lacks something, constructed rather than
+	// borrowed. This used DefaultRegistry and named call_graph and entry_point,
+	// which core/callgraph now provides — at which point the test was asserting
+	// a property of the installation rather than of the matrix. An installation
+	// can gain a plugin at any time; the fixture has to own its gap.
+	reg := capability.NewRegistry()
+	reg.Register(lexOnly{})
+
+	got := report.CapabilitiesFrom(reg, nil)
+	if len(got) != len(capability.All()) {
+		t.Fatalf("matrix has %d rows, want one per capability", len(got))
+	}
+	var unprovided int
 	for _, row := range got {
-		if !row.Provided {
-			seen[row.Capability] = true
-			if len(row.Providers) != 0 {
-				t.Errorf("%s: unprovided but names providers %v", row.Capability, row.Providers)
-			}
+		if row.Provided {
+			continue
+		}
+		unprovided++
+		if len(row.Providers) != 0 {
+			t.Errorf("%s: unprovided but names providers %v", row.Capability, row.Providers)
 		}
 	}
-	for c := range want {
-		if !seen[c] {
-			t.Errorf("%s is not provided by any builtin, but the matrix does not say so", c)
-		}
+	if unprovided != len(capability.All())-1 {
+		t.Errorf("%d capabilities reported unprovided; the fixture registry offers exactly "+
+			"one, and every other row must say so rather than being omitted", unprovided)
 	}
+}
+
+// lexOnly provides a single capability, so every other row in the matrix is a
+// genuine, fixture-owned gap.
+type lexOnly struct{}
+
+func (lexOnly) Name() string { return "test/lex-only" }
+func (lexOnly) Provides() []capability.AnalysisCapability {
+	return []capability.AnalysisCapability{capability.LexicalContext}
 }
 
 // THE EXIT CRITERION for milestone 1.2: two scans differing only in what could

--- a/core/scan.go
+++ b/core/scan.go
@@ -37,6 +37,7 @@ import (
 	"github.com/nox-hq/nox/core/analyzers/variants"
 	"github.com/nox-hq/nox/core/analyzers/weakcrypto"
 	"github.com/nox-hq/nox/core/baseline"
+	"github.com/nox-hq/nox/core/callgraph"
 	"github.com/nox-hq/nox/core/capability"
 	"github.com/nox-hq/nox/core/consteval"
 	"github.com/nox-hq/nox/core/discovery"
@@ -868,6 +869,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	// a larger change than this one and are left to the E track.
 	recordObservations(reasons, allFindings)
 	recordCapabilityCoverage(coverage, allFindings)
+	recordCallGraphCoverage(coverage, allFindings, target)
 	competenceProfiles := assignCompetenceProfiles(coverage, allFindings)
 	recordAnalysisLimitations(allFindings, target, reasons)
 	divergences, conflicts := adjudicateFindings(reasons, allFindings)
@@ -2168,6 +2170,103 @@ func adjudicateFindings(store *reasoning.Store, fs *findings.FindingSet) ([]adju
 		})
 	}
 	return out, conflicts
+}
+
+// recordCallGraphCoverage answers, per finding, whether a call path reaches it
+// and whether one starts where execution actually begins.
+//
+// Two capabilities that nothing provided until core/callgraph existed, so every
+// finding used to carry "nothing on this installation can answer it" for both.
+//
+// The states are chosen to make a wrong answer impossible in the direction that
+// matters. Positive when a path was found — existential, and the witness is a
+// real chain of call expressions. NEVER Negative: a syntactic graph cannot see
+// interface dispatch, function values or reflection, so "no path found" is
+// Unknown, and Unknown cannot suppress a finding. Unsupported outside Go,
+// because there the question genuinely cannot be put and NotEvaluated would
+// read as a gap somebody could close.
+//
+// The graph is built once per scan and only when the target holds a Go module.
+// On nox's own tree that is ~0.2s for 7,600 functions; a repository with no
+// go.mod pays nothing.
+func recordCallGraphCoverage(cov *capability.Coverage, fs *findings.FindingSet, target string) {
+	if cov == nil || fs == nil {
+		return
+	}
+	items := fs.Findings()
+
+	// Non-Go findings first, and unconditionally: they are Unsupported whether
+	// or not a graph was built, and saying so is the whole reason declaring
+	// these capabilities at installation level stays honest.
+	var anyGo bool
+	for _, f := range items {
+		if strings.HasSuffix(f.Location.FilePath, ".go") {
+			anyGo = true
+			continue
+		}
+		subject := SubjectForFinding(f)
+		cov.Record(subject, capability.CallGraph, capability.Unsupported)
+		cov.Record(subject, capability.EntryPoint, capability.Unsupported)
+	}
+	if !anyGo {
+		return
+	}
+
+	root := scanRootDir(target)
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		// Go files with no module: the import paths cannot be resolved, so a
+		// graph would be mostly disconnected. Unsupported rather than a bad
+		// answer.
+		for _, f := range items {
+			if !strings.HasSuffix(f.Location.FilePath, ".go") {
+				continue
+			}
+			subject := SubjectForFinding(f)
+			cov.Record(subject, capability.CallGraph, capability.Unsupported)
+			cov.Record(subject, capability.EntryPoint, capability.Unsupported)
+		}
+		return
+	}
+
+	g := callgraph.BuildGo(root)
+	for i := range items {
+		f := items[i]
+		if !strings.HasSuffix(f.Location.FilePath, ".go") {
+			continue
+		}
+		subject := SubjectForFinding(f)
+		key, ok := g.FuncAt(filepath.Join(root, f.Location.FilePath), f.Location.StartLine)
+		if !ok {
+			// The line is outside any function — a package-level declaration,
+			// an import. There is no call path to a var.
+			cov.Record(subject, capability.CallGraph, capability.Unknown)
+			cov.Record(subject, capability.EntryPoint, capability.Unknown)
+			continue
+		}
+		path, reached := g.PathToFunc(key)
+		// A path of one is the function itself, reached from nothing. It means
+		// no caller was resolved, which is the opposite of establishing that a
+		// call path exists — reach.CallPathExists is "a call path reaches the
+		// symbol FROM somewhere". Recording Positive for it would turn "we
+		// found no caller" into "we found a route".
+		if len(path) > 1 {
+			cov.Record(subject, capability.CallGraph, capability.Positive)
+			fs.SetMetadata(i, "call_path", strings.Join(path, " -> "))
+		} else {
+			cov.Record(subject, capability.CallGraph, capability.Unknown)
+		}
+		// EntryPoint is the stronger question and gets the stricter answer.
+		// Reaching an exported function establishes that an outside caller
+		// COULD arrive, not that execution begins anywhere — so only a
+		// concrete or test entry counts as answered.
+		switch reached {
+		case callgraph.EntryConcrete, callgraph.EntryTest:
+			cov.Record(subject, capability.EntryPoint, capability.Positive)
+			fs.SetMetadata(i, "entry_kind", reached.String())
+		default:
+			cov.Record(subject, capability.EntryPoint, capability.Unknown)
+		}
+	}
 }
 
 // assignCompetenceProfiles groups findings by what was NOT answered about them

--- a/core/scan_reasoning_test.go
+++ b/core/scan_reasoning_test.go
@@ -421,8 +421,20 @@ func TestCapabilityCoverageIsReportedOnEveryScan(t *testing.T) {
 	if res.Capabilities == nil || res.Coverage == nil {
 		t.Fatal("a scan without reasoning reported no capability registry or coverage")
 	}
-	if len(res.Capabilities.Missing()) == 0 {
-		t.Error("the scan claims nox is missing no capability, which cannot be true " +
+	// Every defined capability now has an implementation, so Missing() is
+	// empty — a true statement about the INSTALLATION and a misleading one on
+	// its own. What must remain true is that a SCAN still leaves questions
+	// unanswered, because it executes nothing and reads one language for call
+	// graphs. That is the property worth asserting, and it does not evaporate
+	// when somebody implements a capability.
+	var unanswered int
+	for _, c := range capability.All() {
+		if answered, _ := res.Coverage.Answered(c); answered == 0 {
+			unanswered++
+		}
+	}
+	if unanswered == 0 {
+		t.Error("this scan answered every capability for something, which cannot be true " +
 			"of a scanner that never executes the code it reads")
 	}
 

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -311,21 +311,53 @@ never scored a true positive on any corpus.
 (`testdata/reachability-suite`, exactly one suppressible case, asserted by
 name).
 
-**Missing.** One implementation, Go-only (`goVulnReachable`). No other
-ecosystem has an equivalent, and `call_graph` / `entry_point` are the two
-capabilities the installation reports as **not provided**.
+**Missing.** 7.2 and 7.3.
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **7.1** | Implement `call_graph` and `entry_point` for one more ecosystem | `analysis-capabilities` reports 9 of 9 for that language |
-| **7.2** | Every negative reachability claim records entry-point scope | no unqualified "unreachable" |
-| **7.3** | Applicability composition into the ladder, surfaced per finding | one dependency CVE demonstrated present-but-non-impacting with scope-sound evidence, and one genuinely impacting |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **7.1** | Implement `call_graph` and `entry_point` | `analysis-capabilities` reports 9 of 9 for that language | ✅ #613 |
+| **7.2** | Every negative reachability claim records entry-point scope | no unqualified "unreachable" | already met |
+| **7.3** | Applicability composition into the ladder, surfaced per finding | one dependency CVE demonstrated present-but-non-impacting with scope-sound evidence, and one genuinely impacting | |
 
-**Size:** large per ecosystem. This is the phase with the most build and the
-most product value — it is the SCA differentiator.
+**The plan's premise for 7.1 was wrong.** It read "one *more* ecosystem", but
+`call_graph` and `entry_point` were provided by **nothing** — there was no
+first. `core/callgraph` is it, for Go, in `core/callgraph`.
 
-**Gate:** B, and each new ecosystem arrives with its unsupported case converted
-to a determined one (the reachability-suite's own rule 4).
+The design decision that matters is what it refuses to do. A syntactic graph
+cannot see interface dispatch, function values, generics, embedding, reflection
+or generated code, so **it never refutes**. Every `reach.Scope` it builds carries
+a limitation, which makes `reach.Refute` decline to construct a negative from it.
+Reporting "no call path" from a graph like that would be reporting a blind spot
+as an all-clear — the one failure this whole model exists to prevent.
+
+Measured on nox's own tree: 7,655 functions, **6** concrete entry points, and
+witness paths that are real chains of call expressions, verified edge by edge
+against the source. Two earlier versions were wrong and the measurement caught
+both: counting every exported function as an entry point made 5,088 of 7,652
+functions "entries" and every answer a trivial length-1 path; and treating a
+length-1 path as `CallPathExists` turned "no caller found" into "a route
+exists".
+
+7.2 is met by construction rather than by new work: this analysis produces no
+negative reachability claims at all, and the one that exists (`goSymbolReferenced`)
+already refuses an incomplete scope and records `reach_limitations` since #605.
+
+**Consequence to watch.** Every defined capability now has an implementation, so
+`Registry.Missing()` is empty. That is true of the *installation* and misleading
+alone — seven tests asserted "something must be missing" and each had to move to
+asserting the property it actually cared about. `nox analysis-capabilities` now
+prints its standing limits unconditionally, guarded by
+`TestAFullMatrixStillStatesItsLimits`, because a full matrix with no caveat
+reads as a full answer.
+
+**Size:** large. This is the phase with the most build and the most product
+value — it is the SCA differentiator.
+
+**Gate:** B. `TestCallGraphNeverSuppressesAFinding` is the scan-level form: the
+call graph may never reach a state that hides a finding, in any language. Per
+finding, a language it cannot read reports `unsupported` rather than
+`not_evaluated` — declaring a capability at installation level must not make a
+Python finding read as a gap somebody could close.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1150,6 +1150,41 @@ This is why the matrix is emitted even when everything worked: a report listing
 only the capabilities that succeeded is one a reader will take for the complete
 set of questions nox asks.
 
+#### Call paths, for Go
+
+A Go finding can carry the chain of calls that reaches it:
+
+```json
+{
+  "RuleID": "SEC-330",
+  "Location": {"FilePath": "core/attack/graph.go", "StartLine": 818},
+  "Metadata": {
+    "call_path": "cli.main -> cli.run -> cli.runAttack -> core/attack.BuildPlan -> ...",
+    "entry_kind": "concrete"
+  }
+}
+```
+
+`entry_kind` says what the path starts at, and the three are different claims:
+
+| kind | means |
+|---|---|
+| `concrete` | `main` or `init` — execution genuinely begins here when the program runs |
+| `test` | the test runner reaches it; real execution, of the test suite |
+| `exported` | an outside caller *could* reach it. Not evidence that anybody does |
+
+**It never reports that no path exists.** A syntactic call graph cannot see
+interface dispatch, function values, generics, embedding, reflection or
+generated code — each is a call it does not have, and each is a place a path
+could hide. So a finding with no `call_path` is one nox did not find a route to,
+never one it showed unreachable, and nothing here can suppress a finding.
+
+Go only. For every other language a finding's own capability matrix reads
+`unsupported` for `call_graph` and `entry_point` — nothing could have asked, as
+distinct from nobody having asked. A Go project with no `go.mod` is also
+`unsupported`: without the module path the cross-package edges cannot be
+resolved, and a mostly-disconnected graph's silence would mean nothing.
+
 #### Asking what would settle it: `--emit-hypotheses`
 
 A scan can write the active-testing questions its findings raise:

--- a/server/evidence.go
+++ b/server/evidence.go
@@ -62,23 +62,37 @@ func (s *Server) handleAnalysisCapabilities(_ context.Context, _ emptyInput) (mc
 			ProvidedBy: pc.result.Capabilities.ProvidedBy(c),
 			Answered:   answered, Inconclusive: inconclusive,
 		}
-		switch {
-		case !provided:
-			row.Meaning = "Nothing on this installation can establish it. Findings that " +
-				"depend on it are unevaluated, not cleared."
-		case answered > 0:
-			row.Meaning = "Established for some findings in this scan."
-		case inconclusive > 0:
-			row.Meaning = "The analysis ran and could not determine anything."
-		default:
-			row.Meaning = "Available, but nothing in this scan put the question."
-		}
+		row.Meaning = capabilityMeaning(provided, answered, inconclusive)
 		out.Capabilities = append(out.Capabilities, row)
 	}
 	sort.Slice(out.Capabilities, func(i, j int) bool {
 		return out.Capabilities[i].Capability < out.Capabilities[j].Capability
 	})
 	return structured(out)
+}
+
+// capabilityMeaning states, in words, what a row implies for a reader.
+//
+// Extracted so every branch is directly testable. The unprovided branch cannot
+// be reached through a real scan any more — core/callgraph filled the last
+// capability nothing implemented — and a test that could only exercise it by
+// accident of the installation was one plugin away from becoming vacuous.
+//
+// The wording carries the weight here. An agent summarising a scan reads this
+// string, and the difference between "nothing looked" and "nothing was found"
+// is the difference between a gap and a clearance.
+func capabilityMeaning(provided bool, answered, inconclusive int) string {
+	switch {
+	case !provided:
+		return "Nothing on this installation can establish it. Findings that " +
+			"depend on it are unevaluated, not cleared."
+	case answered > 0:
+		return "Established for some findings in this scan."
+	case inconclusive > 0:
+		return "The analysis ran and could not determine anything."
+	default:
+		return "Available, but nothing in this scan put the question."
+	}
 }
 
 // whyInput selects the finding to explain.

--- a/server/evidence_test.go
+++ b/server/evidence_test.go
@@ -60,11 +60,10 @@ func TestAnAgentCanLearnWhatWasNotEvaluated(t *testing.T) {
 	// describe an unasked question as "no issues found" and the test still
 	// passed — a guard reading the reassurance instead of the claim. Found by
 	// falsifying it and watching nothing fail.
-	var sawUnprovided, sawUnasked bool
+	var sawUnasked bool
 	for _, row := range report.Capabilities {
 		switch {
 		case !row.Provided:
-			sawUnprovided = true
 			if !strings.Contains(row.Meaning, "Nothing on this installation can establish it") {
 				t.Errorf("%s is unprovided but its meaning reads %q", row.Capability, row.Meaning)
 			}
@@ -76,9 +75,13 @@ func TestAnAgentCanLearnWhatWasNotEvaluated(t *testing.T) {
 			}
 		}
 	}
-	if !sawUnprovided || !sawUnasked {
-		t.Errorf("the corpus exercised unprovided=%v unasked=%v; both must appear or "+
-			"the assertions above are vacuous", sawUnprovided, sawUnasked)
+	// The unprovided branch is no longer reachable through a real scan —
+	// core/callgraph filled the last capability nothing implemented — so it is
+	// exercised directly in TestEveryCapabilityMeaningIsDistinct rather than
+	// left as an arm that happens never to run. Only the branch a scan can
+	// still reach is required here.
+	if !sawUnasked {
+		t.Error("the corpus exercised no unasked capability, so the assertion above is vacuous")
 	}
 	// Never a clearance. An agent summarising this must not be handed a word
 	// that lets it write "no issues".
@@ -209,5 +212,45 @@ func decode(t *testing.T, r, into any) {
 	}
 	if err := json.Unmarshal(b, into); err != nil {
 		t.Fatalf("could not decode structured result: %v\n%s", err, b)
+	}
+}
+
+// Every branch of capabilityMeaning, exercised directly.
+//
+// The scan-driven test above can no longer reach the unprovided arm, and an
+// assertion inside a branch that never runs is not an assertion. The wording is
+// what an agent reads when summarising a scan, so each case has to say
+// something different — and none of them may say a gap was a clean result.
+func TestEveryCapabilityMeaningIsDistinct(t *testing.T) {
+	cases := []struct {
+		name         string
+		provided     bool
+		answered     int
+		inconclusive int
+		want         string
+	}{
+		{"unprovided", false, 0, 0, "Nothing on this installation can establish it"},
+		{"answered", true, 3, 0, "Established for some findings"},
+		{"inconclusive", true, 0, 2, "ran and could not determine anything"},
+		{"unasked", true, 0, 0, "nothing in this scan put the question"},
+	}
+	seen := map[string]string{}
+	for _, tc := range cases {
+		got := capabilityMeaning(tc.provided, tc.answered, tc.inconclusive)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: meaning %q does not contain %q", tc.name, got, tc.want)
+		}
+		if prev, dup := seen[got]; dup {
+			t.Errorf("%s and %s render the same sentence %q; two different states an "+
+				"operator must respond to differently are being reported identically",
+				tc.name, prev, got)
+		}
+		seen[got] = tc.name
+		for _, banned := range []string{"safe", "no issues", "not vulnerable", "clean"} {
+			if strings.Contains(strings.ToLower(got), banned) {
+				t.Errorf("%s: meaning %q contains %q, which reads as a clearance",
+					tc.name, got, banned)
+			}
+		}
 	}
 }


### PR DESCRIPTION
`call_graph` and `entry_point` were provided by **nothing**, so every finding carried *"nothing on this installation can answer it"* for both. The plan called 7.1 "one **more** ecosystem" — there was no first. `core/callgraph` is it.

## What it refuses to do is the design

A syntactic graph cannot see interface dispatch, function values, struct fields holding funcs, generics, embedding, reflection or generated code. Each is a call it does not have, and each is a place a path could hide.

**So it never refutes.** Every `reach.Scope` it builds carries a limitation, which makes `reach.Refute` decline to construct a negative from it. A scanner reporting "no call path" from a graph like this would be reporting its own blind spot as an all-clear.

Finding a path is *existential* and stays sound however incomplete the search was — one witness settles it, and the witness is a real chain of call expressions:

```
SEC-330  core/attack/graph.go:818
  cli.main -> cli.run -> cli.runAttack -> cli.runAttackPlan
    -> core/attack.BuildPlan -> core/attack.BuildGraph -> core/attack.addInjectionFindings
  entry_kind: concrete
```

I verified that path edge by edge against the source before trusting it. A fabricated witness would be the worst possible defect here.

## Two versions were wrong, and measurement caught both

**Every exported function as an entry point** made 5,088 of 7,652 functions "entries" on nox's own tree, so every query returned a length-1 path — *"this exported function is reachable because it is exported"*: true, trivial, and reading like a far stronger claim. `EntryKind` now separates:

| kind | means |
|---|---|
| `concrete` | `main`/`init` — execution genuinely begins here |
| `test` | the test runner reaches it |
| `exported` | an outside caller *could*. Not evidence anybody does |

**Treating a length-1 path as `CallPathExists`** turned "no caller was found" into "a route exists". `reach.CallPathExists` is *"a call path reaches the symbol **from** somewhere"*; a path of one is the function itself.

## Per-finding honesty keeps the declaration truthful

Declaring a capability at installation level says the question *can* be put. For a **Python** finding nothing could have asked it, so the state is `unsupported`, not `not_evaluated` — the latter reads as a gap somebody could close by scanning differently. A Go project with **no go.mod** is likewise `unsupported`: without the module path the cross-package edges don't resolve, and a mostly-disconnected graph's silence means nothing.

`adjudicate.MissingEvidence` now takes the subject's state into account when saying whether a gap is answerable. `Registry.Provided` answers "does an implementation exist anywhere", and taking that as the whole answer overstates it the moment an implementation covers one language.

## ⚠️ Consequence worth naming

**Every defined capability now has an implementation, so `Registry.Missing()` is empty.** True of the *installation*, misleading alone.

Seven tests asserted "something must be missing". Each moved to asserting the property it actually cared about — that a **scan** still leaves questions unanswered, because it executes nothing and reads one language for call graphs. Three stopped depending on the installation having a gap and now construct a registry that *owns* one, which is what they should have done from the start.

`nox analysis-capabilities` prints its standing limits **unconditionally** now. They used to appear only alongside a missing capability — fine while two were missing, a silent regression the moment the last was filled, because a full matrix with no caveat reads as a full answer. Guarded by `TestAFullMatrixStillStatesItsLimits`.

`server/evidence.go`'s meaning renderer was extracted so every branch is testable: the unprovided arm is no longer reachable through a real scan, and an assertion inside a branch that never runs is not an assertion.

## 7.2 was already met

This analysis produces no negative reachability claims at all, and the one that exists (`goSymbolReferenced`) already refuses an incomplete scope and records `reach_limitations` since #605.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged. Gate B suite green.
- `TestTheGraphCanNeverRefuteACallPath` handed the friendliest possible module — one package, one call, nothing dynamic — and asserts the scope is still incomplete.
- `TestCallGraphNeverSuppressesAFinding` is the scan-level form.
- ~0.2s added to a scan of nox's own tree; a repository with no `go.mod` pays nothing.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT