### PR TITLE
PHASE 6.2: the taint engine records the flows it clears

### DIFF
--- a/core/analyzers/taintflow/taintflow.go
+++ b/core/analyzers/taintflow/taintflow.go
@@ -21,9 +21,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
 	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
 	"github.com/nox-hq/nox/core/taint"
 	"github.com/nox-hq/nox/core/taint/engine"
@@ -33,7 +35,23 @@ import (
 type Analyzer struct {
 	cat *taint.Catalog
 	eng *engine.StructuralEngine
+	// reasoning receives the refutations. Nil until asked for, and every
+	// recording call is nil-safe, so the scan path below never branches on
+	// whether anybody wanted them.
+	reasoning *reasoning.Store
 }
+
+// RecordReasoningTo directs this analyzer's refutations at store.
+//
+// The taint engine performs the most sophisticated refinement in nox —
+// class-precise sanitizer clearing, argument-shape analysis — and recorded none
+// of it. The stage accounting reported TAINT as refuting nothing on every
+// corpus, which was true of the ledger and false of the engine.
+//
+// That gap has cost real defects: an argv exemption that silenced shell sinks
+// in five of six cases, a same-statement sanitizer invisible in every language
+// but Go. In each, the evidence needed to notice was computed and thrown away.
+func (a *Analyzer) RecordReasoningTo(store *reasoning.Store) { a.reasoning = store }
 
 // NewAnalyzer returns a taintflow analyzer backed by the embedded catalog.
 func NewAnalyzer() *Analyzer {
@@ -153,9 +171,24 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, lang lexctx.La
 	// interprocedural flow via function summaries), in addition to the
 	// intraprocedural flows Analyze finds. It de-duplicates a source→sink pair
 	// reachable both ways, so a purely intraprocedural bug is still reported once.
-	flows := a.eng.AnalyzeFile(units)
+	flows, suppressed := a.eng.AnalyzeFileWithSuppressions(units)
 	for j := range flows {
 		fs.Add(a.toFinding(&flows[j]))
+	}
+	a.recordSuppressions(path, suppressed)
+}
+
+// recordSuppressions files what the engine refused to report.
+//
+// The subject is the candidate the flow WOULD have been reported as, so a
+// refutation and the finding it prevented land in the same ledger — which is
+// what lets the stage accounting count them against the same family, and what
+// would let a reader ask why a sink they expected to see is absent.
+func (a *Analyzer) recordSuppressions(path string, ss []taint.Suppression) {
+	for i := range ss {
+		s := &ss[i]
+		subject := reasoning.Candidate(s.RuleID, path, s.SinkLine, 1)
+		a.reasoning.Refute(subject, evidence.KindStatic, "nox-scan", "taint", s.Reason)
 	}
 }
 

--- a/core/scan.go
+++ b/core/scan.go
@@ -533,6 +533,7 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 			"no VARIANT-* detection ran; known CVE variants in this codebase would not be reported")
 	}
 	taintflowAnalyzer := taintflow.NewAnalyzer()
+	taintflowAnalyzer.RecordReasoningTo(reasons)
 	agentflowAnalyzer := agentflow.NewAnalyzer()
 	provenanceAnalyzer := provenance.NewAnalyzer()
 

--- a/core/stage_accounting_test.go
+++ b/core/stage_accounting_test.go
@@ -158,3 +158,33 @@ func TestNoTimingInTheAccounting(t *testing.T) {
 		}
 	}
 }
+
+// TAINT refutes, and the number is what caught it not doing so.
+//
+// The engine performs the most sophisticated refinement in nox — class-precise
+// sanitizer clearing, argument-shape analysis — and recorded none of it. The
+// accounting reported TAINT as 30 candidates and 0 refuted, which was true of
+// the ledger and false of the engine.
+//
+// The gap has cost real defects: an argv exemption that silenced shell sinks in
+// five of six cases, a same-statement sanitizer invisible in every language but
+// Go. In each, the evidence needed to notice was computed and discarded.
+func TestTaintRecordsItsSanitizerDecisions(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, s := range res.Stages {
+		if s.Family != "TAINT" {
+			continue
+		}
+		if s.Refuted == 0 {
+			t.Error("TAINT refuted nothing while the engine clears sanitized flows on " +
+				"every scan; a recognizer that clears the wrong thing then looks " +
+				"exactly like one that had nothing to clear")
+		}
+		return
+	}
+	t.Fatal("no TAINT family in the accounting")
+}

--- a/core/taint/engine.go
+++ b/core/taint/engine.go
@@ -153,6 +153,50 @@ type Flow struct {
 	SinkRole string
 }
 
+// Suppression is a flow the engine REFUSED to report, and why.
+//
+// A tainted value reached a catalog sink and something cleared it: a sanitizer
+// in a prior assignment, one wrapping the value at the call, or an argument
+// shape that makes the call safe (a parameterized query, an exec with no
+// shell). Each is a refutation, each is correct, and each used to be a bare
+// `continue` — the flow and the reason for dropping it discarded in the same
+// statement.
+//
+// That is survivable while refinement is a handful of hand-checked cases and
+// stops being survivable once it is the architecture, because a sanitizer
+// recognizer that clears the WRONG thing produces a result indistinguishable
+// from one that had nothing to clear. Both show no finding. nox has shipped
+// that defect more than once — an argv exemption that silenced shell sinks in
+// five of six cases, a same-statement sanitizer invisible in every language but
+// Go — and in each the evidence needed to notice was computed and thrown away.
+//
+// Reported, never acted on: a Suppression is a record of a decision the engine
+// already made, not an input to it.
+type Suppression struct {
+	// Sink is the catalog sink the value reached, and RuleID the rule it would
+	// have been reported under. The rule ID is what makes a suppression
+	// attributable to a family in the stage accounting.
+	Sink   string
+	RuleID string
+	// SinkCall is the call as written.
+	SinkCall string
+	// SinkLine and FilePath locate it.
+	SinkLine int
+	FilePath string
+	// FuncName is the enclosing function, when known.
+	FuncName string
+	// Language is the source language.
+	Language string
+	// SourceVar is the tainted variable, empty for an inline source expression.
+	SourceVar string
+	// Class is the vulnerability class that was cleared. A sanitizer clears one
+	// class and not others — shell-quoting makes a value safe to re-parse as
+	// shell and leaves it an attacker's URL — so the class is part of the claim.
+	Class string
+	// Reason states what cleared it, in words.
+	Reason string
+}
+
 // TaintEngine analyzes one intraprocedural Unit and returns the taint flows that
 // reach an un-sanitized sink. Implementations must be deterministic: the same
 // Unit must always yield the same Flows in the same order.

--- a/core/taint/engine/interproc.go
+++ b/core/taint/engine/interproc.go
@@ -104,19 +104,28 @@ const maxFixpointIterations = 64
 // summaries converge to a fixpoint independent of iteration count, and flows are
 // sorted by the shared sortFlows ordering before return.
 func (e *StructuralEngine) AnalyzeFile(units []taint.Unit) []taint.Flow {
+	flows, _ := e.AnalyzeFileWithSuppressions(units)
+	return flows
+}
+
+// AnalyzeFileWithSuppressions is AnalyzeFile plus the flows it refused to
+// report. See taint.Suppression.
+func (e *StructuralEngine) AnalyzeFileWithSuppressions(units []taint.Unit) ([]taint.Flow, []taint.Suppression) {
 	if len(units) == 0 {
-		return nil
+		return nil, nil
 	}
 	lang := units[0].Language
 
 	summaries := e.computeSummaries(lang, units)
 
 	var flows []taint.Flow
+	var suppressed []taint.Suppression
 	seen := map[flowKey]struct{}{}
 	for i := range units {
-		unitFlows := e.analyzeUnitInterproc(lang, &units[i], summaries)
-		for j := range unitFlows {
-			f := &unitFlows[j]
+		res := e.forwardPass(lang, &units[i], nil, summaries)
+		suppressed = append(suppressed, res.suppressed...)
+		for j := range res.flows {
+			f := &res.flows[j]
 			k := flowKey{f.SinkLine, f.SinkCall, f.SourceLine, f.SourceVar, f.Sink.RuleID}
 			if _, dup := seen[k]; dup {
 				continue
@@ -126,7 +135,8 @@ func (e *StructuralEngine) AnalyzeFile(units []taint.Unit) []taint.Flow {
 		}
 	}
 	sortFlows(flows)
-	return flows
+	sortSuppressions(suppressed)
+	return flows, suppressed
 }
 
 // flowKey de-duplicates flows that the intraprocedural and interprocedural

--- a/core/taint/engine/structural.go
+++ b/core/taint/engine/structural.go
@@ -165,9 +165,13 @@ type taintInfo struct {
 // passResult is the output of a forward pass: the flows found, the final taint
 // state (for summary observation), and the variables returned by the unit.
 type passResult struct {
-	flows    []taint.Flow
-	state    map[string]taintInfo
-	returned []string
+	flows []taint.Flow
+	// suppressed are the flows the pass refused to report, with the reason.
+	// They are the refutations this engine performs and used to discard — see
+	// taint.Suppression.
+	suppressed []taint.Suppression
+	state      map[string]taintInfo
+	returned   []string
 }
 
 // Analyze implements taint.TaintEngine: intraprocedural, straight-line dataflow
@@ -179,18 +183,50 @@ type passResult struct {
 //
 //nolint:gocritic // Analyze(unit taint.Unit) is the TaintEngine interface signature; the value parameter cannot be a pointer.
 func (e *StructuralEngine) Analyze(unit taint.Unit) []taint.Flow {
-	res := e.forwardPass(unit.Language, &unit, nil, nil)
-	sortFlows(res.flows)
-	return res.flows
+	flows, _ := e.AnalyzeWithSuppressions(unit)
+	return flows
 }
 
-// analyzeUnitInterproc runs the forward pass over one unit WITH interprocedural
-// summary resolution enabled, so calls to locally-defined functions apply their
-// summaries (sink-in-helper, return-taint). Flows are returned unsorted; the
-// caller dedups and sorts.
-func (e *StructuralEngine) analyzeUnitInterproc(lang string, unit *taint.Unit, summaries map[string]*funcSummary) []taint.Flow {
-	res := e.forwardPass(lang, unit, nil, summaries)
-	return res.flows
+// AnalyzeWithSuppressions is Analyze plus the flows it refused to report.
+//
+// A separate method rather than a wider Analyze, because Analyze is the
+// TaintEngine interface and every implementation would have to grow a return
+// value most of them have nothing to put in. A caller that wants the
+// refutations asks for them.
+//
+// The suppressions are what the engine established and used to discard. See
+// taint.Suppression for why that matters more here than anywhere else in nox:
+// a sanitizer recognizer that clears the wrong thing produces a result
+// identical to one that had nothing to clear.
+//
+//nolint:gocritic // mirrors the Analyze signature, which the interface fixes.
+func (e *StructuralEngine) AnalyzeWithSuppressions(unit taint.Unit) ([]taint.Flow, []taint.Suppression) {
+	res := e.forwardPass(unit.Language, &unit, nil, nil)
+	sortFlows(res.flows)
+	sortSuppressions(res.suppressed)
+	return res.flows, res.suppressed
+}
+
+// sortSuppressions orders them deterministically. They reach the artifact
+// through the stage accounting, and findings.json is byte-identical across runs
+// by contract.
+func sortSuppressions(ss []taint.Suppression) {
+	sort.Slice(ss, func(i, j int) bool {
+		a, b := ss[i], ss[j]
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		if a.SinkLine != b.SinkLine {
+			return a.SinkLine < b.SinkLine
+		}
+		if a.SinkCall != b.SinkCall {
+			return a.SinkCall < b.SinkCall
+		}
+		if a.Class != b.Class {
+			return a.Class < b.Class
+		}
+		return a.SourceVar < b.SourceVar
+	})
 }
 
 // stmtFlowKey identifies a flow within ONE statement: the rule it violates and
@@ -227,6 +263,7 @@ func (e *StructuralEngine) forwardPass(
 		tainted[k] = cloneTaintInfo(v)
 	}
 	var flows []taint.Flow
+	var suppressed []taint.Suppression
 	var returned []string
 
 	for i := range unit.Stmts {
@@ -273,7 +310,24 @@ func (e *StructuralEngine) forwardPass(
 			// Unknown shape (no SinkArgInfo at all) is dangerous — we never suppress
 			// on missing evidence.
 			if hasInfo && !e.sinkArgShapeDangerous(&sink, info) {
-				continue // argument shape makes this call safe (parameterized, no shell)
+				// Argument shape makes this call safe: a parameterized query, an
+				// exec form that spawns no shell.
+				//
+				// Deliberately NOT recorded as a refutation, and the distinction
+				// is worth the paragraph. The two sites below observe a
+				// SANITIZER acting on the VALUE — a neutralising operation ran,
+				// which is positive evidence about the value wherever it goes
+				// next. This one observes only that THIS CALL is not the
+				// dangerous form. The value is untouched and just as tainted.
+				//
+				// Filing it as a refutation conflates "this call is safe" with
+				// "this value is safe", and refutation-hard's h2_dynamic_dispatch
+				// is what that costs: an argv `exec.Command("echo", s)` at one
+				// line, an `sh -c` at another, and the choice made by data the
+				// engine cannot follow. Refuting the first reads as resolving
+				// the file. TestNoUnearnedNegativeOnTheHardCorpus caught exactly
+				// that, which is what it is for.
+				continue
 			}
 
 			argVars := info.TaintedArgVars
@@ -293,10 +347,18 @@ func (e *StructuralEngine) forwardPass(
 					continue
 				}
 				if ti.cleared[sink.VulnClass] || ti.src.Excludes(sink.VulnClass) {
-					continue // sanitized for this exact class (prior assignment / inline wrap), or a class the source's value cannot reach
+					// Sanitized for this exact class by a prior assignment, or a
+					// class this source's value cannot reach at all.
+					suppressed = append(suppressed, suppression(lang, unit, st, &sink, rawCall, sourceVar,
+						"a sanitizer cleared this value for "+string(sink.VulnClass)+
+							", or the source cannot reach that class"))
+					continue
 				}
 				if inlineCleared[v][sink.VulnClass] {
-					continue // sanitized inline at the sink call
+					suppressed = append(suppressed, suppression(lang, unit, st, &sink, rawCall, sourceVar,
+						"a sanitizer wrapping the value at the call cleared it for "+
+							string(sink.VulnClass)))
+					continue
 				}
 				// Role-aware gating for LLM prompt sinks: reaching an LLM is necessary
 				// but not sufficient. Determine the chat role the tainted value lands
@@ -435,7 +497,7 @@ func (e *StructuralEngine) forwardPass(
 		tainted[st.Assigns] = taintInfo{src: carried.src, srcLine: carried.srcLine, cleared: cleared, via: carried.via}
 	}
 
-	return passResult{flows: flows, state: tainted, returned: returned}
+	return passResult{flows: flows, suppressed: suppressed, state: tainted, returned: returned}
 }
 
 // interprocSinkFlows returns cross-function flows for a statement's calls to
@@ -1312,4 +1374,26 @@ func sortFlows(flows []taint.Flow) {
 		}
 		return a.SinkCall < b.SinkCall
 	})
+}
+
+// suppression builds the record of a flow the engine refused to report.
+//
+// One constructor rather than a literal at each drop site, so every suppression
+// carries the same fields. A record missing its location or class is one nobody
+// can check, and the sites that build these are the sites least likely to be
+// looked at again.
+func suppression(lang string, unit *taint.Unit, st *taint.Statement, sink *taint.Sink,
+	rawCall, sourceVar, reason string) taint.Suppression {
+	return taint.Suppression{
+		Sink:      sink.Call,
+		RuleID:    sink.RuleID,
+		SinkCall:  rawCall,
+		SinkLine:  st.Line,
+		FilePath:  unit.FilePath,
+		FuncName:  unit.FuncName,
+		Language:  lang,
+		SourceVar: sourceVar,
+		Class:     string(sink.VulnClass),
+		Reason:    reason,
+	}
 }

--- a/core/taint/engine/suppression_test.go
+++ b/core/taint/engine/suppression_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/lexctx"
+	"github.com/nox-hq/nox/core/taint"
+)
+
+func analyzeSuppressions(t *testing.T, path, src string) ([]taint.Flow, []taint.Suppression) {
+	t.Helper()
+	cat := taint.MustDefault()
+	e := NewStructuralEngine(cat)
+	units := ExtractUnits(path, lexctx.LangFromPath(path), []byte(src))
+	return e.AnalyzeFileWithSuppressions(units)
+}
+
+// A sanitizer that clears a value is recorded as a refutation.
+//
+// The engine performs the most sophisticated refinement in nox and recorded
+// none of it: the stage accounting reported TAINT as refuting nothing on every
+// corpus, which was true of the ledger and false of the engine. A sanitizer
+// recognizer that clears the WRONG thing produces a result indistinguishable
+// from one that had nothing to clear — both show no finding — and nox has
+// shipped that defect more than once.
+func TestASanitizedFlowIsRecordedAsRefuted(t *testing.T) {
+	src := `import subprocess, shlex
+from flask import request
+
+def run():
+    cmd = shlex.quote(request.args.get("c"))
+    subprocess.call(cmd, shell=True)
+`
+	flows, suppressed := analyzeSuppressions(t, "app.py", src)
+	if len(flows) != 0 {
+		t.Fatalf("a shlex.quote-ed value reached a shell sink as a finding: %+v", flows)
+	}
+	if len(suppressed) == 0 {
+		t.Fatal("the sanitizer cleared the flow and recorded nothing; the decision is " +
+			"invisible, which is the state this exists to end")
+	}
+	s := suppressed[0]
+	if s.Reason == "" {
+		t.Error("a suppression with no reason is a bare continue with extra steps")
+	}
+	if s.Class == "" {
+		t.Error("no class: a sanitizer clears one class and not others, so which one is " +
+			"part of the claim")
+	}
+	if s.RuleID == "" {
+		t.Error("no rule ID, so the suppression cannot be attributed to a family")
+	}
+}
+
+// The distinction that the refutation-hard corpus taught, pinned.
+//
+// An argument SHAPE that is not dangerous — an argv exec, a parameterized query
+// — says this CALL is safe. It says nothing about the VALUE, which is untouched
+// and just as tainted. A sanitizer says the opposite: an operation ran on the
+// value, and that travels with it.
+//
+// Recording the first as a refutation conflates them, and
+// h2_dynamic_dispatch.go is what it costs: an argv `exec.Command("echo", s)` on
+// one line, an `sh -c` on another, and the choice made by data the engine
+// cannot follow. Refuting the first reads as resolving the file.
+func TestAnUndangerousCallShapeIsNotARefutation(t *testing.T) {
+	src := `package main
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func handle(r *http.Request) error {
+	cmd := r.URL.Query().Get("cmd")
+	return exec.Command("echo", cmd).Run()
+}
+`
+	flows, suppressed := analyzeSuppressions(t, "main.go", src)
+	if len(flows) != 0 {
+		t.Fatalf("an argv exec was reported as a shell injection: %+v", flows)
+	}
+	for _, s := range suppressed {
+		if strings.Contains(s.Reason, "shape") || strings.Contains(s.Reason, "spawns no shell") {
+			t.Errorf("the argument shape was recorded as a refutation: %q. It establishes "+
+				"that this CALL is safe, not that the VALUE is — and the value flows on "+
+				"untouched.", s.Reason)
+		}
+	}
+}
+
+// An un-sanitized flow is still a finding. Without this, "records refutations"
+// is satisfiable by refuting everything.
+func TestAnUnsanitizedFlowStillReports(t *testing.T) {
+	src := `import subprocess
+from flask import request
+
+def run():
+    cmd = request.args.get("c")
+    subprocess.call(cmd, shell=True)
+`
+	flows, _ := analyzeSuppressions(t, "app.py", src)
+	if len(flows) == 0 {
+		t.Error("an un-sanitized value reaching a shell sink produced no finding; the " +
+			"suppression path is swallowing real flows")
+	}
+}
+
+// Suppressions are deterministically ordered: they reach the artifact through
+// the stage accounting, and findings.json is byte-identical across runs.
+func TestSuppressionsAreDeterministic(t *testing.T) {
+	src := `import subprocess, shlex
+from flask import request
+
+def a():
+    subprocess.call(shlex.quote(request.args.get("x")), shell=True)
+
+def b():
+    subprocess.call(shlex.quote(request.args.get("y")), shell=True)
+`
+	var first string
+	for i := 0; i < 6; i++ {
+		_, ss := analyzeSuppressions(t, "app.py", src)
+		var b strings.Builder
+		for _, s := range ss {
+			b.WriteString(s.FilePath + s.SinkCall + s.Class + s.SourceVar + "|")
+		}
+		if i == 0 {
+			first = b.String()
+			continue
+		}
+		if b.String() != first {
+			t.Fatalf("run %d ordered suppressions differently", i+1)
+		}
+	}
+}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -294,7 +294,7 @@ reclassify at all.
 | Milestone | Work | Exit | |
 |---|---|---|---|
 | **6.1** | Reclassify the noisiest regex families as candidate generators | a rule at precision 0.000 is not carried as a detector | blocked, see below |
-| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | blocked with 6.1 |
+| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | TAINT ✅ #616; DATA/SLOP/VARIANT open |
 | **6.3** | Stage accounting: candidates in, refuted, promoted, unknown | precision improves with no refutation-caused recall loss | ✅ #615 |
 
 **6.1's named target is not in this repository, and there is no core substitute
@@ -335,10 +335,27 @@ it. On the precision suite:
 | DATA / SLOP / VARIANT | 7 | 7 | **0** | 0 |
 
 So **6.2's list is measured rather than guessed**: TAINT, DATA, SLOP and
-VARIANT record no refutations at all. TAINT is the interesting one — the engine
-does refine, via sanitizer recognition, so either a sanitized flow never becomes
-a candidate or the refinement is not recorded. That is a question the accounting
-poses and does not answer.
+VARIANT recorded no refutations at all.
+
+**TAINT is answered (#616), and it was the second half of the question.** The
+engine refines and recorded none of it — true of the ledger, false of the
+engine. It now files a refutation for every sanitized flow it clears: 30
+candidates and 0 refuted became **36 and 6** on the precision suite.
+
+That change also cost a claim, which is the more useful half of the story. Three
+sites suppress a flow, and only two of them are refutations. A sanitizer acting
+on the VALUE is positive evidence that travels with it. An argument SHAPE that
+is not dangerous — an argv exec, a parameterized query — says only that THIS
+CALL is safe; the value is untouched and just as tainted. Recording the second
+as a refutation conflated them, and
+`TestNoUnearnedNegativeOnTheHardCorpus` caught it on `h2_dynamic_dispatch.go`:
+an argv `exec.Command("echo", s)` on one line, an `sh -c` on another, and the
+choice made by data the engine cannot follow. Refuting the first reads as
+resolving the file. Only the two value-clearing sites record.
+
+DATA, SLOP and VARIANT remain. Each needs its refinement recorded or its absence
+explained — a family that genuinely refines nothing is a fine answer, and saying
+so is what the accounting is for.
 
 The first thing it found was in IaC, and it was mine. Three filters added in
 #599 and #600 — comments, kind references, artifacts-always — dropped findings
@@ -355,8 +372,7 @@ duration is different every time. Cost belongs on stderr or in a benchmark, and
 `TestNoTimingInTheAccounting` keeps it out.
 
 **Size:** 6.1 remains unsized — it needs per-rule precision on real repositories,
-which nothing yet produces. 6.2 is now sized by the table above: four families,
-each needing its refinement recorded or its absence explained.
+which nothing yet produces. 6.2 is three families short of done.
 
 **Gate:** A on every family reclassified.
 


### PR DESCRIPTION
Stage accounting (#615) reported TAINT as **30 candidates, 0 refuted** on every corpus. That was true of the ledger and false of the engine.

## The gap

The taint engine performs the most sophisticated refinement in nox — class-precise sanitizer clearing, argument-shape analysis — and recorded **none** of it. Three bare `continue`s, which is the pattern `core/reasoning` exists to end.

It is the worst place in the tree for that gap. A sanitizer recognizer that clears the **wrong** thing produces a result indistinguishable from one that had nothing to clear: both show no finding. nox has shipped that defect more than once — an argv exemption that silenced shell sinks in five of six cases, a same-statement sanitizer invisible in every language but Go — and in each, the evidence needed to notice was computed and thrown away.

`taint.Suppression` is now a returned value rather than a discarded one. `AnalyzeWithSuppressions` and `AnalyzeFileWithSuppressions` sit beside the existing entry points, so `core/taint` stays a leaf and the `TaintEngine` interface is unchanged — a caller that wants the refutations asks for them.

**TAINT: 30 candidates / 0 refuted → 36 / 6.**

## The change also cost a claim, which is the more useful half

Three sites suppress a flow, and **only two are refutations**:

| site | what it observes | refutation? |
|---|---|---|
| sanitizer in a prior assignment | an operation ran on the **value** | ✅ |
| sanitizer wrapping the value at the call | an operation ran on the **value** | ✅ |
| argument shape not dangerous (argv exec, parameterized query) | this **call** is safe; the value is untouched | ❌ |

Recording the third conflated "this call is safe" with "this value is safe" — and **`TestNoUnearnedNegativeOnTheHardCorpus` caught it** on `h2_dynamic_dispatch.go`: an argv `exec.Command("echo", s)` on one line, an `sh -c` on another, and the choice made by data the engine cannot follow. Refuting the first reads as resolving the file.

That gate predates this work, is right, and is exactly what it is for. Only the two value-clearing sites record, and `TestAnUndangerousCallShapeIsNotARefutation` pins the distinction.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — unchanged. Nothing here changes what is reported; these are recordings of decisions the engine already made.
- Suppressions are deterministically ordered, because they reach the artifact through the stage accounting.
- `TestAnUnsanitizedFlowStillReports` rules out the failure where "records refutations" is satisfied by refuting everything.
- `analyzeUnitInterproc` removed — `AnalyzeFileWithSuppressions` calls `forwardPass` directly, leaving the wrapper unused.

## Still open in 6.2

DATA, SLOP and VARIANT record nothing. Each needs its refinement recorded **or its absence explained** — a family that genuinely refines nothing is a fine answer, and saying so is what the accounting is for.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT