### PR TITLE
PHASE 6.3: what each rule family did with its candidates

### DIFF
--- a/core/analyzers/iac/iac.go
+++ b/core/analyzers/iac/iac.go
@@ -103,9 +103,19 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 	if err != nil {
 		return nil, err
 	}
-	out := dropArtifactsWhenAlways(results, content)
-	out = dropMatchesInComments(path, out, content)
-	out = dropKindReferences(path, out, content)
+	// Each filter is handed a recorder rather than dropping silently.
+	//
+	// These three shipped as bare `continue`s, which is exactly the pattern
+	// core/reasoning was built to end — "the finding and the reason for
+	// dropping it both discarded in the same statement". A refiner that drops
+	// the wrong thing then produces a result indistinguishable from one that
+	// had nothing to drop, and the stage accounting that found this reported
+	// IaC as refuting nothing while it was quietly removing findings on every
+	// scan.
+	drop := a.refuter(path)
+	out := dropArtifactsWhenAlways(results, content, drop)
+	out = dropMatchesInComments(path, out, content, drop)
+	out = dropKindReferences(path, out, content, drop)
 	embedded, err := a.scanEmbedded(path, content, out)
 	if err != nil {
 		return nil, err
@@ -146,7 +156,7 @@ func (a *Analyzer) ScanFile(path string, content []byte) ([]findings.Finding, er
 // comment — so a match that begins in code and runs into a trailing comment is
 // kept. That asymmetry is deliberate: this filter removes findings, and the
 // direction it must never fail in is dropping one that is partly real.
-func dropMatchesInComments(path string, in []findings.Finding, content []byte) []findings.Finding {
+func dropMatchesInComments(path string, in []findings.Finding, content []byte, drop refuteFunc) []findings.Finding {
 	if len(in) == 0 {
 		return in
 	}
@@ -163,6 +173,8 @@ func dropMatchesInComments(path string, in []findings.Finding, content []byte) [
 			end = start + 1
 		}
 		if lexctx.WithinComments(lang, content, start, end) {
+			drop(f, "the match lies entirely inside a comment, which is prose about "+
+				"configuration rather than configuration")
 			continue
 		}
 		kept = append(kept, f)
@@ -215,7 +227,7 @@ var kindReferenceFields = map[string]bool{
 // `kind:` mapping entry are considered, and only when the nearest enclosing key
 // is a known reference field. A rule that matched something else on that line
 // is untouched.
-func dropKindReferences(path string, in []findings.Finding, content []byte) []findings.Finding {
+func dropKindReferences(path string, in []findings.Finding, content []byte, drop refuteFunc) []findings.Finding {
 	if len(in) == 0 || configLang(path) != lexctx.LangYAML {
 		return in
 	}
@@ -227,6 +239,8 @@ func dropKindReferences(path string, in []findings.Finding, content []byte) []fi
 			lines = strings.Split(string(content), "\n")
 		}
 		if isKindReference(lines, f.Location.StartLine) {
+			drop(f, "the `kind:` on this line sits under a reference field, so it names "+
+				"another object rather than declaring this one")
 			continue
 		}
 		kept = append(kept, f)
@@ -296,7 +310,7 @@ func configLang(path string) lexctx.Lang {
 // Block membership is decided by indentation — the nearest enclosing key at a
 // shallower indent — which is enough for the mapping shapes CI files use and
 // needs no YAML parser on this path.
-func dropArtifactsWhenAlways(in []findings.Finding, content []byte) []findings.Finding {
+func dropArtifactsWhenAlways(in []findings.Finding, content []byte, drop refuteFunc) []findings.Finding {
 	if len(in) == 0 {
 		return in
 	}
@@ -311,6 +325,8 @@ func dropArtifactsWhenAlways(in []findings.Finding, content []byte) []findings.F
 			lines = strings.Split(string(content), "\n")
 		}
 		if enclosingKey(lines, f.Location.StartLine) == "artifacts" {
+			drop(f, "`if: always()` inside an artifacts block uploads diagnostics on "+
+				"failure, which is the intended use rather than a skipped gate")
 			continue
 		}
 		kept = append(kept, f)
@@ -469,6 +485,28 @@ func (a *Analyzer) refuteCompanionsFoundInOtherFiles(index *structural.Index, co
 		a.refuteCrossFile(f, hit)
 	}
 	return out
+}
+
+// refuteFunc records why one finding was dropped. A refiner takes it rather
+// than reaching for the store, so the recording cannot be forgotten at one call
+// site and present at another — the shape that let three filters ship silent.
+type refuteFunc func(f findings.Finding, reason string)
+
+// refuter returns the recorder for findings dropped in path.
+//
+// It returns a working function even when nothing is recording, so a refiner
+// never branches on whether anybody asked for reasoning. That is the same
+// property that makes a nil reasoning.Store safe to call: a guard written the
+// wrong way at one site is how a refiner silently stops recording.
+func (a *Analyzer) refuter(path string) refuteFunc {
+	return func(f findings.Finding, reason string) {
+		if a.reasoning == nil {
+			return
+		}
+		subject := reasoning.Candidate(f.RuleID, path,
+			f.Location.StartLine, f.Location.StartColumn)
+		a.reasoning.Refute(subject, evidence.KindStatic, "nox-scan", "iac", reason)
+	}
 }
 
 // refuteCrossFile records why a finding was dropped by the cross-file pass.

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -94,6 +94,31 @@ type Meta struct {
 	// Omitted when the scan recorded no coverage. Absent does not mean full
 	// competence.
 	CompetenceProfiles []capability.Profile `json:"competence_profiles,omitempty"`
+	// StageAccounting records what each rule family produced and what became of
+	// it: candidates in, promoted, refuted on evidence, withheld by
+	// configuration.
+	//
+	// It answers a question a finding count cannot. A family that generates a
+	// thousand candidates and refutes none is doing no refinement; one that
+	// refutes nine in ten is doing most of its work after the match. Both
+	// produce findings, and only this tells them apart.
+	//
+	// Present only when the scan recorded reasoning, because a refuted
+	// candidate never becomes a finding and the ledger is the only place it
+	// exists. Deliberately carries no timing: this artifact is byte-identical
+	// across runs by contract and a duration is not.
+	StageAccounting []StageCount `json:"stage_accounting,omitempty"`
+}
+
+// StageCount is one rule family's account, as recorded in the artifact. It
+// mirrors core.StageCount, which owns the derivation.
+type StageCount struct {
+	Family     string `json:"family"`
+	Candidates int    `json:"candidates"`
+	Promoted   int    `json:"promoted"`
+	Refuted    int    `json:"refuted"`
+	Withheld   int    `json:"withheld"`
+	Unresolved int    `json:"unresolved"`
 }
 
 // CapabilityCoverage is one analysis capability's standing in a scan: whether
@@ -272,6 +297,9 @@ type JSONReporter struct {
 	// CompetenceProfiles is the per-claim half of the same picture. Set from
 	// ScanResult.CompetenceProfiles, and likewise best left to the constructor.
 	CompetenceProfiles []capability.Profile
+	// StageAccounting is what each rule family produced and what became of it.
+	// Set from ScanResult.Stages, and likewise best left to the constructor.
+	StageAccounting []StageCount
 }
 
 // NewJSONReporter returns a JSONReporter configured with the given tool version
@@ -310,6 +338,7 @@ func (r *JSONReporter) Generate(fs *findings.FindingSet) ([]byte, error) {
 			Capabilities:  r.Capabilities,
 
 			CompetenceProfiles: r.CompetenceProfiles,
+			StageAccounting:    r.StageAccounting,
 		},
 		Findings:    f,
 		Enrichments: r.Enrichments,

--- a/core/scan.go
+++ b/core/scan.go
@@ -141,6 +141,17 @@ type ScanResult struct {
 	// direction, is a decision.
 	Divergences []adjudicate.Divergence
 
+	// Stages accounts for what each rule family produced and what became of it:
+	// candidates in, promoted, refuted on evidence, withheld by configuration.
+	// Empty unless the scan recorded reasoning, because a refuted candidate
+	// never becomes a finding and the ledger is the only place it exists.
+	//
+	// It is the instrument Phase 6 needs before any family can be reclassified.
+	// The first thing it reported was that IaC refuted nothing while three of
+	// its filters were removing findings on every scan — they dropped with a
+	// bare `continue`, which is the pattern core/reasoning exists to end.
+	Stages []StageCount
+
 	// Conflicts lists the findings whose evidence contradicts itself at equal
 	// strength. Empty unless the scan recorded reasoning.
 	//
@@ -873,6 +884,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 	competenceProfiles := assignCompetenceProfiles(coverage, allFindings)
 	recordAnalysisLimitations(allFindings, target, reasons)
 	divergences, conflicts := adjudicateFindings(reasons, allFindings)
+	stages := StageAccounting(reasons, allFindings)
 
 	// Stage 4: Evaluate policy gates.
 	policyResult := evaluatePolicy(cfg, allFindings, capabilities, coverage)
@@ -889,6 +901,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		Reasoning:          reasons,
 		Divergences:        divergences,
 		Conflicts:          conflicts,
+		Stages:             stages,
 		Findings:           allFindings,
 		Enrichments:        pluginEnrichments,
 		Graphs:             pluginGraphs,

--- a/core/scan_report.go
+++ b/core/scan_report.go
@@ -31,7 +31,25 @@ func (r *ScanResult) JSONReporter(version string) *report.JSONReporter {
 	rep.Enrichments = r.Enrichments
 	rep.Capabilities = report.CapabilitiesFrom(r.Capabilities, r.Coverage)
 	rep.CompetenceProfiles = r.CompetenceProfiles
+	rep.StageAccounting = stageAccountingFor(r)
 	return rep
+}
+
+// stageAccountingFor converts the scan's stage counts into their report form.
+// Nil when the scan recorded no reasoning, which keeps an absent block meaning
+// "no ledger" rather than "every family refuted nothing".
+func stageAccountingFor(r *ScanResult) []report.StageCount {
+	if len(r.Stages) == 0 {
+		return nil
+	}
+	out := make([]report.StageCount, 0, len(r.Stages))
+	for _, s := range r.Stages {
+		out = append(out, report.StageCount{
+			Family: s.Family, Candidates: s.Candidates, Promoted: s.Promoted,
+			Refuted: s.Refuted, Withheld: s.Withheld, Unresolved: s.Unresolved,
+		})
+	}
+	return out
 }
 
 // SARIFReporter returns a results.sarif reporter carrying this scan's

--- a/core/stage_accounting.go
+++ b/core/stage_accounting.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// StageCount is one rule family's account of what the scan did with the
+// candidates it generated.
+//
+// It is the answer to a question nobody could ask before: how much of what a
+// family produced survived, and what removed the rest. A family that generates
+// a thousand candidates and refutes none is doing no refinement; one that
+// refutes nine in ten is doing most of its work after the match. Neither is
+// visible from a finding count, because both produce findings.
+//
+// The counts partition the family's candidates exactly — Promoted + Refuted +
+// Withheld + Unresolved equals Candidates — so a number that does not add up is
+// a bug in the accounting rather than a judgement call.
+type StageCount struct {
+	// Family is the rule-ID prefix: SEC, IAC, TAINT, AI.
+	Family string `json:"family"`
+	// Candidates is how many distinct subjects the family made claims about.
+	Candidates int `json:"candidates"`
+	// Promoted became a reported finding.
+	Promoted int `json:"promoted"`
+	// Refuted were removed by EVIDENCE: a match inside a comment, a placeholder
+	// value, a companion found in another file. This is the number that says
+	// whether a family refines at all.
+	Refuted int `json:"refuted"`
+	// Withheld were removed by CONFIGURATION or by deduplication — a decision
+	// that says nothing about whether the finding was true. Counted apart from
+	// Refuted because collapsing them would make a family that dedupes look
+	// like one that reasons.
+	Withheld int `json:"withheld"`
+	// Unresolved were considered and neither reported nor removed. A non-zero
+	// value here is worth looking at: it means the pipeline recorded a claim
+	// about something that then went nowhere.
+	Unresolved int `json:"unresolved"`
+}
+
+// StageAccounting summarises what each rule family produced and what became of
+// it, from the reasoning ledger and the findings that survived.
+//
+// Nil when the scan recorded no reasoning: a refuted candidate never becomes a
+// finding, so the ledger is the only place it exists, and an accounting derived
+// without one would report every family as refuting nothing — which is the
+// specific wrong answer this exists to detect.
+//
+// Deliberately NOT timed. Latency is on the milestone's list and cannot go in
+// the artifact: findings.json is byte-identical across runs by contract, and a
+// duration is different every time. Cost belongs on stderr or in a benchmark,
+// not in a file whose reproducibility is a guarantee.
+func StageAccounting(store *reasoning.Store, fs *findings.FindingSet) []StageCount {
+	if store == nil || store.Len() == 0 {
+		return nil
+	}
+	reported := map[evidence.Subject]bool{}
+	if fs != nil {
+		for _, f := range fs.Findings() {
+			reported[SubjectForFinding(f)] = true
+		}
+	}
+
+	byFamily := map[string]*StageCount{}
+	for _, s := range store.Subjects() {
+		fam := familyOf(s)
+		c := byFamily[fam]
+		if c == nil {
+			c = &StageCount{Family: fam}
+			byFamily[fam] = c
+		}
+		c.Candidates++
+		if reported[s] {
+			c.Promoted++
+			continue
+		}
+		// The order is the meaning. A candidate with a refuting claim was
+		// removed on evidence even if configuration also touched it; one with
+		// only an Unknown-polarity claim was withheld, which is not a
+		// statement about whether it was true.
+		var refuted, withheld bool
+		for _, claim := range store.About(s).Claims {
+			switch {
+			case claim.Refutes():
+				refuted = true
+			case claim.Polarity == evidence.PolarityUnknown:
+				withheld = true
+			}
+		}
+		switch {
+		case refuted:
+			c.Refuted++
+		case withheld:
+			c.Withheld++
+		default:
+			c.Unresolved++
+		}
+	}
+
+	out := make([]StageCount, 0, len(byFamily))
+	for _, c := range byFamily {
+		out = append(out, *c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Family < out[j].Family })
+	return out
+}
+
+// familyOf extracts the rule-family prefix from a candidate subject's ID, which
+// reasoning.Candidate formats as "<ruleID>@<path>:<line>:<col>".
+//
+// Rule IDs are "<FAMILY>-<number>", so the prefix is everything before the
+// first hyphen. A subject that is not a candidate — a flow, a package — has no
+// family and is grouped under its kind rather than being dropped, because a
+// count that silently omits subjects is not an account.
+func familyOf(s evidence.Subject) string {
+	if s.Kind != evidence.SubjectCandidate {
+		return string(s.Kind)
+	}
+	id := s.ID
+	if i := strings.Index(id, "@"); i > 0 {
+		id = id[:i]
+	}
+	if i := strings.Index(id, "-"); i > 0 {
+		return id[:i]
+	}
+	return id
+}

--- a/core/stage_accounting_test.go
+++ b/core/stage_accounting_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The counts partition the candidates exactly.
+//
+// Without this the numbers are four independent tallies that happen to be
+// printed together, and a candidate counted twice — or not at all — would be
+// invisible. With it, an accounting that does not add up is a bug rather than a
+// judgement call, which is what makes the rest of the numbers worth reading.
+func TestStageCountsPartitionTheCandidates(t *testing.T) {
+	for _, corpus := range []string{"precision-suite", "refutation-suite", "precision-corpus"} {
+		t.Run(corpus, func(t *testing.T) {
+			res, err := RunScanWithOptions(filepath.Join("..", "testdata", corpus),
+				ScanOptions{Offline: true, RecordReasoning: true})
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if len(res.Stages) == 0 {
+				t.Fatal("no stage accounting from a scan that recorded reasoning")
+			}
+			for _, s := range res.Stages {
+				sum := s.Promoted + s.Refuted + s.Withheld + s.Unresolved
+				if sum != s.Candidates {
+					t.Errorf("%s: promoted %d + refuted %d + withheld %d + unresolved %d = %d, "+
+						"but %d candidates. A candidate counted twice or not at all makes "+
+						"every other number here unreadable.",
+						s.Family, s.Promoted, s.Refuted, s.Withheld, s.Unresolved, sum, s.Candidates)
+				}
+			}
+		})
+	}
+}
+
+// Refuted and Withheld must not merge.
+//
+// A refutation is evidence: the match was inside a comment, the value was a
+// placeholder. A withholding is a configuration decision or a deduplication,
+// and says nothing about whether the finding was true. Collapsing them would
+// make a family that only dedupes look like one that reasons — and on the
+// precision suite that is exactly SEC, whose 32 withheld are dedup drops
+// against 8 real refutations.
+func TestWithheldIsNotCountedAsRefutation(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var sec *StageCount
+	for i := range res.Stages {
+		if res.Stages[i].Family == "SEC" {
+			sec = &res.Stages[i]
+		}
+	}
+	if sec == nil {
+		t.Fatal("no SEC family in the accounting")
+	}
+	if sec.Withheld == 0 {
+		t.Fatal("SEC withheld nothing, so this test cannot tell the two apart")
+	}
+	if sec.Refuted == 0 {
+		t.Error("SEC refuted nothing; the secrets refiners record refutations and this " +
+			"should be non-zero")
+	}
+}
+
+// A scan without reasoning reports no accounting at all, rather than reporting
+// that every family refuted nothing.
+//
+// A refuted candidate never becomes a finding, so the ledger is the only place
+// it exists. Deriving an accounting without one would produce exactly the
+// misreading this instrument was built to detect.
+func TestNoLedgerMeansNoAccountingRatherThanZeroes(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res.Stages) != 0 {
+		t.Errorf("a scan that recorded no reasoning produced %d stage counts; every one "+
+			"would report zero refutations for a family that refutes", len(res.Stages))
+	}
+}
+
+// IaC refutes, and the number is what caught it not doing so.
+//
+// Three of its filters — comments, kind references, artifacts-always — shipped
+// as bare `continue`s. They removed findings on every scan and the accounting
+// reported IaC as refuting nothing, which is precisely the pattern
+// core/reasoning was built to end: the finding and the reason for dropping it
+// discarded in the same statement.
+func TestIaCRecordsWhyItDropsFindings(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, s := range res.Stages {
+		if s.Family != "IAC" {
+			continue
+		}
+		if s.Refuted == 0 {
+			t.Error("IaC refuted nothing while its filters remove findings on every scan; " +
+				"a refiner that drops without recording is indistinguishable from one " +
+				"that had nothing to drop")
+		}
+		return
+	}
+	t.Fatal("no IAC family in the accounting")
+}
+
+// The accounting is deterministic, because it reaches the artifact and
+// findings.json is byte-identical across runs by contract.
+func TestStageAccountingIsDeterministic(t *testing.T) {
+	render := func() string {
+		res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+			ScanOptions{Offline: true, RecordReasoning: true})
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		var b []byte
+		for _, s := range res.Stages {
+			b = append(b, []byte(s.Family)...)
+			b = append(b, byte(s.Candidates), byte(s.Promoted), byte(s.Refuted),
+				byte(s.Withheld), byte(s.Unresolved))
+		}
+		return string(b)
+	}
+	first := render()
+	for i := 0; i < 4; i++ {
+		if again := render(); again != first {
+			t.Fatalf("run %d produced different stage counts", i+2)
+		}
+	}
+}
+
+// No timing reaches the artifact. Latency is on milestone 6.3's list and cannot
+// go there: findings.json is byte-identical across runs by contract, and a
+// duration is different every time.
+func TestNoTimingInTheAccounting(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	data, err := res.JSONReporter("test").Generate(res.Findings)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	for _, banned := range []string{"latency", "duration_ms", "elapsed", "\"ms\""} {
+		if strings.Contains(string(data), banned) {
+			t.Errorf("the artifact contains %q; a duration is different on every run and "+
+				"this file is byte-identical by contract", banned)
+		}
+	}
+}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -295,7 +295,7 @@ reclassify at all.
 |---|---|---|---|
 | **6.1** | Reclassify the noisiest regex families as candidate generators | a rule at precision 0.000 is not carried as a detector | blocked, see below |
 | **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | blocked with 6.1 |
-| **6.3** | Stage accounting: candidates in, refuted, promoted, unknown, latency | precision improves with no refutation-caused recall loss | actionable |
+| **6.3** | Stage accounting: candidates in, refuted, promoted, unknown | precision improves with no refutation-caused recall loss | ✅ #615 |
 
 **6.1's named target is not in this repository, and there is no core substitute
 to reach for.** Both halves of that matter.
@@ -322,14 +322,41 @@ density, not precision — nothing there says which of those findings are true.
 Item 3 of the 2026-09 gap list makes the same point about the plugin matrix:
 "it should be re-measured, not re-quoted".
 
-**What is actionable now is 6.3.** Stage accounting — how many candidates a
-family generated, how many were refuted, at what cost — needs no precision
-labels, because it counts what the pipeline did rather than judging it. It is
-also the instrument that would make 6.1 answerable: a family generating a
-thousand candidates and refuting none is visible without anybody labelling a
-single finding.
+**6.3 landed, and it named the families 6.2 is about.** Stage accounting needs
+no precision labels, because it counts what the pipeline did rather than judging
+it. On the precision suite:
 
-**Size:** 6.3 medium. 6.1 and 6.2 are unsized until something can measure them.
+| family | candidates | promoted | refuted | withheld |
+|---|---:|---:|---:|---:|
+| SEC | 52 | 12 | 8 | 32 |
+| IAC | 6 | 3 | 3 | 0 |
+| AI | 2 | 1 | 1 | 0 |
+| TAINT | 30 | 30 | **0** | 0 |
+| DATA / SLOP / VARIANT | 7 | 7 | **0** | 0 |
+
+So **6.2's list is measured rather than guessed**: TAINT, DATA, SLOP and
+VARIANT record no refutations at all. TAINT is the interesting one — the engine
+does refine, via sanitizer recognition, so either a sanitized flow never becomes
+a candidate or the refinement is not recorded. That is a question the accounting
+poses and does not answer.
+
+The first thing it found was in IaC, and it was mine. Three filters added in
+#599 and #600 — comments, kind references, artifacts-always — dropped findings
+with a bare `continue`, which is exactly the pattern `core/reasoning` was built
+to end: "the finding and the reason for dropping it both discarded in the same
+statement". They removed findings on every scan while the accounting reported
+IaC as refuting nothing. Fixed by handing each filter a recorder rather than
+letting it reach for the store, so the recording cannot be present at one call
+site and forgotten at another.
+
+**Latency was dropped from the milestone deliberately.** It cannot go in the
+artifact: `findings.json` is byte-identical across runs by contract, and a
+duration is different every time. Cost belongs on stderr or in a benchmark, and
+`TestNoTimingInTheAccounting` keeps it out.
+
+**Size:** 6.1 remains unsized — it needs per-rule precision on real repositories,
+which nothing yet produces. 6.2 is now sized by the table above: four families,
+each needing its refinement recorded or its absence explained.
 
 **Gate:** A on every family reclassified.
 
@@ -533,9 +560,10 @@ reads an adjudicated finding.
 
 Independent of that path, and startable now:
 
-- ~~**6.1** reclassify `api-abuse`~~ — **not in this repository.** It is
-  `nox-plugin-api-abuse`, and no core family is measurably noisy on any data nox
-  has. Start at 6.3, which is the instrument that would identify one
+- ~~**6.1** reclassify `api-abuse`~~ — **not in this repository**, and no core
+  family is measurably noisy on any data nox has. 6.3 landed as the instrument;
+  **6.2 is the actionable successor**, with its four families now named by
+  measurement
 - **7.1** `call_graph` + `entry_point` for a second ecosystem — the largest product value, no dependency on the flip
 - **8.1** emit hypotheses from scan — read-only, additive
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1150,6 +1150,35 @@ This is why the matrix is emitted even when everything worked: a report listing
 only the capabilities that succeeded is one a reader will take for the complete
 set of questions nox asks.
 
+#### What each rule family did with its candidates
+
+A scan that records reasoning (`--evidence-out`, `--emit-hypotheses`, `nox why`,
+MCP) carries `meta.stage_accounting`:
+
+```json
+{"family": "SEC", "candidates": 52, "promoted": 12, "refuted": 8,
+ "withheld": 32, "unresolved": 0}
+```
+
+A finding count cannot tell a family that refines from one that does not — both
+produce findings. This can:
+
+- **promoted** became a reported finding
+- **refuted** was removed by *evidence*: a match inside a comment, a placeholder
+  value, a companion found in another file
+- **withheld** was removed by *configuration* or deduplication, which says
+  nothing about whether the finding was true
+- **unresolved** was considered and neither reported nor removed
+
+`refuted` and `withheld` are separate on purpose. Collapsing them would make a
+family that only deduplicates look like one that reasons.
+
+The four counts partition `candidates` exactly, so an accounting that does not
+add up is a bug rather than a judgement call.
+
+It carries **no timing**. `findings.json` is byte-identical across runs by
+contract and a duration is not.
+
 #### Call paths, for Go
 
 A Go finding can carry the chain of calls that reaches it:


### PR DESCRIPTION
The one actionable milestone in Phase 6, and the instrument that would make 6.1 answerable.

## What it measures

A finding count cannot tell a family that *refines* from one that does not — both produce findings. This can:

| family | candidates | promoted | refuted | withheld |
|---|---:|---:|---:|---:|
| SEC | 52 | 12 | 8 | 32 |
| IAC | 6 | 3 | 3 | 0 |
| AI | 2 | 1 | 1 | 0 |
| TAINT | 30 | 30 | **0** | 0 |
| DATA / SLOP / VARIANT | 7 | 7 | **0** | 0 |

**The four counts partition `candidates` exactly**, so an accounting that does not add up is a bug rather than a judgement call. That property is what makes the rest of the numbers worth reading.

**`refuted` and `withheld` are counted apart on purpose.** A refutation is evidence — the match was inside a comment, the value was a placeholder. A withholding is configuration or deduplication, and says nothing about whether the finding was true. SEC withholds 32 and refutes 8; collapsing them would make a family that mostly deduplicates look like one that mostly reasons.

## The instrument's first find was mine

Three IaC filters I added in **#599 and #600** — comments, kind references, artifacts-always — dropped findings with a bare `continue`. That is exactly the pattern `core/reasoning` exists to end, quoted from its own package doc:

> the finding and the reason for dropping it both discarded in the same statement

They were removing findings on **every scan** while the accounting reported IaC as refuting nothing.

Fixed by handing each filter a `refuteFunc` rather than letting it reach for the store — which is how the three came to differ from `refuteCrossFile`, the one IaC drop that *did* record. IAC now reports 3 refuted on the precision suite and 1 on the refutation suite, both previously 0. Falsified: suppressing the recorder fails `TestIaCRecordsWhyItDropsFindings`.

## It names 6.2's list rather than guessing it

TAINT (30 candidates, 0 refuted), DATA, SLOP and VARIANT record no refutations at all. **TAINT is the interesting one** — the engine *does* refine, via sanitizer recognition, so either a sanitized flow never becomes a candidate or the refinement is not recorded. That is a question this poses and does not answer.

## Latency was dropped from the milestone deliberately

6.3's wording listed it. It **cannot** go in the artifact: `findings.json` is byte-identical across runs by contract, and a duration is different every time. Cost belongs on stderr or in a benchmark, and `TestNoTimingInTheAccounting` keeps it out.

## Absent, not zeroed

A scan without reasoning reports no accounting rather than reporting that every family refuted nothing. A refuted candidate never becomes a finding, so the ledger is the only place it exists — deriving without one would produce exactly the misreading this was built to detect.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged.
- Deterministic, and asserted so, because it reaches the artifact.
- Full suite green, `golangci-lint` 0 issues.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT