### PR TITLE
PHASE 6.2: the last three families, one of them answered by explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,15 @@ code, and one of them was hiding findings.
 - `reach_limitations` on a finding: the machine-readable half of `reach_scope`,
   which is prose. Parsing English back out is not a contract.
 
+- `meta.stage_accounting`: what each rule family produced and what became of it —
+  candidates in, promoted, refuted on evidence, withheld by configuration. A
+  finding count cannot tell a family that refines from one that does not; both
+  produce findings. The four counts partition the candidates exactly, and
+  `refuted` is kept apart from `withheld` because a deduplication is not a
+  judgement about whether a finding was true. Present only when the scan records
+  reasoning, and deliberately carrying no timing: this artifact is
+  byte-identical across runs by contract and a duration is not.
+
 ### Fixed
 
 - **Undetermined reachability was recorded as never-evaluated** (#603).
@@ -107,6 +116,18 @@ code, and one of them was hiding findings.
   every path in `core/attack`. The run path already was; replay, regress and the
   MCP path were not, and were safe only by accident of each building a fresh
   single-purpose ledger.
+- **Four analyzer families dropped findings without recording why**, which is the
+  pattern `core/reasoning` exists to end. Stage accounting reported each as
+  refuting nothing — true of the ledger, false of the analyzer. IaC's comment,
+  kind-reference and artifacts-always filters (added in 1.34.0's successors) now
+  record; the taint engine records the sanitized flows it clears, going from 0
+  refutations to 6 on the precision suite; SLOP records why an import resolved,
+  and refutes 18 against 3 reported. DATA refines nothing and reporting zero for
+  it is correct.
+
+  Nothing reported changes: these are recordings of decisions the analyzers
+  already made. What changes is that a recognizer clearing the WRONG thing no
+  longer looks identical to one that had nothing to clear.
 - A plan with nothing to attempt serialises as `[]` rather than `null`.
 - An unnamed entry point no longer renders as "the entry point  is reachable by
   an attacker" — a hole where a value should be, rather than the assumption it

--- a/core/analyzers/slop/slop.go
+++ b/core/analyzers/slop/slop.go
@@ -17,9 +17,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/analyzers/slop/feed"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
 )
 
@@ -32,6 +34,30 @@ type Analyzer struct {
 	// imported name that matches a feed entry additionally raises a distinct
 	// SLOP-002 predictive finding; the SLOP-001 baseline is never altered.
 	feed *feed.Loaded
+
+	// reasoning receives the refutations. Nil until asked for, and every
+	// recording call is nil-safe.
+	reasoning *reasoning.Store
+}
+
+// RecordReasoningTo directs this analyzer's refutations at store.
+//
+// SLOP-001 fires on an import that resolves to nothing, so every check that
+// RESOLVES one is a refutation: it is in the standard library, it is a
+// first-party module, it is a private module no registry can hold, it is
+// declared in a manifest. Stage accounting reported SLOP as refuting nothing,
+// which was true of the ledger and false of the analyzer — and this family
+// refutes more often than it reports.
+//
+// The other `continue`s here are scope: a vendored path, an ecosystem with no
+// extractor, a relative specifier. None produced a candidate, so none refutes
+// one.
+func (a *Analyzer) RecordReasoningTo(store *reasoning.Store) { a.reasoning = store }
+
+// refute files why an import did not become a slopsquat candidate.
+func (a *Analyzer) refute(path string, line int, reason string) {
+	a.reasoning.Refute(reasoning.Candidate("SLOP-001", path, line, 1),
+		evidence.KindStatic, "nox-scan", "slop", reason)
 }
 
 // Option configures an Analyzer.
@@ -181,11 +207,15 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 			continue // relative/local specifier
 		}
 		if isStdlib(eco, pkg) {
+			a.refute(path, imp.line, "\""+pkg+"\" is in the "+string(eco)+
+				" standard library, so it resolves without a registry package")
 			continue
 		}
 		if eco == ecoPyPI {
 			if _, isLocal := local[pkg]; isLocal {
-				continue // first-party Python module
+				a.refute(path, imp.line, "\""+pkg+"\" is a first-party module in this "+
+					"repository, not a package anybody could squat")
+				continue
 			}
 			// PEP 508 requires a distribution name to start with a letter or
 			// digit, so an underscore-led import (_ssl, _typeshed, _pytest,
@@ -193,6 +223,9 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 			// private module of CPython or of an installed package, and there
 			// is nothing here for a squatter to register.
 			if strings.HasPrefix(pkg, "_") {
+				a.refute(path, imp.line, "\""+pkg+"\" starts with an underscore, and PEP 508 "+
+					"requires a distribution name to start with a letter or digit — no "+
+					"registry package can carry this name")
 				continue
 			}
 		}
@@ -207,9 +240,17 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, eco ecosystem, path string,
 		a.emitPredictive(fs, eco, path, pkg, imp, seenPred)
 
 		if declaredHas(declared, eco, pkg) {
+			a.refute(path, imp.line, "\""+pkg+"\" is declared in a dependency manifest, so "+
+				"the import resolves to a package this project already depends on")
 			continue
 		}
 		if _, dup := seen[pkg]; dup {
+			// Deduplication, not evidence: the second import of the same
+			// unresolved package is the same finding. Withheld weighs nothing,
+			// which is the only honest weight — the candidate was not wrong.
+			a.reasoning.Withheld(reasoning.Candidate("SLOP-001", path, imp.line, 1),
+				"nox-scan", "slop",
+				"already reported for \""+pkg+"\" elsewhere in this file")
 			continue
 		}
 		seen[pkg] = struct{}{}

--- a/core/analyzers/variants/refutation_test.go
+++ b/core/analyzers/variants/refutation_test.go
@@ -1,0 +1,71 @@
+package variants
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
+)
+
+// A signature's counter-pattern is a refutation and is recorded as one.
+//
+// VARIANT-002 matches `yaml.load(...)` — CVE-2020-1747's shape — and excludes
+// the form that carries a safe Loader. That exclusion is the analyzer's only
+// refinement, and stage accounting reported VARIANT as refuting nothing: true
+// of the ledger, false of the analyzer.
+//
+// It is asserted here rather than from a corpus because no committed corpus
+// exercises it. A refinement whose recording is only claimed is exactly what
+// this milestone is about.
+func TestAnExcludedMatchIsRecordedAsRefuted(t *testing.T) {
+	a := NewAnalyzer()
+	if a.LoadErr() != nil {
+		t.Fatalf("signatures did not load: %v", a.LoadErr())
+	}
+	store := reasoning.New()
+	a.RecordReasoningTo(store)
+
+	// The vulnerable shape and the fixed shape, one line each.
+	src := "import yaml\n" +
+		"bad = yaml.load(stream)\n" +
+		"good = yaml.load(stream, Loader=yaml.SafeLoader)\n"
+
+	fs := findings.NewFindingSet()
+	a.scanFile(fs, "app.py", []byte(src))
+
+	var reported int
+	for _, f := range fs.Findings() {
+		if f.RuleID == "VARIANT-002" {
+			reported++
+		}
+	}
+	if reported == 0 {
+		t.Fatal("the vulnerable line produced no VARIANT-002; this test asserts nothing")
+	}
+
+	var refutations int
+	for _, s := range store.Subjects() {
+		for _, c := range store.About(s).Claims {
+			if !c.Refutes() {
+				continue
+			}
+			refutations++
+			if !strings.Contains(c.Statement, "exclusion pattern") {
+				t.Errorf("refutation does not say what removed the match: %q", c.Statement)
+			}
+		}
+	}
+	if refutations == 0 {
+		t.Error("the safe form was excluded and nothing recorded why. A counter-pattern " +
+			"that drops the wrong match then looks exactly like one that had nothing " +
+			"to drop — both report only the vulnerable line.")
+	}
+}
+
+// A nil store is safe, so the recording call needs no guard at the drop site.
+func TestNilStoreIsSafeForVariants(t *testing.T) {
+	a := NewAnalyzer()
+	fs := findings.NewFindingSet()
+	a.scanFile(fs, "app.py", []byte("bad = yaml.load(stream)\n"))
+}

--- a/core/analyzers/variants/variants.go
+++ b/core/analyzers/variants/variants.go
@@ -16,8 +16,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nox-hq/nox-core/evidence"
 	"github.com/nox-hq/nox/core/discovery"
 	"github.com/nox-hq/nox/core/findings"
+	"github.com/nox-hq/nox/core/reasoning"
 	"github.com/nox-hq/nox/core/rules"
 )
 
@@ -54,7 +56,23 @@ type Analyzer struct {
 	// the pipeline can report that CVE-variant detection did not run, rather
 	// than emitting zero findings and calling it clean.
 	loadErr error
+
+	// reasoning receives the refutations. Nil until asked for, and every
+	// recording call is nil-safe.
+	reasoning *reasoning.Store
 }
+
+// RecordReasoningTo directs this analyzer's refutations at store.
+//
+// One signature refinement exists here and it was invisible: a counter-pattern
+// that drops a match the CVE pattern found. Stage accounting reported VARIANT
+// as refuting nothing, which was true of the ledger and false of the analyzer.
+//
+// The other `continue`s in this file are scope, not refinement — an extension
+// that does not match, an artifact type not scanned, a file that would not
+// read. None of them says anything about a candidate, because none of them
+// produced one.
+func (a *Analyzer) RecordReasoningTo(store *reasoning.Store) { a.reasoning = store }
 
 // LoadErr reports a whole-database load failure, or nil when the signature
 // database parsed. A non-nil value means no VARIANT-* rule can match.
@@ -150,6 +168,13 @@ func (a *Analyzer) scanFile(fs *findings.FindingSet, path string, content []byte
 				continue
 			}
 			if s.exclude != nil && s.exclude.MatchString(line) {
+				// The signature's counter-pattern matched: this line has the
+				// shape of the CVE and also the shape of its fixed form.
+				a.reasoning.Refute(
+					reasoning.Candidate(s.ID, path, ln+1, 1),
+					evidence.KindStatic, "nox-scan", "variants",
+					"the signature's exclusion pattern matched this line, which is the "+
+						"shape of the fix rather than of the vulnerability")
 				continue
 			}
 			meta := map[string]string{"cve": s.CVE}

--- a/core/scan.go
+++ b/core/scan.go
@@ -519,11 +519,13 @@ func RunScanContext(ctx context.Context, target string, opts ScanOptions) (*Scan
 		}
 	}
 	slopAnalyzer := slop.NewAnalyzer(slopOpts...)
+	slopAnalyzer.RecordReasoningTo(reasons)
 	cryptoAnalyzer := weakcrypto.NewAnalyzer()
 	filepermsAnalyzer := fileperms.NewAnalyzer()
 	hardeningAnalyzer := hardening.NewAnalyzer()
 	memsafeAnalyzer := memsafe.NewAnalyzer()
 	variantsAnalyzer := variants.NewAnalyzer()
+	variantsAnalyzer.RecordReasoningTo(reasons)
 	// A signature database that fails to parse leaves every VARIANT-* rule
 	// unable to match. The scan would otherwise report zero variant findings
 	// and look clean.

--- a/core/stage_accounting_test.go
+++ b/core/stage_accounting_test.go
@@ -188,3 +188,67 @@ func TestTaintRecordsItsSanitizerDecisions(t *testing.T) {
 	}
 	t.Fatal("no TAINT family in the accounting")
 }
+
+// SLOP refutes more often than it reports, and that is the shape of the family.
+//
+// SLOP-001 fires on an import that resolves to nothing, so every check that
+// RESOLVES one — standard library, first-party module, private module, declared
+// in a manifest — is a refutation. On the precision suite it promotes 3 and
+// refutes 18; on the refutation suite it promotes nothing and refutes 5.
+//
+// None of that was recorded. A family doing six times more refuting than
+// reporting looked, in the ledger, like one doing none.
+func TestSlopRecordsWhyAnImportResolved(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, s := range res.Stages {
+		if s.Family != "SLOP" {
+			continue
+		}
+		if s.Refuted == 0 {
+			t.Error("SLOP refuted nothing while resolving imports against the standard " +
+				"library, the manifest and the local tree on every scan")
+		}
+		if s.Refuted <= s.Promoted {
+			t.Errorf("SLOP refuted %d and promoted %d; this family resolves far more "+
+				"imports than it flags, and a ledger that does not show it is not "+
+				"describing the analyzer", s.Refuted, s.Promoted)
+		}
+		return
+	}
+	t.Fatal("no SLOP family in the accounting")
+}
+
+// DATA refines nothing, and that is the correct answer rather than a gap.
+//
+// core/analyzers/data is a pass-through to the rules engine: every rule match
+// becomes a finding, with no filter, exclusion or counter-pattern anywhere in
+// the analyzer. A family that genuinely refines nothing SHOULD report zero
+// refutations, and the accounting reporting zero for it is the instrument
+// working rather than a family still to be instrumented.
+//
+// Pinned so that if DATA ever grows a refinement, this fails and somebody
+// records it rather than adding a silent drop.
+func TestDataRefinesNothingAndSaysSo(t *testing.T) {
+	res, err := RunScanWithOptions(filepath.Join("..", "testdata", "precision-suite"),
+		ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, s := range res.Stages {
+		if s.Family != "DATA" {
+			continue
+		}
+		if s.Candidates != s.Promoted {
+			t.Errorf("DATA has %d candidates and promoted %d. It gained a refinement "+
+				"since this was measured — record why it drops, rather than dropping "+
+				"silently, which is what every other family in this file had to fix.",
+				s.Candidates, s.Promoted)
+		}
+		return
+	}
+	t.Fatal("no DATA family in the accounting")
+}

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -294,7 +294,7 @@ reclassify at all.
 | Milestone | Work | Exit | |
 |---|---|---|---|
 | **6.1** | Reclassify the noisiest regex families as candidate generators | a rule at precision 0.000 is not carried as a detector | blocked, see below |
-| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | TAINT ✅ #616; DATA/SLOP/VARIANT open |
+| **6.2** | Extend cheap refutation to the families that lack it | measured precision gain per family | ✅ #616, #617 |
 | **6.3** | Stage accounting: candidates in, refuted, promoted, unknown | precision improves with no refutation-caused recall loss | ✅ #615 |
 
 **6.1's named target is not in this repository, and there is no core substitute
@@ -353,9 +353,32 @@ an argv `exec.Command("echo", s)` on one line, an `sh -c` on another, and the
 choice made by data the engine cannot follow. Refuting the first reads as
 resolving the file. Only the two value-clearing sites record.
 
-DATA, SLOP and VARIANT remain. Each needs its refinement recorded or its absence
-explained — a family that genuinely refines nothing is a fine answer, and saying
-so is what the accounting is for.
+**The other three are done, and one of them by explanation rather than by code
+(#617).**
+
+**SLOP refutes six times more often than it reports.** SLOP-001 fires on an
+import that resolves to nothing, so every check that RESOLVES one — standard
+library, first-party module, private module, declared in a manifest — is a
+refutation. Precision suite: 3 promoted, **18 refuted**. Refutation suite: 0
+promoted, 5 refuted. None of it was recorded, so a family doing almost nothing
+but refining looked like one doing none.
+
+**VARIANT has exactly one refinement** — a signature's counter-pattern, which
+drops a line carrying the shape of the fix rather than of the CVE. No committed
+corpus exercises it, so it is asserted directly rather than from a corpus that
+would report zero either way.
+
+**DATA refines nothing, and that is the answer.** It is a pass-through to the
+rules engine: every match becomes a finding, with no filter, exclusion or
+counter-pattern anywhere in the analyzer. A family that genuinely refines
+nothing SHOULD report zero, and the accounting reporting zero for it is the
+instrument working rather than a family still to instrument. Pinned, so that if
+DATA ever grows a refinement it fails rather than dropping silently.
+
+The distinction that ran through all four: a `continue` for SCOPE — an
+extension that does not match, a vendored path, an ecosystem with no extractor —
+produced no candidate and refutes nothing. Only a drop that acts on a candidate
+is a refutation.
 
 The first thing it found was in IaC, and it was mine. Three filters added in
 #599 and #600 — comments, kind references, artifacts-always — dropped findings
@@ -372,7 +395,7 @@ duration is different every time. Cost belongs on stderr or in a benchmark, and
 `TestNoTimingInTheAccounting` keeps it out.
 
 **Size:** 6.1 remains unsized — it needs per-rule precision on real repositories,
-which nothing yet produces. 6.2 is three families short of done.
+which nothing yet produces. 6.2 and 6.3 are done.
 
 **Gate:** A on every family reclassified.
 


### PR DESCRIPTION
Closes Phase 6.2. Also adds the 6.3 and 6.2 entries to the v1.35.0 changelog, which predated both.

## SLOP refutes six times more often than it reports

SLOP-001 fires on an import that resolves to **nothing**, so every check that *resolves* one is a refutation: standard library, first-party module, private module no registry can hold, declared in a manifest.

| corpus | promoted | refuted |
|---|---:|---:|
| precision-suite | 3 | **18** |
| refutation-suite | 0 | **5** |

None of it was recorded. A family doing almost nothing but refining looked, in the ledger, like one doing none.

## VARIANT has exactly one refinement

A signature's counter-pattern, dropping a line that carries the shape of the **fix** rather than of the CVE — `yaml.load(x, Loader=yaml.SafeLoader)` against `yaml.load(x)`.

No committed corpus exercises it, so it is asserted **directly against the analyzer** rather than from a corpus that would report zero either way. A refinement whose recording is only claimed is exactly what this milestone is about.

## DATA refines nothing, and that is the answer

`core/analyzers/data` is a pass-through to the rules engine: every match becomes a finding, with no filter, exclusion or counter-pattern anywhere in the analyzer.

A family that genuinely refines nothing **should** report zero, and the accounting reporting zero for it is the instrument working rather than a family still to instrument. Pinned — if DATA ever grows a refinement, the test fails and somebody records it rather than dropping silently.

## The distinction that ran through all four

A `continue` for **scope** — an extension that does not match, a vendored path, an ecosystem with no extractor — produced no candidate and refutes nothing. Only a drop that acts on a **candidate** is a refutation.

SLOP has nine `continue`s and four of them are refutations. Getting that wrong in either direction is how a ledger stops describing the analyzer — over-record and you get the unearned negative that `refutation-hard` caught in #616; under-record and you get the silence this milestone started from.

Deduplication is recorded as `Withheld`, not `Refuted`, matching what secrets already does: the second import of the same unresolved package is the same finding, and the candidate was not wrong.

## Verification

- **Detection 231/0/0, refutation 37/0/0** — nothing reported changes. These are recordings of decisions the analyzers already made.
- Full suite green, `golangci-lint` 0 issues.

Phase 6 now stands: **6.2 and 6.3 done; 6.1 remains blocked** on per-rule precision from real repositories, which nothing yet produces.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT