### PR TITLE
PHASE 1.3 (partial): the uncertainty default follows the declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ code, and one of them was hiding findings.
   claim than it is. `EvidenceConfidence` stays conditional, because that one IS
   derived from the ledger and an empty ledger aggregates to `LOW`.
 
+- **`policy.uncertainty` defaults to `fail` where a requirement is declared.**
+  With no `require_capabilities` listed nothing changes — that is every existing
+  repository. With one listed, an unmet requirement now exits non-zero rather
+  than warning: declaring the requirement is itself the deliberate act, and
+  answering it with a warning nobody gates on is how a project stops finding out
+  that what it relies on stopped being answered. Set `uncertainty: warn`
+  explicitly to keep the signal without the gate.
+
+  §1.5.3 specified this default moving "only after a release where the warning
+  names the flag". That was 1.32.0; 1.33.0 and 1.34.0 have shipped since.
+
 - **A waived finding no longer grounds an attack hypothesis.** A `nox:ignore`, a
   baseline entry or a VEX statement did not stop `nox attack plan` building one,
   so `nox attack run --authorize` would fire real payloads at a live target for

--- a/core/policy/uncertainty.go
+++ b/core/policy/uncertainty.go
@@ -21,8 +21,8 @@ type Uncertainty string
 // Uncertainty modes.
 const (
 	// UncertaintyWarn reports what was not evaluated and does not gate. The
-	// default, and deliberately so — see RequireCapabilities for why the
-	// stricter setting cannot be the default yet.
+	// default when a project has declared no requirement — see
+	// Uncertainty.Effective for why declaring one changes it.
 	UncertaintyWarn Uncertainty = "warn"
 	// UncertaintyFail treats an unmet capability requirement as a failure.
 	UncertaintyFail Uncertainty = "fail"
@@ -44,12 +44,33 @@ func (u Uncertainty) Valid() bool {
 	return false
 }
 
-// Effective resolves the zero value to the default.
-func (u Uncertainty) Effective() Uncertainty {
-	if u == "" {
-		return UncertaintyWarn
+// Effective resolves the zero value to the default, which depends on whether
+// the project declared a requirement.
+//
+// With no requirement declared there is nothing to gate on, so the mode is
+// immaterial and warn is the honest resting state.
+//
+// With one declared, the default is FAIL. Declaring `require_capabilities` is
+// itself the deliberate act — a repository listing reachability is asserting
+// that its triage depends on reachability being answered — and answering that
+// assertion with a warning under-serves it. A warning in a CI log that nobody
+// gates on is how "nox stopped knowing something this project relies on"
+// becomes something nobody finds out about. An operator who wants the signal
+// without the gate still has `warn`, explicitly.
+//
+// This was previously warn in both cases, with a note that the stricter setting
+// "cannot be the default yet" because three capabilities had no implementation
+// and failing on any gap would turn every build red. That premise is gone:
+// core/callgraph filled the last of them, and this gate never failed on "any
+// gap" in the first place — it fails on a DECLARED requirement going unmet.
+func (u Uncertainty) Effective(declaredRequirements bool) Uncertainty {
+	if u != "" {
+		return u
 	}
-	return u
+	if declaredRequirements {
+		return UncertaintyFail
+	}
+	return UncertaintyWarn
 }
 
 // CapabilityGate is the capability half of a policy decision.
@@ -120,7 +141,7 @@ func EvaluateCapabilities(cfg Config, gate CapabilityGate, run CapabilityRun, r 
 	if r == nil {
 		r = &Result{Pass: true, ExitCode: 0}
 	}
-	mode := cfg.Uncertainty.Effective()
+	mode := cfg.Uncertainty.Effective(len(cfg.RequireCapabilities) > 0)
 	if mode == UncertaintyIgnore || len(cfg.RequireCapabilities) == 0 {
 		return r
 	}

--- a/core/policy/uncertainty_test.go
+++ b/core/policy/uncertainty_test.go
@@ -71,18 +71,33 @@ func TestNoAdoptionCliff(t *testing.T) {
 	}
 }
 
-// TestUnmetRequirementWarnsByDefaultAndNamesTheFlag. §1.5 of the design doc
-// requires a release in which the stricter behaviour is announced by the
-// warning that precedes it, so switching the default later surprises nobody.
-func TestUnmetRequirementWarnsByDefaultAndNamesTheFlag(t *testing.T) {
+// A declared requirement that goes unmet fails the build, and the warning still
+// names the flag.
+//
+// §1.5.3 of the design doc specifies `fail` "available immediately and becoming
+// the default only after a release where the warning names the flag". That
+// release was v1.32.0, and v1.33.0 and v1.34.0 have shipped since, so the
+// condition is met and the default has moved.
+//
+// It moves only where a requirement was DECLARED. Declaring
+// `require_capabilities` is itself the deliberate act — a repository listing
+// reachability is asserting its triage depends on that question being answered
+// — and answering that assertion with a warning under-serves it. A project that
+// wants the signal without the gate still has `warn`, explicitly.
+//
+// The warning's content is asserted unchanged, because it is what the operator
+// reads either way and it is what the deprecation contract was about.
+func TestUnmetRequirementFailsByDefaultAndNamesTheFlag(t *testing.T) {
 	cfg := policy.Config{
 		FailOn:              findings.SeverityCritical,
 		RequireCapabilities: []string{"reachability"},
 	}
 	r := policy.EvaluateCapabilities(cfg, gate{}, gate{}, policy.Evaluate(cfg, nil))
 
-	if !r.Pass {
-		t.Error("the default mode failed the build; warn must not gate")
+	if r.Pass {
+		t.Error("a declared requirement went unmet and the build passed. Declaring the " +
+			"requirement is the opt-in; a warning nobody gates on is how a project " +
+			"stops being told that what it relies on stopped being answered.")
 	}
 	if len(r.Warnings) == 0 {
 		t.Fatal("an unmet requirement produced no warning")
@@ -328,5 +343,59 @@ func assertUnmet(t *testing.T, r *policy.Result, capName, want string) {
 	if !strings.Contains(got, want) {
 		t.Errorf("the warning does not say %q, so the reader cannot tell which of the "+
 			"three ways this went unmet: %q", want, got)
+	}
+}
+
+// The escape hatch still works, and it is what makes moving the default
+// acceptable. A project that wants the signal without the gate says so.
+func TestExplicitWarnStillDoesNotGate(t *testing.T) {
+	cfg := policy.Config{
+		FailOn:              findings.SeverityCritical,
+		RequireCapabilities: []string{"reachability"},
+		Uncertainty:         policy.UncertaintyWarn,
+	}
+	r := policy.EvaluateCapabilities(cfg, gate{}, gate{}, policy.Evaluate(cfg, nil))
+	if !r.Pass {
+		t.Error("an explicit warn gated the build; the escape hatch is what makes the " +
+			"stricter default acceptable")
+	}
+	if len(r.Warnings) == 0 {
+		t.Error("explicit warn produced no warning, so it is now indistinguishable " +
+			"from ignore")
+	}
+}
+
+// A project that declared nothing is untouched, which is every existing
+// repository. The default moved for the opted-in case only.
+func TestNoDeclarationMeansNoChange(t *testing.T) {
+	cfg := policy.Config{FailOn: findings.SeverityCritical}
+	r := policy.EvaluateCapabilities(cfg, gate{}, gate{}, policy.Evaluate(cfg, nil))
+	if !r.Pass {
+		t.Error("a project that declared no requirement was failed by the capability gate")
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("a project that declared no requirement heard %d warning(s)", len(r.Warnings))
+	}
+}
+
+// Effective is the whole of the change, so it is asserted directly.
+func TestEffectiveDependsOnWhetherAnythingWasDeclared(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		set      policy.Uncertainty
+		declared bool
+		want     policy.Uncertainty
+	}{
+		{"unset, nothing declared", "", false, policy.UncertaintyWarn},
+		{"unset, something declared", "", true, policy.UncertaintyFail},
+		{"explicit warn wins", policy.UncertaintyWarn, true, policy.UncertaintyWarn},
+		{"explicit ignore wins", policy.UncertaintyIgnore, true, policy.UncertaintyIgnore},
+		{"explicit fail with nothing declared", policy.UncertaintyFail, false, policy.UncertaintyFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.set.Effective(tc.declared); got != tc.want {
+				t.Errorf("Effective(%v) = %q, want %q", tc.declared, got, tc.want)
+			}
+		})
 	}
 }

--- a/docs/design/phase-execution-plan.md
+++ b/docs/design/phase-execution-plan.md
@@ -65,7 +65,7 @@ are provided (`call_graph` and `entry_point` are not). `ScanResult` carries
 |---|---|---|---|
 | **1.1** | Nothing — the states exist and are used | already met | ✅ |
 | **1.2** | `capabilities` on `report.Meta` from `ScanResult.Coverage`; SARIF `invocations[].toolExecutionNotifications` for the same | two scans differing only by analyzer availability are not byte-identical | ✅ #602 |
-| **1.3** | Default `policy.uncertainty` to a value that does not treat unevaluated as clean | uninstalling an analyzer cannot turn a failing scan green **by default**, not only when configured | |
+| **1.3** | Default `policy.uncertainty` to a value that does not treat unevaluated as clean | uninstalling an analyzer cannot turn a failing scan green **by default**, not only when configured | ⚠️ partial #618 |
 
 1.2 landed larger than "a struct field and a serializer" for one reason worth
 carrying forward: the four adapter sites each set `Degradations` by hand, and
@@ -79,8 +79,29 @@ pins the constructor rather than the assignments.
 **Size:** 1.3 is a default flip and needs a deprecation note — it can fail scans
 that pass today.
 
-**Gate:** B (unevaluated honesty). 1.3 must ship with a corpus case where a
-capability is removed and the scan goes from pass to fail. 1.2's own Gate B case
+**1.3 shipped the half that is defensible, and its stated exit is not met.**
+
+`policy.uncertainty` now defaults to `fail` where a requirement is declared,
+which §1.5.3 specified as legitimate "only after a release where the warning
+names the flag" — that was 1.32.0, and two releases have shipped since. The
+premise the code gave for waiting is also gone: it named three capabilities with
+no implementation, and `core/callgraph` filled the last of them.
+
+**It does not meet the exit, and cannot.** The exit says "by default, not only
+when configured", and this gate reads `require_capabilities`, which is empty by
+default — so flipping the mode is a no-op for every repository that has not
+opted in. Meeting the exit literally needs something that acts with no
+configuration at all, and the code argues persuasively against the obvious
+version: "fail on any gap" turns every build red, and a gate everybody disables
+protects nothing.
+
+What would meet it is a comparison against history — a capability that answered
+last time and does not now — which nox has nowhere to keep except the baseline.
+That is a design, not a default, and it is not this milestone.
+
+**Gate:** B (unevaluated honesty). The corpus case 1.3 asked for —
+a capability removed, the scan going pass to fail — exists as
+`TestUnmetRequirementFailsByDefaultAndNamesTheFlag` for the declared case only. 1.2's own Gate B case
 is `TestLosingAProviderChangesTheArtifact`: an installation without the taint
 engine used to write a byte-identical `findings.json` to one that had it and
 found nothing.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1471,10 +1471,21 @@ can go unmet, worded apart because each needs a different response:
 | `ran but could not determine anything` | The analysis ran and came back empty | Look at why — a slow or partial source, a timeout |
 | `provided, but nothing in this scan put the question` | The capability exists and this scan never used it | Check the scan reached the code you think it did |
 
-**`uncertainty`** — what an unmet requirement does. `warn` (the default) prints
-and does not change the exit code; `fail` exits non-zero; `ignore` skips the
-check. A mistyped value is rejected rather than resolved to the permissive
-default.
+**`uncertainty`** — what an unmet requirement does. `fail` exits non-zero;
+`warn` prints and does not change the exit code; `ignore` skips the check. A
+mistyped value is rejected rather than resolved to the permissive default.
+
+**The default follows the declaration.** With no `require_capabilities` listed
+there is nothing to gate on and the mode is immaterial. With one listed, the
+default is `fail`: declaring a requirement is itself the deliberate act, and
+answering it with a warning nobody gates on is how a project stops finding out
+that what it relies on stopped being answered. Set `warn` explicitly to keep the
+signal without the gate.
+
+> **Changed in 1.35.0.** This defaulted to `warn` in both cases. §1.5.3 of the
+> design specified `fail` becoming the default "only after a release where the
+> warning names the flag" — that was 1.32.0, and two releases have shipped
+> since. Only projects that already list `require_capabilities` are affected.
 
 Worth knowing what this does *not* cover: `require_capabilities` speaks about
 analyses, not about every check completing. For "fail if any part of the scan


### PR DESCRIPTION
`policy.uncertainty` now defaults to **`fail` where a project declared a requirement**, and stays `warn` where it declared none.

**Marked partial, not done.** The milestone's stated exit is not met, and why is below.

## The change

Declaring `require_capabilities` is itself the deliberate act. A repository listing `reachability` is asserting that its triage depends on that question being answered — and answering that assertion with a warning under-serves it. A warning in a CI log that nobody gates on is how a project stops finding out that what it relies on stopped being answered.

`warn` remains, explicitly, and that escape hatch is what makes moving the default acceptable.

## Two preconditions, checked rather than assumed

**The deprecation contract is satisfied.** §1.5.3 specified `fail` "available immediately and becoming the default only after a release where the warning names the flag". That release was **v1.32.0**, which shipped the warning naming `policy.uncertainty=fail`; v1.33.0 and v1.34.0 have shipped since.

**The code's own reason for waiting is gone.** `core/policy` named three capabilities with no implementation and argued that failing on any gap *"turns every build on earth red on upgrade"*. `core/callgraph` (#613) filled the last of them — and this gate never failed on *any gap* in the first place, only on a **declared** requirement going unmet.

## Why this does not meet the exit

> uninstalling an analyzer cannot turn a failing scan green **by default**, not only when configured

This gate reads `require_capabilities`, which is **empty by default** — so flipping the mode is a no-op for every repository that has not opted in. It is still "only when configured".

Meeting the exit literally needs something that acts with **no configuration at all**, and the obvious version is the one `core/policy` already argues against at length: *"fail on any gap turns every build on earth red... A gate everybody disables protects nothing."* That argument still holds — a scan never answers `dynamic_verification`, and `call_graph` is `unsupported` outside Go.

What *would* meet it is a comparison against history — a capability that answered last time and does not now — which nox has nowhere to keep except the baseline. **That is a design, not a default**, and it is not this milestone. Recorded in the plan as partial with the reasoning rather than ticked.

## Blast radius

Every existing repository with no `require_capabilities` is untouched — asserted by `TestNoDeclarationMeansNoChange`. Only projects that already opted in are affected, and only when a requirement they declared goes unmet.

Changelog and `docs/usage.md` both carry the behaviour change.

Full suite green, `golangci-lint` 0 issues.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT