### PR TITLE
PHASE 2.3: a negative cannot render as if it were universal

### DIFF
--- a/core/analyzers/taintflow/taintflow.go
+++ b/core/analyzers/taintflow/taintflow.go
@@ -188,7 +188,18 @@ func (a *Analyzer) recordSuppressions(path string, ss []taint.Suppression) {
 	for i := range ss {
 		s := &ss[i]
 		subject := reasoning.Candidate(s.RuleID, path, s.SinkLine, 1)
-		a.reasoning.Refute(subject, evidence.KindStatic, "nox-scan", "taint", s.Reason)
+		// Scoped, not bare. A sanitizer refutation is a universal claim about
+		// this value at this sink, and it is only as good as the analysis
+		// behind it — which here is syntactic and per-file. Naming the blind
+		// spots is what lets a reader decide whether they matter: a value that
+		// arrives through an interface, a function value or reflection is a
+		// value this engine did not follow, and the sanitizer it saw may not be
+		// the one that ran.
+		a.reasoning.RefuteWithin(subject, evidence.KindStatic, "nox-scan", "taint",
+			s.Reason, reasoning.Scope{
+				Analysis: "the " + s.Language + " taint engine, over this file",
+				Limits:   "interface dispatch, function values, reflection, or a sanitizer applied in another file",
+			})
 	}
 }
 

--- a/core/explain/explain.go
+++ b/core/explain/explain.go
@@ -199,7 +199,7 @@ func argument(l evidence.Ledger, s evidence.Subject) (supports, against []string
 		}
 		switch {
 		case c.Refutes():
-			against = append(against, line)
+			against = append(against, qualify(line, c))
 		case c.Supports():
 			supports = append(supports, line)
 		default:
@@ -374,4 +374,34 @@ func whatToDo(rule catalog.RuleMeta) string {
 	}
 	return "This rule carries no remediation guidance. Treat the evidence above as the " +
 		"input to your own judgement rather than waiting for nox to make it."
+}
+
+// qualify makes a refutation say what it holds within.
+//
+// A refutation is a UNIVERSAL claim — "this does not hold" — and it is only as
+// good as the search behind it. reach.Result has always rendered its negatives
+// this way ("does not hold within the scope searched (...). Nothing here rules
+// out another build or another path"); a ledger refutation rendered as a bare
+// sentence, which reads as settled.
+//
+// A claim recorded through Store.RefuteWithin names its analysis and what that
+// analysis cannot see, and those are what a reader needs to decide whether the
+// blind spot matters to their code. One recorded without a scope still gets a
+// qualifier — generic, because that is all there is to say — so that no path
+// through this function can render a negative unqualified. That is the point:
+// not that every refutation is well described, but that none of them can be
+// mistaken for a universal one.
+func qualify(line string, c evidence.Claim) string {
+	analysis := c.Attributes["scope"]
+	limits := c.Attributes["limits"]
+	switch {
+	case analysis != "" && limits != "":
+		return line + " — established by " + analysis + ", which cannot see " + limits
+	case analysis != "":
+		return line + " — established by " + analysis + ", within what it could see"
+	case limits != "":
+		return line + " — within what that analysis could see; it cannot see " + limits
+	default:
+		return line + " — within what that analysis could see"
+	}
 }

--- a/core/explain/qualified_negative_test.go
+++ b/core/explain/qualified_negative_test.go
@@ -1,0 +1,101 @@
+package explain_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nox-hq/nox-core/evidence"
+	"github.com/nox-hq/nox/core/explain"
+)
+
+// refutation builds a claim against the base fixture's subject.
+func refutation(statement string, attrs map[string]string) evidence.Claim {
+	return evidence.Claim{
+		Kind:       evidence.KindStatic,
+		Statement:  statement,
+		Polarity:   evidence.PolarityRefutes,
+		Subject:    subject(),
+		Attributes: attrs,
+		Provenance: evidence.Provenance{Source: "nox-scan", Tool: "taint"},
+	}
+}
+
+// No path through the renderer can produce an unqualified negative.
+//
+// A refutation is a UNIVERSAL claim — "this does not hold" — and it is only as
+// good as the search behind it. reach.Result has always rendered its negatives
+// that way; a ledger refutation rendered as a bare sentence, which reads as
+// settled.
+//
+// The table walks every combination a refiner can produce, including the one
+// where it recorded no scope at all. That case still has to be qualified,
+// generically, because "some limit exists" is the least a reader is owed.
+func TestNoNegativeRendersUnqualified(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		attrs map[string]string
+	}{
+		{"scope and limits", map[string]string{
+			"scope": "the python taint engine, over this file", "limits": "interface dispatch",
+		}},
+		{"scope only", map[string]string{"scope": "YAML comment lexing"}},
+		{"limits only", map[string]string{"limits": "another file"}},
+		{"neither", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := baseInputs()
+			in.Ledger = evidence.Ledger{Claims: []evidence.Claim{
+				refutation("a sanitizer cleared this value", tc.attrs),
+			}}
+			joined := strings.Join(explain.Explain(in).Against, "\n")
+
+			if !strings.Contains(joined, "a sanitizer cleared this value") {
+				t.Fatalf("the refutation is missing entirely: %q", joined)
+			}
+			if !strings.Contains(joined, "could see") && !strings.Contains(joined, "cannot see") {
+				t.Errorf("the negative renders unqualified: %q. A refutation that reads as "+
+					"settled invites the reader to treat the finding as resolved, and no "+
+					"analysis that could not resolve a dispatch is entitled to that.", joined)
+			}
+		})
+	}
+}
+
+// A refiner that named its blind spot has it rendered, because that is what
+// lets a reader decide whether it matters to their code. "Cannot see interface
+// dispatch" is actionable; "within what it could see" is only honest.
+func TestANamedBlindSpotIsRendered(t *testing.T) {
+	in := baseInputs()
+	in.Ledger = evidence.Ledger{Claims: []evidence.Claim{
+		refutation("a sanitizer cleared this value", map[string]string{
+			"scope":  "the python taint engine, over this file",
+			"limits": "interface dispatch, function values, reflection",
+		}),
+	}}
+	joined := strings.Join(explain.Explain(in).Against, "\n")
+
+	for _, want := range []string{
+		"the python taint engine, over this file",
+		"cannot see",
+		"interface dispatch",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the rendered negative does not carry %q: %q", want, joined)
+		}
+	}
+}
+
+// A supporting claim is not qualified this way. The asymmetry is the point: an
+// existential claim is settled by one witness however narrow the search was,
+// and hedging it would train a reader to discount both.
+func TestSupportIsNotQualifiedLikeARefutation(t *testing.T) {
+	in := baseInputs()
+	in.Ledger = evidence.Ledger{Claims: []evidence.Claim{{
+		Kind: evidence.KindStatic, Statement: "the embedded checksum verifies",
+		Subject: subject(), Provenance: evidence.Provenance{Source: "nox-scan"},
+	}}}
+	joined := strings.Join(explain.Explain(in).Supports, "\n")
+	if strings.Contains(joined, "within what that analysis could see") {
+		t.Errorf("a supporting claim was hedged like a negative: %q", joined)
+	}
+}

--- a/core/reasoning/reasoning.go
+++ b/core/reasoning/reasoning.go
@@ -101,6 +101,56 @@ func (s *Store) Refute(subject evidence.Subject, kind evidence.Kind, source, too
 	})
 }
 
+// Scope names what an analysis covered when it refuted something, and what it
+// could not see.
+//
+// A refutation is a UNIVERSAL claim — "this does not hold" — and it is only as
+// good as the search behind it. `reach.Result` has carried a scope since it
+// existed, and its rendering is careful for exactly this reason: "does not hold
+// within the scope searched (...). Nothing here rules out another build or
+// another path." A ledger refutation carried a bare sentence.
+//
+// Both fields are prose, deliberately. They are read by a person deciding
+// whether to trust a negative, and a structured limitation vocabulary already
+// exists for the one analysis that needs it (reach.Limitation). Duplicating it
+// here would put two spellings of "this analysis could not see X" in the tree.
+type Scope struct {
+	// Analysis names what produced the refutation, so a reader can weigh it:
+	// "intraprocedural taint over one statement", "YAML comment lexing".
+	Analysis string
+	// Limits states what that analysis cannot see. Empty means the refiner
+	// claims no blind spot, which is a strong claim and should be rare.
+	Limits string
+}
+
+// RefuteWithin is Refute plus the scope the refutation holds within.
+//
+// Prefer it. A negative with no scope renders qualified anyway — see
+// core/explain — but qualified generically, which tells the reader that some
+// limit exists without saying which. Naming the limit is what lets them decide
+// whether it matters to their code.
+func (s *Store) RefuteWithin(subject evidence.Subject, kind evidence.Kind,
+	source, tool, statement string, scope Scope) {
+	attrs := map[string]string{}
+	if scope.Analysis != "" {
+		attrs["scope"] = scope.Analysis
+	}
+	if scope.Limits != "" {
+		attrs["limits"] = scope.Limits
+	}
+	if len(attrs) == 0 {
+		attrs = nil
+	}
+	s.Record(evidence.Claim{
+		Kind:       kind,
+		Statement:  statement,
+		Polarity:   evidence.PolarityRefutes,
+		Subject:    subject,
+		Attributes: attrs,
+		Provenance: evidence.Provenance{Source: source, Tool: tool},
+	})
+}
+
 // About returns the ledger for one subject. The zero Ledger is returned for a
 // subject nothing was recorded about, and for a nil Store.
 func (s *Store) About(subject evidence.Subject) evidence.Ledger {

--- a/core/taint_scope_test.go
+++ b/core/taint_scope_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The taint engine's refutations name what the engine could not see.
+//
+// A sanitizer refutation is a universal claim about this value at this sink,
+// and it is only as good as the analysis behind it — syntactic, per-file. A
+// value that arrives through an interface, a function value or reflection is a
+// value the engine did not follow, and the sanitizer it saw may not be the one
+// that ran. Naming that is what lets a reader decide whether it matters to
+// their code.
+func TestTaintRefutationsCarryTheirScope(t *testing.T) {
+	dir := t.TempDir()
+	src := `import subprocess, shlex
+from flask import request
+
+def run():
+    cmd = shlex.quote(request.args.get("c"))
+    subprocess.call(cmd, shell=True)
+`
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	res, err := RunScanWithOptions(dir, ScanOptions{Offline: true, RecordReasoning: true})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var checked int
+	for _, s := range res.Reasoning.Subjects() {
+		for _, c := range res.Reasoning.About(s).Claims {
+			if !c.Refutes() || c.Provenance.Tool != "taint" {
+				continue
+			}
+			checked++
+			if c.Attributes["scope"] == "" {
+				t.Errorf("a taint refutation names no analysis: %q", c.Statement)
+			}
+			if !strings.Contains(c.Attributes["limits"], "interface dispatch") {
+				t.Errorf("a taint refutation does not name its blind spot: %q",
+					c.Attributes["limits"])
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("the sanitized flow produced no taint refutation; this test asserts nothing")
+	}
+}


### PR DESCRIPTION
A refutation is a **universal** claim — "this does not hold" — and it is only as good as the search behind it.

`reach.Result` has always rendered its negatives that way:

> *"does not hold within the scope searched (…). Nothing here rules out another build or another path."*

A **ledger** refutation rendered as a bare sentence, which reads as settled.

## The property, not a checklist

`Store.RefuteWithin` carries the analysis that made the claim and what that analysis cannot see. `core/explain.qualify` renders them — and qualifies *generically* where a refiner recorded none.

**No path through the renderer can produce an unqualified negative.** That is the exit stated as a property rather than as a list of refiners somebody has to remember to update. The test walks all four combinations, including "refiner recorded no scope at all", because that is the case a per-refiner approach would miss.

Supporting claims are deliberately **not** hedged the same way. An existential claim is settled by one witness however narrow the search was, and hedging both directions would train a reader to discount both.

## The taint engine names its blind spots concretely

> a sanitizer cleared this value for command_injection — established by the python taint engine, over this file, which **cannot see interface dispatch, function values, reflection, or a sanitizer applied in another file**

That is what lets a reader decide whether the gap matters to *their* code. "Cannot see interface dispatch" is actionable; "within what it could see" is only honest.

The engine is the right first caller because its limits are the ones that have already cost nox real defects — an argv exemption that silenced shell sinks in five of six cases, a same-statement sanitizer invisible in every language but Go.

## Also closes 5.1 for Go

Since #613 a finding carries `call_path`, which is *"a finding can reference the path that established it"* for the one language that has a call graph. Marked as such rather than left open.

## Verification

- **Detection 231/0/0** — nothing here changes what is reported.
- Full suite green, `golangci-lint` 0 issues.

https://claude.ai/code/session_01Rjr4PEHRsSBps8rCsomBAT