### PR TITLE
docs: v1.35.0 release notes, and Phase 6 re-scoped to what can be measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,133 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.35.0] - 2026-09-08
+
+Seven changes and three defects, all one theme: a scan now says what it did not
+establish, per finding, instead of leaving silence to be read as an all-clear.
+
+The largest is that every finding carries the questions nobody answered about
+it. A YAML finding and a Go finding in the same scan are not equally well
+understood — nox has no YAML lexer, so it cannot tell a match in a comment from
+one in a value — and until now nothing in the output said so. Competence is
+grouped rather than repeated: measured, 53 findings on the precision suite
+resolve to 4 distinct profiles and 62 on nox's own tree to 3, because it varies
+by language and analyses rather than by finding.
+
+`call_graph` and `entry_point` were provided by nothing at all. They are now
+answered for Go, with a witness that is a real chain of call expressions. What
+that analysis refuses to do is the design: a syntactic graph cannot see
+interface dispatch, function values, generics, reflection or generated code, so
+it never reports that no path exists. Every scope it builds carries a
+limitation, which makes `reach.Refute` decline to build a negative from it.
+
+Three defects were found by writing the measurements rather than by reading the
+code, and one of them was hiding findings.
+
+### ⚠️ Behaviour changes
+
+- **A baseline entry now accepts one finding, not every finding sharing its
+  fingerprint.** Two genuinely distinct findings can share a digest: the v2
+  fingerprint is `sha256(rule_id, path, message)`, and a rule whose message is a
+  static description — most IaC rules — produces one digest for every occurrence
+  in a file. Accepting one of four `continue-on-error` steps accepted all four,
+  and accepted the fifth added a month later: born baselined, with `nox scan`
+  reporting `0 findings (3 suppressed)`.
+
+  **If your baseline has fewer entries than there are findings sharing a
+  fingerprint, the surplus will start appearing.** They were suppressed without
+  anyone having accepted them. Run `nox baseline update .` to accept the ones
+  you want and prune the rest. A baselined finding that MOVES in its file still
+  matches, which is what the v2 fingerprint was designed for and what a fix
+  keyed on position would have cost.
+
+- **`Exploitability` is now on every finding**, not only on scans that recorded
+  reasoning. It is `POTENTIAL` for every static finding, always — the state
+  comes from the run outcome, and a scan executes nothing. Saying so is the
+  point: a finding silent about never having been validated reads as a stronger
+  claim than it is. `EvidenceConfidence` stays conditional, because that one IS
+  derived from the ledger and an empty ledger aggregates to `LOW`.
+
+- **A waived finding no longer grounds an attack hypothesis.** A `nox:ignore`, a
+  baseline entry or a VEX statement did not stop `nox attack plan` building one,
+  so `nox attack run --authorize` would fire real payloads at a live target for
+  something explicitly accepted. Waived findings now appear in the plan's
+  `skipped` list saying so.
+
+### Added
+
+- `findings.json` carries `meta.capabilities`: what each analysis can establish
+  on this installation, and how many subjects it actually concluded about.
+  `provided` and `answered` are separate fields because they answer different
+  questions and come apart the moment something fails at runtime.
+- `results.sarif` carries the same as `invocations[].toolExecutionNotifications`
+  at level `note`. SARIF has no other slot for a statement about the run rather
+  than the code, and without it Code Scanning renders a scan that could not look
+  and one that looked and found nothing identically.
+- Every finding names a competence profile: the set of questions unanswered
+  about it, resolved through `meta.competence_profiles`. In SARIF the list is
+  resolved inline as `properties.nox_unevaluated`, because a profile ID is a nox
+  concept a SARIF consumer cannot look up.
+- `core/callgraph` answers `call_graph` and `entry_point` for Go. A finding can
+  carry `call_path` and `entry_kind`, which distinguishes `concrete` (main or
+  init), `test` and `exported` — an exported function is reachable by somebody,
+  which is not evidence that anybody does.
+- `nox scan --emit-hypotheses <file>` writes the active-testing questions a scan
+  raises: subject, entry point, attacker input, trigger condition, expected
+  oracle, assumptions, and the open questions about that finding. Nothing is
+  tested; running them stays behind `nox attack run --plan ... --authorize`.
+- `nox analysis-capabilities` states its standing limits unconditionally. They
+  used to print only alongside a missing capability, which became a silent
+  regression the moment the last one was implemented: a full matrix with no
+  caveat reads as a full answer.
+- `reach_limitations` on a finding: the machine-readable half of `reach_scope`,
+  which is prose. Parsing English back out is not a contract.
+
+### Fixed
+
+- **Undetermined reachability was recorded as never-evaluated** (#603).
+  `goSymbolReferenced` returns `ok=false` for every undetermined outcome and the
+  analyzer gated its whole metadata block on that value, so "asked and could not
+  tell" arrived looking exactly like "nobody asked" — and the `Undetermined` arm
+  of the switch that maps it was unreachable code. The common path is an
+  advisory with no `ecosystem_specific.imports`; only the Go vulndb populates
+  that field, so every GHSA-sourced Go advisory landed there. No vulnerability
+  was hidden — both states are non-conclusive and neither may suppress a finding
+  — but the two call for different responses and the operator was told the wrong
+  one. The suite had declared `want_state` in every fixture since it was written
+  and nothing asserted it.
+- **A baseline entry absorbed every future finding sharing its fingerprint**
+  (#609). See the behaviour change above.
+- **`attack plan` built hypotheses from waived findings** (#611). See above.
+- Adjudication is scoped to the subject being decided, in the scan and across
+  every path in `core/attack`. The run path already was; replay, regress and the
+  MCP path were not, and were safe only by accident of each building a fresh
+  single-purpose ledger.
+- A plan with nothing to attempt serialises as `[]` rather than `null`.
+- An unnamed entry point no longer renders as "the entry point  is reachable by
+  an attacker" — a hole where a value should be, rather than the assumption it
+  is.
+
+### Changed
+
+- The Phase 4.1 divergence measurement was re-run. "15 of 37 findings diverge,
+  all over-claimed" was measured on 2026-08-30, quoted in four documents, and
+  carried through three PRs that changed IaC output. It is **17 of 53**, and the
+  "all over-claimed" half stopped being true: IaC rules author `LOW` while their
+  static evidence aggregates to `MEDIUM`, so 1 of 17 here and 14 of 19 on the
+  refutation suite run the other way. Pinned by a deliberately brittle test whose
+  failure says to re-measure rather than edit the constant.
+- Two documented claims were corrected in place: `Finding.Exploitability` said
+  `POTENTIAL` meant "static evidence exists and no attack path was constructed"
+  (the first half was never carried by the value), and
+  `ScanOptions.RecordReasoning` said a scan with it off is byte-identical to one
+  with it on (already untrue when written).
+
+### Unchanged
+
+Detection **231 TP / 0 FP / 0 FN** and refutation **37 / 0 / 0** across all
+nine changes. Every one adds output or corrects a state; none removes a finding.
+
 ## [1.34.0] - 2026-09-05
 
 Ten changes, eight of them defects nox found in itself. The theme is one shape:

--- a/docs/benchmarks/2026-09/README.md
+++ b/docs/benchmarks/2026-09/README.md
@@ -99,7 +99,14 @@ it is recorded here so the next person does not rediscover it as a defect.
 
 ## Capability coverage
 
-`nox analysis-capabilities` declares nine and provides seven:
+> **Superseded for this section by v1.35.0.** As measured here,
+> `nox analysis-capabilities` declared nine and provided seven, and nothing about
+> capabilities reached `findings.json` at all. Both are now closed — 1.2 put the
+> matrix in the artifact, and #613 implemented `call_graph` and `entry_point` for
+> Go — so the numbers below are the historical baseline they were taken as, not
+> the current state. The rest of this page still stands.
+
+`nox analysis-capabilities` declared nine and provided seven:
 
 ```
 call_graph             — not provided
@@ -107,9 +114,9 @@ entry_point            — not provided
 ```
 
 Both are prerequisites for the reachability propositions in Phase 7. Neither
-appears in `findings.json`: the scan's `meta` block carries `degradations` and
+appeared in `findings.json`: the scan's `meta` block carried `degradations` and
 `sast_languages`, and nothing about which capabilities were unavailable. A
-consumer reading only the canonical output cannot tell that two of nine
+consumer reading only the canonical output could not tell that two of nine
 questions were never asked — which is Milestone 1.2, stated as a measurement
 rather than as an intention.
 

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -287,16 +287,49 @@ secrets refiners that record why they drop a candidate. #599 extended lexical
 refinement to the IaC path.
 
 **Missing.** Stage accounting. Nobody can currently say how many candidates a
-rule family generated, how many were refuted, and at what cost.
+rule family generated, how many were refuted, and at what cost — which is both
+the milestone and, as it turns out, the prerequisite for choosing a family to
+reclassify at all.
 
-| Milestone | Work | Exit |
-|---|---|---|
-| **6.1** | Reclassify the noisiest regex families as candidate generators | a rule at precision 0.000 is not carried as a detector |
-| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family |
-| **6.3** | Stage accounting: candidates in, refuted, promoted, unknown, latency | precision improves with no refutation-caused recall loss |
+| Milestone | Work | Exit | |
+|---|---|---|---|
+| **6.1** | Reclassify the noisiest regex families as candidate generators | a rule at precision 0.000 is not carried as a detector | blocked, see below |
+| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | blocked with 6.1 |
+| **6.3** | Stage accounting: candidates in, refuted, promoted, unknown, latency | precision improves with no refutation-caused recall loss | actionable |
 
-**Size:** medium. 6.1 has a named first target: `api-abuse` API-ABUSE-001 has
-never scored a true positive on any corpus.
+**6.1's named target is not in this repository, and there is no core substitute
+to reach for.** Both halves of that matter.
+
+`api-abuse` is `nox-plugin-api-abuse`, a separate repo, and
+`docs/design/rule-family-migration.md` already records the boundary: its
+API-ABUSE-001 sits at precision 0.000 and "cannot be fixed from this
+repository". Naming it as the first target of a milestone in this plan was an
+error — the work belongs to that repo, or to the plugin contract that decides
+what a plugin may emit.
+
+Nor can a core family be substituted by picking one. Core scores **231 TP / 0 FP
+/ 0 FN** across the detection corpora and 37/0/0 on refutation; the only two FPs
+in the 2026-09 benchmark are artefacts of pointing `bench --precision` at
+corpora that are deliberately not fire-rate scored, and that page already says
+so. **No core rule is measurably a non-detector on any data nox currently
+has.** Choosing one anyway would be choosing by intuition, which is the thing
+this programme replaced.
+
+So 6.1 is blocked on a measurement rather than on implementation, and the
+measurement is named: per-rule precision on real repositories. `scripts/rule-diff.sh`
+already scans ten pinned repos and reports per-rule counts, but counts are
+density, not precision — nothing there says which of those findings are true.
+Item 3 of the 2026-09 gap list makes the same point about the plugin matrix:
+"it should be re-measured, not re-quoted".
+
+**What is actionable now is 6.3.** Stage accounting — how many candidates a
+family generated, how many were refuted, at what cost — needs no precision
+labels, because it counts what the pipeline did rather than judging it. It is
+also the instrument that would make 6.1 answerable: a family generating a
+thousand candidates and refuting none is visible without anybody labelling a
+single finding.
+
+**Size:** 6.3 medium. 6.1 and 6.2 are unsized until something can measure them.
 
 **Gate:** A on every family reclassified.
 
@@ -500,7 +533,9 @@ reads an adjudicated finding.
 
 Independent of that path, and startable now:
 
-- **6.1** reclassify `api-abuse` — measured, self-contained, immediate precision gain
+- ~~**6.1** reclassify `api-abuse`~~ — **not in this repository.** It is
+  `nox-plugin-api-abuse`, and no core family is measurably noisy on any data nox
+  has. Start at 6.3, which is the instrument that would identify one
 - **7.1** `call_graph` + `entry_point` for a second ecosystem — the largest product value, no dependency on the flip
 - **8.1** emit hypotheses from scan — read-only, additive
 


### PR DESCRIPTION
Both of the things I flagged, in one PR because they are both docs and both about saying what is true rather than what was planned.

## v1.35.0 release notes

Covers the nine merged changes since v1.34.0 (#602, #605, #607, #608, #610, #612, #613, plus issues #603, #609, #611).

**It leads with the behaviour changes**, because two of them can turn a green build red on upgrade — and burying that under an "Added" list would be the same failure the release is about:

- **A baseline entry now accepts one finding**, not every finding sharing its fingerprint. Surplus findings that were suppressed *without anyone having accepted them* will start appearing. `nox baseline update .` accepts the ones you want and prunes the rest.
- **`Exploitability` on every finding** — `POTENTIAL` always, because a finding silent about never having been validated reads as a stronger claim than it is.
- **A waived finding no longer grounds an attack hypothesis**, so `attack run --authorize` will not fire payloads for something explicitly accepted.

I have **not** tagged or published anything — that is yours to decide. This is the notes only.

## Phase 6 re-scoped, and the honest answer is that 6.1 is blocked

**Its named first target is not in this repository.** `api-abuse` is `nox-plugin-api-abuse`, and `docs/design/rule-family-migration.md` already records the boundary — its API-ABUSE-001 sits at precision 0.000 and *"cannot be fixed from this repository"*. Naming it as the first target of a milestone in this plan was an error.

**Nor is there a core family to substitute.** Core scores **231/0/0** on detection and **37/0/0** on refutation. The only two FPs in the 2026-09 benchmark are artefacts of pointing `bench --precision` at corpora deliberately not fire-rate scored — that page already says so. No core rule is measurably a non-detector on any data nox has, and picking one anyway would be picking by intuition, which is what this programme replaced.

So 6.1 is blocked on a **measurement**, not on implementation, and the measurement is named: per-rule precision on real repositories. `rule-diff.sh` gives density across ten pinned repos, but density is not precision — nothing there says which findings are true. The 2026-09 gap list makes the same point about the plugin matrix: *"it should be re-measured, not re-quoted."*

**What is actionable is 6.3.** Stage accounting needs no precision labels, because it counts what the pipeline did rather than judging it — and it is the instrument that would make 6.1 answerable: a family generating a thousand candidates and refuting none is visible without anybody labelling a single finding.

## Also

Marks the capability section of `docs/benchmarks/2026-09/README.md` superseded. It reads *"declares nine and provides seven"* and *"call_graph — not provided"*, both of which stopped being true in this release. The numbers stay as the historical baseline they were taken as; the rest of the page still stands.

Docs only — full suite green, `golangci-lint` 0 issues.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT